### PR TITLE
Allow manual control legend elements visibility for plots

### DIFF
--- a/Radzen.Blazor/CartesianSeries.cs
+++ b/Radzen.Blazor/CartesianSeries.cs
@@ -146,7 +146,7 @@ namespace Radzen.Blazor
         }
 
         /// <inheritdoc />
-        public bool ShowInLegend { get => Visible; }
+        public bool ShowInLegend { get; set; } = true;
 
         /// <summary>
         /// The name of the property of <typeparamref name="TItem" /> that provides the Y axis (a.k.a. value axis) values.

--- a/Radzen.Blazor/Rendering/Legend.razor
+++ b/Radzen.Blazor/Rendering/Legend.razor
@@ -5,7 +5,7 @@
         <ul class="rz-legend-items">
         @foreach (var series in Chart.Series)
         {
-            @if (series.ShowInLegend)
+            @if (series.ShowInLegend && series.Visible)
             {
                 @series.RenderLegendItem()
             }


### PR DESCRIPTION
**ShowInLegend** property - public setter was added
The default value was set as _true_ to not to break the previous default value (Visible property is _true_ by default)
Preventing legend from rendering, when ShowInLegend is _true_ but Visible is _false_