### PR TITLE
Add RadioButtonList DisabledProperty & VisibleProperty parameters and support for data parameter field binding

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -591,6 +591,21 @@ namespace Radzen
             return Expression.Lambda<Func<object, T>>(body, arg).Compile();
         }
 
+        public static bool TryGetItemOrValueFromProperty<T>(object item, string property, out T result)
+        {
+            result = default(T);
+
+            object r = GetItemOrValueFromProperty(item, property);
+
+            var tryResult = (r != null);
+            if (tryResult)
+            {
+                result = (T)r;
+            }
+
+            return tryResult;
+        }
+
         public static object GetItemOrValueFromProperty(object item, string property)
         {
             if (item == null)

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -595,7 +595,7 @@ namespace Radzen
         {
             object r = GetItemOrValueFromProperty(item, property);
 
-            if (r == null)
+            if (r != null)
             {
                 result = (T)r;
                 return true;
@@ -604,6 +604,7 @@ namespace Radzen
                 result = default;
                 return false;
             }
+
         }
 
         public static object GetItemOrValueFromProperty(object item, string property)

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -593,17 +593,17 @@ namespace Radzen
 
         public static bool TryGetItemOrValueFromProperty<T>(object item, string property, out T result)
         {
-            result = default(T);
-
             object r = GetItemOrValueFromProperty(item, property);
 
-            var tryResult = (r != null);
-            if (tryResult)
+            if (r == null)
             {
                 result = (T)r;
+                return true;
+            } else
+            {
+                result = default;
+                return false;
             }
-
-            return tryResult;
         }
 
         public static object GetItemOrValueFromProperty(object item, string property)

--- a/Radzen.Blazor/RadzenRadioButtonList.razor
+++ b/Radzen.Blazor/RadzenRadioButtonList.razor
@@ -44,6 +44,12 @@
 
     [Parameter]
     public string TextProperty { get; set; }
+    
+    [Parameter]
+    public string DisabledProperty { get; set; }
+
+    [Parameter]
+    public string VisibleProperty { get; set; }
 
     IEnumerable<RadzenRadioButtonListItem<TValue>> allItems
     {
@@ -54,6 +60,17 @@
                 var item = new RadzenRadioButtonListItem<TValue>();
                 item.SetText((string)PropertyAccess.GetItemOrValueFromProperty(i, TextProperty));
                 item.SetValue((TValue)PropertyAccess.GetItemOrValueFromProperty(i, ValueProperty));
+
+                if (DisabledProperty != null && PropertyAccess.TryGetItemOrValueFromProperty<bool>(i, DisabledProperty, out var disabledResult))
+                {
+                    item.SetDisabled(disabledResult);
+                }
+
+                if (VisibleProperty != null && PropertyAccess.TryGetItemOrValueFromProperty<bool>(i, VisibleProperty, out var visibleResult))
+                {
+                    item.SetVisible(visibleResult);
+                }
+
                 return item;
             }));
         }

--- a/Radzen.Blazor/RadzenRadioButtonListItem.razor
+++ b/Radzen.Blazor/RadzenRadioButtonListItem.razor
@@ -61,4 +61,14 @@
     {
         Value = value;
     }
+    
+    internal void SetDisabled(bool value)
+    {
+        Disabled = value;
+    }
+
+    internal void SetVisible(bool value)
+    {
+        Visible = value;
+    }
 }

--- a/RadzenBlazorDemos/Pages/RadioButtonListPage.razor
+++ b/RadzenBlazorDemos/Pages/RadioButtonListPage.razor
@@ -46,7 +46,8 @@
         </RadzenRadioButtonList>
         
         <h3 style="margin-top: 2rem">RadioButtonList using foreach</h3>
