### PR TITLE
Datepicker footer placeholder

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -446,5 +446,23 @@ namespace Radzen.Blazor.Tests
             Assert.True(raised);
             Assert.Equal(kind, ((DateTime)newValue).Kind);
         }
+
+        [Fact]
+        public void DatePicker_Renders_FooterTemplate()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            string actionsTemplate = "<input type=\"button\" value=\"Test\" />";
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameters =>
+            {
+                parameters.Add(p => p.Value, DateTime.MinValue);
+                parameters.Add(p => p.FooterTemplate, actionsTemplate);
+            });
+
+            Assert.Contains(actionsTemplate, component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -96,6 +96,9 @@
                                 </tbody>
                             </table>
                         </div>
+                        <div class="rz-datepicker-footer">
+                             @FooterTemplate
+                        </div>
                     }
                 </div>
                 @if (ShowTime)

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -96,9 +96,12 @@
                                 </tbody>
                             </table>
                         </div>
-                        <div class="rz-datepicker-footer">
-                             @FooterTemplate
-                        </div>
+                        @if (FooterTemplate != null)
+                        {
+                            <div class="rz-datepicker-footer">
+                                 @FooterTemplate
+                            </div>
+                        }
                     }
                 </div>
                 @if (ShowTime)

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -703,6 +703,13 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback<TValue> ValueChanged { get; set; }
 
+        /// <summary>
+        /// Gets or sets the footer template.
+        /// </summary>
+        /// <value>The footer template.</value>
+        [Parameter]
+        public RenderFragment FooterTemplate { get; set; }
+
         string contentStyle = "display:none;";
 
         private string getStyle()

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -13,6 +13,8 @@ $datepicker-header-color: $cool-grey !default;
 $datepicker-header-padding: 0 0.875rem !default;
 $datepicker-header-line-height: 2.5rem !default;
 $datepicker-header-border: none !default;
+$datepicker-footer-padding: 0 0.875rem !default;
+$datepicker-footer-line-height: 2.5rem !default;
 
 $datepicker-calendar-padding: 0.5rem 0.875rem !default;
 $datepicker-calendar-header-font-size: 0.6875rem !default;
@@ -244,6 +246,12 @@ $timepicker-border: none !default;
   .rz-state-disabled {
     opacity: 0.5;
   }
+}
+
+.rz-datepicker-footer {
+    position: relative;
+    line-height: $datepicker-footer-line-height;
+    padding: $datepicker-footer-padding;
 }
 
 .rz-timepicker {

--- a/RadzenBlazorDemos/Pages/DatePickerPage.razor
+++ b/RadzenBlazorDemos/Pages/DatePickerPage.razor
@@ -54,6 +54,16 @@
                     <RadzenDatePicker Disabled="true" @bind-Value=@value Class="w-100" />
                 </RadzenCard>
             </div>
+            <div class="col-lg-6 col-xl-4 p-3">
+                <RadzenCard>
+                    <h4 class="mb-4">DatePicker with footer template</h4>
+                    <RadzenDatePicker @bind-Value=@value DateFormat="d" Class="w-100">
+                        <FooterTemplate>
+                            <RadzenButton Click=@OnTodayClick Text="Today" />
+                        </FooterTemplate>
+                    </RadzenDatePicker>
+                </RadzenCard>
+            </div>
         </div>
     </div>
     <div class="col-lg-12 col-xl-4 p-3">
@@ -90,5 +100,10 @@
     void DateRender(DateRenderEventArgs args)
     {
         args.Disabled = dates.Contains(args.Date);
+    }
+
+    void OnTodayClick()
+    {
+        value = DateTime.Now;
     }
 }


### PR DESCRIPTION
This PR adds the ability to optionally add custom functionality to the Radzen datepicker, in an easy and flexible way. For example a today button, as added as a demo.

<img src="https://user-images.githubusercontent.com/42466440/158639685-635f505c-32b1-4f52-84e2-8091ecfc8349.png" width="350">
