### PR TITLE
Bugfix: resolve duplicate enums in filters by grouping descriptions for duplicates

### DIFF
--- a/Radzen.Blazor/Extensions.cs
+++ b/Radzen.Blazor/Extensions.cs
@@ -24,12 +24,14 @@ namespace Radzen.Blazor
 
         public static IEnumerable<object> EnumAsKeyValuePair(Type enumType)
         {
-            var values = Enum.GetValues(enumType);
-            var items = new List<object>(values.Length);
+            var values = Enum.GetValues(enumType).Cast<Enum>().ToList();
 
-            foreach (Enum val in values)
+            var items = new List<object>(values.Count);
+            foreach (var val in values.GroupBy(v => Convert.ToInt32(v)))
             {
-                items.Add(new { Value = Convert.ToInt32(val), Text = val.GetDisplayDescription() });
+                var description = string.Join('/', val.Select(v => v.GetDisplayDescription()));
+
+                items.Add(new { Value = val.Key, Text = description });
             }
 
             return items;


### PR DESCRIPTION
This is a bugfix for #542. In brief currently there is a bug when using enums with duplicate values such as the official HttpStatusCode enum. The core issue is dropdowns do not allow duplicate values. as discussed in the Issue there are a number of solutions but this solution seems the cleanest, safest and quickest to implement for now.

This fix is to group duplicate ids and only list one dropdown item for each ID (resolving the duplicate issue) while appending each of the duplicate descriptions as a '/' seperated list. This resolves the issue without the user not being able to find the result they need but does have the downside of making the additional/duplicate descriptions potentially more likely to go beyond the width of the dropdown. Given the alternative is to not support (or exception in production) some enum types, this seems an appropriate compremise i am happy to deal with in my use case.

This change does not affect behaviour of existing enums with no duplicates 