### PR TITLE
RadzenDataGrid: Added Is Empty and Is not empty Filter operators

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -827,9 +827,17 @@ namespace Radzen
         /// </summary>
         IsNull,
         /// <summary>
+        /// Satisfied if the current value is <see cref="string.Empty"/>.
+        /// </summary>
+        IsEmpty,
+        /// <summary>
         /// Satisfied if the current value is not null.
         /// </summary>
-        IsNotNull
+        IsNotNull,
+        /// <summary>
+        /// Satisfied if the current value is not <see cref="string.Empty"/>.
+        /// </summary>
+        IsNotEmpty
     }
 
     /// <summary>

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -45,7 +45,9 @@ namespace Radzen
             {FilterOperator.Contains, "Contains"},
             {FilterOperator.DoesNotContain, "DoesNotContain"},
             {FilterOperator.IsNull, "=="},
-            {FilterOperator.IsNotNull, "!="}
+            {FilterOperator.IsEmpty, "=="},
+            {FilterOperator.IsNotNull, "!="},
+            {FilterOperator.IsNotEmpty, "!="}
         };
 
         /// <summary>
@@ -64,7 +66,9 @@ namespace Radzen
             {FilterOperator.Contains, "contains"},
             {FilterOperator.DoesNotContain, "DoesNotContain"},
             {FilterOperator.IsNull, "eq"},
-            {FilterOperator.IsNotNull, "ne"}
+            {FilterOperator.IsEmpty, "eq"},
+            {FilterOperator.IsNotNull, "ne"},
+            {FilterOperator.IsNotEmpty, "ne"}
         };
 
         /// <summary>
@@ -140,8 +144,10 @@ namespace Radzen
         public static string ToFilterString<T>(this IEnumerable<RadzenDataGridColumn<T>> columns)
         {
             Func<RadzenDataGridColumn<T>, bool> canFilter = (c) => c.Filterable && c.FilterPropertyType != null &&
-                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull)
-                    && c.GetFilterProperty() != null;
+               (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) || c.GetFilterOperator() == FilterOperator.IsNotNull 
+                   || c.GetFilterOperator() == FilterOperator.IsNull || c.GetFilterOperator() == FilterOperator.IsEmpty 
+                   || c.GetFilterOperator() == FilterOperator.IsNotEmpty)
+               && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
             {
@@ -232,7 +238,10 @@ namespace Radzen
                         secondValue = (string)Convert.ChangeType(column.GetSecondFilterValue(), typeof(string));
                     }
 
