### PR TITLE
Radzen data grid column filter

### DIFF
--- a/Radzen.Blazor.Tests/DataGridColumnTests.cs
+++ b/Radzen.Blazor.Tests/DataGridColumnTests.cs
@@ -1,0 +1,41 @@
+using AngleSharp.Dom;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Radzen.Blazor.Rendering;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridColumnTests
+    {
+        class Testable<TItem> : RadzenDataGridColumn<TItem> 
+        {
+			public Testable() {
+                Grid = new RadzenDataGrid<TItem>();
+            }
+            public void PublicMorozov_OnInitialized() 
+            {
+                OnInitialized();
+            }
+        }
+
+        [Fact]
+        public void DataGridColumn_FilterPropertyType_Used_From_Type_Parameter()
+        {
+            
+            var column = new Testable<int>() 
+            { 
+                Type = typeof(string)
+            };
+
+            column.PublicMorozov_OnInitialized();
+            Assert.Equal(column.FilterOperator, FilterOperator.Contains);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridColumnTests.cs
+++ b/Radzen.Blazor.Tests/DataGridColumnTests.cs
@@ -14,28 +14,93 @@ namespace Radzen.Blazor.Tests
 {
     public class DataGridColumnTests
     {
-        class Testable<TItem> : RadzenDataGridColumn<TItem> 
+        class TestModel
         {
-			public Testable() {
-                Grid = new RadzenDataGrid<TItem>();
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+        class Testable : RadzenDataGridColumn<TestModel>
+        {
+            public Testable()
+            {
+                Grid = new RadzenDataGrid<TestModel>();
             }
-            public void PublicMorozov_OnInitialized() 
+            public void PublicMorozov_OnInitialized()
             {
                 OnInitialized();
+            }
+            public Type PublicMorozov_FilterPropertyType()
+            {
+                var propertyInfo = this.GetType()
+                    .GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                    .FirstOrDefault(x => x.Name == "FilterPropertyType");
+
+                return propertyInfo?.GetValue(this) as Type;
             }
         }
 
         [Fact]
-        public void DataGridColumn_FilterPropertyType_Used_From_Type_Parameter()
+        public void FilterPropertyType_Assigned_From_Type_Parameter()
         {
-            
-            var column = new Testable<int>() 
-            { 
-                Type = typeof(string)
+            var column = new Testable()
+            {
+                Property = nameof(TestModel.Id),
+                Type = typeof(string),
+                FilterProperty = null
             };
 
             column.PublicMorozov_OnInitialized();
-            Assert.Equal(column.FilterOperator, FilterOperator.Contains);
+
+            Assert.Equal(typeof(string), column.PublicMorozov_FilterPropertyType());
+            Assert.Equal(FilterOperator.Contains, column.FilterOperator);
+        }
+
+        [Fact]
+        public void FilterPropertyType_Assigned_From_FilterProperty_Parameter()
+        {
+            var column = new Testable()
+            {
+                Property = nameof(TestModel.Id),
+                Type = null,
+                FilterProperty = nameof(TestModel.Name)
+            };
+
+            column.PublicMorozov_OnInitialized();
+
+            Assert.Equal(typeof(string), column.PublicMorozov_FilterPropertyType());
+            Assert.Equal(FilterOperator.Contains, column.FilterOperator);
+        }
+
+        [Fact]
+        public void FilterPropertyType_Assigned_From_ColumnType()
+        {
+            var column = new Testable()
+            {
+                Property = nameof(TestModel.Id),
+                Type = null,
+                FilterProperty = null
+            };
+
+            column.PublicMorozov_OnInitialized();
+
+            Assert.Equal(typeof(Guid), column.PublicMorozov_FilterPropertyType());
+            Assert.Equal(FilterOperator.Equals, column.FilterOperator);
+        }
+
+        [Fact]
+        public void FilterPropertyType_Assigned_From_Type_If_FilterProperty_Is_Fake_Field()
+        {
+            var column = new Testable()
+            {
+                Property = nameof(TestModel.Id),
+                Type = typeof(decimal),
+                FilterProperty = "NotExistsField"
+            };
+
+            column.PublicMorozov_OnInitialized();
+
+            Assert.Equal(typeof(decimal), column.PublicMorozov_FilterPropertyType());
         }
     }
 }

--- a/Radzen.Blazor.Tests/DataGridColumnTests.cs
+++ b/Radzen.Blazor.Tests/DataGridColumnTests.cs
@@ -1,13 +1,5 @@
-using AngleSharp.Dom;
-using Bunit;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Rendering;
-using Radzen.Blazor.Rendering;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Radzen.Blazor.Tests

--- a/Radzen.Blazor/RadzenDataGridColumn.razor
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor
@@ -10,7 +10,7 @@
         {
             Grid.AddColumn(this);
 
-            if (Type == null)
+            if (!string.IsNullOrEmpty(FilterProperty) || Type == null)
             {
                 var property = GetFilterProperty();
 

--- a/Radzen.Blazor/RadzenDataGridColumn.razor
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor
@@ -10,25 +10,28 @@
         {
             Grid.AddColumn(this);
 
-            var property = GetFilterProperty();
-
-            if (!string.IsNullOrEmpty(property))
+            if (Type == null)
             {
-                _filterPropertyType = PropertyAccess.GetPropertyType(typeof(TItem), property);
+                var property = GetFilterProperty();
 
-                if (_filterPropertyType == null)
+                if (!string.IsNullOrEmpty(property))
                 {
-                    _filterPropertyType = Type;
+                    _filterPropertyType = PropertyAccess.GetPropertyType(typeof(TItem), property);
                 }
-                else
-                {
-                    propertyValueGetter = PropertyAccess.Getter<TItem, object>(Property);
-                }
+            }
+            
+            if (_filterPropertyType == null)
+            {
+                _filterPropertyType = Type;
+            }
+            else
+            {
+                propertyValueGetter = PropertyAccess.Getter<TItem, object>(Property);
+            }
 
-                if (_filterPropertyType == typeof(string))
-                {
-                    FilterOperator = FilterOperator.Contains;
-                }
+            if (_filterPropertyType == typeof(string))
+            {
+                FilterOperator = FilterOperator.Contains;
             }
         }
     }


### PR DESCRIPTION
I was faced with the need to set the filter data type, which is different from the data type in the column itself, for example, a field with data that is formed in the Template Context, for example, my case:
- a table of users, with a field with a list of the selected roles of each user
- a list of roles, this is a array of dto model with fields, [System.Guid Id], [string Name].
- the output of roles in one column of the table occurs in the Template Context, @ string.Join (",", user.Roles.Select (x => x.Name))

Currently I use workaround, set a fake value in the FilterProperty with a non-existent field. This allowed parts of the RadzenDataGridColumn.razor: 21 code to work, and set the required _filterPropertyType:
```C#
                _filterPropertyType = PropertyAccess.GetPropertyType(typeof(TItem), property);
                if (_filterPropertyType == null)
                {
                    _filterPropertyType = Type;  //<-------------
                }
```
Getting the source code of RadzenDataGridColumn.razor, I decided how to fix this inconvenience with setting a fake field, and formed it in this PR.
The main idea is to be able to explicit set the same data type for the filter and for the column itself if the FilterProperty property is not specified.

In this PR, I did the following:
- in the RadzenDataGridColumn.OnInitialized () method, _filterPropertyType is copied from Type if Type is set but FilterProperty is not defined:
- added tests related to this task:
    - copying FilterPropertyType from Type. (FilterPropertyType_Assigned_From_Type_Parameter)
    - copying the FilterPropertyType from the FilterProperty field type. (FilterPropertyType_Assigned_From_FilterProperty_Parameter)
    - copying the FilterPropertyType from the column field type. (FilterPropertyType_Assigned_From_ColumnType)
    - copying FilterPropertyType from Type in case of non-existent field in FilterProperty. (FilterPropertyType_Assigned_From_Type_If_FilterProperty_Is_Fake_Field)