### PR TITLE
Make TagName of HeadlineTitle configurable

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -192,7 +192,6 @@ namespace Radzen
                 Bottom = options != null && !string.IsNullOrEmpty(options.Bottom) ? options.Bottom : "",
                 Height = options != null && !string.IsNullOrEmpty(options.Height) ? options.Height : "",
                 ShowTitle = options != null ? options.ShowTitle : true,
-                TitleTagName = options != null && !string.IsNullOrEmpty(options.TitleTagName) ? options.TitleTagName : "span",
                 ShowClose = options != null ? options.ShowClose : true,
                 Resizable = options != null ? options.Resizable : false,
                 Draggable = options != null ? options.Draggable : false,
@@ -312,12 +311,6 @@ namespace Radzen
         public bool ShowTitle { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the name of the title tag.
-        /// </summary>
-        /// <value>The name of the title tag.</value>
-        public string TitleTagName { get; set; } = "span";
-
-        /// <summary>
         /// Gets or sets a value indicating whether to show the close button. Set to <c>true</c> by default.
         /// </summary>
         /// <value><c>true</c> if the close button is shown; otherwise, <c>false</c>.</value>
@@ -333,7 +326,6 @@ namespace Radzen
         /// </summary>
         /// <value><c>true</c> if draggable; otherwise, <c>false</c>.</value>
         public bool Draggable { get; set; } = false;
-
         /// <summary>
         /// Gets or sets the X coordinate of the dialog. Maps to the <c>left</c> CSS attribute.
         /// </summary>

--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -192,6 +192,7 @@ namespace Radzen
                 Bottom = options != null && !string.IsNullOrEmpty(options.Bottom) ? options.Bottom : "",
                 Height = options != null && !string.IsNullOrEmpty(options.Height) ? options.Height : "",
                 ShowTitle = options != null ? options.ShowTitle : true,
+                TitleTagName = options != null && !string.IsNullOrEmpty(options.TitleTagName) ? options.TitleTagName : "span",
                 ShowClose = options != null ? options.ShowClose : true,
                 Resizable = options != null ? options.Resizable : false,
                 Draggable = options != null ? options.Draggable : false,
@@ -311,6 +312,12 @@ namespace Radzen
         public bool ShowTitle { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the name of the title tag.
+        /// </summary>
+        /// <value>The name of the title tag.</value>
+        public string TitleTagName { get; set; } = "span";
+
+        /// <summary>
         /// Gets or sets a value indicating whether to show the close button. Set to <c>true</c> by default.
         /// </summary>
         /// <value><c>true</c> if the close button is shown; otherwise, <c>false</c>.</value>
@@ -326,6 +333,7 @@ namespace Radzen
         /// </summary>
         /// <value><c>true</c> if draggable; otherwise, <c>false</c>.</value>
         public bool Draggable { get; set; } = false;
+
         /// <summary>
         /// Gets or sets the X coordinate of the dialog. Maps to the <c>left</c> CSS attribute.
         /// </summary>

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -10,7 +10,7 @@
             {
                 <Draggable Drag="@OnDrag" DragStart="@OnDragStart">
                     <div class="rz-dialog-titlebar">
-                        <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
+                        <div class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
                         @if (Dialog.Options.ShowClose)
                         {
                             <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">
@@ -23,7 +23,7 @@
             else
             {
                 <div class="rz-dialog-titlebar">
-                    <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
+                    <div class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
                     @if (Dialog.Options.ShowClose)
                     {
                         <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -10,7 +10,7 @@
             {
                 <Draggable Drag="@OnDrag" DragStart="@OnDragStart">
                     <div class="rz-dialog-titlebar">
-                        <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
+                        @((MarkupString)$"<{Dialog.Options.TitleTagName} class=\"rz-dialog-title\" id=\"rz-dialog-0-label\">{Dialog.Title}</{Dialog.Options.TitleTagName}>")
                         @if (Dialog.Options.ShowClose)
                         {
                             <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">
@@ -23,7 +23,7 @@
             else
             {
                 <div class="rz-dialog-titlebar">
-                    <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
+                    @((MarkupString)$"<{Dialog.Options.TitleTagName} class=\"rz-dialog-title\" id=\"rz-dialog-0-label\">{Dialog.Title}</{Dialog.Options.TitleTagName}>")
                     @if (Dialog.Options.ShowClose)
                     {
                         <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -10,7 +10,7 @@
             {
                 <Draggable Drag="@OnDrag" DragStart="@OnDragStart">
                     <div class="rz-dialog-titlebar">
-                        @((MarkupString)$"<{Dialog.Options.TitleTagName} class=\"rz-dialog-title\" id=\"rz-dialog-0-label\">{Dialog.Title}</{Dialog.Options.TitleTagName}>")
+                        <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
                         @if (Dialog.Options.ShowClose)
                         {
                             <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">
@@ -23,7 +23,7 @@
             else
             {
                 <div class="rz-dialog-titlebar">
-                    @((MarkupString)$"<{Dialog.Options.TitleTagName} class=\"rz-dialog-title\" id=\"rz-dialog-0-label\">{Dialog.Title}</{Dialog.Options.TitleTagName}>")
+                    <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
                     @if (Dialog.Options.ShowClose)
                     {
                         <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">


### PR DESCRIPTION
To improve the accessibility it is necessary to mark the heading of a modal window with a <h...> tag.
#477 