### PR TITLE
RadzenSelectBar - RadzenSelectBarItem add disabled-property

### DIFF
--- a/Radzen.Blazor/RadzenSelectBar.razor
+++ b/Radzen.Blazor/RadzenSelectBar.razor
@@ -17,6 +17,6 @@
     <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
         @foreach (var item in allItems.Where(i => i.Visible))
         {<div @onclick="@(args => SelectItem(item))" @onkeypress="@(async args => { if (args.Code == "Space") { await SelectItem(item); } })" @attributes="item.Attributes" style="@item.Style"
-              class=@ButtonClassList(item) aria-label="@item.Text" tabindex="@TabIndex">@if(item.Template != null){ @item.Template(item)}else{@if (!string.IsNullOrEmpty(item.Icon)){<i class="rzi rz-navigation-item-icon" style="margin-right:2px;">@((MarkupString)item.Icon)</i>}@if (!string.IsNullOrEmpty(item.Image)){<img class="rz-navigation-item-icon" src="@item.Image" style="@item.ImageStyle"/>}<span class="rz-button-text">@item.Text</span>}</div>}
+              class=@ButtonClassList(item) aria-label="@item.Text" tabindex="@(Disabled || item.Disabled ? "-1" : $"{TabIndex}")">@if(item.Template != null){ @item.Template(item)}else{@if (!string.IsNullOrEmpty(item.Icon)){<i class="rzi rz-navigation-item-icon" style="margin-right:2px;">@((MarkupString)item.Icon)</i>}@if (!string.IsNullOrEmpty(item.Image)){<img class="rz-navigation-item-icon" src="@item.Image" style="@item.ImageStyle"/>}<span class="rz-button-text">@item.Text</span>}</div>}
     </div>
 }

--- a/Radzen.Blazor/RadzenSelectBar.razor.cs
+++ b/Radzen.Blazor/RadzenSelectBar.razor.cs
@@ -31,18 +31,18 @@ namespace Radzen.Blazor
         {
             return Size == ButtonSize.Medium ? "md" : Size == ButtonSize.Large ? "lg" : Size == ButtonSize.Small ? "sm" : "xs";
         }
-        
+
         /// <summary>
         /// Gets or sets the size.
         /// </summary>
         /// <value>The size.</value>
         [Parameter]
         public ButtonSize Size { get; set; } = ButtonSize.Medium;
-        
-        
+
+
         ClassList ButtonClassList(RadzenSelectBarItem item) => ClassList.Create($"rz-button rz-button-{getButtonSize()} rz-button-text-only")
                             .Add("rz-state-active", IsSelected(item))
-                            .AddDisabled(Disabled);
+                            .AddDisabled(Disabled || item.Disabled);
 
         /// <summary>
         /// Gets or sets the value property.
