### PR TITLE
Diacritics symbol insencitive

### DIFF
--- a/Radzen.Blazor.Tests/DropDownDataGridTests.cs
+++ b/Radzen.Blazor.Tests/DropDownDataGridTests.cs
@@ -21,27 +21,127 @@ namespace Radzen.Blazor.Tests
         public void RadzenDataGrid_Search_CaseInsensitive_DiacriticsInsensitive()
         {
             using var ctx = new TestContext();
-            List<TestModel> testModels = new List<TestModel>();
-            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 7, LastName = "Ξαγοράρη", Name = " Άρτεμις" });
-            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 4, LastName = "Ξαγοράρης", Name = "Φοίβος" });
-            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 44, LastName = "Ξαγοράρης", Name = "Κών/νος" });
-            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 44, LastName = "Δούμουρα", Name = " Λητώ" });
-            var component = ctx.RenderComponent<RadzenDropDownDataGrid<TestModel>>(parameterBuilder => parameterBuilder.Add  (p => p.Data, testModels)
-            .Add(p=>p.AllowFiltering,true).Add(p=>p.FilterCaseSensitivity, FilterCaseSensitivity.CaseInsensitive).Add(p => p.FilterDiacriticsSensitivity, FilterDiacriticsSensitivity.DiacriticsInsensitive));
-             var raised = false;
-            LoadDataArgs newArgs = null;
+            IRenderedComponent<RadzenDropDownDataGrid<TestModel>> component = _initiateComponent(ctx);
 
-            component.SetParametersAndRender(parameters => {
-                parameters.Add(p => p.AllowFiltering, true);
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.FilterCaseSensitivity, FilterCaseSensitivity.CaseInsensitive);
                 parameters.Add(p => p.FilterDiacriticsSensitivity, FilterDiacriticsSensitivity.DiacriticsInsensitive);
-                });
+            });
+            _invokeSearch(ctx, component, "οραρ");
 
-            var comp = component.Find(".rz-lookup-search input"); 
-            ctx.JSInterop.Setup<String>("Radzen.getInputValue", _ => true).SetResult("οραρ");
-            comp.Change("οραρ");
+            Assert.Equal(2, component.Instance.View.Cast<TestModel>().ToList().Count());
+        }
+
+        private static void _invokeSearch(TestContext ctx, IRenderedComponent<RadzenDropDownDataGrid<TestModel>> component,string searchText)
+        {
+            var comp = component.Find(".rz-lookup-search input");
+            ctx.JSInterop.Setup<String>("Radzen.getInputValue", _ => true).SetResult(searchText);
+            comp.Change(searchText);
+        }
+
+        [Fact]
+        public void RadzenDataGrid_Search_CaseInsensitive_SymbolsInsensitive_DiacriticsInsensitive()
+        {
+            using var ctx = new TestContext();
+            IRenderedComponent<RadzenDropDownDataGrid<TestModel>> component = _initiateComponent(ctx);
+
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(p => p.FilterCaseSensitivity, FilterCaseSensitivity.CaseInsensitive);
+                parameters.Add(p => p.FilterDiacriticsSensitivity, FilterDiacriticsSensitivity.DiacriticsInsensitive);
+                parameters.Add(p => p.FilterSymbolsSensitivity, FilterSymbolsSensitivity.SymbolInsensitive);
+            });
+
+            _invokeSearch(ctx, component, "οραρ");
+
 
             Assert.Equal(3, component.Instance.View.Cast<TestModel>().ToList().Count());
