### PR TITLE
Fixing error when YearRange is set but from calledar arrow <, > was a…

### DIFF
--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -32,10 +32,10 @@
                     @if (!TimeOnly)
                     {
                         <div class="rz-datepicker-header">
-                            <a href="javascript:void(0)" class="rz-datepicker-prev" @onclick="@(async () => { if (!Disabled) { try {CurrentDate = CurrentDate.AddMonths(-1);} catch (ArgumentOutOfRangeException) {}} })">
+                            <a href="javascript:void(0)" class="rz-datepicker-prev" @onclick="@(async () => { if (!Disabled) { try { if(CurrentDate.AddMonths(-1).Year >= YearFrom) {CurrentDate = CurrentDate.AddMonths(-1);}} catch (ArgumentOutOfRangeException) {}} })">
                                 <span class="rz-datepicker-prev-icon rzi rzi-chevron-left"></span>
                             </a>
-                            <a href="javascript:void(0)" class="rz-datepicker-next" @onclick="@(async () => { if (!Disabled) { try {CurrentDate = CurrentDate.AddMonths(1);} catch (ArgumentOutOfRangeException) {} } })">
+                            <a href="javascript:void(0)" class="rz-datepicker-next" @onclick="@(async () => { if (!Disabled) { try { if(CurrentDate.AddMonths(1).Year <= YearTo) {CurrentDate = CurrentDate.AddMonths(1);}} catch (ArgumentOutOfRangeException) {} } })">
                                 <span class="rz-datepicker-next-icon rzi rzi-chevron-right"></span>
                             </a>
                             <div class="rz-datepicker-title">

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -209,13 +209,19 @@ namespace Radzen.Blazor
         IList<NameValue> months;
         IList<NameValue> years;
 
+        int YearFrom { get; set; }
+        int YearTo { get; set; }
+
         /// <inheritdoc />
         protected override void OnInitialized()
         {
             base.OnInitialized();
 
+            YearFrom = int.Parse(YearRange.Split(':').First());
+            YearTo = int.Parse(YearRange.Split(':').Last());
+
             months = Enumerable.Range(1, 12).Select(i => new NameValue() { Name = Culture.DateTimeFormat.GetMonthName(i), Value = i }).ToList();
-            years = Enumerable.Range(int.Parse(YearRange.Split(':').First()), int.Parse(YearRange.Split(':').Last()) - int.Parse(YearRange.Split(':').First()) + 1)
+            years = Enumerable.Range(YearFrom, YearTo - YearFrom + 1)
                 .Select(i => new NameValue() { Name = $"{i}", Value = i }).ToList();
         }
 
@@ -345,7 +351,7 @@ namespace Radzen.Blazor
                 }
                 return _currentDate;
             }
-            set 
+            set
             {
                 _currentDate = value;
                 CurrentDateChanged.InvokeAsync(value);
@@ -362,7 +368,8 @@ namespace Radzen.Blazor
         {
             get
             {
-                if (CurrentDate == DateTime.MinValue) {
+                if (CurrentDate == DateTime.MinValue)
+                {
                     return DateTime.MinValue;
                 }
 
@@ -672,7 +679,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The year range.</value>
         [Parameter]
-        public string YearRange { get; set; } = "1950:2050";
+        public string YearRange { get; set; } = $"1950:{DateTime.Now.AddYears(30).Year}";
 
         /// <summary>
         /// Gets or sets the hour format.
@@ -773,7 +780,7 @@ namespace Radzen.Blazor
         {
             if (ShowTimeOkButton)
             {
-                CurrentDate = new DateTime(newValue.Year, newValue.Month,newValue.Day, CurrentDate.Hour, CurrentDate.Minute, CurrentDate.Second);
+                CurrentDate = new DateTime(newValue.Year, newValue.Month, newValue.Day, CurrentDate.Hour, CurrentDate.Minute, CurrentDate.Second);
                 await OkClick();
             }
             else


### PR DESCRIPTION
This change is to fix the bug when you have YearRange set like 2020:2021  if in the calendar you have 01/01/2020 and press the arrow  [ <  ] it would allow you move to 2019