### PR TITLE
fix: RadzenDropDownItem behavior on older versions of the blazor.js f…

### DIFF
--- a/Radzen.Blazor/RadzenDropDownItem.razor
+++ b/Radzen.Blazor/RadzenDropDownItem.razor
@@ -8,8 +8,8 @@
 {
     <li class="@GetComponentCssClass("rz-multiselect")"
         aria-label="@PropertyAccess.GetItemOrValueFromProperty(Item, DropDown.TextProperty)" style="display: block;white-space: nowrap;"
-    @onmousedown:preventDefault @onmousedown="@SelectItem"
-        @onclick:preventDefault @onclick="@SelectItem">
+    @onmousedown:preventDefault @onmousedown="args=>SelectItem(args,false)"
+        @onclick:preventDefault @onclick="args=>SelectItem(args,true)">
         <div class="rz-chkbox ">
             <div class="@(DropDown.isSelected(Item) ? "rz-chkbox-box    rz-state-active" : "rz-chkbox-box   ") @(Disabled ? " rz-state-disabled  " : "")">
                 <span class="@(DropDown.isSelected(Item) ? "rz-chkbox-icon  rzi rzi-check" : "rz-chkbox-icon ")"></span>
@@ -30,8 +30,8 @@
 else
 {
     <li role="option" class="@GetComponentCssClass("rz-dropdown")" aria-label=">@PropertyAccess.GetItemOrValueFromProperty(Item, DropDown.TextProperty)"
-    @onmousedown:preventDefault @onmousedown="@SelectItem"
-    @onclick:preventDefault @onclick="@SelectItem">
+    @onmousedown:preventDefault @onmousedown="args=>SelectItem(args,false)"
+    @onclick:preventDefault @onclick="args=>SelectItem(args,true)">
         <span>
             @if (DropDown.Template != null)
             {
@@ -54,11 +54,11 @@ else
     [Parameter]
     public object Item { get; set; }
 
-    async Task SelectItem(MouseEventArgs args)
+    async Task SelectItem(MouseEventArgs args,bool isclick)
     {
         var condition = DropDown.LoadData.HasDelegate && !string.IsNullOrEmpty(DropDown.searchText);
 
-        if (!Disabled && args.Type == "click" ? !condition : condition)
+        if (!Disabled && isclick ? !condition : condition)
         {
             await DropDown.OnSelectItemInternal(Item);
         }


### PR DESCRIPTION
Unfortunately in older versions of NET CORE 6 the framework blazor.js does not include the passage in SignalIR of the field "type" (as in the figure appears comparing the version 6.0.1 and 6.0.7). The dropdown, if used with the old version, is no longer selectable with the mouse (type='click' is always false as type is always empty). 

![compare](https://user-images.githubusercontent.com/87013463/182790258-925ead2e-b177-4ea6-8c9f-c973ab109992.png)
