### PR TITLE
DataGrid Filtering on Enum and Nullable Enum

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -1479,6 +1479,11 @@ namespace Radzen
                 return Guid.Parse((string)value);
             }
 
+            if (Nullable.GetUnderlyingType(type).IsEnum)
+            {
+                return Enum.Parse(Nullable.GetUnderlyingType(type), value.ToString());
+            }
+            
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
                 Type itemType = type.GetGenericArguments()[0];
@@ -1698,6 +1703,30 @@ namespace Radzen
                 default:
                     return false;
             }
+        }
+
+        /// <summary>
+        /// Determines whether the specified type is an enum.
+        /// </summary>
+        /// <param name="source">The type.</param>
+        /// <returns><c>true</c> if the specified source is an enum; otherwise, <c>false</c>.</returns>
+        public static bool IsEnum(Type source)
+        {
+            if (source == null)
+                return false;
+
+            return source.IsEnum;
+        }
+
+        /// <summary> 
+        /// Determines whether the specified type is a Nullable enum. 
+        /// </summary> 
+        /// <param name="source">The type.</param> 
+        /// <returns><c>true</c> if the specified source is an enum; otherwise, <c>false</c>.</returns> 
+        public static bool IsNullableEnum(Type source)
+        {
+            Type u = Nullable.GetUnderlyingType(source);
+            return (u != null) && u.IsEnum;
         }
 
         /// <summary>

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -168,6 +168,17 @@ namespace Radzen
                             secondValue = sv is DateTime ? ((DateTime)sv).ToString("yyyy-MM-ddTHH:mm:ss.fffZ") : sv is DateTimeOffset ? ((DateTimeOffset)sv).UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") : "";
                         }
                     }
