### PR TITLE
Addition of a YearView for the Scheduler

### DIFF
--- a/Radzen.Blazor/RadzenYearView.razor
+++ b/Radzen.Blazor/RadzenYearView.razor
@@ -1,0 +1,36 @@
+@using Radzen.Blazor
+@using Radzen.Blazor.Rendering
+
+@inherits SchedulerViewBase
+
+@code {    
+    public override RenderFragment Render()
+    {
+        var appointments = Scheduler.GetAppointmentsInRange(StartDate, EndDate);
+
+        var maxAppointmentsInSlot = 0;
+
+        if (MaxAppointmentsInSlot != null)
+        {
+            maxAppointmentsInSlot = MaxAppointmentsInSlot.Value;
+        }
+        else
+        {
+            var slotHeight = (Scheduler.Height - 60) / 12;
+            maxAppointmentsInSlot = Convert.ToInt32(Math.Floor(slotHeight / 24)) - 1;
+        }
+
+        return @<CascadingValue Value=@Scheduler>
+            <YearView StartDate=@StartDate 
+                      EndDate=@EndDate 
+                      MaxAppointmentsInSlot=@maxAppointmentsInSlot 
+                      MoreText=@MoreText 
+                      Appointments=@appointments 
+                      MonthLabelColor=@MonthLabelColor 
+                      NotInMonthColor=@NotInMonthColor 
+                      WeekendColor=@WeekendColor 
+                      AppointmentHeight=@AppointmentHeight
+                      ShowAppointmentContent=@ShowAppointmentContent />
+        </CascadingValue>;
+    }
+}

--- a/Radzen.Blazor/RadzenYearView.razor.cs
+++ b/Radzen.Blazor/RadzenYearView.razor.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Components;
+using Radzen.Blazor.Rendering;
+using System;
+using System.Drawing;
+using System.Globalization;
+
+namespace Radzen.Blazor
+{
+    /// <summary>
+    /// Displays the appointments in a month day in <see cref="RadzenScheduler{TItem}" />
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// &lt;RadzenScheduler Data="@appointments"&gt;
+    ///     &lt;RadzenMonthView /&gt;
+    /// &lt;/RadzenScheduler&gt;
+    /// </code>
+    /// </example>
+    public partial class RadzenYearView : SchedulerViewBase
+    {
+        /// <inheritdoc />
+        public override string Icon => "view_list";
+
+        /// <inheritdoc />
+        public override string Title
+        {
+            get => Scheduler.CurrentDate.ToString("yyyy", Scheduler.Culture);
+        }
+
+        /// <inheritdoc />
+        [Parameter]
+        public override string Text { get; set; } = "Year";
+
+        /// <summary>
+        /// Specifies the maximum appointnments to render in a slot.
+        /// </summary>
+        /// <value>The maximum appointments in slot.</value>
+        [Parameter]
+        public int? MaxAppointmentsInSlot { get; set; }
+
+        /// <summary>
+        /// Specifies the text displayed when there are more appointments in a slot than <see cref="MaxAppointmentsInSlot" />.
+        /// </summary>
+        /// <value>The more text. Set to <c>"+ {0} more"</c> by default.</value>
+        [Parameter]
+        public string MoreText { get; set; } = "+ {0} more";
+
+        /// <summary>
+        /// Specifies the background color of the Month label in the view />.
+        /// </summary>
+        /// <value>The color of the month labels. Initially set to "#00000000" (transparent)</value>
+        [Parameter]
+        public string MonthLabelColor { get; set; } = "#00000000";
+
+        /// <summary>
+        /// Specifies the background color of the cells that don't fall in the month for that row in the view />.
+        /// </summary>
+        /// <value>The color of the cells in a month row that are not part of the previous or next month. Initially set to "#00000000" (transparent)</value>
+        [Parameter]
+        public string NotInMonthColor { get; set; } = "#00000000";
+
+        /// <summary>
+        /// Specifies the background color of the cells that don't fall in the month for that row in the view />.
+        /// </summary>
+        /// <value>The color of the cells that fall on the weekend. Initially set to "#00000000" (transparent)</value>
+        [Parameter]
+        public string WeekendColor { get; set; } = "#00000000";
+
+        /// <summary>
+        /// Specifies the height of Appointments in the year view />.
+        /// </summary>
+        /// <value>The height of each appointment in the view. Initially set to 1.5</value>
+        [Parameter]
+        public double AppointmentHeight { get; set; } = 1.5;
+
+        /// <summary>
+        /// Specifies whether to show content in the appointments/>.
+        /// </summary>
+        /// <value>Show content in the views appointments. Initially set to false</value>
+        [Parameter]
+        public bool ShowAppointmentContent { get; set; } = false;
+
+
+        /// <inheritdoc />
+        public override DateTime StartDate
+        {
+            get
+            {
+                var d = new DateTime(Scheduler.CurrentDate.Date.Year, 1, 1).StartOfWeek();
+                if (d.DayOfWeek == DateTimeFormatInfo.CurrentInfo.FirstDayOfWeek) d.AddDays(-7);
+
+                return  d;
+            }
+        }
+
+        /// <inheritdoc />
+        public override DateTime EndDate
+        {
+            get
+            {
+                var d = new DateTime(Scheduler.CurrentDate.Date.Year, 1, 1).AddDays(DateTime.IsLeapYear(Scheduler.CurrentDate.Date.Year) ? 366 : 365).EndOfWeek();
+
+                return d;
+            }
+        }
+
+        /// <inheritdoc />
+        public override DateTime Next()
+        {
+            return Scheduler.CurrentDate.Date.AddYears(1);
+        }
+
+        /// <inheritdoc />
+        public override DateTime Prev()
+        {
+            return Scheduler.CurrentDate.Date.AddYears(-1);
+        }
+    }
+}

