### PR TITLE
Fix side dialog width + title

### DIFF
--- a/Radzen.Blazor/RadzenDialog.razor
+++ b/Radzen.Blazor/RadzenDialog.razor
@@ -19,7 +19,7 @@
         @if (sideDialogOptions.ShowTitle)
         {
             <div class="rz-dialog-side-titlebar">
-                <div class="rz-dialog-side-title" style="display: inline" id="rz-dialog-side-label">@sideDialogOptions.Title</div>
+                <div class="rz-dialog-side-title" style="display: inline" id="rz-dialog-side-label">@((MarkupString)sideDialogOptions.Title)</div>
                 @if (sideDialogOptions.ShowClose)
                 {
                     <a href="javascript:void(0)" class="rz-dialog-side-titlebar-close" @onclick="@(_ => Service.CloseSide(null))" role="button">

--- a/Radzen.Blazor/themes/components/blazor/_dialog.scss
+++ b/Radzen.Blazor/themes/components/blazor/_dialog.scss
@@ -191,6 +191,7 @@ $dialog-zindex: 1001 !default;
   right: 0;
   min-width: 150px;
   width: 400px;
+  max-width: 100%;
   height: 100%;
 }
 
@@ -198,6 +199,7 @@ $dialog-zindex: 1001 !default;
   left: 0;
   min-width: 150px;
   width: 400px;
+  max-width: 100%;
   height: 100%;
 }
 


### PR DESCRIPTION
I found two issues with the side dialog
1. It's to wide on smaller screens. Fixed by adding `max-width` to the css classes.
2. The title behavior is different from the normal dialog title (doesn't respect markup)

Hope these are okay fixes :)