### PR TITLE
RadzenCheckBox label support.

### DIFF
--- a/Radzen.Blazor/RadzenCheckBox.razor
+++ b/Radzen.Blazor/RadzenCheckBox.razor
@@ -5,9 +5,9 @@
 @if (Visible)
 {
     <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" 
-         @onmouseup="@OnMouseUp" @onkeypress="@(async (args) => { if (args.Code == "Space") { await Toggle(); } })" style="@Style" tabindex="@TabIndex" id="@GetId()">
+         @onmouseup=@Toggle @onkeypress=@OnKeyPress @onkeypress:preventDefault style="@Style" tabindex="@TabIndex" id="@GetId()">
         <div class="rz-helper-hidden-accessible">
-            <input type="text" name="@Name" value="@Value" tabindex="-1">
+            <input type="checkbox" @onchange=@Toggle name=@Name id=@Name checked=@(Object.Equals(Value, true)) tabindex="-1">
         </div>
         <div class="@getInnerCssClass()">
             <span class="@getCheckBoxCssClass()"></span>
@@ -49,12 +49,15 @@
         return $"rz-chkbox {(Disabled ? " rz-state-disabled" : "")} {fieldCssClass}";
     }
 
-    public async Task OnMouseUp(MouseEventArgs args)
+    async Task OnKeyPress(KeyboardEventArgs args)
     {
-        await Toggle();
+        if (args.Code == "Space")
+        {
+            await Toggle();
+        }
     }
 
-    async System.Threading.Tasks.Task Toggle()
+    async Task Toggle()
     {
         if (Disabled)
         {

--- a/RadzenBlazorDemos/Pages/CheckBoxPage.razor
+++ b/RadzenBlazorDemos/Pages/CheckBoxPage.razor
@@ -4,10 +4,11 @@
 <div class="row">
     <div class="col-xl-6">
         <h3>CheckBox</h3>
-        <RadzenCheckBox @bind-Value=@checkBox1Value  TValue="bool" Change=@(args => OnChange(args, "CheckBox1 CheckBox")) />
+        <RadzenCheckBox @bind-Value=@checkBox1Value  Name="CheckBox1" TValue="bool" Change=@(args => OnChange(args, "CheckBox1 CheckBox")) />
         <RadzenLabel Text="CheckBox1" Component="CheckBox1" Style="margin-left: 5px;" />
         <h3 style="margin-top: 2rem">Tri State</h3>
-        <RadzenCheckBox @bind-Value=@checkBox2Value TriState="true" TValue="bool?" Change=@(args => OnChange(args, "TriState CheckBox")) /><RadzenLabel Text="TriState" Style="margin-left: 5px" Component="CheckBox2" />
+        <RadzenCheckBox @bind-Value=@checkBox2Value Name="CheckBox2" TriState="true" TValue="bool?" Change=@(args => OnChange(args, "TriState CheckBox")) />
+        <RadzenLabel Text="TriState" Style="margin-left: 5px" Component="CheckBox2" />
         <h3 style="margin-top: 2rem">Disabled</h3>
         <RadzenCheckBox @bind-Value=@checkBox3Value Disabled="true" TriState="true" TValue="bool?" /><RadzenLabel Text="Disabled" Style="margin-left: 5px" Component="CheckBox3" />
     </div>


### PR DESCRIPTION
The RadzenCheckBox uses `<input type="checkbox">` with its `id` set to the Name property. This allows clicking any `<label for="checkboxName">` to check it.