### PR TITLE
Fix the missing call to get the type of the property for the interface

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -2187,7 +2187,6 @@ namespace Radzen
             return false;
         }
 
-
         /// <summary>
         /// Gets the type of the property.
         /// </summary>
@@ -2199,10 +2198,32 @@ namespace Radzen
             if (property.Contains("."))
             {
                 var part = property.Split('.').FirstOrDefault();
-                return GetPropertyType(type?.GetProperty(part)?.PropertyType, property.Replace($"{part}.", ""));
+                return GetPropertyType(GetPropertyIncludeInterface(type, part), property.Replace($"{part}.", ""));
             }
 
-            return type?.GetProperty(property)?.PropertyType;
+            return GetPropertyIncludeInterface(type, property);
+        }
+
+        private static Type GetPropertyIncludeInterface(Type type, string property)
+        {
+            if (type == null) return null;
+            if (!type.IsInterface)
+            {
+                return type.GetProperty(property)?.PropertyType;
+            }
+            else
+            {
+                foreach (var interfaceType in new Type[] { type }
+                                    .Concat(type.GetInterfaces()))
+                {
+                    var propertyInfo = interfaceType.GetProperty(property);
+                    if (propertyInfo != null)
+                    {
+                        return propertyInfo.PropertyType;
+                    }
+                }
+            }
+            return null;
         }
     }
 

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -2198,13 +2198,13 @@ namespace Radzen
             if (property.Contains("."))
             {
                 var part = property.Split('.').FirstOrDefault();
-                return GetPropertyType(GetPropertyIncludeInterface(type, part), property.Replace($"{part}.", ""));
+                return GetPropertyType(GetPropertyTypeIncludeInterface(type, part), property.Replace($"{part}.", ""));
             }
 
-            return GetPropertyIncludeInterface(type, property);
+            return GetPropertyTypeIncludeInterface(type, property);
         }
 
-        private static Type GetPropertyIncludeInterface(Type type, string property)
+        private static Type GetPropertyTypeIncludeInterface(Type type, string property)
         {
             if (type == null) return null;
             if (!type.IsInterface)

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -2210,7 +2210,10 @@ namespace Radzen
             {
                 return !type.IsInterface ?
                     type.GetProperty(property)?.PropertyType :
-                        new Type[] { type }.Concat(type.GetInterfaces()).FirstOrDefault(t => t.GetProperty(property) != null);
+                        new Type[] { type }
+                        .Concat(type.GetInterfaces())
+                        .FirstOrDefault(t => t.GetProperty(property) != null)
+                        .GetProperty(property).PropertyType;
             }
 
             return null;


### PR DESCRIPTION
Fix the missing call to get the type of the property for the interface.

@enchev   It seems the "refactor commit" miss calling "GetProperty(property).PropertyTye" to get the property type of the interface.

My previous commit is using "foreach" instead of "linq" as I do not want to call "GetProperty" twice