### PR TITLE
Support custom filtering

### DIFF
--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -725,12 +725,12 @@ namespace Radzen.Blazor.Tests
                     builder.AddAttribute(4, "FilterValue", filterValue);
                     builder.AddAttribute(5, "Type", typeof(string));
                     builder.AddAttribute(6, "CustomFiltering", (Func<CustomFilteringArgs<Tuple<int, List<Tuple<int, string>>>>, bool>)(args => {
-                        if (args.Column.Property == "Item2")
+                        if (args.Property == "Item2")
                         {
-                            switch (args.Column.FilterOperator)
+                            switch (args.FilterOperator)
                             {
                                 case FilterOperator.Contains:
-                                    return args.Data.Item2.Any(x => x.Item2.Contains(args.Column.FilterValue as string));
+                                    return args.Data.Item2.Any(x => x.Item2.Contains(args.FilterValue as string));
                                 default:
                                     break;
                             }

--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -715,6 +715,10 @@ namespace Radzen.Blazor.Tests
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 
+            var testSecondFilterOperator = FilterOperator.Equals;
+            object testSecondFilterValue = null;
+            var testLogicalFilterOperator = LogicalFilterOperator.And;
+
             Func<string, RenderFragment> columnRenderFragmentFunc = (filterValue) => {
                 return delegate (RenderTreeBuilder builder)
                 {
@@ -724,9 +728,15 @@ namespace Radzen.Blazor.Tests
                     builder.AddAttribute(3, "FilterOperator", FilterOperator.Contains);
                     builder.AddAttribute(4, "FilterValue", filterValue);
                     builder.AddAttribute(5, "Type", typeof(string));
-                    builder.AddAttribute(6, "CustomFiltering", (Func<CustomFilteringArgs<Tuple<int, List<Tuple<int, string>>>>, bool>)(args => {
+                    builder.AddAttribute(6, "SecondFilterOperator", FilterOperator.DoesNotContain);
+                    builder.AddAttribute(7, "SecondFilterValue", $"second_{filterValue}");
+                    builder.AddAttribute(8, "LogicalFilterOperator", LogicalFilterOperator.Or);
+                    builder.AddAttribute(9, "CustomFiltering", (Func<CustomFilteringArgs<Tuple<int, List<Tuple<int, string>>>>, bool>)(args => {
                         if (args.Property == "Item2")
                         {
+                            testSecondFilterOperator = args.SecondFilterOperator;
+                            testSecondFilterValue = args.SecondFilterValue;
+                            testLogicalFilterOperator = args.LogicalFilterOperator;
                             switch (args.FilterOperator)
                             {
                                 case FilterOperator.Contains:
@@ -752,6 +762,10 @@ namespace Radzen.Blazor.Tests
             });
 
             Assert.Equal<IEnumerable<string>>(component.Instance.View.SelectMany(x => x.Item2).Select(x => x.Item2), new string[] { "Detail_10", "Detail_11" });
+            Assert.Equal(FilterOperator.DoesNotContain, testSecondFilterOperator);
+            Assert.Equal("second_Detail_1", testSecondFilterValue);
+            Assert.Equal(LogicalFilterOperator.Or, testLogicalFilterOperator);
+
 
             component.SetParametersAndRender(parameters => {
                 parameters.Add<RenderFragment>(p => p.Columns, columnRenderFragmentFunc("nonexistent"));

--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -580,7 +580,7 @@ namespace Radzen.Blazor.Tests
             ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 
             var component = ctx.RenderComponent<RadzenDataGrid<Tuple<string>>>(parameterBuilder => {
-                parameterBuilder.Add<IEnumerable<Tuple<string>>>(p => p.Data, new[] { new Tuple<string>("Name_0"), new Tuple<string>("Name_1"), new Tuple<string>("Name_2") });
+                parameterBuilder.Add(p => p.Data, new[] { new Tuple<string>("Name_0"), new Tuple<string>("Name_1"), new Tuple<string>("Name_2") });
                 parameterBuilder.Add<RenderFragment>(p => p.Columns, builder => {
                     builder.OpenComponent(0, typeof(RadzenDataGridColumn<Tuple<string>>));
                     builder.AddAttribute(1, "Property", "Item1");
@@ -604,7 +604,7 @@ namespace Radzen.Blazor.Tests
             ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 
             var component = ctx.RenderComponent<RadzenDataGrid<Tuple<string>>>(parameterBuilder => {
-                parameterBuilder.Add<IEnumerable<Tuple<string>>>(p => p.Data, new[] { new Tuple<string>("Name_0"), new Tuple<string>("Name_1"), new Tuple<string>("Name_2") });
+                parameterBuilder.Add(p => p.Data, new[] { new Tuple<string>("Name_0"), new Tuple<string>("Name_1"), new Tuple<string>("Name_2") });
                 parameterBuilder.Add<RenderFragment>(p => p.Columns, builder => {
                     builder.OpenComponent(0, typeof(RadzenDataGridColumn<Tuple<string>>));
                     builder.AddAttribute(1, "Property", "Item1");
@@ -656,7 +656,7 @@ namespace Radzen.Blazor.Tests
             };
 
             var component = ctx.RenderComponent<RadzenDataGrid<Tuple<int, List<Tuple<int, string>>>>>(parameterBuilder => {
-                parameterBuilder.Add<IEnumerable<Tuple<int, List<Tuple<int, string>>>>>(p => p.Data, new[] {
+                parameterBuilder.Add(p => p.Data, new[] {
                     new Tuple<int, List<Tuple<int, string>>>(0, new List<Tuple<int, string>>() { new Tuple<int, string>(100, "Detail_00"), new Tuple<int, string>(101, "Detail_01") }),
                     new Tuple<int, List<Tuple<int, string>>>(1, new List<Tuple<int, string>>() { new Tuple<int, string>(110, "Detail_10"), new Tuple<int, string>(111, "Detail_11") }),
                 });
@@ -671,8 +671,8 @@ namespace Radzen.Blazor.Tests
             });
 
             IEnumerable<Tuple<int, List<Tuple<int, string>>>> filtered = null;
-            component.InvokeAsync(() => filtered = component.Instance.View.ToList<Tuple<int, List<Tuple<int, string>>>>()).Wait();
-            Assert.Equal<IEnumerable<string>>(filtered.SelectMany(x => x.Item2).Select(x => x.Item2), new string[] { });
+            component.InvokeAsync(() => filtered = component.Instance.View.ToList()).Wait();
+            Assert.Equal<IEnumerable<string>>(filtered.SelectMany(x => x.Item2).Select(x => x.Item2), Enumerable.Empty<string>());
         }
     }
 }

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -752,7 +752,7 @@ namespace Radzen
 
     }
 
-    public class RadzenSplitterResizeEventArgs:RadzenSplitterEventArgs
+    public class RadzenSplitterResizeEventArgs : RadzenSplitterEventArgs
     {
         public double NewSize { get; set; }
     }

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -744,4 +744,10 @@ namespace Radzen
             return false;
         }
     }
+
+    public class CustomFilteringArgs<T>
+    {
+        public Blazor.RadzenDataGridColumn<T> Column { get; internal set; }
+        public T Data { get; internal set; }
+    }
 }

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -747,7 +747,12 @@ namespace Radzen
 
     public class CustomFilteringArgs<T>
     {
-        public Blazor.RadzenDataGridColumn<T> Column { get; internal set; }
         public T Data { get; internal set; }
+        public string Property { get; set; }
+        public FilterOperator FilterOperator { get; internal set; }
+        public object FilterValue { get; internal set; }
+        public FilterOperator SecondFilterOperator { get; internal set; }
+        public object SecondFilterValue { get; internal set; }
+        public LogicalFilterOperator LogicalFilterOperator { get; internal set; }
     }
 }

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -814,38 +814,42 @@
     {
         get
         {
-            var view = base.View.Where<TItem>(columns);
-            var orderBy = GetOrderBy();
+            bool serverSideDataOperations = LoadData.HasDelegate;
+            var view = base.View;
+            if (!serverSideDataOperations)
+            {            
+                var orderBy = GetOrderBy();
 
-            if (!string.IsNullOrEmpty(orderBy))
-            {
-                if (typeof(TItem) == typeof(object))
+                if (!string.IsNullOrEmpty(orderBy))
                 {
-                    var firstItem = view.FirstOrDefault();
-                    if (firstItem != null)
+                    if (typeof(TItem) == typeof(object))
                     {
-                        view = view.Cast(firstItem.GetType()).AsQueryable().OrderBy(orderBy).Cast<TItem>();
+                        var firstItem = view.FirstOrDefault();
+                        if (firstItem != null)
+                        {
+                            view = view.Cast(firstItem.GetType()).AsQueryable().OrderBy(orderBy).Cast<TItem>();
+                        }
+                    }
+                    else
+                    {
+                        view = view.OrderBy(orderBy);
                     }
                 }
-                else
-                {
-                    view = view.OrderBy(orderBy);
-                }
-            }
 
-            if (!LoadData.HasDelegate && (!IsVirtualizationAllowed() || AllowPaging))
-            {
-                var count = view.Count();
-                if (count != Count)
+                if (!IsVirtualizationAllowed() || AllowPaging)
                 {
-                    Count = count;
-
-                    if (skip >= Count && Count > PageSize)
+                    var count = view.Count();
+                    if (count != Count)
                     {
-                        skip = Count - PageSize;
-                    }
+                        Count = count;
 
-                    StateHasChanged();
+                        if (skip >= Count && Count > PageSize)
+                        {
+                            skip = Count - PageSize;
+                        }
+
+                        StateHasChanged();
+                    }
                 }
             }
 

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -1494,7 +1494,15 @@
     {
         foreach (var column in columns)
         {
-            var args = new Radzen.CustomFilteringArgs<TItem>() { Data = item, Column = column };
+            var args = new Radzen.CustomFilteringArgs<TItem>() {
+                Data = item,
+                Property = column.Property,
+                FilterOperator = column.GetFilterOperator(),
+                FilterValue = column.GetFilterValue(),
+                SecondFilterOperator = column.GetSecondFilterOperator(),
+                SecondFilterValue = column.GetSecondFilterValue(),
+                LogicalFilterOperator = column.GetLogicalFilterOperator()
+            };
             if (column.CustomFiltering(args))
             {
                 return true;

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -1473,7 +1473,7 @@
         }
     }
 
-    internal bool ApplyDataCustomFiltering(TItem item, List<RadzenDataGridColumn<TItem>> columns)
+    internal bool ApplyDataCustomFiltering(TItem item, IEnumerable<RadzenDataGridColumn<TItem>> columns)
     {
         bool matched = false;
         foreach (var column in columns)

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -817,7 +817,11 @@
             bool serverSideDataOperations = LoadData.HasDelegate;
             var view = base.View;
             if (!serverSideDataOperations)
-            {            
+            {
+                var columnsWithNoCustomFiltering = columns.Where(c => c.CustomFiltering == null);
+                var columnsWithCustomFiltering = columns.Where(c => c.CustomFiltering != null);
+                view = view.Where<TItem>(columnsWithNoCustomFiltering);
+                view = view.Where<TItem>(x => ApplyDataCustomFiltering(x, columnsWithCustomFiltering));
                 var orderBy = GetOrderBy();
 
                 if (!string.IsNullOrEmpty(orderBy))
@@ -1467,5 +1471,23 @@
                 JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", $"{PopupID}{column.GetFilterProperty()}");
             }
         }
+    }
+
+    internal bool ApplyDataCustomFiltering(TItem item, List<RadzenDataGridColumn<TItem>> columns)
+    {
+        bool matched = false;
+        foreach (var column in columns)
+        {
+            if (column.CustomFiltering != null)
+            {
+                var args = new Radzen.CustomFilteringArgs<TItem>() { Data = item, Column = column };
+                matched = column.CustomFiltering(args);
+                if (matched)
+                {
+                    break;
+                }
+            }
+        }
+        return matched;
     }
 }

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -834,7 +834,7 @@
                 var columnsWithCustomFiltering = columns.Where(c => c.CustomFiltering != null);
                 if (columnsWithCustomFiltering.Any())
                 {
-                    view = view.Where<TItem>(x => ApplyDataCustomFiltering(x, columnsWithCustomFiltering));
+                    view = view.AsEnumerable<TItem>().Where<TItem>(x => ApplyDataCustomFiltering(x, columnsWithCustomFiltering)).AsQueryable();
                 }
 
                 var orderBy = GetOrderBy();

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -819,9 +819,14 @@
             if (!serverSideDataOperations)
             {
                 var columnsWithNoCustomFiltering = columns.Where(c => c.CustomFiltering == null);
-                var columnsWithCustomFiltering = columns.Where(c => c.CustomFiltering != null);
                 view = view.Where<TItem>(columnsWithNoCustomFiltering);
-                view = view.Where<TItem>(x => ApplyDataCustomFiltering(x, columnsWithCustomFiltering));
+
+                var columnsWithCustomFiltering = columns.Where(c => c.CustomFiltering != null);
+                if (columnsWithCustomFiltering.Any())
+                {
+                    view = view.Where<TItem>(x => ApplyDataCustomFiltering(x, columnsWithCustomFiltering));
+                }
+
                 var orderBy = GetOrderBy();
 
                 if (!string.IsNullOrEmpty(orderBy))
@@ -1473,21 +1478,16 @@
         }
     }
 
-    internal bool ApplyDataCustomFiltering(TItem item, IEnumerable<RadzenDataGridColumn<TItem>> columns)
+    bool ApplyDataCustomFiltering(TItem item, IEnumerable<RadzenDataGridColumn<TItem>> columns)
     {
-        bool matched = false;
         foreach (var column in columns)
         {
-            if (column.CustomFiltering != null)
+            var args = new Radzen.CustomFilteringArgs<TItem>() { Data = item, Column = column };
+            if (column.CustomFiltering(args))
             {
-                var args = new Radzen.CustomFilteringArgs<TItem>() { Data = item, Column = column };
-                matched = column.CustomFiltering(args);
-                if (matched)
-                {
-                    break;
-                }
+                return true;
             }
         }
-        return matched;
+        return false;
     }
 }

--- a/Radzen.Blazor/RadzenDataGridColumn.razor
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor
@@ -404,4 +404,7 @@
     {
         Grid?.RemoveColumn(this);
     }
+
+    [Parameter]
+    public Func<CustomFilteringArgs<TItem>, bool> CustomFiltering { get; set; } = null;
 }


### PR DESCRIPTION
This PR adds following:
- ability to filter data with custom rules by assigning the RadzenDataGridColumn.CustomFiltering function in Client-side mode.
- disabling unnecessary filtering/sorting operations in RadzenDataGrid.View in Server-side mode.
- added related tests, 
   - DataGrid_View_Use_ClientSide_Filtering_When_LoadData_Empty
   - DataGrid_View_Use_ServerSide_Filtering_When_LoadData_Used
   - DataGrid_View_Use_Custom_Filtering 

 RadzenDataGridColumn custom filtering:
```cs
    [Parameter]
    public Func<CustomFilteringArgs<TItem>, bool> CustomFiltering { get; set; } = null;
```
```cs
    public class CustomFilteringArgs<T>
    {
        public Blazor.RadzenDataGridColumn<T> Column { get; internal set; }
        public T Data { get; internal set; }
    }
```

Trigger to this PR was the System.Linq.Dynamic.Core.Exceptions.ParseException that was thrown when trying to use RadzenDataGrid.View in event LoadData and active filter FilterOperator.Contains in a column with composite data, for example, an array of objects with fields [int Id], [string Name]