### PR TITLE
Added click event support to the popup Notification Message.

### DIFF
--- a/Radzen.Blazor/NotificationService.cs
+++ b/Radzen.Blazor/NotificationService.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Components;
+using Radzen.Blazor;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
@@ -35,7 +37,10 @@ namespace Radzen
                 Severity = message.Severity,
                 Summary = message.Summary,
                 Detail = message.Detail,
-                Style = message.Style
+                Style = message.Style,
+                Click = message.Click,
+                CloseOnClick = message.CloseOnClick,
+                Payload = message.Payload
             };
 
             if (!Messages.Contains(newMessage))
@@ -44,21 +49,27 @@ namespace Radzen
             }
         }
 
-        /// <summary>
-        /// Notifies the specified severity.
-        /// </summary>
-        /// <param name="severity">The severity.</param>
-        /// <param name="summary">The summary.</param>
-        /// <param name="detail">The detail.</param>
-        /// <param name="duration">The duration.</param>
-        public void Notify(NotificationSeverity severity = NotificationSeverity.Info, string summary = "", string detail = "", double duration = 3000)
+      /// <summary>
+      /// Notifies the specified severity.
+      /// </summary>
+      /// <param name="severity">The severity.</param>
+      /// <param name="summary">The summary.</param>
+      /// <param name="detail">The detail.</param>
+      /// <param name="duration">The duration.</param>
+      /// <param name="click">The click event.</param>
+      /// <param name="closeOnClick">If true, then the notification will be closed when clicked on.</param>
+      /// <param name="payload">Used to store a custom payload that can be retreived later in the click event handler.</param>
+      public void Notify(NotificationSeverity severity = NotificationSeverity.Info, string summary = "", string detail = "", double duration = 3000, Action<NotificationMessage> click = null, bool closeOnClick = false, object payload = null)
         {
             var newMessage = new NotificationMessage()
             {
                 Duration = duration,
                 Severity = severity,
                 Summary = summary,
-                Detail = detail
+                Detail = detail,
+                Click = click,
+                CloseOnClick = closeOnClick,
+                Payload = payload
             };
 
             if (!Messages.Contains(newMessage))
@@ -98,5 +109,20 @@ namespace Radzen
         /// </summary>
         /// <value>The style.</value>
         public string Style { get; set; }
-    }
+        /// <summary>
+        /// Gets or sets the click event.
+        /// </summary>
+        /// <value>This event handler is called when the notification is clicked on.</value>
+        public Action<NotificationMessage> Click { get; set; }
+        /// <summary>
+        /// Gets or sets click on close action.
+        /// </summary>
+        /// <value>If true, then the notification will be closed when clicked on.</value>
+        public bool CloseOnClick { get; set; }
+        /// <summary>
+        /// Gets or sets notification payload.
+        /// </summary>
+        /// <value>Used to store a custom payload that can be retreived later in the click event handler.</value>
+        public object Payload { get; set; }
+   }
 }

