### PR TITLE
Placeholders for htmleditorcomponents

### DIFF
--- a/Radzen.Blazor/RadzenHtmlEditorFontName.razor
+++ b/Radzen.Blazor/RadzenHtmlEditorFontName.razor
@@ -1,6 +1,6 @@
 @using Radzen.Blazor.Rendering
 
-<EditorDropDown Title=@Title Value=@Editor.State.FontName Change=@OnChange Placeholder="Font"
+<EditorDropDown Title=@Title Value=@Editor.State.FontName Change=@OnChange Placeholder="@Placeholder"
     PopupStyle="width: 200px; max-height: 200px; overflow: auto;">
     <CascadingValue Value=@this>
         @if (ChildContent != null)

--- a/Radzen.Blazor/RadzenHtmlEditorFontName.razor.cs
+++ b/Radzen.Blazor/RadzenHtmlEditorFontName.razor.cs
@@ -36,6 +36,12 @@ namespace Radzen.Blazor
         public RenderFragment ChildContent { get; set; }
 
         /// <summary>
+        /// Specifies the placeholder displayed to the user. Set to <c>"Font"</c> by default.
+        /// </summary>
+        [Parameter]
+        public string Placeholder { get; set; } = "Font";
+
+        /// <summary>
         /// Specifies the title (tooltip) displayed when the user hovers the tool. Set to <c>"Font name"</c> by default.
         /// </summary>
         [Parameter]

--- a/Radzen.Blazor/RadzenHtmlEditorFontSize.razor
+++ b/Radzen.Blazor/RadzenHtmlEditorFontSize.razor
@@ -1,6 +1,6 @@
 @using Radzen.Blazor.Rendering
 
-<EditorDropDown Title=@Title Value=@Editor.State.FontSize Change=@OnChange Placeholder="Font size">
+<EditorDropDown Title=@Title Value=@Editor.State.FontSize Change=@OnChange Placeholder="@Placeholder">
     <EditorDropDownItem Text="10px" Value="1" style="font-size: x-small" />
     <EditorDropDownItem Text="13px" Value="2" style="font-size: small" />
     <EditorDropDownItem Text="16px" Value="3" style="font-size: medium" />

--- a/Radzen.Blazor/RadzenHtmlEditorFontSize.razor.cs
+++ b/Radzen.Blazor/RadzenHtmlEditorFontSize.razor.cs
@@ -25,6 +25,12 @@ namespace Radzen.Blazor
         public RadzenHtmlEditor Editor { get; set; }
 
         /// <summary>
+        /// Specifies the placeholder displayed to the user. Set to <c>"Font size"</c> by default.
+        /// </summary>
+        [Parameter]
+        public string Placeholder { get; set; } = "Font size";
+
+        /// <summary>
         /// Specifies the title (tooltip) displayed when the user hovers the tool. Set to <c>"Font size"</c> by default.
         /// </summary>
         [Parameter]

--- a/Radzen.Blazor/RadzenHtmlEditorFormatBlock.razor
+++ b/Radzen.Blazor/RadzenHtmlEditorFormatBlock.razor
@@ -1,6 +1,6 @@
 @using Radzen.Blazor.Rendering
 
-<EditorDropDown Title=@Title Value=@Editor.State.FormatBlock Change=@OnChange Placeholder="Format block"
+<EditorDropDown Title=@Title Value=@Editor.State.FormatBlock Change=@OnChange Placeholder="@Placeholder"
     PopupStyle="width: 200px; max-height: 200px; overflow: auto;">
     <EditorDropDownItem Text="Normal" Value="p">
         <p style="margin:0">@context.Text</p>

--- a/Radzen.Blazor/RadzenHtmlEditorFormatBlock.razor.cs
+++ b/Radzen.Blazor/RadzenHtmlEditorFormatBlock.razor.cs
@@ -25,6 +25,12 @@ namespace Radzen.Blazor
         public RadzenHtmlEditor Editor { get; set; }
 
         /// <summary>
+        /// Specifies the placeholder displayed to the user. Set to <c>"Format block"</c> by default.
+        /// </summary>
+        [Parameter]
+        public string Placeholder { get; set; } = "Format block";
+
+        /// <summary>
         /// Specifies the title (tooltip) displayed when the user hovers the tool. Set to <c>"Text style"</c> by default.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
This PR adds possibility to set the Placeholder-texts for the sub components to the RadzenHtmlEditor, specifically RadzenHtmlEditorFontName, RadzenHtmlEditorFontSize and RadzenHtmlEditorFormatBlock. As all titles/tooltips colud already be set, this was the only(?) thing missing to make it possible to change language for the html-editor.