### PR TITLE
Add Separator parameter to RadzenDropdown

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -817,6 +817,13 @@ namespace Radzen
         }
 
         /// <summary>
+        /// Gets or sets the item separator for Multiple dropdown.
+        /// </summary>
+        /// <value>Item separator</value>
+        [Parameter]
+        public string Separator { get; set; } = ",";
+
+        /// <summary>
         /// Gets the items.
         /// </summary>
         /// <value>The items.</value>

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -56,13 +56,13 @@
                 {
                     @if (Template == null)
                     {
-                        @(string.Join(",", selectedItems.Select(i => PropertyAccess.GetItemOrValueFromProperty(i, TextProperty))))
+                        @(string.Join(Separator, selectedItems.Select(i => PropertyAccess.GetItemOrValueFromProperty(i, TextProperty))))
                     }
                     else
                     {
                         foreach (var item in selectedItems)
                         {
-                            @Template(item)@(",")
+                            @Template(item)@(Separator)
                         }
                     }
                 }


### PR DESCRIPTION
Added Separator parameter to RadzenDropdown for use with Multiple flag.

Partially fixes #494 