### PR TITLE
Add Width & Height Parameter in RadzenHtmlEditorImage

### DIFF
--- a/Radzen.Blazor/RadzenHtmlEditorImage.razor
+++ b/Radzen.Blazor/RadzenHtmlEditorImage.razor
@@ -13,6 +13,8 @@
     {
         public string Src { get; set; }
         public string Alt { get; set; }
+        public string Width { get; set; }
+        public string Height { get; set; }
     }
 
     [Parameter]
@@ -35,6 +37,12 @@
 
     [Parameter]
     public string CancelText { get; set; } = "Cancel";
+
+    [Parameter]
+    public string WidthText { get; set; } = "Image Width";
+
+    [Parameter]
+    public string HeightText { get; set; } = "Image Height";
 
     ImageAttributes Attributes { get; set; }
     RadzenUpload FileUpload { get; set; }
@@ -78,6 +86,14 @@
             {
                 html.AppendFormat(" alt=\"{0}\"", Attributes.Alt);
             }
+            if (!String.IsNullOrEmpty(Attributes.Width))
+            {
+                html.AppendFormat(" width=\"{0}\"", Attributes.Width);
+            }
+            if (!String.IsNullOrEmpty(Attributes.Height))
+            {
+                html.AppendFormat(" height=\"{0}\"", Attributes.Height);
+            }
             html.AppendFormat(">");
 
             await Editor.ExecuteCommandAsync("insertHTML", html.ToString());
@@ -90,7 +106,7 @@
 
         var uploadHeaders = Editor.UploadHeaders ?? new Dictionary<string, string>();
 
-        Attributes = await JSRuntime.InvokeAsync<ImageAttributes>("Radzen.selectionAttributes", "img", new [] {"src", "alt"});
+        Attributes = await JSRuntime.InvokeAsync<ImageAttributes>("Radzen.selectionAttributes", "img", new [] {"src", "alt", "width", "height"});
 
         var result = await DialogService.OpenAsync(Title, ds =>
         @<div class="rz-html-editor-dialog">
@@ -102,6 +118,14 @@
                         <RadzenUploadHeader Name=@header.Key Value=@header.Value />
                     }
                 </RadzenUpload>
+            </div>
+                <div class="rz-html-editor-dialog-item">
+                <label>@WidthText</label>
+                <RadzenTextBox @bind-Value=@Attributes.Width style="width: 100%" />
+            </div>
+                <div class="rz-html-editor-dialog-item">
+                <label>@HeightText</label>
+                <RadzenTextBox @bind-Value=@Attributes.Height style="width: 100%" />
             </div>
             <div class="rz-html-editor-dialog-item">
                 <label>@UrlText</label>


### PR DESCRIPTION
The image in HtmlEditor is not resizable, so to add width & height parameter to allow user to adjust the image size