### PR TITLE
Filter DataGrid by Multiselect ComboBox with LoadData event defined

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -174,7 +174,7 @@ namespace Radzen
 
                         List<string> multivalueFilterList = new List<string>();
                         IEnumerable<string> filterValues = (IEnumerable<string>)column.GetFilterValue();
-                        //Combine all the above linqoperator stuff
+                        //Combine the linq queries for all filter values selected
                         foreach (string item in filterValues)
                         {
                             multivalueFilterList.Add(GetColumnFilter(column, item));

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -362,6 +362,10 @@ namespace Radzen
                     return $@"({property} == null ? """" : {property}){filterCaseSensitivityOperator} != ""{value}""{filterCaseSensitivityOperator}";
                 }
             }
+            else if (column.FilterPropertyType == typeof(System.Enum) || column.FilterPropertyType.BaseType == typeof(System.Enum))
+            {
+                return $@"{property} {linqOperator} ""{value}""";
+            }
             else if (PropertyAccess.IsNumeric(column.FilterPropertyType))
             {
                 return $"{property} {linqOperator} {value}";

--- a/Radzen.Blazor/Radzen.Blazor.csproj
+++ b/Radzen.Blazor/Radzen.Blazor.csproj
@@ -63,7 +63,7 @@
     <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
   </Target>
   <Target Name="PreBuild" AfterTargets="ToolRestore">
-    <!--<Exec Command="dotnet tool run webcompiler -r themes -o wwwroot/css -z disable -m disable -p disable" StandardOutputImportance="high" />-->
+    <Exec Command="dotnet tool run webcompiler -r themes -o wwwroot/css -z disable -m disable -p disable" StandardOutputImportance="high" />
     <ItemGroup>
       <CssFiles Include="$(MSBuildProjectDirectory)\themes\*.css" />
     </ItemGroup>

--- a/Radzen.Blazor/Radzen.Blazor.csproj
+++ b/Radzen.Blazor/Radzen.Blazor.csproj
@@ -63,6 +63,7 @@
     <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
   </Target>
   <Target Name="PreBuild" AfterTargets="ToolRestore">
+    <!--<Exec Command="dotnet tool run webcompiler -r themes -o wwwroot/css -z disable -m disable -p disable" StandardOutputImportance="high" />-->
     <ItemGroup>
       <CssFiles Include="$(MSBuildProjectDirectory)\themes\*.css" />
     </ItemGroup>
@@ -72,5 +73,6 @@
     <Delete Files="@(CssFiles)" />
     <Delete Files="@(BootstrapFiles)" />
     <RemoveDir Directories="$(MSBuildProjectDirectory)\wwwroot\css\bootstrap" />
+    <RemoveSourceMap />
   </Target>
 </Project>

--- a/Radzen.Blazor/Radzen.Blazor.csproj
+++ b/Radzen.Blazor/Radzen.Blazor.csproj
@@ -72,6 +72,5 @@
     <Delete Files="@(CssFiles)" />
     <Delete Files="@(BootstrapFiles)" />
     <RemoveDir Directories="$(MSBuildProjectDirectory)\wwwroot\css\bootstrap" />
-    <RemoveSourceMap />
   </Target>
 </Project>

--- a/Radzen.Blazor/Radzen.Blazor.csproj
+++ b/Radzen.Blazor/Radzen.Blazor.csproj
@@ -63,7 +63,7 @@
     <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
   </Target>
   <Target Name="PreBuild" AfterTargets="ToolRestore">
-    <Exec Command="dotnet tool run webcompiler -r themes -o wwwroot/css -z disable -m disable -p disable" StandardOutputImportance="high" />
+    <!--<Exec Command="dotnet tool run webcompiler -r themes -o wwwroot/css -z disable -m disable -p disable" StandardOutputImportance="high" />-->
     <ItemGroup>
       <CssFiles Include="$(MSBuildProjectDirectory)\themes\*.css" />
     </ItemGroup>

--- a/Radzen.Blazor/Radzen.Blazor.csproj
+++ b/Radzen.Blazor/Radzen.Blazor.csproj
@@ -63,7 +63,6 @@
     <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
   </Target>
   <Target Name="PreBuild" AfterTargets="ToolRestore">
-    <Exec Command="dotnet tool run webcompiler -r themes -o wwwroot/css -z disable -m disable -p disable" StandardOutputImportance="high" />
     <ItemGroup>
       <CssFiles Include="$(MSBuildProjectDirectory)\themes\*.css" />
     </ItemGroup>

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
@@ -1,5 +1,7 @@
 ﻿@page "/datagrid-filter-template"
 
+@using System.Linq.Dynamic.Core
+
 <h1>DataGrid custom Column FilterTemplate</h1>
 
 <p>This page demonstrates how to define custom DataGrid column filter template.</p>
@@ -11,9 +13,14 @@
     }
     else
     {
-        <RadzenDataGrid @ref="grid" Data=@filteredEmployees FilterMode="FilterMode.Simple" AllowFiltering="true" AllowPaging="true" AllowSorting="true" TItem="Employee" ColumnWidth="200px">
+        <RadzenDataGrid @ref="grid" Data=@filteredEmployees Count="@itemCount" FilterMode="FilterMode.Simple" AllowFiltering="true" AllowPaging="true" AllowSorting="true" TItem="Employee" LoadData="@OnLoadData" ColumnWidth="150px">
             <Columns>
                 <RadzenDataGridColumn TItem="Employee" Property="ID" Title="ID" />
+                <RadzenDataGridColumn TItem="Employee" Property="CompanyName" Title="Customer" FilterValue="@CompanyNameFilter" FilterOperator="FilterOperator.Equals" LogicalFilterOperator="LogicalFilterOperator.Or">
+                    <FilterTemplate>
+                        <RadzenDropDown @bind-Value=@CompanyNameFilter Change=@OnChange Data="@(CompanyNames)" AllowClear="true" Multiple="true" />
+                    </FilterTemplate>
+                </RadzenDataGridColumn>
                 <RadzenDataGridColumn TItem="Employee" Property="Name" Title="Name" />
                 <RadzenDataGridColumn TItem="Employee" Property="TitleOfCourtesy" Title="Title Of Courtesy" 
                     FilterValue="@currentTOC">
@@ -40,12 +47,21 @@
         All = -1
     }
 
