### PR TITLE
Refresh RadzenRadioButtonList when RadzenRadioButtonListItem Text property changes

### DIFF
--- a/Radzen.Blazor/RadzenRadioButtonList.razor
+++ b/Radzen.Blazor/RadzenRadioButtonList.razor
@@ -109,7 +109,9 @@
         if (items.Contains(item))
         {
             items.Remove(item);
-            try { InvokeAsync(StateHasChanged); } catch { }
+            try
+            { InvokeAsync(StateHasChanged); }
+            catch { }
         }
     }
 
@@ -126,7 +128,8 @@
         Value = item.Value;
 
         await ValueChanged.InvokeAsync(Value);
-        if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
+        if (FieldIdentifier.FieldName != null)
+        { EditContext?.NotifyFieldChanged(FieldIdentifier); }
         await Change.InvokeAsync(Value);
 
         StateHasChanged();
@@ -135,5 +138,10 @@
     private string getDisabledState(RadzenRadioButtonListItem<TValue> item)
     {
         return Disabled || item.Disabled ? " rz-state-disabled" : "";
+    }
+
+    public void Refresh()
+    {
+        StateHasChanged();
     }
 }

--- a/Radzen.Blazor/RadzenRadioButtonListItem.razor
+++ b/Radzen.Blazor/RadzenRadioButtonListItem.razor
@@ -1,8 +1,25 @@
 ﻿@inherits RadzenComponent
 @typeparam TValue
 @code {
+    private string _text;
     [Parameter]
-    public string Text { get; set; }
+    public string Text
+    {
+        get
+        {
+            return _text;
+        }
+        set
+        {
+            if (value != _text)
+            {
+                _text = value;
+
+                if (List != null)
+                    List.Refresh();
+            }
+        }
+    }
 
     [Parameter]
     public TValue Value { get; set; }


### PR DESCRIPTION
Refresh RadzenRadioButtonList when RadzenRadioButtonListItem Text property changes. 
Needed when application localization changes and UI doesn't follow. 