### PR TITLE
Dropdown reinitialization fix (Resolves #419)

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -56,7 +56,7 @@ namespace Radzen.Blazor
             builder.OpenComponent(0, typeof(RadzenDropDownItem<TValue>));
             builder.AddAttribute(1, "DropDown", this);
             builder.AddAttribute(2, "Item", item);
-            builder.SetKey(item);
+            builder.SetKey(PropertyAccess.GetItemOrValueFromProperty(item, ValueProperty));
             builder.CloseComponent();
         }
 

--- a/Radzen.Blazor/RadzenListBox.razor.cs
+++ b/Radzen.Blazor/RadzenListBox.razor.cs
@@ -21,7 +21,7 @@ namespace Radzen.Blazor
             builder.OpenComponent(0, typeof(RadzenListBoxItem<TValue>));
             builder.AddAttribute(1, "ListBox", this);
             builder.AddAttribute(2, "Item", item);
-            builder.SetKey(item);
+            builder.SetKey(PropertyAccess.GetItemOrValueFromProperty(item, ValueProperty));
             builder.CloseComponent();
         }
 


### PR DESCRIPTION
This pull request addresses issue #419 In both the RadzenDropdown and RadzenListBox components, the children are remounted everytime the selection changes. The cause of this was the Key set on the children component. I made changes so that the key can be a primitive value, particularly the ```ValueProperty```.