### PR TITLE
Handle JSDisconnectedException when JSRuntime goes away before Dispose

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -16,7 +16,7 @@ namespace Radzen
     /// <typeparam name="T"></typeparam>
     public class DropDownBase<T> : DataBoundFormComponent<T>
     {
-#if NET5
+#if NET5_0_OR_GREATER
         internal Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<object> virtualize;
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Radzen
         /// <returns><c>true</c> if virtualization is allowed; otherwise, <c>false</c>.</returns>
         internal bool IsVirtualizationAllowed()
         {
-#if NET5
+#if NET5_0_OR_GREATER
             return AllowVirtualization;
 #else
             return false;
@@ -89,7 +89,7 @@ namespace Radzen
         {
             return new RenderFragment(builder =>
             {
-#if NET5
+#if NET5_0_OR_GREATER
                 if (AllowVirtualization)
                 {
                     builder.OpenComponent(0, typeof(Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<object>));
@@ -299,7 +299,7 @@ namespace Radzen
                         selectedItems.Clear();
                     }
 
-                    OnDataChanged();
+                    _ = OnDataChanged();
 
                     StateHasChanged();
                 }
@@ -488,7 +488,7 @@ namespace Radzen
                 _view = null;
                 if (IsVirtualizationAllowed())
                 {
-#if NET5
+#if NET5_0_OR_GREATER
                     if (virtualize != null)
                     {
                         await virtualize.RefreshDataAsync();
@@ -505,7 +505,7 @@ namespace Radzen
             {
                 if (IsVirtualizationAllowed())
                 {
-#if NET5
+#if NET5_0_OR_GREATER
                     if (virtualize != null)
                     {
                         await InvokeAsync(virtualize.RefreshDataAsync);
@@ -556,7 +556,7 @@ namespace Radzen
         /// <returns>LoadDataArgs.</returns>
         internal virtual async System.Threading.Tasks.Task<LoadDataArgs> GetLoadDataArgs()
         {
-#if NET5
+#if NET5_0_OR_GREATER
             if (AllowVirtualization)
             {
                 return new Radzen.LoadDataArgs() { Skip = 0, Top = PageSize, Filter = await JSRuntime.InvokeAsync<string>("Radzen.getInputValue", search) };
@@ -602,7 +602,7 @@ namespace Radzen
         /// <returns>A Task representing the asynchronous operation.</returns>
         public override async Task SetParametersAsync(ParameterView parameters)
         {
-#if NET5
+#if NET5_0_OR_GREATER
             var pageSize = parameters.GetValueOrDefault<int>(nameof(PageSize));
             if(pageSize != default(int))
             {

--- a/Radzen.Blazor/Radzen.Blazor.csproj
+++ b/Radzen.Blazor/Radzen.Blazor.csproj
@@ -1,72 +1,62 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
-  <PropertyGroup>
-    <NoWarn>BL9993</NoWarn>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
-    <RazorLangVersion>3.0</RazorLangVersion>
-    <LangVersion>7.3</LangVersion>
-    <OutputType>Library</OutputType>
-    <IsPackable>true</IsPackable>
-    <PackageId>Radzen.Blazor</PackageId>
-    <Product>Radzen.Blazor</Product>
-    <Version>3.15.5</Version>
-    <Copyright>Radzen Ltd.</Copyright>
-    <Authors>Radzen Ltd.</Authors>
-    <Description>Native Blazor UI components by Radzen Ltd.</Description>
-    <PackageTags>blazor blazor-component blazor-grid blazor-datagrid</PackageTags>
-    <PackageProjectUrl>https://www.radzen.com</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <Title>Radzen Components for Blazor</Title>
-    <RepositoryUrl>https://github.com/radzenhq/radzen-blazor</RepositoryUrl>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <DefineConstants>NET5</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="LibSassBuilder" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Condition="'$(TargetFramework)' == 'netstandard2.1'" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Condition="'$(TargetFramework)' == 'netstandard2.1'" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Condition="'$(TargetFramework)' == 'net5.0'" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Condition="'$(TargetFramework)' == 'net5.0'" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.12" />
-  </ItemGroup>
+	<PropertyGroup>
+		<NoWarn>BL9993</NoWarn>
+		<TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
+		<RazorLangVersion>3.0</RazorLangVersion>
+		<LangVersion>7.3</LangVersion>
+		<OutputType>Library</OutputType>
+		<IsPackable>true</IsPackable>
+		<PackageId>Radzen.Blazor</PackageId>
+		<Product>Radzen.Blazor</Product>
+		<Version>3.15.5</Version>
+		<Copyright>Radzen Ltd.</Copyright>
+		<Authors>Radzen Ltd.</Authors>
+		<Description>Native Blazor UI components by Radzen Ltd.</Description>
+		<PackageTags>blazor blazor-component blazor-grid blazor-datagrid</PackageTags>
+		<PackageProjectUrl>https://www.radzen.com</PackageProjectUrl>
+		<PackageIcon>icon.png</PackageIcon>
+		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+		<Title>Radzen Components for Blazor</Title>
+		<RepositoryUrl>https://github.com/radzenhq/radzen-blazor</RepositoryUrl>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="LibSassBuilder" Version="2.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" Condition="'$(TargetFramework)' == 'netstandard2.1'" Version="3.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Condition="'$(TargetFramework)' == 'netstandard2.1'" Version="3.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" Condition="'$(TargetFramework)' == 'net5.0'" Version="5.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Condition="'$(TargetFramework)' == 'net5.0'" Version="5.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" Condition="'$(TargetFramework)' == 'net6.0'" Version="6.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Condition="'$(TargetFramework)' == 'net6.0'" Version="6.0.2" />
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.12" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" PackagePath="" />
-    <None Include="icon.png" Pack="true" PackagePath="" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="LICENSE.txt" Pack="true" PackagePath="" />
+		<None Include="icon.png" Pack="true" PackagePath="" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="LinkerConfig.xml">
-      <LogicalName>$(MSBuildProjectName).xml</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="LinkerConfig.xml">
+			<LogicalName>$(MSBuildProjectName).xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
 
-  <PropertyGroup>
-    <LibSassOutputStyle>expanded</LibSassOutputStyle>
-    <EnableDefaultSassItems>false</EnableDefaultSassItems>  
-  </PropertyGroup>
+	<PropertyGroup>
+		<LibSassOutputStyle>expanded</LibSassOutputStyle>
+		<EnableDefaultSassItems>false</EnableDefaultSassItems>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Sass Include="$(MSBuildProjectDirectory)/themes/*.scss" Exclude="$(MSBuildProjectDirectory)/themes/_*.scss" Condition="'$(TargetFramework)' == 'net5.0'" />
-  </ItemGroup>
+	<ItemGroup>
+		<SassFile Include="$(MSBuildProjectDirectory)/themes/*.scss" Exclude="$(MSBuildProjectDirectory)/themes/_*.scss" Condition="'$(TargetFramework)' == 'net6.0'" />
+	</ItemGroup>
 
- <Target Name="Sass" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' == 'net5.0'">
-    <PropertyGroup>
-      <_SassFileList>@(Sass->'&quot;%(FullPath)&quot;', ' ')</_SassFileList>
-      <LibSassBuilderArgs>files $(_SassFileList) --outputstyle $(LibSassOutputStyle) --level $(LibSassOutputLevel)</LibSassBuilderArgs>
-    </PropertyGroup>
-    <Message Text="$(LibSassBuilderArgs)" Importance="$(LibSassMessageLevel)" />
-    <Message Text="Converted SassFile list to argument" Importance="$(LibSassMessageLevel)" />
-  </Target>
-
-  <Target Name="MoveCss" AfterTargets="AfterCompile" Condition="'$(TargetFramework)' == 'net5.0'" >
-    <ItemGroup>
-        <CssFile Include="$(MSBuildProjectDirectory)/themes/*.css" />
-    </ItemGroup>
-    <Move SourceFiles="@(CssFile)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/css/" />
-  </Target>
+	<Target Name="MoveCss" AfterTargets="AfterCompile" Condition="'$(TargetFramework)' == 'net6.0'" >
+		<ItemGroup>
+			<CssFile Include="$(MSBuildProjectDirectory)/themes/*.css" />
+		</ItemGroup>
+		<Move SourceFiles="@(CssFile)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/css/" />
+	</Target>
 
 </Project>

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -213,8 +213,11 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
         }
 
         private bool firstRender = true;

--- a/Radzen.Blazor/RadzenBody.razor.cs
+++ b/Radzen.Blazor/RadzenBody.razor.cs
@@ -27,7 +27,7 @@ namespace Radzen.Blazor
             var classList = ClassList.Create("rz-body")
                                      .Add("body")
                                      .Add("body-expanded", Expanded);
-                                     
+
             return classList.ToString();
         }
 
@@ -111,8 +111,11 @@ namespace Radzen.Blazor
         {
             if (IsJSRuntimeAvailable && Layout != null)
             {
-                JSRuntime.InvokeVoidAsync("eval", $"document.getElementById('{GetId()}').scrollTop = 0");
+                SafeInvokeJSRuntime(onLocationChangedInternal);
             }
+
+            async Task onLocationChangedInternal() =>
+                await JSRuntime.InvokeVoidAsync("eval", $"document.getElementById('{GetId()}').scrollTop = 0");
         }
 
         /// <inheritdoc />

--- a/Radzen.Blazor/RadzenChart.razor.cs
+++ b/Radzen.Blazor/RadzenChart.razor.cs
@@ -459,8 +459,11 @@ namespace Radzen.Blazor
 
             if (Visible && IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyChart", Element);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyChart", Element);
         }
 
         /// <inheritdoc />

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -26,7 +26,7 @@ namespace Radzen.Blazor
     /// </example>
     public partial class RadzenDataGrid<TItem> : PagedDataBoundComponent<TItem>
     {
-#if NET5
+#if NET5_0_OR_GREATER
         internal void SetAllowVirtualization(bool allowVirtualization)
         {
             AllowVirtualization = allowVirtualization;
@@ -54,7 +54,7 @@ namespace Radzen.Blazor
             var totalItemsCount = LoadData.HasDelegate ? Count : view.Count();
             var top = request.Count;
 
-            if(top <= 0)
+            if (top <= 0)
             {
                 top = PageSize;
             }
@@ -70,7 +70,7 @@ namespace Radzen.Blazor
         {
             var top = request.Count;
 
-            if(top <= 0)
+            if (top <= 0)
             {
                 top = PageSize;
             }
@@ -88,10 +88,10 @@ namespace Radzen.Blazor
         {
             return new RenderFragment(builder =>
             {
-#if NET5
+#if NET5_0_OR_GREATER
                 if (AllowVirtualization)
                 {
-                    if(AllowGrouping && groups.Any() && !LoadData.HasDelegate)
+                    if (AllowGrouping && groups.Any() && !LoadData.HasDelegate)
                     {
                         builder.OpenComponent(0, typeof(Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<GroupResult>));
                         builder.AddAttribute(1, "ItemsProvider", new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<GroupResult>(LoadGroups));
@@ -116,7 +116,7 @@ namespace Radzen.Blazor
                     {
                         builder.OpenComponent(0, typeof(Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>));
                         builder.AddAttribute(1, "ItemsProvider", new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem>(LoadItems));
-                    
+
                         builder.AddAttribute(2, "ChildContent", (RenderFragment<TItem>)((context) =>
                         {
                             return (RenderFragment)((b) =>
@@ -429,7 +429,8 @@ namespace Radzen.Blazor
 
                 if (FilterMode == FilterMode.Advanced)
                 {
-                    builder.AddAttribute(4, "oninput", EventCallback.Factory.Create<ChangeEventArgs>(this, args => {
+                    builder.AddAttribute(4, "oninput", EventCallback.Factory.Create<ChangeEventArgs>(this, args =>
+                    {
                         var value = $"{args.Value}";
                         column.SetFilterValue(!string.IsNullOrWhiteSpace(value) ? Convert.ChangeType(value, Nullable.GetUnderlyingType(type)) : null, isFirst);
                     }));
@@ -800,7 +801,7 @@ namespace Radzen.Blazor
         /// <value>The empty template.</value>
         [Parameter]
         public RenderFragment EmptyTemplate { get; set; }
-#if NET5
+#if NET5_0_OR_GREATER
         /// <summary>
         /// Gets or sets a value indicating whether this instance is virtualized.
         /// </summary>
@@ -988,7 +989,7 @@ namespace Radzen.Blazor
         {
             get
             {
-                if(LoadData.HasDelegate)
+                if (LoadData.HasDelegate)
                 {
                     return base.View;
                 }
@@ -1040,14 +1041,14 @@ namespace Radzen.Blazor
 
         internal bool IsVirtualizationAllowed()
         {
-    #if NET5
+#if NET5_0_OR_GREATER
             return AllowVirtualization;
-    #else
+#else
             return false;
-    #endif
+#endif
         }
 
-        IList<TItem> _value;
+        private IList<TItem> _value;
 
         /// <summary>
         /// Gets or sets the selected item.
@@ -1208,7 +1209,7 @@ namespace Radzen.Blazor
                 allColumns.ToList().ForEach(c => { c.SetFilterValue(null); c.SetFilterValue(null, false); c.SetSecondFilterOperator(FilterOperator.Equals); });
                 allColumns.ToList().ForEach(c => { c.ResetSortOrder(); });
                 sorts.Clear();
-           }
+            }
         }
 
         /// <summary>
@@ -1223,17 +1224,17 @@ namespace Radzen.Blazor
             {
                 Count = 1;
             }
-#if NET5
+#if NET5_0_OR_GREATER
             if (AllowVirtualization)
             {
-                if(!LoadData.HasDelegate)
+                if (!LoadData.HasDelegate)
                 {
-                    if(virtualize != null)
+                    if (virtualize != null)
                     {
                         await virtualize.RefreshDataAsync();
                     }
 
-                    if(groupVirtualize != null)
+                    if (groupVirtualize != null)
                     {
                         await groupVirtualize.RefreshDataAsync();
                     }
@@ -1254,15 +1255,15 @@ namespace Radzen.Blazor
             }
             else
             {
-#if NET5
+#if NET5_0_OR_GREATER
                 if (AllowVirtualization)
                 {
-                    if(virtualize != null)
+                    if (virtualize != null)
                     {
                         await virtualize.RefreshDataAsync();
                     }
 
-                    if(groupVirtualize != null)
+                    if (groupVirtualize != null)
                     {
                         await groupVirtualize.RefreshDataAsync();
                     }
@@ -1632,7 +1633,7 @@ namespace Radzen.Blazor
         /// <param name="item">The item.</param>
         public async System.Threading.Tasks.Task EditRow(TItem item)
         {
-            if(itemToInsert != null)
+            if (itemToInsert != null)
             {
                 CancelEditRow(itemToInsert);
             }
@@ -1703,7 +1704,7 @@ namespace Radzen.Blazor
         {
             if (object.Equals(itemToInsert, item))
             {
-                if(!IsVirtualizationAllowed())
+                if (!IsVirtualizationAllowed())
                 {
                     var list = this.PagedView.ToList();
                     list.Remove(item);
@@ -1714,14 +1715,14 @@ namespace Radzen.Blazor
                 }
                 else
                 {
-#if NET5
+#if NET5_0_OR_GREATER
                     itemToInsert = default(TItem);
-                    if(virtualize != null)
+                    if (virtualize != null)
                     {
                         virtualize.RefreshDataAsync();
                     }
 
-                    if(groupVirtualize != null)
+                    if (groupVirtualize != null)
                     {
                         groupVirtualize.RefreshDataAsync();
                     }
@@ -1761,7 +1762,7 @@ namespace Radzen.Blazor
         public async System.Threading.Tasks.Task InsertRow(TItem item)
         {
             itemToInsert = item;
-            if(!IsVirtualizationAllowed())
+            if (!IsVirtualizationAllowed())
             {
                 var list = this.PagedView.ToList();
                 list.Insert(0, item);
@@ -1770,13 +1771,13 @@ namespace Radzen.Blazor
             }
             else
             {
-#if NET5
-                if(virtualize != null)
+#if NET5_0_OR_GREATER
+                if (virtualize != null)
                 {
                     await virtualize.RefreshDataAsync();
                 }
 
-                if(groupVirtualize != null)
+                if (groupVirtualize != null)
                 {
                     await groupVirtualize.RefreshDataAsync();
                 }
@@ -1791,7 +1792,7 @@ namespace Radzen.Blazor
 
         internal bool IsOData()
         {
-            if(isOData == null && Data != null)
+            if (isOData == null && Data != null)
             {
                 isOData = typeof(ODataEnumerable<TItem>).IsAssignableFrom(Data.GetType());
             }
@@ -1848,8 +1849,8 @@ namespace Radzen.Blazor
         /// Gets or sets the group descriptors.
         /// </summary>
         /// <value>The groups.</value>
-        public List<GroupDescriptor> Groups 
-        { 
+        public List<GroupDescriptor> Groups
+        {
             get
             {
                 return groups;
@@ -1864,16 +1865,16 @@ namespace Radzen.Blazor
 
         internal async Task EndColumnDropToGroup()
         {
-            if(indexOfColumnToReoder != null)
+            if (indexOfColumnToReoder != null)
             {
                 var column = columns.Where(c => c.Visible).ElementAtOrDefault(indexOfColumnToReoder.Value);
 
-                if(column != null && column.Groupable && !string.IsNullOrEmpty(column.GetGroupProperty()))
+                if (column != null && column.Groupable && !string.IsNullOrEmpty(column.GetGroupProperty()))
                 {
                     var descriptor = groups.Where(d => d.Property == column.GetGroupProperty()).FirstOrDefault();
                     if (descriptor == null)
                     {
-                        descriptor = new GroupDescriptor() { Property = column.GetGroupProperty(), Title = column.Title, SortOrder = column.GetSortOrder()  };
+                        descriptor = new GroupDescriptor() { Property = column.GetGroupProperty(), Title = column.Title, SortOrder = column.GetSortOrder() };
                         groups.Add(descriptor);
                         _groupedPagedView = null;
 
@@ -1885,7 +1886,7 @@ namespace Radzen.Blazor
                 }
 
                 indexOfColumnToReoder = null;
-            }  
+            }
         }
 
         /// <summary>
@@ -1975,10 +1976,26 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
+                SafeInvokeJSRuntime(disposeAsync);
+            }
+
+            GC.SuppressFinalize(this);
+
+            Task disposeAsync()
+            {
+                // Fire and forget each column's popup
                 foreach (var column in allColumns.ToList().Where(c => c.Visible))
                 {
-                    JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", $"{PopupID}{column.GetFilterProperty()}");
+                    var valueTask = JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", $"{PopupID}{column.GetFilterProperty()}");
+
+                    // If the JSRuntime is being disposed it will synchronously fault so stop firing
+                    if (valueTask.IsFaulted)
+                    {
+                        return valueTask.AsTask();
+                    }
                 }
+
+                return Task.CompletedTask;
             }
         }
 

--- a/Radzen.Blazor/RadzenDataGridCell.razor
+++ b/Radzen.Blazor/RadzenDataGridCell.razor
@@ -86,7 +86,7 @@ else
     {
         if (Grid != null)
         {
-#if NET5
+#if NET5_0_OR_GREATER
             await Grid.OnCellContextMenu(new DataGridCellMouseEventArgs<TItem>
             {
                 Data = Item,
@@ -133,7 +133,7 @@ else
     {
         if (Grid != null)
         {
-#if NET5
+#if NET5_0_OR_GREATER
             await Grid.OnRowClick(new DataGridRowMouseEventArgs<TItem>
             {
                 Data = Item,
@@ -177,7 +177,7 @@ else
     {
         if (Grid != null)
         {
-#if NET5
+#if NET5_0_OR_GREATER
             await Grid.OnRowDblClick(new DataGridRowMouseEventArgs<TItem>
             {
                 Data = Item,

--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -593,7 +593,7 @@ namespace Radzen.Blazor
                     FilterValue = filterValue;
                     if (Grid.IsVirtualizationAllowed())
                     {
-#if NET5
+#if NET5_0_OR_GREATER
                         if (Grid.virtualize != null)
                         {
                             await Grid.virtualize.RefreshDataAsync();

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -871,8 +871,11 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -135,11 +135,14 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
         }
 
-        internal async System.Threading.Tasks.Task ClosePopup()
+        internal async Task ClosePopup()
         {
             await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID);
         }

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -137,7 +137,7 @@ namespace Radzen.Blazor
         [Parameter]
         public int MaxSelectedLabels { get; set; } = 4;
 
-#if !NET5
+#if !NET5_0_OR_GREATER
         /// <summary>
         /// Gets or sets the page size.
         /// </summary>
@@ -174,7 +174,7 @@ namespace Radzen.Blazor
         {
             if (firstRender)
             {
-    #if NET5
+#if NET5_0_OR_GREATER
                 if (grid != null)
                 {
                     grid.SetAllowVirtualization(AllowVirtualization);
@@ -444,7 +444,7 @@ namespace Radzen.Blazor
 
         async Task RefreshAfterFilter()
         {
-    #if NET5
+#if NET5_0_OR_GREATER
             if (grid?.virtualize != null)
             {
                 if(string.IsNullOrEmpty(searchText))
@@ -520,8 +520,11 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
         }
     }
 }

--- a/Radzen.Blazor/RadzenGoogleMap.razor.cs
+++ b/Radzen.Blazor/RadzenGoogleMap.razor.cs
@@ -159,8 +159,11 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyMap", UniqueID);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyMap", UniqueID);
         }
     }
 }

--- a/Radzen.Blazor/RadzenHtmlEditor.razor.cs
+++ b/Radzen.Blazor/RadzenHtmlEditor.razor.cs
@@ -256,8 +256,11 @@ namespace Radzen.Blazor
 
             if (Visible && IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyEditor", ContentEditable);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyEditor", ContentEditable);
         }
     }
 }

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -273,7 +273,7 @@ namespace Radzen.Blazor
         }
 
 
-#if NET5
+#if NET5_0_OR_GREATER
         /// <summary>
         /// Sets the focus on the input element.
         /// </summary>

--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -504,8 +504,11 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroyScheduler", Element);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroyScheduler", Element);
         }
 
         private bool heightIsSet = false;

--- a/Radzen.Blazor/RadzenSlider.razor.cs
+++ b/Radzen.Blazor/RadzenSlider.razor.cs
@@ -104,8 +104,11 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                JSRuntime.InvokeVoidAsync("Radzen.destroySlider", UniqueID, Element);
+                SafeInvokeJSRuntime(disposeAsync);
             }
+
+            async Task disposeAsync() =>
+                await JSRuntime.InvokeVoidAsync("Radzen.destroySlider", UniqueID, Element);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenTooltip.razor
+++ b/Radzen.Blazor/RadzenTooltip.razor
@@ -13,9 +13,9 @@
                 </div>
             }
             else if (tooltip.Options.ChildContent != null)
-       {
-        @tooltip.Options.ChildContent(Service)
-    }
+            {
+                @tooltip.Options.ChildContent(Service)
+            }
         </div>
     </div>
 }
@@ -74,12 +74,33 @@
     {
         if (IsJSRuntimeAvailable)
         {
-            JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", UniqueID);
+#if NET6_0_OR_GREATER
+          var runtimeTask = disposeAsync();
+
+            Exception ex = runtimeTask?.Exception;
+            if (ex != null)
+            {
+                if (ex is AggregateException)
+                {
+                    ex = ex?.InnerException;
+                }
+                if (ex is JSDisconnectedException)
+                {
+                    IsJSRuntimeAvailable = false;
+                }
+            }
+#else
+            _ = disposeAsync();
+#endif
         }
 
         Service.OnOpen -= OnOpen;
         Service.OnClose -= OnClose;
         Service.OnNavigate -= OnNavigate;
+
+        async Task disposeAsync() =>
+            await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", UniqueID);
+
     }
 
     protected override void OnInitialized()

--- a/Radzen.Blazor/Rendering/Popup.razor
+++ b/Radzen.Blazor/Rendering/Popup.razor
@@ -46,7 +46,10 @@
 
         if (IsJSRuntimeAvailable)
         {
-            JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", GetId());
+            SafeInvokeJSRuntime(disposeAsync);
         }
+
+        async Task disposeAsync() =>
+            await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", GetId());
     }
 }


### PR DESCRIPTION
As described in [#373](https://github.com/radzenhq/radzen-blazor/issues/373), in .Net 6.0, there is a race condition where the `JSRuntime` will become unavailable
before a component's `Dispose` is able to be called (may take upwards of 60 seconds). As a result, Blazor will throw a `JSDisconnectedException` on each subsequent call to `JSRuntime.InvokeVoidAsync`.

The fix is to wrap the calls in `Dispose` to catch `JSDisconnectedException` and set `IsJSRuntimeAvailable` to `false`.
Because `JSRuntime.InvokeVoidAsync` is in fact async, the code must await the result in order to catch exceptions.
This pattern of calling into the runtime in `Dispose` is in many components so a wrapper was created to handle the
common boilerplate code needed to wrap the component specific functionality.

The improvement is most notable in the DataGrid component which calls the runtime once per column, which may trigger 4-5 exceptions being thrown per column! After this fix the first exceptions are caught and further exceptions prevented.

This change in behavior is only observed in .Net 6.0, so as part of this fix a new Target was enabled and the associated changes were made.