### PR TITLE
Add Display Attribute and localization for Enum Filter

### DIFF
--- a/Radzen.Blazor/Extensions.cs
+++ b/Radzen.Blazor/Extensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+
+namespace Radzen.Blazor
+{
+    public static class EnumExtensions
+    {
+        public static string GetDisplayDescription(this Enum enumValue)
+        {
+            var val = enumValue.GetType().GetMember(enumValue.ToString()).FirstOrDefault();
+
+            if (val is null)
+                return enumValue.ToString();
+
+            var attribute = val?.GetCustomAttribute<DisplayAttribute>();
+            if (attribute != null)
+                return attribute?.Description;
+
+            return enumValue.ToString();
+        }
+
+        public static IEnumerable<object> EnumAsKeyValuePair(Type enumType)
+        {
+            var values = Enum.GetValues(enumType);
+            var items = new List<object>(values.Length);
+
+            foreach (Enum val in values)
+            {
+                items.Add(new { Value = val, Text = val.GetDisplayDescription() });
+            }
+
+            return items;
+        }
+
+    }
+}
+

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -224,7 +224,7 @@
                                                     {
                                                         <RadzenDropDown Style="width:100%" AllowClear="true" AllowFiltering="false" TValue="@object"
                                                                         Value=@column.GetFilterValue() Multiple="false" Placeholder="@EnumFilterSelectText" 
-                                                                        Data=@Enum.GetValues(Nullable.GetUnderlyingType(column.FilterPropertyType) ?? column.FilterPropertyType)
+                                                                        Data=@EnumExtensions.EnumAsKeyValuePair(Nullable.GetUnderlyingType(column.FilterPropertyType) ?? column.FilterPropertyType)
                                                                         Change="@(args => {column.SetFilterValue(args);ApplyFilter(column, true);})" />
                                                     }
                                                     else if (PropertyAccess.IsNumeric(column.FilterPropertyType))

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -67,7 +67,7 @@
                                 @if (PropertyAccess.IsNullableEnum(Column.FilterPropertyType) || PropertyAccess.IsEnum(Column.FilterPropertyType))
                                 {
                                     <RadzenDropDown AllowClear="false" AllowFiltering="false" TValue="@object"
-                                                    Value=@Column.GetFilterValue() Multiple="false" Placeholder="Select..." Data=@Enum.GetValues(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType)
+                                                    Value=@Column.GetFilterValue() Multiple="false" Placeholder="@Grid.EnumFilterSelectText" TextProperty="Text" ValueProperty="Value" Data=@EnumExtensions.EnumAsKeyValuePair(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType)
                                                     Change="@(args => Column.SetFilterValue(args))" />
                                 }
                                 else if (PropertyAccess.IsNumeric(Column.FilterPropertyType))
@@ -96,7 +96,7 @@
                                 @if (PropertyAccess.IsNullableEnum(Column.FilterPropertyType) || PropertyAccess.IsEnum(Column.FilterPropertyType))
                                 {
                                     <RadzenDropDown AllowClear="false" AllowFiltering="false" TValue="@object"
-                                                    Value=@Column.GetSecondFilterValue() Multiple="false" Placeholder="@Grid.EnumFilterSelectText" Data=@Enum.GetValues(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType)
+                                                    Value=@Column.GetSecondFilterValue() Multiple="false" Placeholder="@Grid.EnumFilterSelectText" TextProperty="Text" ValueProperty="Value" Data=@EnumExtensions.EnumAsKeyValuePair(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType)
                                                     Change="@(args => Column.SetFilterValue(args,false))" />
                                 }
                                 else if (PropertyAccess.IsNumeric(Column.FilterPropertyType))

--- a/RadzenBlazorDemos/Pages/DataGridColumnEnumFilterPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnEnumFilterPage.razor
@@ -1,19 +1,20 @@
 ﻿@page "/datagrid-enum-filter"
 @using System.Linq.Dynamic.Core
-
+@using System.ComponentModel.DataAnnotations
 <h1>DataGrid Enum Column Filter</h1>
 
 <p>This page demonstrates how to use enums in the DataGrid column filter.</p>
 
 <RadzenExample Name="DataGrid" Source="DataGridColumnEnumFilter" Heading="false">
