### PR TITLE
DataGrid - CheckBox Only Selection 

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1427,10 +1427,17 @@ namespace Radzen.Blazor
             await CellContextMenu.InvokeAsync(args);
         }
 
-        internal async Task OnRowClick(DataGridRowMouseEventArgs<TItem> args)
+        internal async Task OnRowClick(DataGridRowMouseEventArgs<TItem> args, RadzenDataGridColumn<TItem> column)
         {
-            await RowClick.InvokeAsync(args);
-            await OnRowSelect(args.Data);
+            if(column.IsSelectColumn)
+            {
+                await OnRowSelect(args.Data);
+            }
+            else
+            {
+                await RowClick.InvokeAsync(args);
+                await OnRowSelect(args.Data);
+            }
         }
 
         internal async System.Threading.Tasks.Task OnRowSelect(object item, bool raiseChange = true)

--- a/Radzen.Blazor/RadzenDataGridCell.razor
+++ b/Radzen.Blazor/RadzenDataGridCell.razor
@@ -151,7 +151,7 @@ else
                 ScreenY = args.ScreenY,
                 ShiftKey = args.ShiftKey,
                 Type = args.Type
-            });
+            }, Column);
 #else
             await Grid.OnRowClick(new DataGridRowMouseEventArgs<TItem>
             {
@@ -168,7 +168,7 @@ else
                 ScreenY = args.ScreenY,
                 ShiftKey = args.ShiftKey,
                 Type = args.Type
-            });
+            },Column);
 #endif
         }
     }

--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -238,6 +238,12 @@ namespace Radzen.Blazor
         [Parameter]
         public bool Filterable { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="RadzenDataGridColumn{TItem}"/> is a (multi-)select column. Which does not trigger a RowClick.
+        /// </summary>
+        /// <value><c>true</c> if selectcolumn; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool IsSelectColumn { get; set; }
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="RadzenDataGridColumn{TItem}"/> is sortable.
         /// </summary>

--- a/RadzenBlazorDemos/Pages/DataGridMultipleSelectionPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridMultipleSelectionPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/datagrid-multiple-selection"
+@page "/datagrid-multiple-selection"
 @using Radzen
 @using RadzenBlazorDemos.Data
 @using RadzenBlazorDemos.Models.Northwind
@@ -9,10 +9,10 @@
 
 <RadzenExample Name="DataGrid" Source="DataGridMultipleSelection" Heading="false">
     <RadzenDataGrid AllowFiltering="true" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive" AllowPaging="true" PageSize="4"
-                AllowSorting="true" Data="@employees" TItem="Employee" ColumnWidth="200px"
+                AllowSorting="true" Data="@employees" TItem="Employee" ColumnWidth="200px" RowClick="OnRowClicked"
                 SelectionMode="DataGridSelectionMode.Multiple" @bind-Value=@selectedEmployees>
         <Columns>
-            <RadzenDataGridColumn TItem="Employee" Width="40px" Sortable="false" Filterable="false">
+            <RadzenDataGridColumn TItem="Employee" Width="40px" Sortable="false" Filterable="false" IsSelectColumn="true">
                 <HeaderTemplate>
                     <RadzenCheckBox TriState="false" TValue="bool" Value="@(employees.Any(i => selectedEmployees != null && selectedEmployees.Contains(i)))"
                                     Change="@(args => selectedEmployees = args ? employees.ToList() : null)" />
@@ -35,12 +35,22 @@
         </Columns>
     </RadzenDataGrid>
 </RadzenExample>
+
+<RadzenCard class="mt-4">
+    <EventConsole @ref="console"></EventConsole>
+</RadzenCard>
 @code {
     IEnumerable<Employee> employees;
     IList<Employee> selectedEmployees;
+    private EventConsole console;
 
     protected override void OnInitialized()
     {
         employees = dbContext.Employees;
+    }
+
+    private void OnRowClicked(DataGridRowMouseEventArgs<Employee> args)
+    {
+        console.Log($"Clicked on non-selectable-cell with data: {args.Data.EmployeeID}"); 
     }
 }


### PR DESCRIPTION
If the datagrid is using multiselect or selectable rows, it should be possible to only Select items and not trigger the OnRowClick, For example when navigation to another page on normal cell click, but only select items when using the Checkbox.
This feature introduces no breaking changes, only additional opt-in behavior.

This feature is similar to Telerik's 
https://demos.telerik.com/blazor-ui/grid/checkbox-only-selection

![checkboxselect](https://user-images.githubusercontent.com/10981553/150360339-e4486b43-b7f7-475b-9156-ba2de6b529e9.gif)

