### PR TITLE
Fixes Entity Framework (not core) LINQ errors

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -729,7 +729,7 @@ namespace Radzen
                         }
                         else
                         {
-                            _view = (typeof(IQueryable).IsAssignableFrom(Data.GetType())) ? Query.Cast<object>().ToList().AsQueryable() : Query;
+                            _view = (typeof(IQueryable).IsAssignableFrom(Data.GetType())) ? (Query as IEnumerable).Cast<object>().ToList().AsQueryable() : Query;
                         }
                     }
                 }


### PR DESCRIPTION
Fixes Error: System.NotSupportedException: Unable to cast the type 'BlazorRadzenTests.Country' to type 'System.Object'. LINQ to Entities only supports casting EDM primitive or enumeration types.

In order to fix the problem, we convert the IQueryable to IEnumerable, we perform the cast to IEnumerable<object> and then we call ToList()

More info and test project here:
https://forum.radzen.com/t/selecting-an-item-in-a-dropdowndatagrid-causes-exception/9131