### PR TITLE
Add Click Parameter on MenuItem

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Web;
 using Radzen.Blazor;
 using System;
 using System.Collections;
@@ -100,7 +101,7 @@ namespace Radzen
     /// <summary>
     /// Supplies information about a <see cref="RadzenMenu.Click" /> event that is being raised.
     /// </summary>
-    public class MenuItemEventArgs
+    public class MenuItemEventArgs : MouseEventArgs
     {
         /// <summary>
         /// Gets text of the clicked item.

--- a/Radzen.Blazor/RadzenMenuItem.razor.cs
+++ b/Radzen.Blazor/RadzenMenuItem.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using System.Threading.Tasks;
 
 namespace Radzen.Blazor
 {
@@ -71,6 +72,13 @@ namespace Radzen.Blazor
         public RenderFragment ChildContent { get; set; }
 
         /// <summary>
+        /// Gets or sets the click callback.
+        /// </summary>
+        /// <value>The click callback.</value>
+        [Parameter]
+        public EventCallback<MenuItemEventArgs> Click { get; set; }
+
+        /// <summary>
         /// Gets or sets the parent.
         /// </summary>
         /// <value>The parent.</value>
@@ -81,11 +89,34 @@ namespace Radzen.Blazor
         /// Handles the <see cref="E:Click" /> event.
         /// </summary>
         /// <param name="args">The <see cref="MouseEventArgs"/> instance containing the event data.</param>
-        public async System.Threading.Tasks.Task OnClick(MouseEventArgs args)
+        public async Task OnClick(MouseEventArgs args)
         {
             if (Parent != null)
             {
-                await Parent.Click.InvokeAsync(new MenuItemEventArgs() { Text = this.Text, Path = this.Path, Value = this.Value });
+                var eventArgs = new MenuItemEventArgs 
+                { 
+                    Text = Text,
+                    Path = Path,
+                    Value = Value,
+                    AltKey = args.AltKey,
+                    Button = args.Button,
+                    Buttons = args.Buttons,
+                    ClientX = args.ClientX,
+                    ClientY = args.ClientY,
+                    CtrlKey = args.CtrlKey,
+                    Detail = args.Detail,
+                    MetaKey = args.MetaKey,
+                    ScreenX = args.ScreenX,
+                    ScreenY = args.ScreenY,
+                    ShiftKey = args.ShiftKey,
+                    Type = args.Type,
+                };
+                await Parent.Click.InvokeAsync(eventArgs);
+
+                if (Click.HasDelegate)
+                {
+                    await Click.InvokeAsync(eventArgs);
+                }
             }
         }
     }

--- a/RadzenBlazorDemos/Pages/MenuPage.razor
+++ b/RadzenBlazorDemos/Pages/MenuPage.razor
@@ -2,11 +2,11 @@
 
 <RadzenExample Name="Menu">
 <RadzenCard Style="margin-bottom: 200px; width: fit-content; min-width: 200px;" Class="mt-3 mx-auto">
-    <RadzenMenu>
+    <RadzenMenu Click="OnParentClicked">
             <RadzenMenuItem Text="General" Icon="home">
                 <RadzenMenuItem Text="Buttons" Path="buttons" Icon="account_circle"></RadzenMenuItem>
                 <RadzenMenuItem Text="Menu" Path="menu" Icon="line_weight"></RadzenMenuItem>
-                <RadzenMenuItem Text="FileInput" Path="fileinput" Icon="attach_file"></RadzenMenuItem>
+                <RadzenMenuItem Click="OnChildClicked" Text="ChildClick" Icon="attach_file"></RadzenMenuItem>
                 <RadzenMenuItem Text="Dialog" Path="dialog" Icon="perm_media"></RadzenMenuItem>
                 <RadzenMenuItem Text="Notification" Path="notification" Icon="announcement"></RadzenMenuItem>
             </RadzenMenuItem>
@@ -45,3 +45,19 @@
     </RadzenMenu>
 </RadzenCard>
 </RadzenExample>
+
+<EventConsole @ref=@console class="mt-4" />
+
+@code {
+    EventConsole console;
+
+    void OnParentClicked(MenuItemEventArgs args)
+    {
+        console.Log($"{args.Text} clicked from parent");
+    }
+
+    void OnChildClicked(MenuItemEventArgs args)
+    {
+        console.Log($"{args.Text} from child clicked");
+    }
+}


### PR DESCRIPTION
Currently it's only possible to provide a `Path` parameter to the children of the `<Menu>` and the `<Menu>` takes full control. 

This PR makes it possible to also add the `Click` EventCallback to the children (`MenuItem`), this way we can use additional logical before navigation and have more control of the component if we don't want to use the `Click` of the parent

This PR introduces no breaking changes, but an additional parameter `Click` to the `MenuItem`


![menuitem-click](https://user-images.githubusercontent.com/10981553/151600381-c9f21c62-a7b4-4e96-9124-581aed70ec00.gif)

