### PR TITLE
Optimize rendering of chart tooltip

### DIFF
--- a/Radzen.Blazor/CartesianSeries.cs
+++ b/Radzen.Blazor/CartesianSeries.cs
@@ -467,7 +467,7 @@ namespace Radzen.Blazor
                 builder.AddAttribute(1, nameof(ChartTooltip.X), x + marginLeft);
                 builder.AddAttribute(2, nameof(ChartTooltip.Y), y + marginTop);
 
-                builder.AddAttribute(3, nameof(ChartTooltip.ChildContent), TooltipTemplate == null ? null : TooltipTemplate(item));
+                builder.AddAttribute(3, nameof(ChartTooltip.ChildContent), TooltipTemplate?.Invoke(item));
 
                 builder.AddAttribute(4, nameof(ChartTooltip.Title), TooltipTitle(item));
                 builder.AddAttribute(5, nameof(ChartTooltip.Label), TooltipLabel(item));

--- a/Radzen.Blazor/RadzenChart.razor
+++ b/Radzen.Blazor/RadzenChart.razor
@@ -38,10 +38,13 @@
                 @donut.RenderTitle(MarginLeft, MarginTop)
             }
         }
-    @if (tooltip != null)
-    {
-        @tooltip
-    }
+        <ChartTooltipContainer @ref="@chartTooltipContainer">
+            @if (tooltip != null)
+            {
+                @tooltip
+            }
+        </ChartTooltipContainer>
+        
     </CascadingValue>
 }
 </div>

--- a/Radzen.Blazor/RadzenChart.razor.cs
+++ b/Radzen.Blazor/RadzenChart.razor.cs
@@ -207,12 +207,7 @@ namespace Radzen.Blazor
             ValueScale.Fit(ValueAxis.TickDistance);
             CategoryScale.Fit(CategoryAxis.TickDistance);
 
-            var stateHasChanged = false;
-
-            if (!ValueScale.IsEqualTo(valueScale))
-            {
-                stateHasChanged = true;
-            }
+            var stateHasChanged = !ValueScale.IsEqualTo(valueScale);
 
             if (!CategoryScale.IsEqualTo(categoryScale))
             {
@@ -254,6 +249,7 @@ namespace Radzen.Blazor
             }
         }
 
+        ChartTooltipContainer chartTooltipContainer;
         RenderFragment tooltip;
         object tooltipData;
         double mouseX;
@@ -313,7 +309,7 @@ namespace Radzen.Blazor
                             {
                                 tooltipData = null;
                                 tooltip = overlay.RenderTooltip(mouseX, mouseY, MarginLeft, MarginTop);
-                                StateHasChanged();
+                                chartTooltipContainer.Refresh();
                                 await Task.Yield();
                                 
                                 return;
@@ -328,7 +324,7 @@ namespace Radzen.Blazor
                             {
                                 tooltipData = data;
                                 tooltip = series.RenderTooltip(data, MarginLeft, MarginTop);
-                                StateHasChanged();
+                                chartTooltipContainer.Refresh();
                                 await Task.Yield();
                             }
 
@@ -342,7 +338,7 @@ namespace Radzen.Blazor
                     tooltipData = null;
                     tooltip = null;
 
-                    StateHasChanged();
+                    chartTooltipContainer.Refresh();
                     await Task.Yield();
                 }
             }

--- a/Radzen.Blazor/Rendering/ChartTooltipContainer.razor
+++ b/Radzen.Blazor/Rendering/ChartTooltipContainer.razor
@@ -1,0 +1,12 @@
+﻿@ChildContent
+
+@code {
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
+    internal void Refresh()
+    {
+        StateHasChanged();
+    }
+
+}


### PR DESCRIPTION
This pull request optimizes the rendering of chart tooltip. Only the tooltip will be rendered on mouse movement, it avoids the rerendering of the whole chart and can improve performance of charts with many values.