### PR TITLE
Update RadzenScheduler.razor.cs

### DIFF
--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -206,7 +206,7 @@ namespace Radzen.Blazor
 
         IList<ISchedulerView> Views { get; set; } = new List<ISchedulerView>();
 
-        ISchedulerView SelectedView
+        public ISchedulerView SelectedView
         {
             get
             {


### PR DESCRIPTION
Currently there's no easy way to get the current selected view. This is because the selectedIndex that gets updated is the field, not the public property.
The Scheduler.IsSelected() is not an easy way to get it, as you need to test every view to get the current one.
Please consider updating the SelectedIndex property or making that SelectedView getter public.

This is the easier way I found to get synced with the current view and, as you can see, not a handful one.
![image](https://user-images.githubusercontent.com/54379860/206461224-24f98b57-7b29-4603-af0b-3c96676f2a70.png)
![image](https://user-images.githubusercontent.com/54379860/206461594-714c64fa-c218-42f9-b6ec-72da4fdd3408.png)
![image](https://user-images.githubusercontent.com/54379860/206461976-2f959c33-3815-45a5-ae73-df5a2e5c3743.png)
![image](https://user-images.githubusercontent.com/54379860/206461779-2fdde485-9ac0-4811-a66e-0112203a8491.png)