-        <h3>Advanced Filter Mode of enums</h3>
-        <RadzenDataGrid LoadData="LoadData" IsLoading=@isLoading Count="count" Data=@employees FilterMode="FilterMode.Advanced" AllowFiltering="true" AllowPaging="true" AllowSorting="true" TItem="Employee" ColumnWidth="200px">
-            <Columns>
-                <RadzenDataGridColumn TItem="Employee" Property="ID" Title="ID" />
-                <RadzenDataGridColumn TItem="Employee" Property="Gender" Title="Gender" />
-                <RadzenDataGridColumn TItem="Employee" Property="Status" Title="Nullable Status" />
-            </Columns>
-        </RadzenDataGrid>
+    <h3>Advanced Filter Mode of enums</h3>
+    <RadzenDataGrid LoadData="LoadData" IsLoading=@isLoading Count="count" Data=@employees FilterMode="FilterMode.Advanced" AllowFiltering="true" AllowPaging="true" AllowSorting="true" TItem="Employee" ColumnWidth="200px">
+        <Columns>
+            <RadzenDataGridColumn TItem="Employee" Property="ID" Title="ID" />
+            <RadzenDataGridColumn TItem="Employee" Property="Gender" Title="Gender" />
+            <RadzenDataGridColumn TItem="Employee" Property="Status" Title="Nullable Status" />
+            <RadzenDataGridColumn TItem="Employee" Property="Color" Title="Favorite Color (Display Attribute in Filter)" />
+        </Columns>
+    </RadzenDataGrid>
 </RadzenExample>
 
 @code {
@@ -27,6 +28,7 @@
         public int ID { get; set; }
         public GenderType Gender { get; set; }
         public StatusType? Status { get; set; }
+        public ColorType Color { get; set; }
     }
 
     public enum GenderType
@@ -34,6 +36,23 @@
         Ms,
         Mr,
         Unknown,
+    }
+
+    public enum ColorType
+    {
+        Red,
+        Green,
+        Blue,
+        [Display(Description = "Almond Green")]
+        AlmondGreen,
+        [Display(Description = "Amber Gray")]
+        AmberGray,
+        [Display(Description = "Apple Blue... ")]
+        AppleBlueSeaGreen,
+        //[Display(Description = "Miss", ResourceType = typeof(ResourceFile)] localization example
+        [Display(Description = "Azure")]
+        AzureBlue,
+
     }
 
     public enum StatusType
@@ -49,7 +68,8 @@
             {
                 ID = i,
                 Gender = i < 3 ? GenderType.Mr : i < 6 ? GenderType.Ms : GenderType.Unknown,
-                Status = i < 3 ? StatusType.Active: i < 6 ? StatusType.Inactive : null
+                Status = i < 3 ? StatusType.Active : i < 6 ? StatusType.Inactive : null,
+                Color = i < 2 ? ColorType.Red: i < 4 ? ColorType.AlmondGreen : i < 6 ? ColorType.AppleBlueSeaGreen : ColorType.AzureBlue,
             });
     }
 


### PR DESCRIPTION
Continues on PR #435 
We can now use the built-in Display attribute to manipulate the Enum Description. For example:
```cs
public enum ColorType
{
        Red,
        Green,
        Blue,
        [Display(Description = "Almond Green")]
        AlmondGreen,
        [Display(Description = "Amber Gray")]
        AmberGray,
        [Display(Description = "Apple Blue... ")]
        AppleBlueSeaGreen,
        //[Display(Description = "Miss", ResourceType = typeof(ResourceFile)] localization example
        [Display(Description = "Azure")]
        AzureBlue,
}
```

This PR does not introduce breaking changes, it's an opt-in to localise the enum values in the filter or give a nicer description while keeping the API simple. 

```razor
<RadzenDataGridColumn TItem="Employee" Property="Color" Title="Favorite Color (Display Attribute in Filter)" />
```
<img width="1637" alt="Screenshot 2022-05-11 at 15 11 35" src="https://user-images.githubusercontent.com/10981553/167858143-4fc016bc-6582-47d2-8e36-6872c93e0237.png">
