### PR TITLE
NullReferenceException in RadzenDropDownDataGrid fixed.

### DIFF
--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -197,7 +197,7 @@
 
     private string GetPropertyFilterExpression(string property, string filterCaseSensitivityOperator)
     {
-        return $"{property}{filterCaseSensitivityOperator}.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0)";
+        return $"({property} ?? \"\"){filterCaseSensitivityOperator}.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0)";
     }
 
     private bool IsColumnFilterPropertyTypeString(RadzenGridColumn<object> column)


### PR DESCRIPTION
Please consider to merge this fix. It improves the creation of the filter expression in the RadzenDropDownDataGrid.razor by considering the string value can be null.
Fixes #96