### PR TITLE
[BreadCrumb] Allow Item specific Templates

### DIFF
--- a/Radzen.Blazor/RadzenBreadCrumbItem.razor
+++ b/Radzen.Blazor/RadzenBreadCrumbItem.razor
@@ -3,7 +3,11 @@
 @if (Visible)
 {
     <div class="@GetCssClass()" id="@GetId()" style="@Style" @attributes="@Attributes">
-        @if (Template != null)
+        @if (ChildContent != null)
+        {
+            @ChildContent
+        }
+        else if (Template != null)
         {
             @Template(this)
         }

--- a/Radzen.Blazor/RadzenBreadCrumbItem.razor.cs
+++ b/Radzen.Blazor/RadzenBreadCrumbItem.razor.cs
@@ -8,7 +8,7 @@ namespace Radzen.Blazor
     public partial class RadzenBreadCrumbItem : RadzenComponent
     {
         /// <summary>
-        /// Cascaded TEmplate Parameter from <see cref="RadzenBreadCrumb"/> Component
+        /// Cascaded Template Parameter from <see cref="RadzenBreadCrumb"/> Component
         /// </summary>
         [CascadingParameter]
         public RenderFragment<RadzenBreadCrumbItem> Template { get; set; }
@@ -30,6 +30,13 @@ namespace Radzen.Blazor
         /// </summary>
         [Parameter]
         public string Icon { get; set; }
+
+        /// <summary>
+        /// Template Parameter used only for this Item
+        /// Note: this overrides the <see cref="Template"/> Cascading Parameter
+        /// </summary>
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
 
         /// <inheritdoc/>
         protected override string GetComponentCssClass()

--- a/RadzenBlazorDemos/Pages/BreadCrumbPage.razor
+++ b/RadzenBlazorDemos/Pages/BreadCrumbPage.razor
@@ -28,5 +28,27 @@
             </RadzenCard>
         </div>
     </div>
+
+    <div class="row px-3">
+        <div class="col-md-6 p-3">
+            <RadzenCard class="pb-4">
+                <RadzenHeading Size="H4" Text="With ChildContent" Class="mb-4" />
+                <RadzenBreadCrumb>
+                    <Template Context="item">
+                        <RadzenLink Path="@item.Path" Icon="@item.Icon" Text="@item.Text" />
+                        (Template)
+                    </Template>
+                    <ChildContent>
+                        <RadzenBreadCrumbItem Path="/" Text="Components" />
+                        <RadzenBreadCrumbItem>
+                            <RadzenLink Path="/badge" Icon="bolt" Text="Badge" />
+                            (Child Content)
+                        </RadzenBreadCrumbItem>
+                        <RadzenBreadCrumbItem Text="Add" />
+                    </ChildContent>
+                </RadzenBreadCrumb>
+            </RadzenCard>
+        </div>
+    </div>
 </RadzenExample>
 


### PR DESCRIPTION
This PR introduces an implementation of the `ChildContent` property for `RadzenBreadCrumbItem` components.

Setting a `ChildContent` overrides the default display of the compoent and any set `Template` cascading parameter.