--- a/Radzen.Blazor/Rendering/YearAppointment.razor
+++ b/Radzen.Blazor/Rendering/YearAppointment.razor
@@ -1,0 +1,74 @@
+@using Radzen.Blazor
+@using Radzen.Blazor.Rendering
+
+<div class="rz-event" style=@Style @onclick=@OnClick>
+    <div class="rz-event-content" title=@Data?.Text @attributes=@Attributes>
+        @if(ShowAppointmentContent)
+        {
+            @Scheduler.RenderAppointment(Data)
+        }
+    </div>
+</div>
+@code {
+    [Parameter]
+    public double? Top { get; set; }
+
+    [Parameter]
+    public double? Left { get; set; }
+
+    [Parameter]
+    public double? Width { get; set; }
+
+    [Parameter]
+    public double? Height { get; set; }
+
+    [Parameter]
+    public EventCallback<AppointmentData> Click { get; set; }
+
+    IDictionary<string, object> Attributes { get; set; }
+
+    [Parameter]
+    public AppointmentData Data { get; set; }
+
+    [Parameter]
+    public bool ShowAppointmentContent { get; set; } = false;
+
+    [CascadingParameter]
+    public IScheduler Scheduler { get; set; }
+
+    string Style { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        Attributes = Scheduler.GetAppointmentAttributes(Data);
+
+        var style = new List<string>();
+
+        if (Top.HasValue)
+        {
+            style.Add($"top: {Top.ToInvariantString()}em");
+        }
+
+        if (Left.HasValue)
+        {
+            style.Add($"left: {Left.ToInvariantString()}%");
+        }
+
+        if (Width.HasValue)
+        {
+            style.Add($"width: {Width.ToInvariantString()}%");
+        }
+
+        if (Height.HasValue)
+        {
+            style.Add($"height: {Height.ToInvariantString()}em");
+        }
+
+        Style = String.Join(";", style);
+    }
+
+    async Task OnClick()
+    {
+        await Click.InvokeAsync(Data);
+    }
+}

