### PR TITLE
Components - Added id/name-attribute to support more accessiblity

### DIFF
--- a/Radzen.Blazor/RadzenAutoComplete.razor
+++ b/Radzen.Blazor/RadzenAutoComplete.razor
@@ -16,7 +16,7 @@
                 oninput="@OpenScript()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"  @onchange="@OnChange"
                 aria-autocomplete="list" aria-haspopup="true" autocomplete="off" role="combobox"
                 class="@InputClassList"
-                id="@Name" aria-expanded="true" placeholder="@Placeholder" />
+                id="@Name" aria-expanded="true" placeholder="@Placeholder" name="@Name" />
         }
         else
         {
@@ -24,7 +24,7 @@
                 oninput="@OpenScript()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" @onchange="@OnChange"
                 aria-autocomplete="list" aria-haspopup="true" autocomplete="off" role="combobox"
                 class="@InputClassList"
-                type="text" id="@Name" aria-expanded="true" placeholder="@Placeholder" />
+                type="text" id="@Name" aria-expanded="true" placeholder="@Placeholder" name="@Name"/>
         }
         <div id="@PopupID" class="rz-autocomplete-panel" style="@PopupStyle">
             <ul @ref="@list" class="rz-autocomplete-items rz-autocomplete-list" role="listbox">

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -14,7 +14,7 @@
         <div class="rz-helper-hidden-accessible">
             <input disabled="@Disabled" aria-haspopup="listbox" readonly="" type="text" tabindex="-1"
                    name="@Name" value="@(internalValue != null ? internalValue : "")"
-                   aria-label="@(!Multiple && internalValue != null ? internalValue : "")" />
+                   aria-label="@(!Multiple && internalValue != null ? internalValue : "")" id="@Name" />
         </div>
 
         @if (ValueTemplate != null && selectedItem != null)

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -14,7 +14,7 @@
          @onkeydown="@((args) => OnKeyPress(args))">
         <div class="rz-helper-hidden-accessible">
             <input tabindex="-1" disabled="@Disabled" style="width:100%" aria-haspopup="listbox" readonly="" type="text"
-                   name="@Name" aria-label="@(!Multiple && internalValue != null ? PropertyAccess.GetItemOrValueFromProperty(internalValue, TextProperty) : "")" />
+                   name="@Name" aria-label="@(!Multiple && internalValue != null ? PropertyAccess.GetItemOrValueFromProperty(internalValue, TextProperty) : "")" id="@Name" />
 
         </div>
 

--- a/Radzen.Blazor/RadzenMask.razor
+++ b/Radzen.Blazor/RadzenMask.razor
@@ -6,6 +6,6 @@
 @if (Visible)
 {
     <input @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange" id="@GetId()"
-           oninput="Radzen.mask('@GetId()', '@Mask', '@Pattern', '@CharacterPattern')"/>
+           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange" id="@Name"
+           @oninput="@OnInput"/>
 }

--- a/Radzen.Blazor/RadzenMask.razor
+++ b/Radzen.Blazor/RadzenMask.razor
@@ -7,5 +7,5 @@
 {
     <input @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
            placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange" id="@Name"
-           @oninput="@OnInput"/>
+           oninput="Radzen.mask('@Name', '@Mask', '@Pattern', '@CharacterPattern')" />
 }

--- a/Radzen.Blazor/RadzenMask.razor.cs
+++ b/Radzen.Blazor/RadzenMask.razor.cs
@@ -81,8 +81,18 @@ namespace Radzen.Blazor
 
             if (firstRender)
             {
-                JSRuntime.InvokeVoidAsync("eval", $"Radzen.mask('{GetId()}', '{Mask}', '{Pattern}', '{CharacterPattern}')");
+                JSRuntime.InvokeVoidAsync("eval", $"Radzen.mask('{Name}', '{Mask}', '{Pattern}', '{CharacterPattern}')");
             }
