### PR TITLE
Fix right edge cropping of the filter button in simple filter mode on DataGrid

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_grid.scss
+++ b/Radzen.Blazor/themes/components/blazor/_grid.scss
@@ -876,5 +876,4 @@ $column-drag-handle-hover-color: $column-drag-handle-color !default;
 
 .rz-filter-button {
     margin-right: 10px;
-    width: 3.5rem;
 }


### PR DESCRIPTION
Not sure why it was there, maybe there were no non-fixed width elements there before.
Before:
![image](https://user-images.githubusercontent.com/20819706/173207916-362405ab-a92e-4b75-940b-ff480484fa45.png)
After:
![image](https://user-images.githubusercontent.com/20819706/173207918-848be008-8b28-4183-87c3-208e271cdbc6.png)
