### PR TITLE
Change span to div to enable a valid <h..> inside

### DIFF
--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -10,7 +10,7 @@
             {
                 <Draggable Drag="@OnDrag" DragStart="@OnDragStart">
                     <div class="rz-dialog-titlebar">
-                        <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
+                        <div class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
                         @if (Dialog.Options.ShowClose)
                         {
                             <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">
@@ -23,7 +23,7 @@
             else
             {
                 <div class="rz-dialog-titlebar">
-                    <span class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</span>
+                    <div class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
                     @if (Dialog.Options.ShowClose)
                     {
                         <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -10,7 +10,7 @@
             {
                 <Draggable Drag="@OnDrag" DragStart="@OnDragStart">
                     <div class="rz-dialog-titlebar">
-                        <div class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
+                        <div class="rz-dialog-title" style="display: inline" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
                         @if (Dialog.Options.ShowClose)
                         {
                             <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">
@@ -23,7 +23,7 @@
             else
             {
                 <div class="rz-dialog-titlebar">
-                    <div class="rz-dialog-title" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
+                    <div class="rz-dialog-title" style="display: inline" id="rz-dialog-0-label">@((MarkupString)Dialog.Title)</div>
                     @if (Dialog.Options.ShowClose)
                     {
                         <a href="javascript:void(0)" @onclick=@Close role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">


### PR DESCRIPTION
To improve the accessibility it is necessary to mark the heading of a modal window with a `<h...>` tag.
Because `<h..>` inside of `<span>` is not valid HTML, `<span>` will be changed to `<div>`
#477