### PR TITLE
enable possibility to add custom css class to dialog

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -200,6 +200,7 @@ namespace Radzen
                 AutoFocusFirstElement = options != null ? options.AutoFocusFirstElement : true,
                 CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
                 CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
+                CssClass = options != null ? options.CssClass : "",
             });
         }
 
@@ -260,6 +261,7 @@ namespace Radzen
                 AutoFocusFirstElement = options != null ? options.AutoFocusFirstElement : true,
                 CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
                 CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
+                CssClass = options != null ? options.CssClass : "",
             };
 
             await JSRuntime.InvokeAsync<string>("Radzen.openDialog", dialogOptions, Reference);
@@ -380,6 +382,11 @@ namespace Radzen
         /// </summary>
         /// <value><c>true</c> if closeable; otherwise, <c>false</c>.</value>
         public bool CloseDialogOnEsc { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets dialog box custom class
+        /// </summary>
+        public string CssClass { get; set; }
     }
 
     /// <summary>

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -3,7 +3,7 @@
 @inject IJSRuntime JSRuntime
 @implements IDisposable
 <div class="rz-dialog-wrapper">
-    <div @ref="dialog" class="rz-dialog" role="dialog" aria-labelledby="rz-dialog-0-label" style=@Style>
+    <div @ref="dialog" class="@CssClass" role="dialog" aria-labelledby="rz-dialog-0-label" style=@Style>
         @if (Dialog.Options.ShowTitle)
         {
             @if (Dialog.Options.Draggable)
@@ -123,6 +123,15 @@
     void Close()
     {
         Service.Close();
+    }
+
+    string CssClass
+    {
+        get
+        {
+            var baseCss = "rz-dialog";
+            return string.IsNullOrEmpty(Dialog.Options.CssClass) ? baseCss : $"{baseCss} {Dialog.Options.CssClass}";
+        }
     }
 
     string Style


### PR DESCRIPTION
when creating dialog customization on CSS is needed for layout, but it is not desired to modify all dialog boxes visual appearance, so custom CSS class can be added and it enables to style dialog that way.

```
dialogService.Open<DialogCardPage>($"Dialog Name",
                        new Dictionary<string, object>() { { "OrderID", orderID } },
                        new DialogOptions(){ cssClass="CustomClass" }))
```

Rendered Dialog html will be

```
<div class="rz-dialog CustomClass" >
...
</div>
```
