### PR TITLE
Add functionality to close a dialog on clicking outside

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -324,7 +324,7 @@ namespace Radzen
         /// <summary>
         /// Gets or sets a value indicating whether the dialog should be closed by clicking the overlay.
         /// </summary>
-        /// <value><c>true</c> if closable; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if closeable; otherwise, <c>false</c>.</value>
         public bool CloseDialogOnOverlayClick { get; set; } = false;
     }
 

--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -165,7 +165,8 @@ namespace Radzen
                 Draggable = options != null ? options.Draggable : false,
                 ChildContent = options?.ChildContent,
                 Style = options != null ? options.Style : "",
-                AutoFocusFirstElement = options != null ? options.AutoFocusFirstElement : true
+                AutoFocusFirstElement = options != null ? options.AutoFocusFirstElement : true,
+                CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
             });
         }
 
@@ -320,6 +321,11 @@ namespace Radzen
         /// </summary>
         /// <value><c>true</c> if [automatic focus first element]; otherwise, <c>false</c>.</value>
         public bool AutoFocusFirstElement { get; set; } = true;
+        /// <summary>
+        /// Gets or sets a value indicating whether the dialog should be closed by clicking the overlay.
+        /// </summary>
+        /// <value><c>true</c> if closable; otherwise, <c>false</c>.</value>
+        public bool CloseDialogOnOverlayClick { get; set; } = false;
     }
 
     /// <summary>

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -28,7 +28,7 @@
                             <span class="rzi rzi-times"></span>
                         </a>
                     }
-                </div>                
+                </div>
             }
         }
         <div class="rz-dialog-content">
@@ -42,7 +42,14 @@
             }
         </div>
     </div>
-    <div class="rz-dialog-mask" style="z-index: 1000;"></div>
+    @if (Dialog.Options.CloseDialogOnOverlayClick)
+    {
+        <div @onclick="@Close" class="rz-dialog-mask" style="z-index: 1000;"></div>
+    }
+    else
+    {
+        <div class="rz-dialog-mask" style="z-index: 1000;"></div>
+    }
 </div>
 
 @code {

--- a/RadzenBlazorDemos/Pages/DialogPage.razor
+++ b/RadzenBlazorDemos/Pages/DialogPage.razor
@@ -16,6 +16,8 @@
             <RadzenButton Text="Show busy dialog" Click=@(args => ShowBusyDialog(false)) />
             <h3 style="margin-top: 20px;">Confirm Dialog</h3>
             <RadzenButton Text="Show confirm dialog" Click=@(args => DialogService.Confirm("Are you sure?", "MyTitle", new ConfirmOptions() { OkButtonText = "Yes", CancelButtonText = "No" })) />
+            <h3 style="margin-top: 20px;">Close Dialog by clicking outside</h3>
+            <RadzenButton Text="Show dialog with clickable overlay" Click=@ShowCloseableFromOverlayDialog />
         </div>
         <div class="col-xl-6">
             <EventConsole @ref=@console />
@@ -73,6 +75,14 @@
         </div>);
     
       console.Log($"Dialog result: {result}");
+    }
+
+    async Task ShowCloseableFromOverlayDialog()
+    {
+     await DialogService.OpenAsync("Closeable from overlay Dialog", ds =>
+        @<div>
+            Click outside to close this Dialog
+        </div>, new DialogOptions() { CloseDialogOnOverlayClick = true });
     }
 
     async Task ShowBusyDialog(bool withMessageAsString)


### PR DESCRIPTION
This PR adds an option that allows the dialog to be closed by clicking on the overlay.

Are there possibly any problems with this implementation? Could I be missing something? Because something important like this has been missing until now, and the effort was relatively small.