### PR TITLE
Support for Remove/Clear to the RadzenUpload control #376

### DIFF
--- a/Radzen.Blazor/RadzenUpload.razor.cs
+++ b/Radzen.Blazor/RadzenUpload.razor.cs
@@ -231,10 +231,39 @@ namespace Radzen.Blazor
         }
 
         /// <summary>
+        /// Clear selected file(s) from the upload selection
+        /// </summary>
+        public async System.Threading.Tasks.Task ClearFiles()
+        {
+            while(files.Count > 0)
+            {
+                await OnRemove(files[0], false);
+            }
+
+            await Change.InvokeAsync(new UploadChangeEventArgs() { Files = files.Select(f => new FileInfo() { Name = f.Name, Size = f.Size }).ToList() });
+        }
+
+        /// <summary>
+        /// Called on file remove.
+        /// </summary>
+        /// <param name="fileName">The name of the file to remove.</param>
+        /// <param name="ignoreCase">Specify true is file name casing should be ignored (default: false)</param>
+        public async System.Threading.Tasks.Task RemoveFile(string fileName, bool ignoreCase = false)
+        {
+            var comparisonMethod = ignoreCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            var fileInfo = files.FirstOrDefault(f => string.Equals(f.Name, fileName, comparisonMethod));
+            if (fileInfo != null)
+            {
+                await OnRemove(fileInfo);
+            }
+        }
+
+        /// <summary>
         /// Called on file remove.
         /// </summary>
         /// <param name="file">The file.</param>
-        protected async System.Threading.Tasks.Task OnRemove(PreviewFileInfo file)
+        /// <param name="fireChangeEvent">If the linked <see cref="Change" /> event should be fired as a result of this removal (default: true)</param>
+        protected async System.Threading.Tasks.Task OnRemove(PreviewFileInfo file, bool fireChangeEvent = true)
         {
             files.Remove(file);
             await JSRuntime.InvokeVoidAsync("Radzen.removeFileFromUpload", fileUpload, file.Name);

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -471,6 +471,16 @@ window.Radzen = {
     var uploadComponent =
       Radzen.uploadComponents && Radzen.uploadComponents[fileInput.id];
     if (uploadComponent) {
+      if (uploadComponent.localFiles) {
+        // Clear any previously created preview URL(s)
+        for (var i = 0; i < uploadComponent.localFiles.length; i++) {
+          var file = uploadComponent.localFiles[i];
+          if (file.Url) {
+            URL.revokeObjectURL(file.Url);
+          }
+        }
+      }
+
       uploadComponent.files = Array.from(fileInput.files);
       uploadComponent.localFiles = files;
       uploadComponent.invokeMethodAsync('RadzenUpload.OnChange', files);

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -472,19 +472,26 @@ window.Radzen = {
       Radzen.uploadComponents && Radzen.uploadComponents[fileInput.id];
     if (uploadComponent) {
       uploadComponent.files = Array.from(fileInput.files);
+      uploadComponent.localFiles = files;
       uploadComponent.invokeMethodAsync('RadzenUpload.OnChange', files);
     }
 
     for (var i = 0; i < fileInput.files.length; i++) {
       var file = fileInput.files[i];
-      URL.revokeObjectURL(file.Url);
+      if (file.Url) {
+        URL.revokeObjectURL(file.Url);
+      }
     }
   },
   removeFileFromUpload: function (fileInput, name) {
     var uploadComponent = Radzen.uploadComponents && Radzen.uploadComponents[fileInput.id];
     if (!uploadComponent) return;
     var file = uploadComponent.files.find(function (f) { return f.name == name; })
-    if (!file) return;
+    if (!file) { return; }
+    var localFile = uploadComponent.localFiles.find(function (f) { return f.Name == name; });
+    if (localFile) {
+      URL.revokeObjectURL(localFile.Url);
+    }
     var index = uploadComponent.files.indexOf(file)
     if (index != -1) {
         uploadComponent.files.splice(index, 1);
@@ -493,8 +500,8 @@ window.Radzen = {
   },
   upload: function (fileInput, url, multiple, clear) {
     var uploadComponent = Radzen.uploadComponents && Radzen.uploadComponents[fileInput.id];
-    if(!uploadComponent) return;
-      if (!uploadComponent.files || clear) {
+    if (!uploadComponent) { return; }
+    if (!uploadComponent.files || clear) {
         uploadComponent.files = Array.from(fileInput.files);
     }
     var data = new FormData();


### PR DESCRIPTION
(Included) FIX:  Preview URLs generated during file selection are not freed on removal