--- a/Radzen.Blazor/Rendering/YearView.razor
+++ b/Radzen.Blazor/Rendering/YearView.razor
@@ -1,0 +1,271 @@
+@using Radzen
+@using Radzen.Blazor
+@using Radzen.Blazor.Rendering
+@inject DialogService DialogService
+
+@{
+    var days = 0;
+    var points = new Dictionary<AppointmentData, double>();
+    var startyear = StartDate.AddDays(7).Year;
+    DateTime date = StartDate;
+    DateTime realstart = StartDate;
+    int daysinmonth;
+
+    const double NUMBER_DAYS_COLUMNS = 37.0;
+    const double MONTH_LABEL_WIDTH = 50.0;
+}
+
+<div class="rz-view rz-month-view">
+    <div class="rz-view-header">
+        <div class="rz-slot-header">
+            Month
+        </div>
+        @for (var dateheader = StartDate; dateheader <= StartDate.AddDays(NUMBER_DAYS_COLUMNS - 1); dateheader = dateheader.AddDays(1))
+        {
+            <div class="rz-slot-header">
+                @dateheader.ToString("ddd", Scheduler.Culture).Substring(0,1)
+            </div>
+        }
+        <div class="rz-slot-header">
+            Month
+        </div>
+    </div>
+    <div class="rz-view-content">
+        @for (int month = 1; month < 13; month++)
+        {
+            realstart = new DateTime(startyear, month, 1);
+            daysinmonth = DateTime.DaysInMonth(startyear, month);
+            date = realstart.StartOfMonth().StartOfWeek();
+
+            <div class="rz-week">
+                <div class="rz-events">
+                    @for (var start = date; start < date.AddDays(NUMBER_DAYS_COLUMNS); start = start.AddDays(1))
+                    {
+                        var end = start.AddDays(1);
+                        var appointments = AppointmentsInSlot(start, end);
+                        var excessCount = appointments.Count() - MaxAppointmentsInSlot;
+                        var existingTops = ExistingTops(points, appointments.Take(MaxAppointmentsInSlot));
+
+                        // if not in month, don't bother trying to get appointments. We'll get them next month pass.
+                        if (start.Month == month)
+                        {
+                            @foreach (var item in appointments.Take(MaxAppointmentsInSlot))
+                            {
+                                // Get slot index for first real date in this month
+                                var startSlotIndex = realstart.Subtract(date).Days + 1; // 1 is left-hand month label column
+                                var slotIndex = startSlotIndex + item.Start.Date.Subtract(realstart).Days;
+                                var slotWidth = 100 / (NUMBER_DAYS_COLUMNS + 2);
+                                var left = slotIndex * slotWidth;
+
+                                var length = Math.Max(1, Math.Ceiling(item.End.Subtract(realstart).TotalDays) - (slotIndex - startSlotIndex));
+                                var width = item.End <= realstart.AddDays(daysinmonth - 1) ? (length) * slotWidth : (daysinmonth + startSlotIndex - slotIndex) * slotWidth;
+                                if (!points.TryGetValue(item, out var top))
+                                {
+                                    top = DetermineTop(existingTops);
+                                    points.Add(item, top);
+                                    existingTops.Add(top);
+                                }
+                                var height = AppointmentHeight;
+                                var data = item;
+
+
+                                @if (item.Start >= realstart && item.Start <= end)
+                                {
+                                    <YearAppointment Data=@item Top=@top Left=@left Width=@width Height=@height Click=@OnAppointmentClick ShowAppointmentContent=@ShowAppointmentContent />
+                                }
+                                else if (realstart == start)
+                                {
+                                    left = startSlotIndex * slotWidth;
+                                    length = Math.Max(1, Math.Min(daysinmonth, Math.Ceiling(item.End.Subtract(date).TotalDays - (startSlotIndex - 1)))); // the 1 is the month label column
+                                    width = length * slotWidth;
+
+                                    <YearAppointment Data=@item Top=@top Left=@left Width=@width Height=@height Click=@OnAppointmentClick ShowAppointmentContent=@ShowAppointmentContent />
+                                }
+                            }
+
+                        }
+
+                        @if (excessCount > 0)
+                        {
+                            var slotIndex = start.Subtract(date).Days;
+                            var slotWidth = 100 / (NUMBER_DAYS_COLUMNS + 2);
+                            var left = (slotIndex + 1) * slotWidth; //1 is month column
+                            var top = AppointmentHeight * (MaxAppointmentsInSlot + 1);
+                            var listDate = start;
+                            <a class="rz-event-list-btn" style="top: @(top.ToInvariantString())em; left: @(left.ToInvariantString())%" @onclick=@(args => OnListClick(listDate, appointments))>@String.Format(MoreText, excessCount)</a>
+                        }
+                    }
+                </div>
+                <div class="rz-slots">
+                    <div @onclick="@(args => OnSlotClick(realstart))" @attributes=@Attributes(realstart) style="background-color:@MonthLabelColor">
+                        <div class="rz-slot-header rz-month-label-left">
+                            @realstart.ToString("MMM", Scheduler.Culture)
+                        </div>
+                    </div>
+                    @for (var day = 0; day < NUMBER_DAYS_COLUMNS; day++)
+                    {
+                        string backcolor = "";
+                        var dayOfWeek = date.AddDays(day);
+
+
+                        backcolor = ((dayOfWeek.DayOfWeek == DayOfWeek.Saturday) || (dayOfWeek.DayOfWeek == DayOfWeek.Sunday)) ? WeekendColor : "transparent";
+                        backcolor = dayOfWeek.Month != month ? NotInMonthColor : backcolor;
+
+                        <div @onclick="@(args => OnSlotClick(dayOfWeek))" @attributes=@Attributes(dayOfWeek) style="background-color:@backcolor">
+                            <div class="rz-slot-title">
+                                @if (dayOfWeek.Month == month)
+                                    @dayOfWeek.Day
+
+
+
+
+                                </div>
+                            </div>
+                    }
+                    <div @onclick="@(args => OnSlotClick(realstart))" @attributes=@Attributes(realstart) style="background-color:@MonthLabelColor">
+                        <div class="rz-slot-header rz-month-label-right">
+                            @realstart.ToString("MMM", Scheduler.Culture)
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+<style>
+
+    .rz-month-label-left {
+        writing-mode: vertical-lr;
+        transform: rotate(-180deg) translateX(-0.3rem);
+        text-align: center;
+        color: #f4f9fb;
+    }
+
+    .rz-month-label-right {
+        writing-mode: vertical-rl;
+        transform: translateX(0.6rem);
+        text-align: center;
+        color: #f4f9fb;
+    }
+
+    .rz-month-header {
+        height: 1.5em;
+        text-align: right;
+        padding: 0 4px;
+        width: 80px;
+        border-right: 1px solid #88989b;
+        white-space: nowrap;
+        background-color: #e9edf0;
+    }
+
+</style>
+
+@code {
+    [Parameter]
+    public DateTime StartDate { get; set; }
+
+    [Parameter]
+    public DateTime EndDate { get; set; }
+
+    [Parameter]
+    public int MaxAppointmentsInSlot { get; set; }
+
+    [Parameter]
+    public string MoreText { get; set; }
+
+    [Parameter]
+    public string MonthLabelColor { get; set; }
+
+    [Parameter]
+    public string NotInMonthColor { get; set; }
+
+    [Parameter]
+    public string WeekendColor { get; set; }
+
+    [Parameter]
+    public double AppointmentHeight { get; set; }
+
+    [Parameter]
+    public bool ShowAppointmentContent { get; set; }
+
+    [CascadingParameter]
+    public IScheduler Scheduler { get; set; }
+
+    [Parameter]
+    public IEnumerable<AppointmentData> Appointments { get; set; }
+
+    IDictionary<string, object> Attributes(DateTime start)
+    {
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1));
+        attributes["class"] = ClassList.Create("rz-slot").Add(attributes).ToString();
+        return attributes;
+    }
+
+    async Task OnSlotClick(DateTime date)
+    {
+        await Scheduler.SelectSlot(date, date.AddDays(1));
+    }
+
+    double DetermineTop(HashSet<double> existingTops)
+    {
+        var top = 1.5;
+
+        while (existingTops.Contains(top))
+        {
+            top += AppointmentHeight;
+        }
+
+        return top;
+    }
+
+    HashSet<double> ExistingTops(IDictionary<AppointmentData, double> tops, IEnumerable<AppointmentData> appointments)
+    {
+        var existingTops = new HashSet<double>();
+
+        foreach (var appointment in appointments)
+        {
+            if (tops.TryGetValue(appointment, out var existingTop))
+            {
+                existingTops.Add(existingTop);
+            }
+        }
+
+        return existingTops;
+    }
+
+    async Task OnAppointmentClick(AppointmentData data)
+    {
+        await Scheduler.SelectAppointment(data);
+    }
+
+    private AppointmentData[] AppointmentsInSlot(DateTime start, DateTime end)
+    {
+        if (Appointments == null)
+        {
+            return Array.Empty<AppointmentData>();
+        }
+
+        return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
+    }
+
+    async Task OnListClick(DateTime date, IEnumerable<AppointmentData> appointments)
+    {
+        await DialogService.OpenAsync(date.ToShortDateString(), ds =>
+    @<div class="rz-event-list">
+        <CascadingValue Value=@Scheduler>
+            @foreach (var item in appointments)
+            {
+                <Appointment Data=@item Click="OnListEventClick" />
+            }
+        </CascadingValue>
+    </div>);
+    }
+
+    async Task OnListEventClick(AppointmentData data)
+    {
+        DialogService.Close();
+
+        await OnAppointmentClick(data);
+    }
+}


### PR DESCRIPTION
Created a YearView component to be used in the Scheduler ([Year View Demo](http://radzen.delaci.co.uk/)). Although functionally working, there are a couple of issues that I could do with some help on.

1. I am not conversant with SCSS and to be honest, I can't find how the css is generated, so I have placed some styles within the YearView.razor file that need to be addressed. There are also some properties, namely MonthLabelColor, NotInMonthColor and WeekendColor that may or may not need to be css rather than properties.

2. While creating this, it became apparent that there needed to be an option to reduce the height of an appointment, as a year view is sort of more of a summary. Whilst I did change this for the YearView and added the property AppointmentHeight, I was forced to create a new component called YearAppointment that would react to another boolean property ShowAppointmentContent to hide or show the content. Otherwise it would have still drawn the text, there being no Template to override it, and if there was, would have applied to all views. That made me think that the Template should maybe reside at the View level rather than the Scheduler level. This would let you have a different template per view. Just a thought.