-         }
+        }
+        [Fact]
+        public void RadzenDataGrid_Search_Sensitive()
+        {
+            using var ctx = new TestContext();
+            IRenderedComponent<RadzenDropDownDataGrid<TestModel>> component = _initiateComponent(ctx);
+
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(p => p.FilterCaseSensitivity, FilterCaseSensitivity.Default);
+                parameters.Add(p => p.FilterDiacriticsSensitivity, FilterDiacriticsSensitivity.Default);
+                parameters.Add(p => p.FilterSymbolsSensitivity, FilterSymbolsSensitivity.Default);
+            });
+
+            _invokeSearch(ctx, component, "οραρ");
+
+
+            Assert.Single(component.Instance.View.Cast<TestModel>().ToList());
+        }
+        [Fact]
+        public void RadzenDataGrid_Search_DiacriticsInSensitive_EndsWith()
+        {
+            using var ctx = new TestContext();
+            IRenderedComponent<RadzenDropDownDataGrid<TestModel>> component = _initiateComponent(ctx);
+
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(p => p.FilterOperator, StringFilterOperator.EndsWith);
+                parameters.Add(p => p.FilterDiacriticsSensitivity, FilterDiacriticsSensitivity.Default);
+             });
+
+            _invokeSearch(ctx, component, "άρη");
+
+
+            Assert.Single(component.Instance.View.Cast<TestModel>().ToList());
+        }
+        [Fact]
+        public void RadzenDataGrid_Search_SymbolInSensitive_StartsWith_AllStringProperties()
+        {
+            using var ctx = new TestContext();
+            IRenderedComponent<RadzenDropDownDataGrid<TestModel>> component = _initiateComponent(ctx);
+
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(p => p.FilterOperator, StringFilterOperator.StartsWith);
+                parameters.Add(p => p.FilterSymbolsSensitivity, FilterSymbolsSensitivity.SymbolInsensitive);
+                parameters.Add(p => p.AllowFilteringByAllStringColumns, true);
+            });
+
+            _invokeSearch(ctx, component, "Λητ");
+
+
+            Assert.Single(component.Instance.View.Cast<TestModel>().ToList());
+        }
+        [Fact]
+        public void RadzenDataGrid_Search_SymbolInSensitive_EndsWith_AllStringProperties()
+        {
+            using var ctx = new TestContext();
+            IRenderedComponent<RadzenDropDownDataGrid<TestModel>> component = _initiateComponent(ctx);
+
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(p => p.FilterOperator, StringFilterOperator.EndsWith);
+                parameters.Add(p => p.FilterSymbolsSensitivity, FilterSymbolsSensitivity.SymbolInsensitive);
+                parameters.Add(p => p.AllowFilteringByAllStringColumns, true);
+            });
+
+            _invokeSearch(ctx, component, "ητώ");
+
+
+            Assert.Single(component.Instance.View.Cast<TestModel>().ToList());
+        }
+        private static IRenderedComponent<RadzenDropDownDataGrid<TestModel>> _initiateComponent(TestContext ctx)
+        {
+            List<TestModel> testModels = new List<TestModel>();
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 7, LastName = "Ξαγοράρη", Name = " Άρτεμις" });
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 4, LastName = "Ξαγορ%άρης", Name = "Φοίβος" });
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 44, LastName = "Ξαγοραρης", Name = "Κών/νος" });
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 44, LastName = "Δούμουρα", Name = " Λητώ)" });
+            var component = ctx.RenderComponent<RadzenDropDownDataGrid<TestModel>>(parameterBuilder => parameterBuilder.Add(p => p.Data, testModels)
+            .Add(p => p.AllowFiltering, true).Add(p => p.TextProperty, "LastName")
+            .Add<RadzenDataGridColumn<dynamic>>(p => p.Columns, c => c.Add(y => y.Property, "LastName").Add(y => y.Filterable, true))
+            .Add<RadzenDataGridColumn<dynamic>>(p => p.Columns, c => c.Add(y => y.Property, "Name").Add(y => y.Filterable, true)));
+            ctx.JSInterop.Setup<String>("Radzen.repositionPopup", _ => true);
+            return component;
+        }
     }
 }

--- a/Radzen.Blazor.Tests/DropDownDataGridTests.cs
+++ b/Radzen.Blazor.Tests/DropDownDataGridTests.cs
@@ -1,0 +1,47 @@
+﻿using Bunit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DropDownDataGridTests
+    {
+        class TestModel
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+            public string LastName { get; set; }
+            public int Age { get; set; }
+        }
+        [Fact]
+        public void RadzenDataGrid_Search_CaseInsensitive_DiacriticsInsensitive()
+        {
+            using var ctx = new TestContext();
+            List<TestModel> testModels = new List<TestModel>();
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 7, LastName = "Ξαγοράρη", Name = " Άρτεμις" });
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 4, LastName = "Ξαγοράρης", Name = "Φοίβος" });
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 44, LastName = "Ξαγοράρης", Name = "Κών/νος" });
+            testModels.Add(new TestModel { Id = Guid.NewGuid(), Age = 44, LastName = "Δούμουρα", Name = " Λητώ" });
+            var component = ctx.RenderComponent<RadzenDropDownDataGrid<TestModel>>(parameterBuilder => parameterBuilder.Add  (p => p.Data, testModels)
+            .Add(p=>p.AllowFiltering,true).Add(p=>p.FilterCaseSensitivity, FilterCaseSensitivity.CaseInsensitive).Add(p => p.FilterDiacriticsSensitivity, FilterDiacriticsSensitivity.DiacriticsInsensitive));
+             var raised = false;
+            LoadDataArgs newArgs = null;
+
+            component.SetParametersAndRender(parameters => {
+                parameters.Add(p => p.AllowFiltering, true);
+                parameters.Add(p => p.FilterCaseSensitivity, FilterCaseSensitivity.CaseInsensitive);
+                parameters.Add(p => p.FilterDiacriticsSensitivity, FilterDiacriticsSensitivity.DiacriticsInsensitive);
+                });
+
+            var comp = component.Find(".rz-lookup-search input"); 
+            ctx.JSInterop.Setup<String>("Radzen.getInputValue", _ => true).SetResult("οραρ");
+            comp.Change("οραρ");
+
+            Assert.Equal(3, component.Instance.View.Cast<TestModel>().ToList().Count());
+         }
+    }
+}

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -693,7 +693,34 @@ namespace Radzen
         /// </summary>
         CaseInsensitive
     }
