### PR TITLE
DatePicker: Added support for DateTime Min and Max.

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -1,7 +1,5 @@
 using Bunit;
-using Radzen.Blazor.Rendering;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -384,6 +382,44 @@ namespace Radzen.Blazor.Tests
             Assert.Null(newValue);
         }
         
+        [Fact]
+        public void DatePicker_Respects_DateTimeMaxValue()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+            
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameters =>
+            {
+                parameters.Add(p => p.Value, DateTime.MaxValue);
+            });
+
+            Assert.Contains(DateTime.MaxValue.ToString(component.Instance.DateFormat), component.Markup);
+
+            var exception = Record.Exception(() => component.Find(".rz-datepicker-next-icon")
+                                                            .Click());
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DatePicker_Respects_DateTimeMinValue()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameters =>
+            {
+                parameters.Add(p => p.Value, DateTime.MinValue);
+            });
+
+            Assert.Contains(DateTime.MinValue.ToString(component.Instance.DateFormat), component.Markup);
+
+            var exception = Record.Exception(() => component.Find(".rz-datepicker-prev-icon")
+                                                            .Click());
+            Assert.Null(exception);
+        }
+
         [Theory]
         [InlineData(DateTimeKind.Local)]
         [InlineData(DateTimeKind.Unspecified)]

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -32,10 +32,10 @@
                     @if (!TimeOnly)
                     {
                         <div class="rz-datepicker-header">
-                            <a href="javascript:void(0)" class="rz-datepicker-prev" @onclick="@(async () => { if (!Disabled) { CurrentDate = CurrentDate.AddMonths(-1); } })">
+                            <a href="javascript:void(0)" class="rz-datepicker-prev" @onclick="@(async () => { if (!Disabled) { try {CurrentDate = CurrentDate.AddMonths(-1);} catch (ArgumentOutOfRangeException) {}} })">
                                 <span class="rz-datepicker-prev-icon rzi rzi-chevron-left"></span>
                             </a>
-                            <a href="javascript:void(0)" class="rz-datepicker-next" @onclick="@(async () => { if (!Disabled) { CurrentDate = CurrentDate.AddMonths(1); } })">
+                            <a href="javascript:void(0)" class="rz-datepicker-next" @onclick="@(async () => { if (!Disabled) { try {CurrentDate = CurrentDate.AddMonths(1);} catch (ArgumentOutOfRangeException) {} } })">
                                 <span class="rz-datepicker-next-icon rzi rzi-chevron-right"></span>
                             </a>
                             <div class="rz-datepicker-title" style="height:40px;">
@@ -68,6 +68,11 @@
                                         <tr>
                                             @for (int j = 0; j < 7; j++)
                                             {
+                                                @if((DateTime.MaxValue - StartDate).TotalDays <= dayNumber)
+                                                {
+                                                    break;
+                                                }
+                                                
                                                 DateTime date = StartDate.AddDays(dayNumber++);
                                                 var dateArgs = DateAttributes(date);
 

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -334,12 +334,6 @@ namespace Radzen.Blazor
                         {
                             DateTimeValue = null;
                         }
-
-                        if (DateTimeValue.HasValue && DateTimeValue.Value == default(DateTime))
-                        {
-                            _value = null;
-                            _dateTimeValue = null;
-                        }
                     }
                 }
             }
@@ -353,7 +347,7 @@ namespace Radzen.Blazor
             {
                 if (_currentDate == default(DateTime))
                 {
-                    _currentDate = HasValue && DateTimeValue.Value != default(DateTime) ? DateTimeValue.Value : DateTime.Today;
+                    _currentDate = HasValue ? DateTimeValue.Value : DateTime.Today;
                 }
                 return _currentDate;
             }


### PR DESCRIPTION
This is a fix for a bug I encountered when using the DatePicker control. 

When the date is a DateTime.MaxValue the control throws a n exception: 

```Error: System.ArgumentOutOfRangeException: The added or subtracted value results in an un-representable DateTime. (Parameter 'value')
   at System.DateTime.ThrowDateArithmetic(Int32 param)
   at System.DateTime.AddTicks(Int64 value)
   at Radzen.Blazor.RadzenDatePicker`1.BuildRenderTree(RenderTreeBuilder __builder)
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, Exception& renderFragmentException)```