--- a/Radzen.Blazor/RadzenNotificationMessage.razor
+++ b/Radzen.Blazor/RadzenNotificationMessage.razor
@@ -4,12 +4,12 @@
 {
     var classes = GetMessageCssClasses();
 
-    <div class="rz-notification-message rz-growl " style="width: 250px;z-index: 1002;position:static;@Style">
-        <div aria-live="polite" class="rz-growl-item-container rz-state-highlight   @classes.Item1">
+   <div class="rz-notification-message rz-growl " style="width: 250px;z-index: 1002;position:static;@(Message.Click != null || Message.CloseOnClick ? "cursor: pointer;" : "") @Style">
+        <div aria-live="polite" class="rz-growl-item-container rz-state-highlight @classes.Item1">
             <div class="rz-growl-item">
                 <div class="rz-growl-icon-close rzi rzi-times" @onclick="@Close" style="cursor:pointer"></div>
-                <span class="rz-growl-image rzi @classes.Item2"></span>
-                <div class="rz-growl-message">
+                <span class="rz-growl-image rzi @classes.Item2" @onclick="NotificationClicked"></span>
+                <div class="rz-growl-message" @onclick="NotificationClicked">
                     <span class="rz-growl-title">@((MarkupString)Message.Summary)</span>
                     <p>@((MarkupString)Message.Detail)</p>
                 </div>
@@ -19,46 +19,54 @@
     </div>
 }
 @code {
-    Tuple<string, string> GetMessageCssClasses()
-    {
-        if (Message.Severity == NotificationSeverity.Error)
-        {
-            return new Tuple<string, string>("rz-growl-message-error", "rzi-times");
-        }
-        else if (Message.Severity == NotificationSeverity.Info)
-        {
-            return new Tuple<string, string>("rz-growl-message-info", "rzi-info-circle");
-        }
-        else if (Message.Severity == NotificationSeverity.Success)
-        {
-            return new Tuple<string, string>("rz-growl-message-success", "rzi-check");
-        }
-        else if (Message.Severity == NotificationSeverity.Warning)
-        {
-            return new Tuple<string, string>("rz-growl-message-warn", "rzi-exclamation-triangle");
-        }
+   Tuple<string, string> GetMessageCssClasses()
+   {
+      if (Message.Severity == NotificationSeverity.Error)
+      {
+         return new Tuple<string, string>("rz-growl-message-error", "rzi-times");
+      }
+      else if (Message.Severity == NotificationSeverity.Info)
+      {
+         return new Tuple<string, string>("rz-growl-message-info", "rzi-info-circle");
+      }
+      else if (Message.Severity == NotificationSeverity.Success)
+      {
+         return new Tuple<string, string>("rz-growl-message-success", "rzi-check");
+      }
+      else if (Message.Severity == NotificationSeverity.Warning)
+      {
+         return new Tuple<string, string>("rz-growl-message-warn", "rzi-exclamation-triangle");
+      }
 
-        return new Tuple<string, string>("", "");
-    }
+      return new Tuple<string, string>("", "");
+   }
 
-    [Inject] private NotificationService Service { get; set; }
+   [Inject] private NotificationService Service { get; set; }
 
-    public bool Visible { get; set; } = true;
+   public bool Visible { get; set; } = true;
 
-    [Parameter]
-    public NotificationMessage Message { get; set; }
+   [Parameter]
+   public NotificationMessage Message { get; set; }
 
-    [Parameter]
-    public string Style { get; set; }
+   [Parameter]
+   public string Style { get; set; }
 
-    public void Close()
-    {
-        Service.Messages.Remove(Message);
-        System.Threading.Tasks.Task.Delay(0).ContinueWith(r => { Visible = false; });
-    }
+   public void Close()
+   {
+      Service.Messages.Remove(Message);
+      System.Threading.Tasks.Task.Delay(0).ContinueWith(r => { Visible = false; });
+   }
 
-    protected override void OnInitialized()
-    {
-        System.Threading.Tasks.Task.Delay(Convert.ToInt32(Message.Duration ?? 3000)).ContinueWith(r => InvokeAsync(Close));
-    }
+   protected override void OnInitialized()
+   {
+      System.Threading.Tasks.Task.Delay(Convert.ToInt32(Message.Duration ?? 3000)).ContinueWith(r => InvokeAsync(Close));
+   }
+
+   private void NotificationClicked()
+   {
+      if (Message.CloseOnClick)
+         Close();
+
+      Message?.Click?.Invoke(Message);
+   }
 }

--- a/RadzenBlazorDemos/Pages/NotificationPage.razor
+++ b/RadzenBlazorDemos/Pages/NotificationPage.razor
@@ -44,6 +44,14 @@
                     Click=@(args => ShowNotification(new NotificationMessage { Style = "position: absolute; left: -1000px;", Severity = NotificationSeverity.Success, Summary = "Success Summary", Detail = "Success Detail", Duration = 40000 })) />
             </RadzenCard>
         </div>
+         <div class="col-lg-6 col-xl-4 p-3">
+            <RadzenCard>
+               <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Info</RadzenText>
+               <RadzenButton Text="Show notification with custom click handler" Class="w-100"
+                             ButtonStyle="ButtonStyle.Info"
+                             Click="@(args => ShowNotification(new NotificationMessage { Severity = NotificationSeverity.Info, Summary = "Info Click Summary", Detail = "Click Me", Duration = 4000, Click=NotificationClick, CloseOnClick = true, Payload = DateTime.Now }))" />
+            </RadzenCard>
+         </div>
     </div>
 </div>
 </RadzenExample>
@@ -51,12 +59,17 @@
 <EventConsole @ref=@console Class="mt-4" />
 
 @code {
-    EventConsole console;
+   EventConsole console;
 
-    void ShowNotification(NotificationMessage message)
-    {
-        NotificationService.Notify(message);
+   void ShowNotification(NotificationMessage message)
+   {
+      NotificationService.Notify(message);
 
-        console.Log($"{message.Severity} notification");
-    }
+      console.Log($"{message.Severity} notification");
+   }
+
+   void NotificationClick(NotificationMessage message)
+   {
+      console.Log($"{message.Summary} clicked, Payload = {message.Payload}");
+   }
 }


### PR DESCRIPTION
Features added:

 -  Ability to process an event when the a notification is clicked on 
 -  Option to close the notification on click
 -  Ability to pass a custom Payload object to the event handler (so the click handler has context)

A simple use case would be the ability to respond to a "You've got mail" notification by opening up the message when the popup is clicked on. The Payload object would contain the context on which message to open. 