### PR TITLE
Fix pager visibility

### DIFF
--- a/Radzen.Blazor.Tests/PagerTests.cs
+++ b/Radzen.Blazor.Tests/PagerTests.cs
@@ -1,0 +1,57 @@
+using Bunit;
+using Bunit.JSInterop;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class PagerTests
+    {
+        [Fact]
+        public void RadzenPager_AutoHide_If_Count_Is_Less_Than_PageSize()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenPager>(parameters =>
+            {
+                parameters.Add<int>(p => p.PageSize, 20);
+                parameters.Add<int>(p => p.Count, 100);
+            });
+
+            component.Render();
+
+            Assert.Contains(@$"rz-paginator", component.Markup);
+
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add<int>(p => p.PageSize, 101);
+                parameters.Add<int>(p => p.Count, 100);
+            });
+            Assert.DoesNotContain(@$"rz-paginator", component.Markup);
+        }
+
+        [Fact]
+        public void RadzenPager_Dont_AutoHide_If_PageSizeOptions_Specified()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenPager>(parameters =>
+            {
+                parameters.Add<int>(p => p.PageSize, 101);
+                parameters.Add<int>(p => p.Count, 100);
+                parameters.Add<IEnumerable<int>>(p => p.PageSizeOptions, new int[] { 3, 7, 15 });
+            });
+
+            component.Render();
+
+            Assert.Contains(@$"rz-paginator", component.Markup);
+            Assert.Contains(@$"rz-dropdown-trigger", component.Markup);
+        }
+
+    }
+}

--- a/Radzen.Blazor/RadzenPager.razor
+++ b/Radzen.Blazor/RadzenPager.razor
@@ -1,5 +1,5 @@
 ﻿@inherits RadzenComponent
-@if (Visible && Count > PageSize)
+@if (GetVisible())
 {
     <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" style="@Style" id="@GetId()">
         @if (skip > 0)
@@ -86,6 +86,11 @@
         }
     }
 
+    protected bool GetVisible()
+    {
+        return Visible && (Count > PageSize || (PageSizeOptions != null && PageSizeOptions.Any()));
+    }
+
     [Parameter]
     public EventCallback<PagerEventArgs> PageChanged { get; set; }
 
@@ -96,7 +101,7 @@
 
     protected override Task OnParametersSetAsync()
     {
-        if (Visible)
+        if (GetVisible())
         {
             InvokeAsync(Reload);
         }


### PR DESCRIPTION
If PageSizeOptions are present, do not hide the Pager element if the number of records is less than PageSize