### PR TITLE
Reset DropDown list after selection

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -206,6 +206,7 @@ namespace Radzen.Blazor
                 if (ClearSearchAfterSelection)
                 {
                     await JSRuntime.InvokeAsync<string>("Radzen.setInputValue", search, string.Empty);
+                    await OnFilter(null);
                 }
 
                 await SelectItem(item);


### PR DESCRIPTION
**Steps to Reproduce:**

1. Add RadzenDropDown component on any Blazor app. Set parameters `ClearSearchAfterSelection="true"` and `Multiple="true"`. Fill DropDown list with any data.
2. Run application.
3. Filter drop-down list => The search results list is shown
4. Select the value from the search results list.
5. Look at the drop-down.

**Actual Results:**
The search results list is not reset when the search query was automatically cleared after selecting a value. Please see the attachments for more details. 

**Expected Results:**
The search results list is reset when the search query was automatically cleared after selecting a value. 
 
![image](https://user-images.githubusercontent.com/54200738/204785788-ba8de9e1-d0ae-47e9-b29c-4da568194c56.png)
![image](https://user-images.githubusercontent.com/54200738/204785885-f061cbd2-7fe8-482d-aab0-1a3dcf491a9f.png)
