### PR TITLE
Add FilterCleared event to DataGrid to fire when filter is cleared

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -594,6 +594,13 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback<DataGridColumnFilterEventArgs<TItem>> Filter { get; set; }
 
+        /// <summary>
+        /// Gets or sets the column filter cleared callback.
+        /// </summary>
+        /// <value>The column filter callback.</value>
+        [Parameter]
+        public EventCallback<DataGridColumnFilterEventArgs<TItem>> FilterCleared { get; set; }
+
         internal async Task ClearFilter(RadzenDataGridColumn<TItem> column, bool closePopup = false)
         {
             if (closePopup)
@@ -606,7 +613,7 @@ namespace Radzen.Blazor
             skip = 0;
             CurrentPage = 0;
 
-            await Filter.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>() 
+            await FilterCleared.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>() 
             { 
                 Column = column, 
                 FilterValue = column.GetFilterValue(),

--- a/Radzen.Blazor/RadzenDataGridFilterMenu.razor
+++ b/Radzen.Blazor/RadzenDataGridFilterMenu.razor
@@ -114,7 +114,7 @@
 
         await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}{Column.GetFilterProperty()}");
 
-        await Grid.Filter.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>()
+        await Grid.FilterCleared.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>()
         {
             Column = Column,
             FilterValue = Column.GetFilterValue(),


### PR DESCRIPTION
Add FilterCleared event to DataGrid to fire when filter is cleared to allow custom logic to tell the difference between operator/value change and filter clear event. In my case it allows me to keep the operator even though it's reset to default in ClearFilter().

It is potentially a breaking change since it now fires FilterCleared from the grid's implementation of the filter menu, so I don't have much hopes that you will approve this PR but submitting it just in case...