### PR TITLE
Feature: Add a required marker to the label component.

### DIFF
--- a/Radzen.Blazor.Tests/LabelTests.cs
+++ b/Radzen.Blazor.Tests/LabelTests.cs
@@ -20,6 +20,22 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Label_Renders_RequiredMarkerParameter()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenLabel>();
+
+            var text = "Test";
+            var requiredMarker = "required";
+
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.Text, text));
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.RequiredMarker, requiredMarker));
+
+            Assert.Contains($@">{text} <span class=""required-marker"">{requiredMarker}</span></label>", component.Markup);
+        }
+
+        [Fact]
         public void Label_Renders_ComponentParameter()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor/RadzenLabel.razor
+++ b/Radzen.Blazor/RadzenLabel.razor
@@ -2,5 +2,8 @@
 
 @if (Visible)
 {
-    <label @ref="@Element" for="@Component" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">@Text</label>
+    <label @ref="@Element" for="@Component" style="@Style"@attributes="Attributes" class="@GetCssClass()"
+           id="@GetId()">@Text@if (RequiredMarker.Trim() != string.Empty)
+        {
+ <span class="required-marker">@RequiredMarker</span>}</label>
 }

--- a/Radzen.Blazor/RadzenLabel.razor.cs
+++ b/Radzen.Blazor/RadzenLabel.razor.cs
@@ -25,14 +25,14 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The text.</value>
         [Parameter]
-        public string Text { get; set; } = string.Empty;
+        public string Text { get; set; } = "";
 
         /// <summary>
         /// Gets or sets the required marker.
         /// </summary>
         /// <value>The text of the required marker.</value>
         [Parameter]
-        public string RequiredMarker { get; set; } = string.Empty;
+        public string RequiredMarker { get; set; } = "";
 
         /// <inheritdoc />
         protected override string GetComponentCssClass()

--- a/Radzen.Blazor/RadzenLabel.razor.cs
+++ b/Radzen.Blazor/RadzenLabel.razor.cs
@@ -25,7 +25,14 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The text.</value>
         [Parameter]
-        public string Text { get; set; } = "";
+        public string Text { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the required marker.
+        /// </summary>
+        /// <value>The text of the required marker.</value>
+        [Parameter]
+        public string RequiredMarker { get; set; } = string.Empty;
 
         /// <inheritdoc />
         protected override string GetComponentCssClass()


### PR DESCRIPTION
This PR adds a new parameter to the `RazenLabel` component named `RequiredMarker`.

This parameter is displayed if it is not an empty string. It appears after the existing `Text` parameter and is span-wrapped (`<span class="required-marker">...</span>`) so that developers can target the required marker with CSS to give it a different presentation than the label text.

The odd line breaks in the razor template are to avoid extra white space. An alternative method to avoid extra whitespace would be to concatenate the `Text` parameter, the span wrapper and the `RequiredMarker` parameter in a class property. However, this method would require the template to output raw HTML, so I felt the odd line breaks were the better approach.

I also added a test for the required marker.

This lets you style form labels like the examples below:

<img width="178" alt="Screen Shot 2023-01-04 at 10 44 21 PM" src="https://user-images.githubusercontent.com/3266985/210697508-9ddf876d-051a-4d4c-9a1c-26592a707cb6.png">

<img width="125" alt="Screen Shot 2023-01-04 at 10 45 30 PM" src="https://user-images.githubusercontent.com/3266985/210697523-facfd239-7af8-43cb-85a8-2fa5a2581d8a.png">

