### PR TITLE
enable customization of RadzenFieldset display style

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -220,6 +220,12 @@ namespace Radzen
         Info
     }
 
+    public enum DisplayStyle
+    {
+        Block,
+        Contents
+    }
+
     public enum FilterMode
     {
         Simple,

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -220,12 +220,6 @@ namespace Radzen
         Info
     }
 
-    public enum DisplayStyle
-    {
-        Block,
-        Contents
-    }
-
     public enum FilterMode
     {
         Simple,

--- a/Radzen.Blazor/RadzenFieldset.razor
+++ b/Radzen.Blazor/RadzenFieldset.razor
@@ -79,15 +79,12 @@
     [Parameter]
     public EventCallback Collapse { get; set; }
 
-    [Parameter]
-    public DisplayStyle DisplayStyle { get; set; } = DisplayStyle.Block;
-
-    string contentStyle = "display: block;";
+    string contentStyle = "";
 
     async System.Threading.Tasks.Task Toggle(EventArgs args)
     {
         collapsed = !collapsed;
-        contentStyle = collapsed ? "display: none;" : $"display: {DisplayStyle.ToString().ToLower()};";
+        contentStyle = collapsed ? "display: none;" : "";
 
         if (collapsed)
         {
@@ -118,7 +115,7 @@
 
     protected override Task OnParametersSetAsync()
     {
-        contentStyle = collapsed ? "display: none;" : $"display: {DisplayStyle.ToString().ToLower()};";
+        contentStyle = collapsed ? "display: none;" : "";
 
         return base.OnParametersSetAsync();
     }

--- a/Radzen.Blazor/RadzenFieldset.razor
+++ b/Radzen.Blazor/RadzenFieldset.razor
@@ -79,12 +79,15 @@
     [Parameter]
     public EventCallback Collapse { get; set; }
 
+	[Parameter]
+	public DisplayStyle DisplayStyle { get; set; } = DisplayStyle.Block;
+
     string contentStyle = "display: block;";
 
     async System.Threading.Tasks.Task Toggle(EventArgs args)
     {
         collapsed = !collapsed;
-        contentStyle = collapsed ? "display: none;" : "display: block;";
+        contentStyle = collapsed ? "display: none;" : $"display: {DisplayStyle.ToString().ToLower()};";
 
         if (collapsed)
         {
@@ -115,7 +118,7 @@
 
     protected override Task OnParametersSetAsync()
     {
-        contentStyle = collapsed ? "display: none;" : "display: block;";
+        contentStyle = collapsed ? "display: none;" : $"display: {DisplayStyle.ToString().ToLower()};";
 
         return base.OnParametersSetAsync();
     }

--- a/Radzen.Blazor/RadzenFieldset.razor
+++ b/Radzen.Blazor/RadzenFieldset.razor
@@ -79,8 +79,8 @@
     [Parameter]
     public EventCallback Collapse { get; set; }
 
-	[Parameter]
-	public DisplayStyle DisplayStyle { get; set; } = DisplayStyle.Block;
+    [Parameter]
+    public DisplayStyle DisplayStyle { get; set; } = DisplayStyle.Block;
 
     string contentStyle = "display: block;";
 


### PR DESCRIPTION
Enables customization of `RadzenFieldset` display style by defining a `DisplayStyle` enum and a `DisplayStyle` property for `RadzenFieldset`.  The default value `DisplayStyle.Block` preserves existing behavior.

Using `DisplayStyle.Block`:
![image](https://user-images.githubusercontent.com/1458084/107600748-43dcdf80-6bea-11eb-8c10-24dc6b58f2bf.png)

Using `DisplayStyle.Contents`:
![image](https://user-images.githubusercontent.com/1458084/107600730-31fb3c80-6bea-11eb-9496-8c72a9c522eb.png)