-                    if (!string.IsNullOrEmpty(value) || column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull)
+                    if (!string.IsNullOrEmpty(value) || column.GetFilterOperator() == FilterOperator.IsNotNull 
+                                                    || column.GetFilterOperator() == FilterOperator.IsNull
+                                                    || column.GetFilterOperator() == FilterOperator.IsEmpty
+                                                    || column.GetFilterOperator() == FilterOperator.IsNotEmpty)
                     {
                         var linqOperator = LinqFilterOperators[column.GetFilterOperator()];
                         if (linqOperator == null)
@@ -408,6 +417,14 @@ namespace Radzen
                 {
                     return $@"np({property}) == null";
                 }
+                else if (columnFilterOperator == FilterOperator.IsEmpty)
+                {
+                    return $@"np({property}) == ''";
+                }
+                else if (columnFilterOperator == FilterOperator.IsNotEmpty)
+                {
+                    return $@"np({property}) != ''";
+                }
                 else if (columnFilterOperator == FilterOperator.IsNotNull)
                 {
                     return $@"np({property}) != null";
@@ -418,6 +435,10 @@ namespace Radzen
                 if (column.GetFilterOperator() == FilterOperator.IsNull || column.GetFilterOperator() == FilterOperator.IsNotNull)
                 {
                     return $"{property} {linqOperator} null";
+                }
+                else if (column.GetFilterOperator() == FilterOperator.IsEmpty || column.GetFilterOperator() == FilterOperator.IsNotEmpty)
+                {
+                    return $"{property} {linqOperator} ''";
                 }
                 else
                 {
@@ -432,6 +453,10 @@ namespace Radzen
                 if (column.GetFilterOperator() == FilterOperator.IsNull || column.GetFilterOperator() == FilterOperator.IsNotNull)
                 {
                     return $"{property} {linqOperator} null";
+                }
+                else if (column.GetFilterOperator() == FilterOperator.IsEmpty || column.GetFilterOperator() == FilterOperator.IsNotEmpty)
+                {
+                    return $"{property} {linqOperator} ''";
                 }
                 else
                 {
@@ -452,6 +477,10 @@ namespace Radzen
                 if (column.GetFilterOperator() == FilterOperator.IsNull || column.GetFilterOperator() == FilterOperator.IsNotNull)
                 {
                     return $"{property} {linqOperator} null";
+                }
+                else if (column.GetFilterOperator() == FilterOperator.IsEmpty || column.GetFilterOperator() == FilterOperator.IsNotEmpty)
+                {
+                    return $"{property} {linqOperator} ''";
                 }
                 else
                 {
@@ -614,6 +643,10 @@ namespace Radzen
                 {
                     return $"{property} {odataFilterOperator} null";
                 }
+                else if (columnFilterOperator == FilterOperator.IsEmpty || columnFilterOperator == FilterOperator.IsNotEmpty)
+                {
+                    return $"{property} {odataFilterOperator} ''";
+                }
             }
             else if (IsEnumerable(column.FilterPropertyType) && column.FilterPropertyType != typeof(string))
             {
@@ -643,6 +676,10 @@ namespace Radzen
                 {
                     return $"{property} {odataFilterOperator} null";
                 }
+                else if (columnFilterOperator == FilterOperator.IsEmpty || columnFilterOperator == FilterOperator.IsNotEmpty)
+                {
+                    return $"{property} {odataFilterOperator} ''";
+                }
                 else
                 {
                     return $"{property} eq {value.ToLower()}";
@@ -656,6 +693,10 @@ namespace Radzen
                 if (columnFilterOperator == FilterOperator.IsNull || columnFilterOperator == FilterOperator.IsNotNull)
                 {
                     return $"{property} {odataFilterOperator} null";
+                }
+                else if (columnFilterOperator == FilterOperator.IsEmpty || columnFilterOperator == FilterOperator.IsNotEmpty)
+                {
+                    return $"{property} {odataFilterOperator} ''";
                 }
                 else
                 {
@@ -733,8 +774,10 @@ namespace Radzen
         public static string ToODataFilterString<T>(this IEnumerable<RadzenDataGridColumn<T>> columns)
         {
             Func<RadzenDataGridColumn<T>, bool> canFilter = (c) => c.Filterable && c.FilterPropertyType != null &&
-                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull)
-                    && c.GetFilterProperty() != null;
+               (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) 
+                || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
+                || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty)
+               && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
             {
@@ -749,7 +792,8 @@ namespace Radzen
                     var value = column.GetFilterValue();
                     var secondValue = column.GetSecondFilterValue();
 
-                    if (value != null || column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull)
+                    if (value != null || column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull
+                        || column.GetFilterOperator() == FilterOperator.IsEmpty || column.GetFilterOperator() == FilterOperator.IsNotEmpty)
                     {
                         var linqOperator = ODataFilterOperators[column.GetFilterOperator()];
                         if (linqOperator == null)
@@ -874,8 +918,10 @@ namespace Radzen
         public static IQueryable<T> Where<T>(this IQueryable<T> source, IEnumerable<RadzenDataGridColumn<T>> columns)
         {
             Func<RadzenDataGridColumn<T>, bool> canFilter = (c) => c.Filterable && c.FilterPropertyType != null &&
-                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull)
-                    && c.GetFilterProperty() != null;
+               (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) 
+                || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
+                || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty)
+               && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
             {
@@ -893,14 +939,18 @@ namespace Radzen
                         property = $"({property})";
                     }
 
-                    if (column.FilterPropertyType == typeof(string) && !(column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull))
+                    if (column.FilterPropertyType == typeof(string) && 
+                        !(column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull
+                            || column.GetFilterOperator() == FilterOperator.IsEmpty || column.GetFilterOperator() == FilterOperator.IsNotEmpty))
                     {
                         property = $@"({property} == null ? """" : {property})";
                     }
 
                     string filterCaseSensitivityOperator = column.FilterPropertyType == typeof(string) 
-                        && column.GetFilterOperator() != FilterOperator.IsNotNull && column.GetFilterOperator() != FilterOperator.IsNull &&
-                        column.Grid.FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? ".ToLower()" : "";
+                           && column.GetFilterOperator() != FilterOperator.IsNotNull && column.GetFilterOperator() != FilterOperator.IsNull
+                           && column.GetFilterOperator() != FilterOperator.IsEmpty && column.GetFilterOperator() != FilterOperator.IsNotEmpty
+                           && column.Grid.FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? ".ToLower()" : "";
+
 
                     var comparison = LinqFilterOperators[column.GetFilterOperator()];
 

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -188,6 +188,12 @@
                                                                                         <li class="@(DateFilterOperatorStyle(column, FilterOperator.IsNull))" @onclick="@((args) => ApplyDateFilterByFilterOperator(column, FilterOperator.IsNull))" style="display: block;">
                                                                                             <span>@IsNullText</span>
                                                                                         </li>
+                                                                                        <li class="@(DateFilterOperatorStyle(column, FilterOperator.IsEmpty))" @onclick="@((args) => ApplyDateFilterByFilterOperator(column, FilterOperator.IsEmpty))" style="display: block;">
+                                                                                            <span>@IsEmptyText</span>
+                                                                                        </li>
+                                                                                        <li class="@(DateFilterOperatorStyle(column, FilterOperator.IsNotEmpty))" @onclick="@((args) => ApplyDateFilterByFilterOperator(column, FilterOperator.IsNotEmpty))" style="display: block;">
+                                                                                            <span>@IsNotEmptyText</span>
+                                                                                        </li>
                                                                                         <li class="@(DateFilterOperatorStyle(column, FilterOperator.IsNotNull))" @onclick="@((args) => ApplyDateFilterByFilterOperator(column, FilterOperator.IsNotNull))" style="display: block;">
                                                                                             <span>@IsNotNullText</span>
                                                                                         </li>

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -849,6 +849,20 @@ namespace Radzen.Blazor
         /// <value>The null text.</value>
         [Parameter]
         public string IsNullText { get; set; } = "Is null";
+        
+        /// <summary>
+        /// Gets or sets the is empty text.
+        /// </summary>
+        /// <value>The empty text.</value>
+        [Parameter]
+        public string IsEmptyText { get; set; } = "Is empty";
+        
+        /// <summary>
+        /// Gets or sets the is not empty text.
+        /// </summary>
+        /// <value>The not empty text.</value>
+        [Parameter]
+        public string IsNotEmptyText { get; set; } = "Is not empty";
 
         internal class NumericFilterEventCallback
         {
@@ -1428,15 +1442,17 @@ namespace Radzen.Blazor
             if (LoadData.HasDelegate)
             {
                 var filters = allColumns.ToList().Where(c => c.Filterable && c.GetVisible() && (c.GetFilterValue() != null
-                        || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull)).Select(c => new FilterDescriptor()
-                        {
+                        || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
+                        || c.GetFilterOperator() == FilterOperator.IsEmpty | c.GetFilterOperator() == FilterOperator.IsNotEmpty))
+                    .Select(c => new FilterDescriptor()
+                    {
                             Property = c.GetFilterProperty(),
                             FilterValue = c.GetFilterValue(),
                             FilterOperator = c.GetFilterOperator(),
                             SecondFilterValue = c.GetSecondFilterValue(),
                             SecondFilterOperator = c.GetSecondFilterOperator(),
                             LogicalFilterOperator = c.GetLogicalFilterOperator()
-                        });
+                    });
 
                 await LoadData.InvokeAsync(new Radzen.LoadDataArgs()
                 {

--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -818,11 +818,10 @@ namespace Radzen.Blazor
 
             return Enum.GetValues(typeof(FilterOperator)).Cast<FilterOperator>().Where(o => {
                 var isStringOperator = o == FilterOperator.Contains ||  o == FilterOperator.DoesNotContain 
-                    || o == FilterOperator.StartsWith || o == FilterOperator.EndsWith;
+                    || o == FilterOperator.StartsWith || o == FilterOperator.EndsWith || o == FilterOperator.IsEmpty || o == FilterOperator.IsNotEmpty;
                 return FilterPropertyType == typeof(string) ? isStringOperator 
                       || o == FilterOperator.Equals || o == FilterOperator.NotEquals 
                       || o == FilterOperator.IsNull || o == FilterOperator.IsNotNull
-                      || o == FilterOperator.IsEmpty || o == FilterOperator.IsNotEmpty
                     : !isStringOperator;
             });
         }
@@ -890,11 +889,13 @@ namespace Radzen.Blazor
                 case FilterOperator.NotEquals:
                     return "≠";
                 case FilterOperator.IsNull:
-                case FilterOperator.IsEmpty:
                     return "∅";
                 case FilterOperator.IsNotNull:
-                case FilterOperator.IsNotEmpty:
                     return "!∅";
+                case FilterOperator.IsEmpty:
+                    return "= ''";
+                case FilterOperator.IsNotEmpty:
+                    return "≠ ''";
                 default:
                     return $"{filterOperator}";
             }

--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -717,7 +717,10 @@ namespace Radzen.Blazor
 
         internal bool CanSetFilterValue()
         { 
-            return GetFilterOperator() == FilterOperator.IsNull || GetFilterOperator() == FilterOperator.IsNotNull;
+            return GetFilterOperator() == FilterOperator.IsNull 
+                    || GetFilterOperator() == FilterOperator.IsNotNull 
+                    ||  GetFilterOperator() == FilterOperator.IsEmpty 
+                    || GetFilterOperator() == FilterOperator.IsNotEmpty;
         }
 
         /// <summary>
@@ -814,10 +817,13 @@ namespace Radzen.Blazor
                 return new FilterOperator[] { FilterOperator.Equals, FilterOperator.NotEquals, FilterOperator.IsNull, FilterOperator.IsNotNull };
 
             return Enum.GetValues(typeof(FilterOperator)).Cast<FilterOperator>().Where(o => {
-                var isStringOperator = o == FilterOperator.Contains ||  o == FilterOperator.DoesNotContain || o == FilterOperator.StartsWith || o == FilterOperator.EndsWith;
+                var isStringOperator = o == FilterOperator.Contains ||  o == FilterOperator.DoesNotContain 
+                    || o == FilterOperator.StartsWith || o == FilterOperator.EndsWith;
                 return FilterPropertyType == typeof(string) ? isStringOperator 
-                    || o == FilterOperator.Equals || o == FilterOperator.NotEquals || o == FilterOperator.IsNull || o == FilterOperator.IsNotNull
-                        : !isStringOperator;
+                      || o == FilterOperator.Equals || o == FilterOperator.NotEquals 
+                      || o == FilterOperator.IsNull || o == FilterOperator.IsNotNull
+                      || o == FilterOperator.IsEmpty || o == FilterOperator.IsNotEmpty
+                    : !isStringOperator;
             });
         }
 
@@ -847,8 +853,12 @@ namespace Radzen.Blazor
                     return Grid?.NotEqualsText;
                 case FilterOperator.IsNull:
                     return Grid?.IsNullText;
+                case FilterOperator.IsEmpty:
+                    return Grid?.IsEmptyText;
                 case FilterOperator.IsNotNull:
                     return Grid?.IsNotNullText;
+                case FilterOperator.IsNotEmpty:
+                    return Grid?.IsNotEmptyText;
                 default:
                     return $"{filterOperator}";
             }
@@ -880,8 +890,10 @@ namespace Radzen.Blazor
                 case FilterOperator.NotEquals:
                     return "≠";
                 case FilterOperator.IsNull:
+                case FilterOperator.IsEmpty:
                     return "∅";
                 case FilterOperator.IsNotNull:
+                case FilterOperator.IsNotEmpty:
                     return "!∅";
                 default:
                     return $"{filterOperator}";

--- a/Radzen.Blazor/RadzenDataGridFilterMenu.razor
+++ b/Radzen.Blazor/RadzenDataGridFilterMenu.razor
@@ -53,8 +53,14 @@
             <li class="@(FilterOperatorStyle(Column, FilterOperator.IsNull))" @onclick="@(args => ApplyFilter(FilterOperator.IsNull))" style="display: block;">
                 <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsNull)</span><span>@Grid.IsNullText</span>
             </li>
+            <li class="@(FilterOperatorStyle(Column, FilterOperator.IsEmpty))" @onclick="@(args => ApplyFilter(FilterOperator.IsEmpty))" style="display: block;">
+                <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsEmpty)</span><span>@Grid.IsEmptyText</span>
+            </li>
             <li class="@(FilterOperatorStyle(Column, FilterOperator.IsNotNull))" @onclick="@(args => ApplyFilter(FilterOperator.IsNotNull))" style="display: block;">
                 <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsNotNull)</span><span>@Grid.IsNotNullText</span>
+            </li>s
+             <li class="@(FilterOperatorStyle(Column, FilterOperator.IsNotEmpty))" @onclick="@(args => ApplyFilter(FilterOperator.IsNotEmpty))" style="display: block;">
+                <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsNotEmpty)</span><span>@Grid.IsNotEmptyText</span>
             </li>
             <li class="rz-multiselect-item" @onclick="@(args => ClearFilter())" style="display:block;">
                 <span class="rz-filter-menu-symbol">x</span><span>@Grid.ClearFilterText</span>
@@ -79,14 +85,16 @@
     protected string FilterIconStyle()
     {
         var additionalStyle = Column.GetFilterValue() != null || Column.GetSecondFilterValue() != null || 
-            Column.GetFilterOperator() == FilterOperator.IsNotNull || Column.GetFilterOperator() == FilterOperator.IsNull 
-                ? "rz-grid-filter-active" : "";
+                              Column.GetFilterOperator() == FilterOperator.IsNotNull || Column.GetFilterOperator() == FilterOperator.IsNull 
+                              || Column.GetFilterOperator() == FilterOperator.IsEmpty || Column.GetFilterOperator() == FilterOperator.IsNotEmpty 
+            ? "rz-grid-filter-active" : "";
         return $"rz-filter-button rz-button rz-button-md rz-button-icon-only btn-light {additionalStyle}";
     }
 
     protected async Task ApplyFilter(FilterOperator value)
     {
-        if (value == FilterOperator.IsNull || value == FilterOperator.IsNotNull)
+        if (value == FilterOperator.IsNull || value == FilterOperator.IsNotNull 
+            || value == FilterOperator.IsEmpty || value == FilterOperator.IsNotEmpty)
         {
             Column.SetFilterValue(null);
             Column.SetFilterValue(null, false);

--- a/Radzen.Blazor/RadzenDataGridFilterMenu.razor
+++ b/Radzen.Blazor/RadzenDataGridFilterMenu.razor
@@ -31,6 +31,12 @@
             <li class="@(FilterOperatorStyle(Column, FilterOperator.EndsWith))" @onclick="@(args => ApplyFilter(FilterOperator.EndsWith))" style="display: block;">
                 <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.EndsWith)</span><span>@Grid.EndsWithText</span>
             </li>
+            <li class="@(FilterOperatorStyle(Column, FilterOperator.IsEmpty))" @onclick="@(args => ApplyFilter(FilterOperator.IsEmpty))" style="display: block;">
+                <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsEmpty)</span><span>@Grid.IsEmptyText</span>
+            </li>
+            <li class="@(FilterOperatorStyle(Column, FilterOperator.IsNotEmpty))" @onclick="@(args => ApplyFilter(FilterOperator.IsNotEmpty))" style="display: block;">
+                <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsNotEmpty)</span><span>@Grid.IsNotEmptyText</span>
+            </li>
             }
             <li class="@(FilterOperatorStyle(Column, FilterOperator.Equals))" @onclick="@(args => ApplyFilter(FilterOperator.Equals))" style="display: block;">
                 <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.Equals)</span><span>@Grid.EqualsText</span>
@@ -53,14 +59,8 @@
             <li class="@(FilterOperatorStyle(Column, FilterOperator.IsNull))" @onclick="@(args => ApplyFilter(FilterOperator.IsNull))" style="display: block;">
                 <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsNull)</span><span>@Grid.IsNullText</span>
             </li>
-            <li class="@(FilterOperatorStyle(Column, FilterOperator.IsEmpty))" @onclick="@(args => ApplyFilter(FilterOperator.IsEmpty))" style="display: block;">
-                <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsEmpty)</span><span>@Grid.IsEmptyText</span>
-            </li>
             <li class="@(FilterOperatorStyle(Column, FilterOperator.IsNotNull))" @onclick="@(args => ApplyFilter(FilterOperator.IsNotNull))" style="display: block;">
                 <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsNotNull)</span><span>@Grid.IsNotNullText</span>
-            </li>s
-             <li class="@(FilterOperatorStyle(Column, FilterOperator.IsNotEmpty))" @onclick="@(args => ApplyFilter(FilterOperator.IsNotEmpty))" style="display: block;">
-                <span class="rz-filter-menu-symbol">@Column.GetFilterOperatorSymbol(FilterOperator.IsNotEmpty)</span><span>@Grid.IsNotEmptyText</span>
             </li>
             <li class="rz-multiselect-item" @onclick="@(args => ClearFilter())" style="display:block;">
                 <span class="rz-filter-menu-symbol">x</span><span>@Grid.ClearFilterText</span>
@@ -96,8 +96,8 @@
         if (value == FilterOperator.IsNull || value == FilterOperator.IsNotNull 
             || value == FilterOperator.IsEmpty || value == FilterOperator.IsNotEmpty)
         {
-            Column.SetFilterValue(null);
-            Column.SetFilterValue(null, false);
+            Column.SetFilterValue(value == FilterOperator.IsEmpty || value == FilterOperator.IsNotEmpty ? string.Empty : null);
+            Column.SetFilterValue(value == FilterOperator.IsEmpty || value == FilterOperator.IsNotEmpty ? string.Empty : null, false);
         }
 
         Column.SetFilterOperator(value);

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -165,6 +165,7 @@ else
     {
         var additionalStyle = column.GetFilterValue() != null || column.GetSecondFilterValue() != null || 
             column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull 
+                || column.GetFilterOperator() == FilterOperator.IsEmpty || column.GetFilterOperator() == FilterOperator.IsNotEmpty
                 ? "rz-grid-filter-active" : "";
         return $"rzi rz-grid-filter-icon {additionalStyle}";
     }


### PR DESCRIPTION
Added Is Empty and Is not empty Filter operators.
Updated the UI to contain these filters.

- Added the enum values to Common.cs
- QueryExtensions.cs has been updated to cater for both scenarios
- RadzenDataGrid has been updated with the filter options.
- RadzenDataGrid.cs has been updated with the text values for the filter, as well as the filter options (HasDelegate)
- RadzenDataGridColumn<TItem>: updated the CanSetFilterValue, GetFilterOperators, GetFilterOperatorText and GetFilterOperatorSymbol functions
- Added the options to the RadzenDataGridFilterMenu, as well as the styling options ( FilterIconStyle and ApplyFilter)
- The header cell's getFilterIconCss has also been updated