### PR TITLE
Add parameter in RadzenDropDown to clear search input after selection.

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -38,6 +38,13 @@ namespace Radzen.Blazor
         /// <value><c>true</c> if popup should open on focus; otherwise, <c>false</c>.</value>
         [Parameter]
         public bool OpenOnFocus { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether search field need to be cleared after selection. Set to <c>false</c> by default.
+        /// </summary>
+        /// <value><c>true</c> if need to be cleared; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ClearSearchAfterSelection { get; set; }
 
         private async Task OnFocus(Microsoft.AspNetCore.Components.Web.FocusEventArgs args)
         {
@@ -194,6 +201,11 @@ namespace Radzen.Blazor
                 if (!Multiple && !isFromKey)
                 {
                     await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID);
+                }
+                
+                if (ClearSearchAfterSelection)
+                {
+                    await JSRuntime.InvokeAsync<string>("Radzen.setInputValue", search, string.Empty);
                 }
 
                 await SelectItem(item);


### PR DESCRIPTION
I'd like an option to clear the search in drop-down every time the user selects an item from the list. So, I've add new parameter to allow developers to set up this behavior.