### PR TITLE
Add IconStyle Property to RadzenIcon

### DIFF
--- a/Radzen.Blazor.Tests/IconTests.cs
+++ b/Radzen.Blazor.Tests/IconTests.cs
@@ -45,5 +45,29 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains(@$"autofocus", component.Markup);
         }
+
+        [Fact]
+        public void Icon_Renders_IconStyleClass()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenIcon>();
+
+            component.SetParametersAndRender(parameters => parameters.Add(icon => icon.IconStyle, IconStyle.Primary));
+
+            Assert.Contains(@$"rzi-primary", component.Markup);
+        }
+
+        [Fact]
+        public void Icon_NotRenders_IconStyleClass_WhenNull()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenIcon>();
+
+            component.SetParametersAndRender(parameters => parameters.Add(icon => icon.IconStyle, null));
+
+            Assert.DoesNotContain(@$"rzi-primary", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -810,6 +810,41 @@ namespace Radzen
     }
 
     /// <summary>
+    /// Specifies the display style of a <see cref="RadzenIcon" />. Affects the visual styling of RadzenIcon (Icon (text) color).
+    /// </summary>
+    public enum IconStyle
+    {
+        /// <summary>
+        /// Primary styling. Similar to primary buttons.
+        /// </summary>
+        Primary,
+        /// <summary>
+        /// Secondary styling. Similar to secondary buttons.
+        /// </summary>
+        Secondary,
+        /// <summary>
+        /// Light styling. Similar to light buttons.
+        /// </summary>
+        Light,
+        /// <summary>
+        /// Success styling.
+        /// </summary>
+        Success,
+        /// <summary>
+        /// Danger styling.
+        /// </summary>
+        Danger,
+        /// <summary>
+        /// Warning styling.
+        /// </summary>
+        Warning,
+        /// <summary>
+        /// Informative styling.
+        /// </summary>
+        Info
+    }
+
+    /// <summary>
     /// Supplies information about a <see cref="RadzenDataGrid{TItem}.ColumnResized" /> event that is being raised.
     /// </summary>
     /// <typeparam name="T"></typeparam>

--- a/Radzen.Blazor/RadzenIcon.razor.cs
+++ b/Radzen.Blazor/RadzenIcon.razor.cs
@@ -19,10 +19,16 @@ namespace Radzen.Blazor
         [Parameter]
         public string Icon { get; set; }
 
+        /// <summary>
+        /// Specifies the display style of the icon.
+        /// </summary>
+        [Parameter]
+        public IconStyle? IconStyle { get; set; }
+
         /// <inheritdoc />
         protected override string GetComponentCssClass()
         {
-            return "rzi d-inline-flex justify-content-center align-items-center";
+            return $"rzi {(IconStyle.HasValue ? $"rzi-{IconStyle.Value.ToString().ToLower()} " : "")}d-inline-flex justify-content-center align-items-center";
         }
     }
 }

--- a/Radzen.Blazor/themes/components/blazor/_icons.scss
+++ b/Radzen.Blazor/themes/components/blazor/_icons.scss
@@ -1,5 +1,36 @@
 $icon-base-font-size: 1.5em !default; /* Preferred icon size */
 
+$icon-styles: () !default;
+$icon-styles: map-merge(
+  (
+    primary: (
+      color: $primary
+    ),
+    light: (
+      color: $light,
+    ),
+    secondary: (
+      color: $secondary
+    ),
+    info: (
+      color: $info
+    ),
+    warning: (
+      color: $warning
+    ),
+    error: (
+      color: $danger
+    ),
+    danger: (
+      color: $danger
+    ),
+    success: (
+      color: $success
+    )
+  ),
+  $icon-styles
+);
+
 .rzi {
   font-family: 'Material Icons';
   font-weight: normal;
@@ -25,4 +56,12 @@ $icon-base-font-size: 1.5em !default; /* Preferred icon size */
 
   /* Support for IE. */
   font-feature-settings: 'liga';
+}
+
+@each $style, $icon in $icon-styles {
+    .rzi-#{$style} {
+        @each $name, $value in $icon {
+            #{$name}: #{$value};
+        }
+    }
 }

--- a/Radzen.DocFX/guides/components/icon.md
+++ b/Radzen.DocFX/guides/components/icon.md
@@ -8,3 +8,10 @@ This article demonstrates how to use the Icon component. Use it to display icons
 <RadzenIcon Icon="accessible" />
 ...
 ```
+
+## Style the Icon
+The Property `IconStyle` allows to modify the icons foreground color. It offers the standard styles defined by the theme.
+
+```
+<RadzenIcon Icon="accessibility" IconStyle="IconStyle.Primary">
+```

--- a/RadzenBlazorDemos/Pages/IconPage.razor
+++ b/RadzenBlazorDemos/Pages/IconPage.razor
@@ -114,6 +114,20 @@
 <RadzenIcon Icon="open_with" />
 <RadzenIcon Icon="pageview" />
 </div>
+
+<h4>Syled icons</h4>
+<RadzenDataList TItem="IconStyle" Data="@(Enum.GetValues<IconStyle>())" WrapItems="true">
+    <Template Context="style">
+        <div>
+            <h5>@style.ToString()</h5>
+            <RadzenIcon Icon="dashboard" IconStyle="@style" />
+            <RadzenIcon Icon="open_with" IconStyle="@style" />
+
+        </div>
+    </Template>
+
+</RadzenDataList>
+
 <style>
     .icons-preview .rzi {
         margin: 1rem;


### PR DESCRIPTION
This PR adds an `IconStyle` Property to the Component RadzenIcon.
The Property controls the rendering of an additional html class, comparable to RadzenButton or RadzenBadge.

The Property is nullable to be backwards compatible.
