### PR TITLE
Get total item count after loading the data into the DataGrid

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -53,7 +53,6 @@ namespace Radzen.Blazor
         private async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>> LoadItems(Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
         {
             var view = AllowPaging ? PagedView : View;
-            var totalItemsCount = LoadData.HasDelegate ? Count : view.Count();
             var top = request.Count;
 
             if(top <= 0)
@@ -62,6 +61,8 @@ namespace Radzen.Blazor
             }
 
             await InvokeLoadData(request.StartIndex, top);
+            
+            var totalItemsCount = LoadData.HasDelegate ? Count : view.Count();
 
             virtualDataItems = (LoadData.HasDelegate ? Data : itemToInsert != null ? (new[] { itemToInsert }).Concat(view.Skip(request.StartIndex).Take(top)) : view.Skip(request.StartIndex).Take(top)).ToList();
 
@@ -1394,7 +1395,6 @@ namespace Radzen.Blazor
                 {
                     if(virtualize != null)
                     {
-                        await virtualize.RefreshDataAsync();
                         await virtualize.RefreshDataAsync();
                     }
 


### PR DESCRIPTION
There was an issue that the count would not reflect the current number of items in the data grid. This was because the DataGrid first gets the total count and then fetches items. 

Now we first get the items and then the total count. 

This will solve this issue below
[https://www.youtube.com/watch?v=0omddDSI8K8](https://www.youtube.com/watch?v=0omddDSI8K8)
[https://forum.radzen.com/t/custom-filter-crashes-virtualized-blazor-datagrid/9650/17?u=thenoninja](https://forum.radzen.com/t/custom-filter-crashes-virtualized-blazor-datagrid/9650/17?u=thenoninja)