### PR TITLE
Select value in multiple DropDown on `Enter` press

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -598,7 +598,7 @@ namespace Radzen
                     //
                 }
             }
-            else if (Multiple && key == "Space")
+            else if (Multiple && key == "Enter")
             {
                 if (selectedIndex >= 0 && selectedIndex <= items.Count() - 1)
                 {


### PR DESCRIPTION
1. It's a bit confusing to select values in drop-down by pressing on `Space` button. 
 I suppose this control should behave like [select2](URL) or another that is similar to `RadzenDropDown`. Most users are used to pressing `Enter` to select an item from a list.
Moreover, there is some unpredictable behavior when drop-down contains values with `Space`.
2. I'd like an option to clear the search in drop-down every time the user selects an item from the list. So, I've add new parameter to allow developers to set up this behavior.