### PR TITLE
Reset Password shall throw event with an empty username

### DIFF
--- a/Radzen.Blazor/RadzenLogin.razor.cs
+++ b/Radzen.Blazor/RadzenLogin.razor.cs
@@ -198,10 +198,7 @@ namespace Radzen.Blazor
         /// <param name="args">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected async Task OnReset(EventArgs args)
         {
-            if (!string.IsNullOrEmpty(Username))
-            {
-                await ResetPassword.InvokeAsync(Username);
-            }
+            await ResetPassword.InvokeAsync(Username);
         }
 
         /// <summary>


### PR DESCRIPTION
In the Login component, the forgot password link, 
does not throw the click event if the Username is empty.

The "visual message" to the user is weird, because the control clicks, but does nothing, as the event is not fired.