### PR TITLE
Refresh RadzenSteps and RadzenGrid when bound properties change

### DIFF
--- a/Radzen.Blazor/RadzenGrid.razor
+++ b/Radzen.Blazor/RadzenGrid.razor
@@ -623,8 +623,21 @@
     [Parameter]
     public string ColumnWidth { get; set; }
 
+    private string _emptyText = "No records to display.";
     [Parameter]
-    public string EmptyText { get; set; } = "No records to display.";
+    public string EmptyText
+    {
+        get { return _emptyText; }
+        set
+        {
+            if (value != _emptyText)
+            {
+                _emptyText = value;
+
+                ChangeState();
+            }
+        }
+    }
 
     [Parameter]
     public bool AllowSorting { get; set; }

--- a/Radzen.Blazor/RadzenSteps.razor
+++ b/Radzen.Blazor/RadzenSteps.razor
@@ -166,11 +166,37 @@
     [Parameter]
     public EventCallback<int> Change { get; set; }
 
+    private string _nextStep = "Next";
     [Parameter]
-    public string NextText { get; set; } = "Next";
+    public string NextText
+    {
+        get { return _nextStep; }
+        set
+        {
+            if (value != _nextStep)
+            {
+                _nextStep = value;
 
+                Refresh();
+            }
+        }
+    }
+
+    private string _previousText = "Previous";
     [Parameter]
-    public string PreviousText { get; set; } = "Previous";
+    public string PreviousText
+    {
+        get { return _previousText; }
+        set
+        {
+            if (value != _previousText)
+            {
+                _previousText = value;
+
+                Refresh();
+            }
+        }
+    }
 
     [Parameter]
     public RenderFragment Steps { get; set; }


### PR DESCRIPTION
When bound text properties change, UI doesn't follow along automatically until a StateHasChanged() has been invoked from anywhere. 
I added a couple of lines in the properties setter to invoke StateHasChanged().