@@ -181,7 +181,7 @@ namespace Radzen.Blazor
         /// <param name="item">The item.</param>
         protected async System.Threading.Tasks.Task SelectItem(RadzenSelectBarItem item)
         {
-            if (Disabled)
+            if (Disabled || item.Disabled)
                 return;
 
             if (Multiple)

--- a/Radzen.Blazor/RadzenSelectBarItem.cs
+++ b/Radzen.Blazor/RadzenSelectBarItem.cs
@@ -49,6 +49,13 @@ namespace Radzen.Blazor
         [Parameter]
         public object Value { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="RadzenSelectBarItem"/> is disabled.
+        /// </summary>
+        /// <value><c>true</c> if disabled; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool Disabled { get; set; }
+
         IRadzenSelectBar _selectBar;
 
         /// <summary>

--- a/RadzenBlazorDemos/Pages/SelectBarPage.razor
+++ b/RadzenBlazorDemos/Pages/SelectBarPage.razor
@@ -1,128 +1,139 @@
 ﻿@page "/selectbar"
 
 <RadzenExample Name="SelectBar">
-<div class="container-fluid">
-    <div class="row px-3">
-        <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Single selection</RadzenText>
-                <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
-                    <Items>
-                        <RadzenSelectBarItem Text="On" Value="true" />
-                        <RadzenSelectBarItem Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
-        </div>
-        <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Multiple selection</RadzenText>
-                <RadzenSelectBar @bind-Value=@values TValue="IEnumerable<int>" Multiple="true" Change=@(args => OnChange(args, "SelectBar with multiple selection"))>
-                    <Items>
-                        <RadzenSelectBarItem Text="Orders" Value="1" />
-                        <RadzenSelectBarItem Text="Employees" Value="2" />
-                        <RadzenSelectBarItem Text="Customers" Value="3" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
-        </div>
-        <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Disabled SelectBar with multiple selection</RadzenText>
-                <RadzenSelectBar Disabled="true" @bind-Value=@values TValue="IEnumerable<int>" Multiple="true">
-                    <Items>
-                        <RadzenSelectBarItem Text="Orders" Value="1" />
-                        <RadzenSelectBarItem Text="Employees" Value="2" />
-                        <RadzenSelectBarItem Text="Customers" Value="3" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
-        </div>
-        <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with icons</RadzenText>
-                <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with icons"))>
-                    <Items>
-                        <RadzenSelectBarItem Icon="filter" Text="On" Value="true" />
-                        <RadzenSelectBarItem Icon="filter_none" Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
-        </div>
-        <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with images</RadzenText>
-                <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with icons"))>
-                    <Items>
-                        <RadzenSelectBarItem Image="images/radzen-nuget.png" ImageStyle="zoom: 30%; margin-right: 20px;" Text="On" Value="true" />
-                        <RadzenSelectBarItem Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
-        </div>
-        <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with template</RadzenText>
-                <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with template"))>
-                    <Items>
-                        <RadzenSelectBarItem Value="true">
-                            <Template>
-                                <i>On</i>
-                            </Template>
-                        </RadzenSelectBarItem>
-                        <RadzenSelectBarItem Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
-        </div>
-        <div class="col-lg-6 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with items from data</RadzenText>
-                <RadzenSelectBar @bind-Value=@values TValue="IEnumerable<int>" Multiple="true" Change=@(args => OnChange(args, "SelectBar with items from data"))
-                            Data="@data" TextProperty="Name" ValueProperty="Id" />
-            </RadzenCard>
-        </div>
-        <div class="col-lg-6 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with declared items and items from data</RadzenText>
-                <RadzenSelectBar @bind-Value=@values Data="@data" TextProperty="Name" ValueProperty="Id" TValue="IEnumerable<int>" Multiple="true" Change=@(args => OnChange(args, "SelectBar with declared items and items from data"))>
-                    <Items>
-                        <RadzenSelectBarItem Text="Static item" Value="0" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
-        </div>
-        <div class="col-lg-12 p-3" style="min-width: fit-content;">
-            <RadzenCard>
-                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Selectbar Size</RadzenText>
-                <RadzenSelectBar Size="ButtonSize.ExtraSmall" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
-                    <Items>
-                        <RadzenSelectBarItem Text="On" Value="true" />
-                        <RadzenSelectBarItem Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-                <RadzenSelectBar Size="ButtonSize.Small" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
-                    <Items>
-                        <RadzenSelectBarItem Text="On" Value="true" />
-                        <RadzenSelectBarItem Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-                <RadzenSelectBar Size="ButtonSize.Medium" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
-                    <Items>
-                        <RadzenSelectBarItem Text="On" Value="true" />
-                        <RadzenSelectBarItem Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-                <RadzenSelectBar Size="ButtonSize.Large" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
-                    <Items>
-                        <RadzenSelectBarItem Text="On" Value="true" />
-                        <RadzenSelectBarItem Text="Off" Value="false" />
-                    </Items>
-                </RadzenSelectBar>
-            </RadzenCard>
+    <div class="container-fluid">
+        <div class="row px-3">
+            <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Single selection</RadzenText>
+                    <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="On" Value="true" />
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Multiple selection</RadzenText>
+                    <RadzenSelectBar @bind-Value=@values TValue="IEnumerable<int>" Multiple="true" Change=@(args => OnChange(args, "SelectBar with multiple selection"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="Orders" Value="1" />
+                            <RadzenSelectBarItem Text="Employees" Value="2" />
+                            <RadzenSelectBarItem Text="Customers" Value="3" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Disabled SelectBar with multiple selection</RadzenText>
+                    <RadzenSelectBar Disabled="true" @bind-Value=@values TValue="IEnumerable<int>" Multiple="true">
+                        <Items>
+                            <RadzenSelectBarItem Text="Orders" Value="1" />
+                            <RadzenSelectBarItem Text="Employees" Value="2" />
+                            <RadzenSelectBarItem Text="Customers" Value="3" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with single selection and disabled items</RadzenText>
+                    <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection and disabled items"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="On" Value="true" Disabled="true" />
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with icons</RadzenText>
+                    <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with icons"))>
+                        <Items>
+                            <RadzenSelectBarItem Icon="filter" Text="On" Value="true" />
+                            <RadzenSelectBarItem Icon="filter_none" Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with images</RadzenText>
+                    <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with icons"))>
+                        <Items>
+                            <RadzenSelectBarItem Image="images/radzen-nuget.png" ImageStyle="zoom: 30%; margin-right: 20px;" Text="On" Value="true" />
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 col-xl-4 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with template</RadzenText>
+                    <RadzenSelectBar @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with template"))>
+                        <Items>
+                            <RadzenSelectBarItem Value="true">
+                                <Template>
+                                    <i>On</i>
+                                </Template>
+                            </RadzenSelectBarItem>
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with items from data</RadzenText>
+                    <RadzenSelectBar @bind-Value=@values TValue="IEnumerable<int>" Multiple="true" Change=@(args => OnChange(args, "SelectBar with items from data"))
+                                     Data="@data" TextProperty="Name" ValueProperty="Id" />
+                </RadzenCard>
+            </div>
+            <div class="col-lg-6 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">SelectBar with declared items and items from data</RadzenText>
+                    <RadzenSelectBar @bind-Value=@values Data="@data" TextProperty="Name" ValueProperty="Id" TValue="IEnumerable<int>" Multiple="true" Change=@(args => OnChange(args, "SelectBar with declared items and items from data"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="Static item" Value="0" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
+            <div class="col-lg-12 p-3" style="min-width: fit-content;">
+                <RadzenCard>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Selectbar Size</RadzenText>
+                    <RadzenSelectBar Size="ButtonSize.ExtraSmall" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="On" Value="true" />
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                    <RadzenSelectBar Size="ButtonSize.Small" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="On" Value="true" />
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                    <RadzenSelectBar Size="ButtonSize.Medium" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="On" Value="true" />
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                    <RadzenSelectBar Size="ButtonSize.Large" @bind-Value=@singleValue TValue="bool" Change=@(args => OnChange(args, "SelectBar with single selection"))>
+                        <Items>
+                            <RadzenSelectBarItem Text="On" Value="true" />
+                            <RadzenSelectBarItem Text="Off" Value="false" />
+                        </Items>
+                    </RadzenSelectBar>
+                </RadzenCard>
+            </div>
         </div>
     </div>
-</div>
 </RadzenExample>
 
 <EventConsole @ref=@console Class="mt-4" />


### PR DESCRIPTION
Added a Display-Property to RadzenSelectBarItem-Class

It is possible now to disable specific items of the selectbar

Updated SelectBarPage-Demo:

![grafik](https://user-images.githubusercontent.com/115212774/196038522-96ef64f2-68c0-474a-9b80-524d4fdd2c1e.png)

![grafik](https://user-images.githubusercontent.com/115212774/196038569-93ef652f-189e-4b00-83ea-d59540082615.png)

set the tabindex of the items depending on display flag:
![grafik](https://user-images.githubusercontent.com/115212774/196038987-2ea4b951-ebdb-4c90-b50c-4db331153adb.png)

