### PR TITLE
Update RadzenTooltip.razor

### DIFF
--- a/Radzen.Blazor/RadzenTooltip.razor
+++ b/Radzen.Blazor/RadzenTooltip.razor
@@ -9,10 +9,10 @@
             @if (!string.IsNullOrEmpty(tooltip.Options.Text))
             {
                 <div>
-                    @tooltip.Options.Text
+                    @((MarkupString)tooltip.Options.Text)
                 </div>
             }
-            else @if (tooltip.Options.ChildContent != null)
+            else if (tooltip.Options.ChildContent != null)
        {
         @tooltip.Options.ChildContent(Service)
     }


### PR DESCRIPTION
I believe the '@' shouldnt be there and if you cast the text to markupstring you dont need the renderfragment implementation? This would mean the overload from the tooltipservice should also be removed of course :-) I stumbled upon this because I implemented your tooltip in my base viewmodel and didnt want to start building a fragment tree.