### PR TITLE
Support Formatting in RadzenNumeric

### DIFF
--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -331,5 +331,23 @@ namespace Radzen.Blazor.Tests
             Assert.DoesNotContain(@$"rz-spinner-up", component.Markup);
             Assert.DoesNotContain(@$"rz-spinner-down", component.Markup);
         }
+
+        [Fact]
+        public void Numeric_Formatted()
+        {
+            using var ctx = new TestContext();
+
+            double valueToTest = 100.234;
+            string format = "0.00";
+
+            var component = ctx.RenderComponent<RadzenNumeric<double>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<double>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<double>.Value), valueToTest)
+            );
+
+            component.Render();
+
+            Assert.Contains($" value=\"{valueToTest.ToString(format)}\"", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenNumeric.razor
+++ b/Radzen.Blazor/RadzenNumeric.razor
@@ -9,18 +9,18 @@
     <span @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
         <input @ref="@input" type="text" inputmode="decimal" name="@Name" disabled="@Disabled" readonly="@ReadOnly"
                class="rz-spinner-input rz-inputtext" tabindex="@TabIndex"
-               placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange"
+               placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "off")" value="@FormattedValue" @onchange="@OnChange"
                onkeypress="Radzen.numericKeyPress(event)" onpaste="Radzen.numericOnPaste(event)" />
         @if (ShowUpDown)
         {
-        <button type="button" class="rz-spinner-button rz-spinner-up rz-corner-tr rz-button" tabindex="-1"
-                @onclick="@((args) => UpdateValueWithStep(true))">
-            <span class="rz-spinner-button-icon rzi rzi-caret-up"></span>
-        </button>
-        <button type="button" class="rz-spinner-button rz-spinner-down rz-corner-br rz-button" tabindex="-1"
-                @onclick="@((args) => UpdateValueWithStep(false))">
-            <span class="rz-spinner-button-icon rzi rzi-caret-down"></span>
-        </button>
+            <button type="button" class="rz-spinner-button rz-spinner-up rz-corner-tr rz-button" tabindex="-1"
+                    @onclick="@((args) => UpdateValueWithStep(true))">
+                <span class="rz-spinner-button-icon rzi rzi-caret-up"></span>
+            </button>
+            <button type="button" class="rz-spinner-button rz-spinner-down rz-corner-br rz-button" tabindex="-1"
+                    @onclick="@((args) => UpdateValueWithStep(false))">
+                <span class="rz-spinner-button-icon rzi rzi-caret-down"></span>
+            </button>
         }
     </span>
 }
@@ -77,6 +77,30 @@
         }
     }
 
+    protected string FormattedValue
+    {
+        get
+        {
+            if (Value != null)
+            {
+                if (Format != null)
+                {
+                    decimal decimalValue = (decimal)Convert.ChangeType(Value, typeof(decimal));
+                    return decimalValue.ToString(Format);
+                }
+                return Value.ToString();
+            }
+            else
+            {
+                return "";
+            }
+        }
+        set
+        {
+            _ = InternalValueChanged(value);
+        }
+    }
+
     public override bool HasValue
     {
         get
@@ -84,6 +108,9 @@
             return Value != null;
         }
     }
+
+    [Parameter]
+    public string Format { get; set; }
 
     [Parameter]
     public string Step { get; set; }
@@ -122,8 +149,13 @@
 
     protected async System.Threading.Tasks.Task OnChange(ChangeEventArgs args)
     {
+        await InternalValueChanged(args.Value);
+    }
+
+    private async System.Threading.Tasks.Task InternalValueChanged(object value)
+    {
         TValue newValue;
-        BindConverter.TryConvertTo<TValue>($"{args.Value}", System.Globalization.CultureInfo.CurrentCulture, out newValue);
+        BindConverter.TryConvertTo<TValue>($"{value}", System.Globalization.CultureInfo.CurrentCulture, out newValue);
 
         decimal? newValueAsDecimal = newValue == null ? default(decimal?) : (decimal)ConvertType.ChangeType(newValue, typeof(decimal));
 

--- a/RadzenBlazorDemos/Pages/NumericPage.razor
+++ b/RadzenBlazorDemos/Pages/NumericPage.razor
@@ -15,6 +15,8 @@
             <RadzenNumeric Disabled="true" TValue="int?" @bind-Value=@value Placeholder="Enter or clear value" />
             <h3 style="margin-top: 2rem">Without Up/Down</h3>
             <RadzenNumeric ShowUpDown="false" TValue="int?" @bind-Value=@value Placeholder="Enter or clear value" />
+            <h3 style="margin-top: 2rem">Formatted Value</h3>
+            <RadzenNumeric TValue="double" Format="0.0000" @bind-Value=@dblValue Placeholder="Enter or clear value" Change="@(args => OnChange(args, "Formatted numeric"))" />
         </div>
         <div class="col-xl-6">
             <EventConsole @ref=@console />
@@ -24,6 +26,8 @@
 
 @code {
     int? value;
+
+    double dblValue = 0.0;
 
     EventConsole console;
 

--- a/RadzenBlazorDemos/Pages/NumericPage.razor
+++ b/RadzenBlazorDemos/Pages/NumericPage.razor
@@ -14,7 +14,7 @@
             <h3 style="margin-top: 2rem">Disabled numeric</h3>
             <RadzenNumeric Disabled="true" TValue="int?" @bind-Value=@value Placeholder="Enter or clear value" />
             <h3 style="margin-top: 2rem">Without Up/Down</h3>
-            <RadzenNumeric ShowUpDown="false" TValue="int?" @bind-Value=@value Placeholder="Enter or clear value" />
+            <RadzenNumeric ShowUpDown="false" TValue="int?" @bind-Value=@value Placeholder="Enter or clear value" Change="@(args => OnChange(args, "Without Up/Down"))" />
             <h3 style="margin-top: 2rem">Formatted Value</h3>
             <RadzenNumeric TValue="double" Format="0.0000" @bind-Value=@dblValue Placeholder="Enter or clear value" Change="@(args => OnChange(args, "Formatted numeric"))" />
         </div>


### PR DESCRIPTION
fixes #89 

This pullrequest adds the optional capability to format the value of a RadzenNumeric.

The current handling always converts the internal value to a decimal in order to handle it. It may be a good Idea to do this only when it is set from external (but maybe this is by design so I did not change it)