### PR TITLE
Expandable Indicator Column Visibility Flag

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -51,7 +51,7 @@
                 {
                     <col>
                 }
-                @if (Template != null)
+                @if (Template != null && ShowExpandableIndicatorColumn)
                 {
                     <col>
                 }
@@ -68,7 +68,7 @@
                             <span class="rz-column-title"></span>
                         </th>
                     }
-                    @if (Template != null)
+                    @if (Template != null && ShowExpandableIndicatorColumn)
                     {
                         <th class="rz-col-icon rz-unselectable-text" scope="col">
                             <span class="rz-column-title"></span>
@@ -199,7 +199,7 @@
                                 <span class="rz-column-title"></span>
                             </th>
                         }
-                        @if (Template != null)
+                        @if (Template != null && ShowExpandableIndicatorColumn)
                         {
                             <th class="rz-col-icon  rz-unselectable-text" scope="col">
                                 <span class="rz-column-title"></span>
@@ -312,7 +312,7 @@
                     else
                     {
                         <tr class=" rz-datatable-emptymessage-row">
-                            <td class="rz-datatable-emptymessage" colspan="@(visibleColumns.Count + (Template != null ? 1 : 0))">
+                            <td class="rz-datatable-emptymessage" colspan="@(visibleColumns.Count + (Template != null && ShowExpandableIndicatorColumn ? 1 : 0))">
                                 @if (EmptyTemplate != null)
                                 {
                                     @EmptyTemplate
@@ -336,7 +336,7 @@
                                 <span class="rz-column-title"></span>
                             </td>
                         }
-                        @if (Template != null)
+                        @if (Template != null && ShowExpandableIndicatorColumn)
                         {
                             <td class="rz-col-icon rz-unselectable-text" scope="col">
                                 <span class="rz-column-title"></span>

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -51,7 +51,7 @@
                 {
                     <col>
                 }
-                @if (Template != null && ShowExpandableIndicatorColumn)
+                @if (Template != null && ShowExpandColumn)
                 {
                     <col>
                 }
@@ -68,7 +68,7 @@
                             <span class="rz-column-title"></span>
                         </th>
                     }
-                    @if (Template != null && ShowExpandableIndicatorColumn)
+                    @if (Template != null && ShowExpandColumn)
                     {
                         <th class="rz-col-icon rz-unselectable-text" scope="col">
                             <span class="rz-column-title"></span>
@@ -199,7 +199,7 @@
                                 <span class="rz-column-title"></span>
                             </th>
                         }
-                        @if (Template != null && ShowExpandableIndicatorColumn)
+                        @if (Template != null && ShowExpandColumn)
                         {
                             <th class="rz-col-icon  rz-unselectable-text" scope="col">
                                 <span class="rz-column-title"></span>
@@ -312,7 +312,7 @@
                     else
                     {
                         <tr class=" rz-datatable-emptymessage-row">
-                            <td class="rz-datatable-emptymessage" colspan="@(visibleColumns.Count + (Template != null && ShowExpandableIndicatorColumn ? 1 : 0))">
+                            <td class="rz-datatable-emptymessage" colspan="@(visibleColumns.Count + (Template != null && ShowExpandColumn ? 1 : 0))">
                                 @if (EmptyTemplate != null)
                                 {
                                     @EmptyTemplate
@@ -336,7 +336,7 @@
                                 <span class="rz-column-title"></span>
                             </td>
                         }
-                        @if (Template != null && ShowExpandableIndicatorColumn)
+                        @if (Template != null && ShowExpandColumn)
                         {
                             <td class="rz-col-icon rz-unselectable-text" scope="col">
                                 <span class="rz-column-title"></span>

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -480,6 +480,13 @@ namespace Radzen.Blazor
         public DataGridExpandMode ExpandMode { get; set; } = DataGridExpandMode.Multiple;
 
         /// <summary>
+        /// Gets or sets whether the expandable indicator column is visible.
+        /// </summary>
+        /// <value>The expandable indicator column visibility.</value>
+        [Parameter]
+        public bool ShowExpandableIndicatorColumn { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the edit mode.
         /// </summary>
         /// <value>The edit mode.</value>

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -484,7 +484,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The expandable indicator column visibility.</value>
         [Parameter]
-        public bool ShowExpandableIndicatorColumn { get; set; } = true;
+        public bool ShowExpandColumn { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the edit mode.

--- a/Radzen.Blazor/RadzenDataGridRow.razor
+++ b/Radzen.Blazor/RadzenDataGridRow.razor
@@ -9,7 +9,7 @@
             <span class="rz-column-title"></span>
         </td>
     }
-    @if (Grid.Template != null)
+    @if (Grid.Template != null && Grid.ShowExpandColumn)
     {
         <td class="rz-col-icon">
             <span class="rz-column-title"></span>
@@ -85,7 +85,7 @@
 @if (Grid.Template != null && Grid.expandedItems.Keys.Contains(Item))
 {
     <tr class="rz-expanded-row-content">
-        <td colspan="@(Columns.Count + 1)">
+        <td colspan="@(Columns.Count + (Grid.ShowExpandColumn ? 1 : 0) + + Grid.groups.Count)">
             <div class="rz-expanded-row-template" style="position:sticky">
                 @Grid.Template(Item)
             </div>


### PR DESCRIPTION
Currently on a DataGrid, if a template is set, it is assumed that we want the expandable indicator column rendered. I added a parameter that gives us the ability to toggle whether we want that column rendered.