### PR TITLE
On Disposal of RadzenSplitButton: Close popup

### DIFF
--- a/Radzen.Blazor/RadzenSplitButton.razor.cs
+++ b/Radzen.Blazor/RadzenSplitButton.razor.cs
@@ -112,5 +112,12 @@ namespace Radzen.Blazor
         {
             return Disabled ? "rz-splitbutton rz-buttonset rz-state-disabled" : "rz-splitbutton rz-buttonset";
         }
+
+        /// <inheritdoc />
+        public override void Dispose()
+        {
+            Close();
+            base.Dispose();
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a little bug in the RadzenSplitButton component.

If the RadzenSplitButton component is removed from the page (from server side) while the user still has the dropdown list/'popup' of it open, then the list is not removed. Instead, the component is gone but the popup is still on the page. In some cases the user wasn't able to remove the list by just clicking around.

https://user-images.githubusercontent.com/66772435/159877576-d41a76f5-b58b-4167-9be9-36c238f9e548.mp4

Demo: https://github.com/mrossberg/RadzenDropdownTest

I didn't check if other components with popup have the same bug
