### PR TITLE
Fix: PropertyAccess.Getter method doesn't allow access of array membe…

### DIFF
--- a/Radzen.Blazor.Tests/PropertyAccessTests.cs
+++ b/Radzen.Blazor.Tests/PropertyAccessTests.cs
@@ -1,0 +1,96 @@
+﻿using AngleSharp.Css;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Dynamic.Core;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class PropertyAccessTests
+    {
+        [Fact]
+        public void Getter_Resolves_Property_On_Simple_Object()
+        {
+            var o = new SimpleObject() { Prop1 = "TestString" };
+            var getter = PropertyAccess.Getter<SimpleObject, string>("Prop1");
+            var value = getter(o);
+            Assert.Equal("TestString", value);
+        }
+
+        [Fact]
+        public void Getter_Resolves_Property_On_Simple_Object_QueryableType()
+        {
+            var _data = new List<SimpleObject>()
+            {
+                new SimpleObject() { Prop1 = "TestString" },
+            };
+
+            Func<object, object> getter = PropertyAccess.Getter<object, object>("Prop1");
+
+            var value = getter(_data[0]);
+            Assert.Equal("TestString", value);
+        }
+
+        [Fact]
+        public void Getter_Resolves_Property_On_Nested_Object()
+        {
+            var o = new NestedObject() { Obj = new SimpleObject { Prop1 = "TestString" } };
+            var getter = PropertyAccess.Getter<NestedObject, string>("Obj.Prop1");
+            var value = getter(o);
+            Assert.Equal("TestString", value);
+        }
+
+        [Fact]
+        public void Getter_Resolves_Property_From_Array()
+        {
+            var o = new ArrayObject() { Values = new string[] { "1", "2", "3" } };
+            var getter = PropertyAccess.Getter<ArrayObject, string>("Values[1]");
+            var value = getter(o);
+            Assert.Equal("2", value);
+        }
+
+        [Fact]
+        public void Getter_Resolves_Property_From_Nested_Array()
+        {
+            var o = new NestedArrayObject() { Obj = new ArrayObject() { Values = new string[] { "1", "2", "3" } } };
+            var getter = PropertyAccess.Getter<NestedArrayObject, string>("Obj.Values[2]");
+            var value = getter(o);
+            Assert.Equal("3", value);
+        }
+
+        [Fact]
+        public void Getter_Resolves_Property_From_List()
+        {
+            var o = new ListObject() { Values = new List<string>() { "1", "2", "3" } };
+            var getter = PropertyAccess.Getter<ListObject, string>("Values[1]");
+            var value = getter(o);
+            Assert.Equal("2", value);
+        }
+
+        public class SimpleObject
+        {
+            public string Prop1 { get; set; }
+        }
+
+        public class NestedObject
+        {
+            public SimpleObject Obj { get; set; }
+        }
+
+        public class ArrayObject
+        {
+            public string[] Values { get; set; }
+        }
+
+        public class NestedArrayObject
+        {
+            public ArrayObject Obj { get; set; }
+        }
+
+        public class ListObject
+        {
+            public List<string> Values { get; set; }
+        }
+    }
+}

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -7,7 +7,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
+using System.Linq.Dynamic.Core.Parser;
 using System.Linq.Expressions;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -1936,32 +1938,10 @@ namespace Radzen
         /// <typeparam name="TItem">The owner type.</typeparam>
         /// <typeparam name="TValue">The value type.</typeparam>
         /// <param name="propertyName">Name of the property to return.</param>
-        /// <param name="type">Type of the object.</param>
         /// <returns>A function which return the specified property by its name.</returns>
-        public static Func<TItem, TValue> Getter<TItem, TValue>(string propertyName, Type type = null)
+        public static Func<TItem, TValue> Getter<TItem, TValue>(string propertyName)
         {
-            var arg = Expression.Parameter(typeof(TItem));
-
-            Expression body = arg;
-
-            if (type != null)
-            {
-                body = Expression.Convert(body, type);
-            }
-
-            foreach (var member in propertyName.Split("."))
-            {
-                body = !body.Type.IsInterface ? 
-                    Expression.PropertyOrField(body, member) :
-                        Expression.Property(
-                            body,
-                            new Type[] { body.Type }.Concat(body.Type.GetInterfaces()).FirstOrDefault(t => t.GetProperty(member) != null),
-                            member);
-            }
-
-            body = Expression.Convert(body, typeof(TValue));
-
-            return Expression.Lambda<Func<TItem, TValue>>(body, arg).Compile();
+            return DynamicExpressionParser.ParseLambda<TItem, TValue>(null, false, propertyName).Compile();
         }
 
         /// <summary>

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -375,28 +375,19 @@ namespace Radzen
 
             if (_data != null)
             {
-                var query = _data.AsQueryable();
-
-                var type = query.ElementType;
-
-                if (type == typeof(object) && typeof(EnumerableQuery).IsAssignableFrom(query.GetType()) && query.Any())
-                { 
-                    type = query.FirstOrDefault().GetType();
-                }
-
                 if (!string.IsNullOrEmpty(ValueProperty))
                 {
-                    valuePropertyGetter = PropertyAccess.Getter<object, object>(ValueProperty, type);
+                    valuePropertyGetter = PropertyAccess.Getter<object, object>(ValueProperty);
                 }
 
                 if (!string.IsNullOrEmpty(TextProperty))
                 {
-                    textPropertyGetter = PropertyAccess.Getter<object, object>(TextProperty, type);
+                    textPropertyGetter = PropertyAccess.Getter<object, object>(TextProperty);
                 }
 
                 if (!string.IsNullOrEmpty(DisabledProperty))
                 {
-                    disabledPropertyGetter = PropertyAccess.Getter<object, object>(DisabledProperty, type);
+                    disabledPropertyGetter = PropertyAccess.Getter<object, object>(DisabledProperty);
                 }
             }
         }


### PR DESCRIPTION
I am trying to use the DataGrid component and discovered that nested properties work correctly, but array indexes don't. This means that Property Names like "Child.Grandchild" work, but "Child[0]" and "Child[0].Grandchild[2]" don't. This is a change to use the DynamicExpressionParser.ParseLambda method from Linq to handle creating the lambda.