-        <RadzenRadioButtonList @bind-Value=@value TValue="int">
+        <RadzenRadioButtonList @bind-Value=@value TValue="int"
+            Change=@(args => OnChange(args, "RadioButtonList using foreach"))>
             <Items>
                 @foreach (var dataItem in data)
                 {
@@ -55,9 +56,9 @@
             </Items>
         </RadzenRadioButtonList>
 
-        <h3 style="margin-top: 2rem">RadioButtonList with items from data using DisabledProperty & VisibleProperty</h3>
+        <h3 style="margin-top: 2rem">RadioButtonList with items from data using optional DisabledProperty and VisibleProperty</h3>
         <RadzenRadioButtonList @bind-Value=@value Data="@data" TextProperty="Name" ValueProperty="Id" DisabledProperty="IsDisabled" VisibleProperty="IsVisible" TValue="int" 
-            Change=@(args => OnChange(args, "RadioButtonList with declared items and items from data"))>
+            Change=@(args => OnChange(args, "RadioButtonList with items from data using optional DisabledProperty and VisibleProperty"))>
         </RadzenRadioButtonList>
     </div>
     <div class="col-xl-6">
@@ -93,7 +94,6 @@
             Id = 4,
             Name = "Companies",
             IsDisabled = true,
-            IsVisible = true
         }, 
         new MyObject() {
             Id = 5,

--- a/RadzenBlazorDemos/Pages/RadioButtonListPage.razor
+++ b/RadzenBlazorDemos/Pages/RadioButtonListPage.razor
@@ -44,6 +44,21 @@
                 <RadzenRadioButtonListItem Text="Customers" Value="3" TValue="int" />
             </Items>
         </RadzenRadioButtonList>
+        
+        <h3 style="margin-top: 2rem">RadioButtonList using foreach</h3>
+        <RadzenRadioButtonList @bind-Value=@value TValue="int">
+            <Items>
+                @foreach (var dataItem in data)
+                {
+                    <RadzenRadioButtonListItem Text="@dataItem.Name" Value="@dataItem.Id" Disabled="@(dataItem.IsDisabled.HasValue ? dataItem.IsDisabled.Value : false)" Visible="@(dataItem.IsVisible.HasValue ? dataItem.IsVisible.Value : true)" />
+                }
+            </Items>
+        </RadzenRadioButtonList>
+
+        <h3 style="margin-top: 2rem">RadioButtonList with items from data using DisabledProperty & VisibleProperty</h3>
+        <RadzenRadioButtonList @bind-Value=@value Data="@data" TextProperty="Name" ValueProperty="Id" DisabledProperty="IsDisabled" VisibleProperty="IsVisible" TValue="int" 
+            Change=@(args => OnChange(args, "RadioButtonList with declared items and items from data"))>
+        </RadzenRadioButtonList>
     </div>
     <div class="col-xl-6">
         <EventConsole @ref=@console />
@@ -56,10 +71,37 @@
     {
         public int Id { get; set; }
         public string Name { get; set; }
+        public bool? IsDisabled { get; set; }
+        public bool? IsVisible { get; set; }
     }
 
-    IEnumerable<MyObject> data = new MyObject[] {
-        new MyObject(){ Id = 1 , Name = "Orders"}, new MyObject() { Id = 2 , Name = "Employees"}, new MyObject() { Id = 3 , Name = "Customers" } };
+    IEnumerable<MyObject> data = new MyObject[] 
+    {
+        new MyObject() {
+            Id = 1,
+            Name = "Orders"
+        },
+        new MyObject() {
+            Id = 2,
+            Name = "Employees"
+        }, 
+        new MyObject() {
+            Id = 3,
+            Name = "Customers" 
+        }, 
+        new MyObject() {
+            Id = 4,
+            Name = "Companies",
+            IsDisabled = true,
+            IsVisible = true
+        }, 
+        new MyObject() {
+            Id = 5,
+            Name = "Companies (Old)",
+            IsDisabled = true,
+            IsVisible = false
+        } 
+    };
 
     int value = 1;
     int? nullableValue = null;


### PR DESCRIPTION
Adds Parameter and Set methods to support designating Disable and Visible states on `RadioButtonListItems` and it's base 'Component', respectfully.

Adds two demo examples to `RadioButtonListPage`:
  - Demonstrating added Property binding functionality
  - Demonstrating using `foreach` on `RenderFragment` as a workaround.
  
  resolves #243 