+        }
+
+        /// <summary>
+        /// Handles the Input event
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        protected async System.Threading.Tasks.Task OnInput(ChangeEventArgs args)
+        {
+            await JSRuntime.InvokeVoidAsync("eval", $"Radzen.mask('{Name}', '{Mask}', '{Pattern}', '{CharacterPattern}')");
         }
     }
 }

--- a/Radzen.Blazor/RadzenMask.razor.cs
+++ b/Radzen.Blazor/RadzenMask.razor.cs
@@ -84,15 +84,5 @@ namespace Radzen.Blazor
                 JSRuntime.InvokeVoidAsync("eval", $"Radzen.mask('{Name}', '{Mask}', '{Pattern}', '{CharacterPattern}')");
             }
         }
-
-        /// <summary>
-        /// Handles the Input event
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        protected async System.Threading.Tasks.Task OnInput(ChangeEventArgs args)
-        {
-            await JSRuntime.InvokeVoidAsync("eval", $"Radzen.mask('{Name}', '{Mask}', '{Pattern}', '{CharacterPattern}')");
-        }
     }
 }

--- a/Radzen.Blazor/RadzenNumeric.razor
+++ b/Radzen.Blazor/RadzenNumeric.razor
@@ -11,7 +11,7 @@
                class="@GetInputCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
                placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "off")" value="@FormattedValue" @onchange="@OnChange"
                onkeypress="Radzen.numericKeyPress(event, @IsInteger().ToString().ToLower())"
-           onblur="@getOnInput()" onpaste="@getOnPaste()" />
+               onblur="@getOnInput()" onpaste="@getOnPaste()" id="@Name" />
         @if (ShowUpDown)
         {
             <button type="button" class="rz-spinner-button rz-spinner-up rz-button" tabindex="-1"

--- a/Radzen.Blazor/RadzenPassword.razor
+++ b/Radzen.Blazor/RadzenPassword.razor
@@ -5,5 +5,5 @@
 @if (Visible)
 {
     <input @ref="@Element" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="password" @attributes="Attributes" class="@GetCssClass()"
-           placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()"/>
+           placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@Name"/>
 }

--- a/Radzen.Blazor/RadzenTextArea.razor
+++ b/Radzen.Blazor/RadzenTextArea.razor
@@ -4,5 +4,5 @@
 @if (Visible)
 {
     <textarea @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" rows="@Rows" cols="@Cols" style="@Style" @attributes="Attributes" class="@GetCssClass()"
-          placeholder="@Placeholder" maxlength="@MaxLength" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()"></textarea>
+          placeholder="@Placeholder" maxlength="@MaxLength" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@Name"></textarea>
 }

--- a/Radzen.Blazor/RadzenTextBox.razor
+++ b/Radzen.Blazor/RadzenTextBox.razor
@@ -2,5 +2,5 @@
 @if (Visible)
 {
     <input @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange" id="@GetId()" />
+           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange" id="@Name" />
 }


### PR DESCRIPTION
I added id/name-attribute to some components:

- AutoComplete
- DropDown
- DropDownDatagrid
- Mask
- Numeric
- Password
- TextAera
- TextBox

Im using this components with RadzenLabel and "Component"-attribute as "for"-attribute. The controls couldnt match with the labels "for"-attribute. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#attributes
https://www.w3schools.com/tags/att_label_for.asp

Accessibility is a more and more important topic and i tried to add or fix the "id"-attributes. 


![grafik](https://user-images.githubusercontent.com/115212774/201373861-e864f36e-e911-4d59-b0cb-8648ada6c105.png)

![grafik](https://user-images.githubusercontent.com/115212774/201373777-5dcc7a37-7a26-4a06-8f14-0f9ca92a76a0.png)

Im using Chrome and an add-on called "WAVE Evaluation Tool" to analyse it:

![grafik](https://user-images.githubusercontent.com/115212774/201374371-f95c293a-a515-4a3a-8116-52b9b0164c12.png)



Im not sure if there are more components that are missing right now. 

Your feedback is welcome in any cases.