+                    else if (PropertyAccess.IsEnum(column.FilterPropertyType) || PropertyAccess.IsNullableEnum(column.FilterPropertyType))
+                    {
+                        if (v != null)
+                        {
+                            value = ((int)v).ToString();
+                        }
+                        if (sv != null)
+                        {
+                            secondValue = ((int)sv).ToString();
+                        }
+                    }
                     else if (typeof(IEnumerable).IsAssignableFrom(column.FilterPropertyType) && column.FilterPropertyType != typeof(string))
                     {
                         var enumerableValue = ((IEnumerable)(v != null ? v : Enumerable.Empty<object>())).AsQueryable();

--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -765,6 +765,12 @@ namespace Radzen.Blazor
 
         internal IEnumerable<FilterOperator> GetFilterOperators()
         {
+            if (PropertyAccess.IsEnum(FilterPropertyType))
+                return new FilterOperator[] { FilterOperator.Equals, FilterOperator.NotEquals };
+            
+            if (PropertyAccess.IsNullableEnum(FilterPropertyType))
+                return new FilterOperator[] { FilterOperator.Equals, FilterOperator.NotEquals, FilterOperator.IsNull, FilterOperator.IsNotNull };
+
             return Enum.GetValues(typeof(FilterOperator)).Cast<FilterOperator>().Where(o => {
                 var isStringOperator = o == FilterOperator.Contains ||  o == FilterOperator.DoesNotContain || o == FilterOperator.StartsWith || o == FilterOperator.EndsWith;
                 return FilterPropertyType == typeof(string) ? isStringOperator 

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -1,4 +1,4 @@
-@typeparam TItem
+﻿@typeparam TItem
 @if (RowIndex == Column.GetLevel())
 {
 <th rowspan="@(Column.GetRowSpan())" colspan="@(Column.GetColSpan())" @attributes="@Attributes" class="@CssClass" scope="col" style="@Column.GetStyle(true, true)" @onmouseup=@(args => Grid.EndColumnReorder(args, ColumnIndex)) >
@@ -64,7 +64,13 @@
                             {
                                 <RadzenLabel Text="@Grid.FilterText" class="rz-grid-filter-label" />
                                 <RadzenDropDown @onclick:preventDefault="true" Data="@(Column.GetFilterOperators().Select(t => new { Value = Column.GetFilterOperatorText(t), Key = t }))" TextProperty="Value" ValueProperty="Key" TValue="FilterOperator" Value="@Column.GetFilterOperator()" Change="@(args => Column.SetFilterOperator((FilterOperator)args))" />
-                                @if (PropertyAccess.IsNumeric(Column.FilterPropertyType))
+                                @if (PropertyAccess.IsNullableEnum(Column.FilterPropertyType) || PropertyAccess.IsEnum(Column.FilterPropertyType))
+                                {
+                                    <RadzenDropDown AllowClear="false" AllowFiltering="false" TValue="@object"
+                                                    Value=@Column.GetFilterValue() Multiple="false" Placeholder="Select..." Data=@Enum.GetValues(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType)
+                                                    Change="@(args => Column.SetFilterValue(args))" />
+                                }
+                                else if (PropertyAccess.IsNumeric(Column.FilterPropertyType))
                                 {
                                     @(Grid.DrawNumericFilter(Column, false))
                                 }
@@ -87,7 +93,13 @@
                                         Data="@(Enum.GetValues(typeof(LogicalFilterOperator)).Cast<LogicalFilterOperator>().Select(t => new { Text = t == LogicalFilterOperator.And ? Grid.AndOperatorText : Grid.OrOperatorText, Value = t }))" TValue="LogicalFilterOperator" Value="@Column.LogicalFilterOperator" Change="@(args => Column.SetLogicalFilterOperator((LogicalFilterOperator)args))" />
 
                                 <RadzenDropDown @onclick:preventDefault="true" Data="@(Column.GetFilterOperators().Select(t => new { Value = Column.GetFilterOperatorText(t), Key = t }))" TextProperty="Value" ValueProperty="Key" TValue="FilterOperator" Value="@Column.GetSecondFilterOperator()" Change="@(args => Column.SetSecondFilterOperator((FilterOperator)args))" />
-                                @if (PropertyAccess.IsNumeric(Column.FilterPropertyType))
+                                @if (PropertyAccess.IsNullableEnum(Column.FilterPropertyType) || PropertyAccess.IsEnum(Column.FilterPropertyType))
+                                {
+                                    <RadzenDropDown AllowClear="false" AllowFiltering="false" TValue="@object"
+                                                    Value=@Column.GetSecondFilterValue() Multiple="false" Placeholder="Select..." Data=@Enum.GetValues(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType)
+                                                    Change="@(args => Column.SetFilterValue(args,false))" />
+                                }
+                                else if (PropertyAccess.IsNumeric(Column.FilterPropertyType))
                                 {
                                     @(Grid.DrawNumericFilter(Column, false, false))
                                 }

--- a/RadzenBlazorDemos/Pages/DataGridColumnEnumFilterPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnEnumFilterPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/datagrid-enum-filter"
 @using System.Linq.Dynamic.Core
 
-<h1>DataGrid Enum Column FilterTemplate</h1>
+<h1>DataGrid Enum Column Filter</h1>
 
 <p>This page demonstrates how to use enums in the DataGrid column filter.</p>
 

--- a/RadzenBlazorDemos/Pages/DataGridColumnEnumFilterPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnEnumFilterPage.razor
@@ -1,0 +1,77 @@
+﻿@page "/datagrid-enum-filter"
+@using System.Linq.Dynamic.Core
+
+<h1>DataGrid Enum Column FilterTemplate</h1>
+
+<p>This page demonstrates how to use enums in the DataGrid column filter.</p>
+
+<RadzenExample Name="DataGrid" Source="DataGridColumnEnumFilter" Heading="false">
+        <h3>Custom filtering template with IQueryable binding</h3>
+        <RadzenDataGrid LoadData="LoadData" IsLoading=@isLoading Count="count" Data=@employees FilterMode="FilterMode.Advanced" AllowFiltering="true" AllowPaging="true" AllowSorting="true" TItem="Employee" ColumnWidth="200px">
+            <Columns>
+                <RadzenDataGridColumn TItem="Employee" Property="ID" Title="ID" />
+                <RadzenDataGridColumn TItem="Employee" Property="Gender" Title="Gender" />
+                <RadzenDataGridColumn TItem="Employee" Property="Status" Title="Nullable Status" />
+            </Columns>
+        </RadzenDataGrid>
+</RadzenExample>
+
+@code {
+    int count;
+    IEnumerable<Employee> initialEmployees;
+    IEnumerable<Employee> employees;
+    bool isLoading = false;
+
+    public class Employee
+    {
+        public int ID { get; set; }
+        public GenderType Gender { get; set; }
+        public StatusType? Status { get; set; }
+    }
+
+    public enum GenderType
+    {
+        Ms,
+        Mr,
+        Unknown,
+    }
+
+    public enum StatusType
+    {
+        Inactive,
+        Active,
+    }
+
+    protected override void OnInitialized()
+    {
+        initialEmployees = Enumerable.Range(0, 10).Select(i =>
+            new Employee
+            {
+                ID = i,
+                Gender = i < 3 ? GenderType.Mr : i < 6 ? GenderType.Ms : GenderType.Unknown,
+                Status = i < 3 ? StatusType.Active: i < 6 ? StatusType.Inactive : null
+            });
+    }
+
+    void LoadData(LoadDataArgs args)
+    {
+        isLoading = true;
+        var query = initialEmployees.AsQueryable();
+
+        if (!string.IsNullOrEmpty(args.Filter))
+        {
+            query = query.Where(args.Filter);
+        }
+
+        if (!string.IsNullOrEmpty(args.OrderBy))
+        {
+            query = query.OrderBy(args.OrderBy);
+        }
+
+        count = query.Count();
+
+        employees = query.Skip(args.Skip.Value).Take(args.Top.Value).ToList();
+        isLoading = false;
+
+    }
+}


### PR DESCRIPTION
Fixes #434 

Which allows for filtering in columns based on an enum and nullable enum.
> In the video, do not look at the icons, I had some issues having them, it should look normal for you.

https://user-images.githubusercontent.com/10981553/164746943-e7fb2d6b-820b-4b1f-8fec-c1b4b52a52ec.mov

Some stuff that is currently not supported:
- Displaytext of the enum for example when using localisation or humanized names.
- Multi select

API:
```cs
<RadzenDataGridColumn TItem="Employee" Property="Gender" Title="Gender" />
<RadzenDataGridColumn TItem="Employee" Property="Status" Title="Nullable Status" />
```