+    public IEnumerable<string> CompanyNameFilter { get; set; }
+    public List<string> CompanyNames = new List<string> {"Vins et alcools Chevalier", "Toms Spezialitäten", "Hanari Carnes", "Richter Supermarkt", "Wellington Importadora", "Centro comercial Moctezuma" };
+
     public class Employee
     {
         public int ID { get; set; }
+        public string CompanyName{ get; set; }
         public string Name { get; set; }
         public TitleOfCourtesy TitleOfCourtesy { get; set; }
+    }
 
+    protected async Task OnLoadData(LoadDataArgs args)
+    {
+        filteredEmployees = employees.Where(args.Filter).ToList();
+        itemCount = filteredEmployees.Count();
     }
 
     async Task OnChange()
@@ -58,8 +74,9 @@
         await grid.Reload();
     }
 
-    IEnumerable<Employee> employees; 
+    IQueryable<Employee> employees; 
     IEnumerable<Employee> filteredEmployees;
+    int itemCount { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -67,10 +84,12 @@
             new Employee
             {
                 ID = i,
+                CompanyName = i < 4 ? CompanyNames[0] : CompanyNames[i - 4],
                 Name = $"Name{i}",
                 TitleOfCourtesy = i < 5 ? TitleOfCourtesy.Mr : TitleOfCourtesy.Ms
-            }));
-        
-        filteredEmployees = employees;
+            }).AsQueryable());
+
+        filteredEmployees = employees.ToList();
+        itemCount = filteredEmployees.Count();
     }
 }

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
@@ -60,7 +60,7 @@
 
     protected async Task OnLoadData(LoadDataArgs args)
     {
-        filteredEmployees = employees.Where(args.Filter).ToList();
+        filteredEmployees =String.IsNullOrWhiteSpace(args.Filter) ? employees.ToList() : employees.Where(args.Filter).ToList();
         itemCount = filteredEmployees.Count();
     }
 

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
@@ -18,7 +18,7 @@
                 <RadzenDataGridColumn TItem="Employee" Property="ID" Title="ID" />
                 <RadzenDataGridColumn TItem="Employee" Property="CompanyName" Title="Customer" FilterValue="@CompanyNameFilter" FilterOperator="FilterOperator.Equals" LogicalFilterOperator="LogicalFilterOperator.Or">
                     <FilterTemplate>
-                        <RadzenDropDown @bind-Value=@CompanyNameFilter Change=@OnChange Data="@(CompanyNames)" AllowClear="true" Multiple="true" />
+                        <RadzenDropDown @bind-Value=@CompanyNameFilter Change=@(args => OnLoadDataMultiselect(args, 1)) Data="@(CompanyNames)" AllowClear="true" Multiple="true" />
                     </FilterTemplate>
                 </RadzenDataGridColumn>
                 <RadzenDataGridColumn TItem="Employee" Property="Name" Title="Name" />
@@ -62,6 +62,17 @@
     {
         filteredEmployees =String.IsNullOrWhiteSpace(args.Filter) ? employees.ToList() : employees.Where(args.Filter).ToList();
         itemCount = filteredEmployees.Count();
+    }
+
+    protected async Task OnLoadDataMultiselect(object value, int columnIndex)
+    {
+        //Have to force a SetParameters call otherwise the multi-select doesn't get it's parameters set until after the reload
+        var parameterDictionary = new Dictionary<string, object>();
+        parameterDictionary.Add("FilterValue", value);
+        ParameterView view = ParameterView.FromDictionary(parameterDictionary);
+        await grid.ColumnsCollection[columnIndex].SetParametersAsync(view);
+
+        await grid.Reload();
     }
 
     async Task OnChange()


### PR DESCRIPTION
This block of code (or something similar) needs to be added to the QueryableExtension file to properly handle a multi-select filter. I have seen sample code for multi-select dropdowns filtering data grids, but they do not work. This is because the FilterValue is stored in an IEnumerable<string> but there is nothing in QueryableExtension that handles that in the ToFilterString method. I was able to get my scenario to work by using this code.

This code works with a LoadData event handler that is used to appropriately filter the grid items by the filter string generated across all columns.