### PR TITLE
Update RadzenDataGrid.razor.cs (reordering columns issue)

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -785,7 +785,7 @@ namespace Radzen.Blazor
 
                 if (columnToReorder != null && columnToReorderTo != null)
                 {
-                    var actualColumnindexFrom = columns.IndexOf(columnToReorder);
+                    var actualColumnIndexFrom = columns.IndexOf(columnToReorder);
                     var actualColumnIndexTo = columns.IndexOf(columnToReorderTo);
                     columns.Remove(columnToReorder);
                     columns.Insert(actualColumnIndexTo, columnToReorder);
@@ -793,7 +793,7 @@ namespace Radzen.Blazor
                     await ColumnReordered.InvokeAsync(new DataGridColumnReorderedEventArgs<TItem>
                     {
                         Column = columnToReorder,
-                        OldIndex = actualColumnindexFrom,
+                        OldIndex = actualColumnIndexFrom,
                         NewIndex = actualColumnIndexTo
                     });
                 }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -785,15 +785,16 @@ namespace Radzen.Blazor
 
                 if (columnToReorder != null && columnToReorderTo != null)
                 {
-                    var actualColumnIndex = columns.IndexOf(columnToReorderTo);
+                    var actualColumnindexFrom = columns.IndexOf(columnToReorder);
+                    var actualColumnIndexTo = columns.IndexOf(columnToReorderTo);
                     columns.Remove(columnToReorder);
-                    columns.Insert(actualColumnIndex, columnToReorder);
+                    columns.Insert(actualColumnIndexTo, columnToReorder);
 
                     await ColumnReordered.InvokeAsync(new DataGridColumnReorderedEventArgs<TItem>
                     {
                         Column = columnToReorder,
-                        OldIndex = indexOfColumnToReoder.Value,
-                        NewIndex = actualColumnIndex
+                        OldIndex = actualColumnindexFrom,
+                        NewIndex = actualColumnIndexTo
                     });
                 }
 


### PR DESCRIPTION
ColumnReorder returns oldIndex from only visible/JS columns, and newIndex from all columns. Proposal is to return indices from all columns for both cases.