### PR TITLE
RadzenDatePicker binds DateTime with Kind == Unspecified 

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -383,5 +383,36 @@ namespace Radzen.Blazor.Tests
             Assert.True(raised);
             Assert.Null(newValue);
         }
+        
+        [Theory]
+        [InlineData(DateTimeKind.Local)]
+        [InlineData(DateTimeKind.Unspecified)]
+        [InlineData(DateTimeKind.Utc)]
+        public void DatePicker_Respects_DateTimeKind(DateTimeKind kind)
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameters =>
+            {
+                parameters.Add(x => x.Kind, kind);
+                parameters.Add(x => x.ShowTime, true);
+            });
+
+            var raised = false;
+            object newValue = null;
+
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(p => p.Change, args => { raised = true; newValue = args; });
+            });
+
+            component.Find(".rz-datepicker-next-icon").Click();
+            component.FindAll(".rz-button-text").First(x => x.TextContent == "Ok").Click();
+
+            Assert.True(raised);
+            Assert.Equal(kind, ((DateTime)newValue).Kind);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -288,6 +288,12 @@ namespace Radzen.Blazor
             return args;
         }
 
+        /// <summary>
+        /// Gets or sets the kind of DateTime bind to control
+        /// </summary>
+        [Parameter]
+        public DateTimeKind Kind { get; set; } = DateTimeKind.Unspecified;
+
         object _value;
 
         /// <summary>
@@ -316,7 +322,14 @@ namespace Radzen.Blazor
                     }
                     else
                     {
-                        DateTimeValue = value as DateTime?;
+                        if (value is DateTime dateTime)
+                        {
+                            DateTimeValue = DateTime.SpecifyKind(dateTime, Kind);
+                        }
+                        else
+                        {
+                            DateTimeValue = null;
+                        }
 
                         if (DateTimeValue.HasValue && DateTimeValue.Value == default(DateTime))
                         {


### PR DESCRIPTION
Hi,

Npgsql releases version 6.0 with significant breaking changes releated to timestamp and DateTime:
https://www.npgsql.org/doc/release-notes/6.0.html#timestamp-rationalization-and-improvements

Now, if someone save DateTime with Kind that set to Unspecified or Local Npgsql will throw exception:
"Error An error occurred while saving the entity changes. See the inner exception for details. 
InnerException: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported. 
Note that it's not possible to mix DateTimes with different Kinds in an array/range. 
See the Npgsql.EnableLegacyTimestampBehavior AppContext switch to enable legacy behavior."

RadzenDatePicker internally creates many DateTime structs with default kind (Unspecified) and without any possibility to control that.

