### PR TITLE
Navigation & Icon on Filtered Sidebar

### DIFF
--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -1169,6 +1169,8 @@ namespace RadzenBlazorDemos
                            .Select(category => new Example
                            {
                                Name = category.Name,
+                               Path = category.Path,
+                               Icon = category.Icon,
                                Expanded = true,
                                Children = category.Children?.Where(deepFilter).Select(example => new Example
                                {


### PR DESCRIPTION
This fixes an issue with the Demo Sidebar. 
Currently, if the sidebar is filtered with text, "categories" without children do not contain their icon, and will also not contain the navigation path 

This implementation will add the icon and path to "categories" which do not contain children, fixing navigation. 