### PR TITLE
Culture for time format in Hours.razor

### DIFF
--- a/Radzen.Blazor/Rendering/Hours.razor
+++ b/Radzen.Blazor/Rendering/Hours.razor
@@ -8,7 +8,7 @@
     }
     else
     {
-        <div class="rz-slot-header">@date.ToString("h tt")</div>
+        <div class="rz-slot-header">@date.ToString("t", System.Globalization.CultureInfo.CurrentCulture)</div>
     }
 
     minor = !minor;


### PR DESCRIPTION
Instead of using a hard coded "h tt" format, use the current user culture to format the time shown on the left hand side of the day and month view.