-
+    /// <summary>
+    /// Specifies the filter Diacritics sensitivity of a component.
+    /// </summary>
+    public enum FilterDiacriticsSensitivity
+    {
+        /// <summary>
+        /// Relies on the underlying provider (LINQ to Objects, Entity Framework etc.) to handle diacritics sensitivity. LINQ to Objects is diacritics sensitive. Entity Framework relies on the database collection settings.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Filters are Diacritics insensitive regardless of the underlying provider.
+        /// </summary>
+        DiacriticsInsensitive
+    }
+    /// <summary>
+    /// Specifies the filter symbol sensitivity of a component. Valid symbols are members of the following categories in UnicodeCategory: MathSymbol, CurrencySymbol, ModifierSymbol, and OtherSymbol.
+    /// </summary>
+    public enum FilterSymbolsSensitivity
+    {
+        /// <summary>
+        /// It is used only on LINQ to Objects provider where the default behaviour is symbol sensitive.   
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Filters are Diacritics insensitive regardless of the underlying provider.
+        /// </summary>
+        SymbolInsensitive
+    }
     /// <summary>
     /// Specifies the logical operator between filters.
     /// </summary>

--- a/Radzen.Blazor/DataBoundFormComponent.cs
+++ b/Radzen.Blazor/DataBoundFormComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Dynamic.Core;
 using System.Linq.Expressions;
@@ -36,6 +37,46 @@ namespace Radzen
         [Parameter]
         public FilterCaseSensitivity FilterCaseSensitivity { get; set; } = FilterCaseSensitivity.Default;
 
+        /// <summary>
+        /// Gets or sets the diacritics sensitivity.
+        /// </summary>
+        /// <value>The filter diacritics sensitivity.</value>
+        [Parameter]
+        public FilterDiacriticsSensitivity FilterDiacriticsSensitivity { get; set; } = FilterDiacriticsSensitivity.Default;
+
+        /// <summary>
+        /// Gets or sets the symbols sensitivity.
+        /// </summary>
+        /// <value>The filter symbols sensitivity.</value>
+        [Parameter]
+        public FilterSymbolsSensitivity FilterSymbolsSensitivity { get; set; } = FilterSymbolsSensitivity.Default;
+
+        /// <summary>
+        /// Returns the compareOptions to be used in filtering oprations according the values of FilterCaseSensitivity,FilterDiacriticsSensitivity,FilterSymbolsSensitivity
+        /// </summary>
+        protected CompareOptions CompareOptions
+        {
+            get {
+                CompareOptions options = CompareOptions.None;
+                if (FilterCaseSensitivity==FilterCaseSensitivity.CaseInsensitive)
+                {
+                    options |= CompareOptions.IgnoreCase;
+                }
+                if (FilterDiacriticsSensitivity == FilterDiacriticsSensitivity.DiacriticsInsensitive)
+                {
+                    options |= CompareOptions.IgnoreNonSpace;
+                }
+                if (FilterSymbolsSensitivity == FilterSymbolsSensitivity.SymbolInsensitive)
+                {
+                    options |= CompareOptions.IgnoreSymbols;
+                }
+                return options;
+            }
+        }
+        protected string GetFilterExpression(string property)
+        {
+            return $"{property}.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0,@1)";
+        }
         /// <summary>
         /// Gets or sets the filter operator.
         /// </summary>

