### PR TITLE
FIX: Menu in DataGrid shows incorrectly due to z-index

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_menu.scss
+++ b/Radzen.Blazor/themes/components/blazor/_menu.scss
@@ -80,7 +80,6 @@ $context-menu-box-shadow: 0 10px 8px 0 rgba(58, 71, 77, 0.06) !default;
 
   .rz-navigation-item {
     position: relative;
-    z-index: 2;
   }
 
   .rz-navigation-menu {
@@ -91,7 +90,7 @@ $context-menu-box-shadow: 0 10px 8px 0 rgba(58, 71, 77, 0.06) !default;
     margin: 0;
     min-width: 100%;
     box-shadow: $context-menu-box-shadow;
-
+    z-index: 20;
     border-radius: $menu-border-radius;
     background-color: $menu-background-color;
 

--- a/Radzen.Blazor/themes/components/blazor/_menu.scss
+++ b/Radzen.Blazor/themes/components/blazor/_menu.scss
@@ -90,7 +90,7 @@ $context-menu-box-shadow: 0 10px 8px 0 rgba(58, 71, 77, 0.06) !default;
     margin: 0;
     min-width: 100%;
     box-shadow: $context-menu-box-shadow;
-    z-index: 20;
+    z-index: 2;
     border-radius: $menu-border-radius;
     background-color: $menu-background-color;
 


### PR DESCRIPTION
Commit  9fa7d0182d57f25cb38ef971b212a974d45f39d8 introduces a fix and a bug at the same time. This PR keeps the fix and removes the bug.

`z-index` set to 20 to give people more room in-between

Before as shown in issue #355
![image](https://user-images.githubusercontent.com/10981553/151607057-79c78e39-2518-4959-9f17-960e3b2542e2.png)

In this PR
Menu above DataGrid Header (same as previous commit)
![image](https://user-images.githubusercontent.com/10981553/151606890-bce8442b-6ee8-47a2-8ed4-fbe9f5f06044.png)

Menu's navigation menu above other Menu's in a DataGrid
![image](https://user-images.githubusercontent.com/10981553/151606981-496cb406-5e1b-4f14-a3c2-ca43f11501f6.png)

