### PR TITLE
Add optional Today and Clear button to Datepicker

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -414,5 +414,47 @@ namespace Radzen.Blazor.Tests
             Assert.True(raised);
             Assert.Equal(kind, ((DateTime)newValue).Kind);
         }
+
+        [Fact]
+        public void DatePicker_TodayButtonClick_SetsDatepickerToToday()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime?>>();
+
+            DateTime? newValue = null;
+
+            component.SetParametersAndRender(parameters => {
+                parameters.Add(p => p.ValueChanged, args => { newValue = args; })
+                          .Add(p => p.Value, DateTime.Now.AddDays(-7))
+                          .Add(p => p.ShowTodayButton, true);
+            });
+
+            component.Find("button[data-action='today']").Click();
+
+            Assert.Equal(newValue.Value.ToShortDateString(), DateTime.Now.ToShortDateString());
+        }
+
+        [Fact]
+        public void DatePicker_ClearButtonClick_ClearsDatepicker()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime?>>();
+
+            DateTime? newValue = null;
+
+            component.SetParametersAndRender(parameters => {
+                parameters.Add(p => p.ValueChanged, args => { newValue = args; })
+                          .Add(p => p.Value, DateTime.Now.AddDays(-7))
+                          .Add(p => p.ShowClearButton, true);
+            });
+
+            component.Find("button[data-action='clear']").Click();
+
+            Assert.Null(newValue);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -134,6 +134,26 @@
                         }
                     </div>
                 }
+                <div class="rz-datepicker-actions">
+                    @if (ShowTodayButton)
+                    {
+                        <button type="button" class="rz-button rz-button-md btn-secondary"
+                            @onclick="@TodayClick"
+                            data-action="today"
+                            onmouseup="@($"Radzen.closePopup('{PopupID}')")">
+                            <span class="rz-button-text">@TodayButtonText</span>
+                        </button>
+                    }
+                    @if (ShowClearButton)
+                    {
+                        <button type="button" class="rz-button rz-button-md btn-secondary"
+                            @onclick="@ClearClick"
+                            data-action="clear"
+                            onmouseup="@($"Radzen.closePopup('{PopupID}')")">
+                            <span class="rz-button-text">@ClearButtonText</span>
+                        </button>
+                    }
+                </div>
             </div>
         
     </div>

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -857,6 +857,50 @@ namespace Radzen.Blazor
             StateHasChanged();
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether a today button is shown
+        /// </summary>
+        /// <value><c>true</c> if button will be shown; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ShowTodayButton { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text that is used on the Today Button. Defaults to Today
+        /// </summary>
+        [Parameter]
+        public string TodayButtonText { get; set; } = "Today";
+
+        async Task TodayClick()
+        {
+            if (!Disabled)
+            {
+                CurrentDate = DateTime.Now;
+
+                await OkClick();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a clear date button is shown
+        /// </summary>
+        /// <value><c>true</c> if button will be shown; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ShowClearButton { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text that is used on the Clear Button. Defaults to Clear
+        /// </summary>
+        [Parameter]
+        public string ClearButtonText { get; set; } = "Clear";
+
+        async Task ClearClick()
+        {
+            if (!Disabled)
+            {
+                await Clear();
+            }
+        }
+
         /// <inheritdoc />
         public override void Dispose()
         {

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -281,3 +281,11 @@ $timepicker-border: none !default;
   background-color: $timepicker-background-color;
   width: 4rem;
 }
+
+.rz-datepicker-actions {
+    padding: 0.5rem;
+	
+	.rz-button {
+		margin-right: 5px;
+	}
+}

--- a/RadzenBlazorDemos/Pages/DatePickerPage.razor
+++ b/RadzenBlazorDemos/Pages/DatePickerPage.razor
@@ -54,6 +54,12 @@
                     <RadzenDatePicker Disabled="true" @bind-Value=@value Class="w-100" />
                 </RadzenCard>
             </div>
+            <div class="col-lg-6 col-xl-4 p-3">
+                <RadzenCard>
+                    <h4 class="mb-4">DatePicker with buttons</h4>
+                    <RadzenDatePicker TValue="DateTime?" DateFormat="d" Change=@(args => OnChange(args, "DatePicker with buttons", "MM/dd/yyyy")) Class="w-100" ShowTodayButton="true" ShowClearButton="true" />
+                </RadzenCard>
+            </div>
         </div>
     </div>
     <div class="col-lg-12 col-xl-4 p-3">


### PR DESCRIPTION
Most other Datepicker components offer an option to set the date to today or clear the date via buttons.

This PR adds this optional functionality.

![afbeelding](https://user-images.githubusercontent.com/42466440/153773450-50bc388e-3e70-4e60-9469-04e108461c75.png)