--- a/Radzen.Blazor/DataBoundFormComponent.cs
+++ b/Radzen.Blazor/DataBoundFormComponent.cs
@@ -75,7 +75,7 @@ namespace Radzen
         }
         protected string GetFilterExpression(string property)
         {
-            return $"{property}.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0,@1)";
+            return $"StringExtensions.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}({property},@0,@1)";
         }
         /// <summary>
         /// Gets or sets the filter operator.

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -703,8 +703,7 @@ namespace Radzen
                 {
                     if (!string.IsNullOrEmpty(searchText))
                     {
-                        var ignoreCase = FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive;
-
+                     
                         var query = new List<string>();
 
                         if (!string.IsNullOrEmpty(TextProperty))
@@ -717,14 +716,8 @@ namespace Radzen
                             query.Add("ToString()");
                         }
 
-                        if (ignoreCase)
-                        {
-                            query.Add("ToLower()");
-                        }
+                        _view = Query.Where($"{GetFilterExpression(String.Join(".", query))}", searchText, CompareOptions);
 
-                        query.Add($"{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0)");
-
-                        _view = Query.Where(String.Join(".", query), ignoreCase ? searchText.ToLower() : searchText);
                     }
                     else
                     {

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -146,10 +146,8 @@ namespace Radzen.Blazor
             {
                 if (Query != null)
                 {
-                    string filterCaseSensitivityOperator = FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? ".ToLower()" : "";
-
-                    return Query.Where($"{TextProperty}{filterCaseSensitivityOperator}.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0)",
-                        FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? searchText.ToLower() : searchText);
+                   
+                    return Query.Where($"{GetFilterExpression(TextProperty)}", searchText, CompareOptions);
                 }
 
                 return null;

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -239,6 +239,7 @@ namespace Radzen.Blazor
                     }
                     else
                     {
+                        
                         query = query.Where($"{GetPropertyFilterExpression(TextProperty)}", searchText,CompareOptions);
                     }
                 }

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -200,14 +200,14 @@ namespace Radzen.Blazor
             await OnLoadData(new Radzen.LoadDataArgs() { Skip = 0, Top = PageSize });
         }
 
