### PR TITLE
Handle Chart DisplayToolTip looping issue

### DIFF
--- a/Radzen.Blazor/CartesianSeries.cs
+++ b/Radzen.Blazor/CartesianSeries.cs
@@ -400,8 +400,7 @@ namespace Radzen.Blazor
                     }
                 }
 
-                Chart.Refresh(false);
-                Chart.DisplayTooltip();
+                await Chart.Refresh(false);
             }
         }
 
@@ -578,10 +577,10 @@ namespace Radzen.Blazor
         /// <summary>
         /// Called when [legend item click].
         /// </summary>
-        private void OnLegendItemClick()
+        private async Task OnLegendItemClick()
         {
             IsVisible = !IsVisible;
-            Chart.Refresh();
+            await Chart.Refresh();
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenChart.razor.cs
+++ b/Radzen.Blazor/RadzenChart.razor.cs
@@ -289,7 +289,7 @@ namespace Radzen.Blazor
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
         [JSInvokable]
-        public void Resize(double width, double height)
+        public async Task Resize(double width, double height)
         {
             var stateHasChanged = false;
 
@@ -311,7 +311,7 @@ namespace Radzen.Blazor
 
             if (stateHasChanged)
             {
-                Refresh();
+                await Refresh();
             }
         }
 
@@ -338,12 +338,12 @@ namespace Radzen.Blazor
         /// <param name="x">The x.</param>
         /// <param name="y">The y.</param>
         [JSInvokable]
-        public void MouseMove(double x, double y)
+        public async Task MouseMove(double x, double y)
         {
             mouseX = x;
             mouseY = y;
 
-            DisplayTooltip();
+            await DisplayTooltip();
         }
 
         /// <summary>
@@ -373,7 +373,7 @@ namespace Radzen.Blazor
         /// <summary>
         /// Displays the tooltip.
         /// </summary>
-        internal void DisplayTooltip()
+        internal async Task DisplayTooltip()
         {
             if (Tooltip.Visible)
             {
@@ -388,6 +388,7 @@ namespace Radzen.Blazor
                             tooltipData = data;
                             tooltip = series.RenderTooltip(data, MarginLeft, MarginTop);
                             StateHasChanged();
+                            await Task.Yield();
                         }
 
                         return;
@@ -400,6 +401,7 @@ namespace Radzen.Blazor
                     tooltip = null;
 
                     StateHasChanged();
+                    await Task.Yield();
                 }
             }
         }
@@ -538,15 +540,17 @@ namespace Radzen.Blazor
         /// Refreshes the specified force.
         /// </summary>
         /// <param name="force">if set to <c>true</c> [force].</param>
-        internal void Refresh(bool force = true)
+        internal async Task Refresh(bool force = true)
         {
             if (widthAndHeightAreSet)
             {
+
                 var stateHasChanged = UpdateScales();
 
                 if (stateHasChanged || force)
                 {
                     StateHasChanged();
+                    await DisplayTooltip();
                 }
             }
         }
@@ -554,9 +558,9 @@ namespace Radzen.Blazor
         /// <summary>
         /// Reloads this instance.
         /// </summary>
-        public void Reload()
+        public async Task Reload()
         {
-            Refresh(true);
+            await Refresh(true);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenChartComponentBase.cs
+++ b/Radzen.Blazor/RadzenChartComponentBase.cs
@@ -67,7 +67,7 @@ namespace Radzen.Blazor
 
             if (shouldRefresh)
             {
-                Chart.Refresh();
+                await Chart.Refresh();
             }
         }
 


### PR DESCRIPTION
This PR resolves #246 by removing `DisplayToolTip` call in `CartesianSeries` `SetParametersAsync` scope; However, given that there are scenarios where `CartesianSeries` should call to `DisplayToolTip`, it is being added to `Chart.Refresh` where it is conditionally called.

---

In respect to [Multiple Asynchronous Phases](https://docs.microsoft.com/en-us/aspnet/core/blazor/components/rendering?view=aspnetcore-5.0#an-asynchronous-handler-involves-multiple-asynchronous-phases-1 ) occurring throughout `DisplayTooltip` execution flow and scaling logic check used to determine on when `StateHasChange` should occur, this PR refactors several methods to async-await to ensure task completions following `StateHasChanged` calls respectfully -- this signals Blazor to Render the State changes -- thus, the changes here ensure rendering in respect to phases.


## Test

Note: I tested all Chart Demo Pages to ensure functionality of ToolTip.

### SS of Demo LineChartPage with data exhibiting this issue -- similar to #246 (modifying Demo Page is not part of this PR though)
![image](https://user-images.githubusercontent.com/967010/137101751-36b7291d-3d2c-4a68-91ec-ecd5c459d346.png)

