### PR TITLE
Call Chart.SeriesClick when legend is clicked

### DIFF
--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -3,6 +3,7 @@ using Radzen.Blazor.Rendering;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Radzen.Blazor
 {
@@ -116,13 +117,38 @@ namespace Radzen.Blazor
                     builder.AddAttribute(3, nameof(LegendItem.MarkerSize), MarkerSize);
                     builder.AddAttribute(4, nameof(LegendItem.MarkerType), MarkerType);
                     builder.AddAttribute(5, nameof(LegendItem.Color), PickColor(Items.IndexOf(data), Fills));
+                    builder.AddAttribute(6, nameof(LegendItem.Click), EventCallback.Factory.Create(this, () => OnLegendClick(data)));
+
                     builder.CloseComponent();
                 };
             };
         }
 
-        /// <inheritdoc />
-        public override bool Contains(double x, double y, double tolerance)
+      private async Task OnLegendClick(object data)
+      {
+        if(Chart.SeriesClick.HasDelegate)
+        {
+          var category = Category(Chart.CategoryScale);
+
+          var args = new SeriesClickEventArgs
+          {
+            Data = data,
+            Title = GetTitle(),
+            Category = PropertyAccess.GetValue(data, CategoryProperty),
+            Value = PropertyAccess.GetValue(data, ValueProperty),
+            Point = new SeriesPoint
+            {
+              Category = category((TItem)data),
+              Value = Value((TItem)data)
+            }
+          };
+
+          await Chart.SeriesClick.InvokeAsync(args);
+        }
+      }
+
+      /// <inheritdoc />
+      public override bool Contains(double x, double y, double tolerance)
         {
             if (Items.Any())
             {


### PR DESCRIPTION
Overrides the following Pull Request made in error
[https://github.com/radzenhq/radzen-blazor/pull/487#issuecomment-1153591621](https://github.com/radzenhq/radzen-blazor/pull/487#issuecomment-1153591621)

If a pie or donut chart is created and the variance between data items is large, i.e. Series1: 600, Series2: 1, Series2 becomes difficult/impossible to 'SeriesClick'. Therefore, saw a requirement to enable that same click through the legend.

Moved Event to Chart rather than Series as advised. But the new Event could be cumbersome as it doesn't apply to all charts. There's already an action for LegendItemClick on some charts. So just made the call to SeriesClick instead.