-        private string GetPropertyFilterExpression(string property, string filterCaseSensitivityOperator)
+        private string GetPropertyFilterExpression(string property )
         {
             if (property == null)
             {
                 property = "it";
             }
             var p = $@"({property} == null ? """" : {property})";
-            return $"{p}{filterCaseSensitivityOperator}.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0)";
+            return GetFilterExpression(p);
         }
 
         private bool IsColumnFilterPropertyTypeString(RadzenDataGridColumn<object> column)
@@ -235,13 +235,11 @@ namespace Radzen.Blazor
                     if (AllowFilteringByAllStringColumns)
                     {
                         query = query.Where(string.Join(" || ", grid.ColumnsCollection.Where(c => c.Filterable && IsColumnFilterPropertyTypeString(c))
-                            .Select(c => GetPropertyFilterExpression(c.GetFilterProperty(), filterCaseSensitivityOperator))),
-                                FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? searchText.ToLower() : searchText);
+                            .Select(c => GetPropertyFilterExpression(c.GetFilterProperty()))),searchText, CompareOptions);
                     }
                     else
                     {
-                        query = query.Where($"{GetPropertyFilterExpression(TextProperty, filterCaseSensitivityOperator)}",
-                            FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? searchText.ToLower() : searchText);
+                        query = query.Where($"{GetPropertyFilterExpression(TextProperty)}", searchText,CompareOptions);
                     }
                 }
 

--- a/Radzen.Blazor/StringExtensions.cs
+++ b/Radzen.Blazor/StringExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq.Dynamic.Core.CustomTypeProviders;
 using System.Text;
 
 namespace Radzen.Blazor
@@ -8,7 +9,9 @@ namespace Radzen.Blazor
     /// <summary>
     /// Class containing various string extension methods
     /// </summary>
-   public static class StringExtensions
+     [DynamicLinqType]
+
+    public static class StringExtensions
     {
         /// <summary>
         /// It checks if a string contains the value if another string.
@@ -31,6 +34,10 @@ namespace Radzen.Blazor
         /// <returns>A boolean indicating if the string starts the value or not</returns>
         public static bool StartsWith(this string source, string value, CompareOptions compareOptions)
         {
+            if ((compareOptions & CompareOptions.IgnoreSymbols) != 0) 
+            {
+                source = source.TrimSartSymbolCharacters();
+            }
             return CultureInfo.InvariantCulture.CompareInfo.IsPrefix(source, value, compareOptions);
            
         }
@@ -46,6 +53,47 @@ namespace Radzen.Blazor
         {
             return CultureInfo.InvariantCulture.CompareInfo.IsSuffix(source, value, compareOptions);
 
+
+        }
+        /// <summary>
+        /// Removes all symbol and whitespace characters from the start of the string. We remove white space characters to be consistent with CompareOptions.IgnoreSymbols option
+        /// </summary>
+        /// <param name="str">The string to remove the symbol characters from </param>
+        /// <returns>The string trimed from symbol characters at the start</returns>
+
+        public static string TrimSartSymbolCharacters(this string str)
+        {
+            StringBuilder sb = new StringBuilder();
+            bool foundNonSymbol = false;
+            foreach (char c in str)
+            {
+                if (!(char.IsSymbol(c)|| char.IsWhiteSpace(c)) || foundNonSymbol)
+                {
+                    foundNonSymbol = true;
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+        /// <summary>
+        /// Removes all symbol and whitespace characters from the enf of the string. We remove white space characters to be consistent with CompareOptions.IgnoreSymbols option
+        /// </summary>
+        /// <param name="str">The string to remove the symbol characters from </param>
+        /// <returns>The string trimed from symbol characters at the end</returns>
+        public static string TrimEndSymbolCharacters(this string str)
+        {
+            StringBuilder sb = new StringBuilder();
+            bool foundNonSymbol = false;
+            for (int i = str.Length - 1;i >= 0; i-- )
+            {
+                char c  = str[i];
+                if (!(char.IsSymbol(c) || char.IsWhiteSpace(c)) || foundNonSymbol)
+                {
+                    foundNonSymbol = true;
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
         }
     }
 }

--- a/Radzen.Blazor/StringExtensions.cs
+++ b/Radzen.Blazor/StringExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Radzen.Blazor
+{
+    /// <summary>
+    /// Class containing various string extension methods
+    /// </summary>
+   public static class StringExtensions
+    {
+        /// <summary>
+        /// It checks if a string contains the value if another string.
+        /// </summary>
+        /// <param name="source">The string to check if it contains the specific value</param>
+        /// <param name="value">The value that the string should contain with</param>
+        /// <param name="compareOptions">Case, dicritics, symbol and more sensitivity options to apply during the comparison</param>
+        /// <returns>A boolean indicating if the string contains the string or not</returns>
+        public static bool Contains(this string source, string value, CompareOptions compareOptions)
+        {
+            var index = CultureInfo.InvariantCulture.CompareInfo.IndexOf(source, value, compareOptions);
+            return index != -1;
+        }
+        /// <summary>
+        /// It checks if a string starts with the value if another string.
+        /// </summary>
+        /// <param name="source">The string to check if it starts with the specific value</param>
+        /// <param name="value">The value that the string should start with</param>
+        /// <param name="compareOptions">Case, dicritics, symbol and more sensitivity options to apply during the comparison</param>
+        /// <returns>A boolean indicating if the string starts the value or not</returns>
+        public static bool StartsWith(this string source, string value, CompareOptions compareOptions)
+        {
+            return CultureInfo.InvariantCulture.CompareInfo.IsPrefix(source, value, compareOptions);
+           
+        }
+        /// <summary>
+        /// It checks if a string ends with the value if another string.
+        /// </summary>
+        /// <param name="source">The string to check if it ends with the specific value</param>
+        /// <param name="value">The value that the string should end with</param>
+        /// <param name="compareOptions">Case, dicritics, symbol and more sensitivity options to apply during the comparison</param>
+        /// <returns>A boolean indicating if the string end the value or not</returns>
+
+        public static bool EndsWith(this string source, string value, CompareOptions compareOptions)
+        {
+            return CultureInfo.InvariantCulture.CompareInfo.IsSuffix(source, value, compareOptions);
+
+        }
+    }
+}


### PR DESCRIPTION
I have added the ability to perform an accent insencitive search on all components that inherit from dropdownbase since it is a hashle for those who right on languages with accents and other diacritics to search with or without accents. I also included the option to ignore symbols as well. I share the code with you in case you are interested on including it in the upstream. I have not yet added support for search on datagrid because I must also take into account linw to sql search.