### PR TITLE
Replacing the boolean autocomplete parameters with strings.

### DIFF
--- a/Radzen.Blazor.Tests/MaskTests.cs
+++ b/Radzen.Blazor.Tests/MaskTests.cs
@@ -119,11 +119,11 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenMask>();
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, false));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.Off));
 
             Assert.Contains(@$"autocomplete=""off""", component.Markup);
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, true));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.On));
 
             Assert.Contains(@$"autocomplete=""on""", component.Markup);
         }

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -184,11 +184,11 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenNumeric<double>>();
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, false));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.Off));
 
             Assert.Contains(@$"autocomplete=""off""", component.Markup);
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, true));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.On));
 
             Assert.Contains(@$"autocomplete=""on""", component.Markup);
         }

--- a/Radzen.Blazor.Tests/PasswordTests.cs
+++ b/Radzen.Blazor.Tests/PasswordTests.cs
@@ -119,11 +119,11 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenPassword>();
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, false));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.NewPassword));
 
             Assert.Contains(@$"autocomplete=""new-password""", component.Markup);
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, true));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.On));
 
             Assert.Contains(@$"autocomplete=""on""", component.Markup);
         }

--- a/Radzen.Blazor.Tests/TextBoxTests.cs
+++ b/Radzen.Blazor.Tests/TextBoxTests.cs
@@ -119,11 +119,11 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenTextBox>();
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, false));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.Off));
 
             Assert.Contains(@$"autocomplete=""off""", component.Markup);
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, true));
+            component.SetParametersAndRender(parameters => parameters.Add<string>(p => p.AutoComplete, ACG.On));
 
             Assert.Contains(@$"autocomplete=""on""", component.Markup);
         }

--- a/Radzen.Blazor/AutoCompleteGuidance.cs
+++ b/Radzen.Blazor/AutoCompleteGuidance.cs
@@ -1,0 +1,82 @@
+﻿namespace Radzen.Blazor
+{
+    /// <summary>
+    /// The <c>ACG</c> is a string-associated enum of browser-supported
+    /// autocomplete attribute values.
+    /// </summary>
+    /// <remarks>
+    /// <c>ACG</c> stands for Auto Complete Guidance. An initialism is used for
+    /// brevity. This class lists the autocomplete attirbute options allowing
+    /// developers to provide the browser with guidance on how to pre-populate
+    /// the form fields. It is a class rather than a simpler enum to associate
+    /// each option with the string the browser expects. For more information
+    /// please review the list of options (https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)
+    /// and the spec (https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+    /// </remarks>
+    public static class ACG
+	{
+        // Options
+		public static string Off { get => "off"; }
+        public static string On { get => "on"; }
+        public static string Name { get => "name"; }
+        public static string HonorificPrefix { get => "honorific-prefix"; }
+        public static string GivenName { get => "given-name"; }
+        public static string AdditionalName { get => "additional-name"; }
+        public static string FamilyName { get => "family-name"; }
+        public static string HonorificSuffix { get => "honorific-suffix"; }
+        public static string NickName { get => "nickname"; }
+        public static string Email { get => "email"; }
+        public static string Username { get => "username"; }
+        public static string NewPassword { get => "new-password"; }
+        public static string CurrentPassword { get => "current-password"; }
+        public static string OneTimeCode { get => "one-time-code"; }
+        public static string OrganizationTitle { get => "organization-title"; }
+        public static string Organization { get => "organization"; }
+        public static string StreetAddress { get => "street-address"; }
+        public static string AddressLine1 { get => "address-line1"; }
+        public static string AddressLine2 { get => "address-line2"; }
+        public static string AddressLine3 { get => "address-line3"; }
+        public static string AddressLevel1 { get => "address-level1"; }
+        public static string AddressLevel2 { get => "address-level2"; }
+        public static string AddressLevel3 { get => "address-level3"; }
+        public static string AddressLevel4 { get => "address-level4"; }
+        public static string Country { get => "country"; }
+        public static string CountryName { get => "country-name"; }
+        public static string PostalCode { get => "postal-code"; }
+        public static string CcName { get => "cc-name"; }
+        public static string CcGivenName { get => "cc-given-name"; }
+        public static string CcAdditionalName { get => "cc-additional-name"; }
+        public static string CcFamilyName { get => "cc-family-name"; }
+        public static string CcNumber { get => "cc-number"; }
+        public static string CcExp { get => "cc-exp"; }
+        public static string CcExpMonth { get => "cc-exp-month"; }
+        public static string CcExpYear { get => "cc-exp-year"; }
+        public static string CcCsc { get => "cc-csc"; }
+        public static string CcType { get => "cc-type"; }
+        public static string TransactionCurrency { get => "transaction-currency"; }
+        public static string TransactionAmount { get => "transaction-amount"; }
+        public static string Language { get => "language"; }
+        public static string BDay { get => "bday"; }
+        public static string BDayDay { get => "bday-day"; }
+        public static string BDayMonth { get => "bday-month"; }
+        public static string BdayYear { get => "bday-year"; }
+        public static string Sex { get => "sex"; }
+        public static string Tel { get => "tel"; }
+        public static string TelCountryCode { get => "tel-country-code"; }
+        public static string TelNational { get => "tel-national"; }
+        public static string TelAreaCode { get => "tel-area-code"; }
+        public static string TelLocal { get => "tel-local"; }
+        public static string TelExtension { get => "tel-extension"; }
+        public static string Impp { get => "impp"; }
+        public static string Url { get => "url"; }
+        public static string Photo { get => "photo"; }
+
+        // Synonyms
+        public static string State { get => AddressLevel1; }
+        public static string Province { get => AddressLevel1; }
+        public static string ZipCode { get => PostalCode; }
+        public static string FirstName { get => GivenName; }
+        public static string MiddleName { get => AdditionalName; }
+        public static string LastName { get => FamilyName; }
+    }
+}

--- a/Radzen.Blazor/RadzenLogin.razor
+++ b/Radzen.Blazor/RadzenLogin.razor
@@ -7,14 +7,14 @@
             <div class="rz-form-row">
                 <label class="rz-label" for=@Id("username")>@UserText</label>
                 <div class="rz-form-input-wrapper">
-                    <RadzenTextBox AutoComplete=@AutoComplete id=@Id("username") Name="Username" @bind-Value=@username />
+                    <RadzenTextBox AutoComplete=@PasswordAutoComplete id=@Id("username") Name="Username" @bind-Value=@username />
                     <RadzenRequiredValidator Component="Username" Text=@UserRequired />
                 </div>
             </div>
             <div class="rz-form-row">
                 <label class="rz-label" for=@Id("password")>@PasswordText</label>
                 <div class="rz-form-input-wrapper">
-                    <RadzenPassword id=@Id("password") AutoComplete=@AutoComplete Name="Password" @bind-Value=@password />
+                    <RadzenPassword id=@Id("password") AutoComplete=@PasswordAutoComplete Name="Password" @bind-Value=@password />
                     <RadzenRequiredValidator Component="Password" Text=@PasswordRequired />
                 </div>
             </div>

--- a/Radzen.Blazor/RadzenLogin.razor.cs
+++ b/Radzen.Blazor/RadzenLogin.razor.cs
@@ -36,11 +36,18 @@ namespace Radzen.Blazor
     public partial class RadzenLogin : RadzenComponent
     {
         /// <summary>
-        /// Gets or sets a value indicating whether automatic complete of inputs is enabled.
+        /// Gets or sets a value guiding the browser on how to populate the username input.
         /// </summary>
-        /// <value><c>true</c> if automatic complete of inputs is enabled; otherwise, <c>false</c>.</value>
+        /// <value>Provide an autocomplete option to disable/configure autocomplete; otherwise, <c>username</c>.</value>
         [Parameter]
-        public bool AutoComplete { get; set; } = true;
+        public string UsernameAutoComplete { get; set; } = ACG.Username;
+
+        /// <summary>
+        /// Gets or sets a value guiding the browser on how to populate the password input.
+        /// </summary>
+        /// <value>Provide an autocomplete option to disable/configure autocomplete; otherwise, <c>current-password</c>.</value>
+        [Parameter]
+        public string PasswordAutoComplete { get; set; } = ACG.CurrentPassword;
 
         /// <inheritdoc />
         protected override string GetComponentCssClass()

--- a/Radzen.Blazor/RadzenMask.razor
+++ b/Radzen.Blazor/RadzenMask.razor
@@ -6,6 +6,6 @@
 @if (Visible)
 {
     <input @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange" id="@GetId()"
+           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@AutoComplete" value="@Value" @onchange="@OnChange" id="@GetId()"
            oninput="Radzen.mask('@GetId()', '@Mask', '@Pattern', '@CharacterPattern')"/>
 }

--- a/Radzen.Blazor/RadzenMask.razor.cs
+++ b/Radzen.Blazor/RadzenMask.razor.cs
@@ -21,11 +21,11 @@ namespace Radzen.Blazor
         public bool ReadOnly { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether input automatic complete is enabled.
+        /// Gets or sets a value guiding the browser on how to populate the input.
         /// </summary>
-        /// <value><c>true</c> if input automatic complete is enabled; otherwise, <c>false</c>.</value>
+        /// <value>Provide an autocomplete option to disable/configure autocomplete; otherwise, <c>on</c>.</value>
         [Parameter]
-        public bool AutoComplete { get; set; } = true;
+        public string AutoComplete { get; set; } = ACG.On;
 
         /// <summary>
         /// Gets or sets the maximum length.

--- a/Radzen.Blazor/RadzenNumeric.razor
+++ b/Radzen.Blazor/RadzenNumeric.razor
@@ -9,7 +9,7 @@
     <span @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
         <input @ref="@input" type="text" inputmode="decimal" name="@Name" disabled="@Disabled" readonly="@ReadOnly"
                class="@GetInputCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-               placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "off")" value="@FormattedValue" @onchange="@OnChange"
+               placeholder="@Placeholder" autocomplete="@AutoComplete" value="@FormattedValue" @onchange="@OnChange"
                onkeypress="Radzen.numericKeyPress(event, @IsInteger().ToString().ToLower())"
            onblur="@getOnInput()" onpaste="@getOnPaste()" />
         @if (ShowUpDown)

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -183,11 +183,11 @@ namespace Radzen.Blazor
         public bool ReadOnly { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether input automatic complete is enabled.
+        /// Gets or sets a value guiding the browser on how to populate the input.
         /// </summary>
-        /// <value><c>true</c> if input automatic complete is enabled; otherwise, <c>false</c>.</value>
+        /// <value>Provide an autocomplete option to enable/configure autocomplete; otherwise, <c>off</c>.</value>
         [Parameter]
-        public bool AutoComplete { get; set; } = false;
+        public string AutoComplete { get; set; } = ACG.Off;
 
         /// <summary>
         /// Gets or sets a value indicating whether up down buttons are shown.

--- a/Radzen.Blazor/RadzenPassword.razor
+++ b/Radzen.Blazor/RadzenPassword.razor
@@ -5,5 +5,5 @@
 @if (Visible)
 {
     <input @ref="@Element" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="password" @attributes="Attributes" class="@GetCssClass()"
-           placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()"/>
+           placeholder="@Placeholder" autocomplete="@AutoComplete" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()"/>
 }

--- a/Radzen.Blazor/RadzenPassword.razor.cs
+++ b/Radzen.Blazor/RadzenPassword.razor.cs
@@ -20,11 +20,11 @@ namespace Radzen.Blazor
         public bool ReadOnly { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether input automatic complete is allowed.
+        /// Gets or sets a value guiding the browser on how to populate the input.
         /// </summary>
-        /// <value><c>true</c> if input automatic complete is allowed; otherwise, <c>false</c>.</value>
+        /// <value>Provide an autocomplete option(<c>current-password</c> recommended) to enable autocomplete; otherwise, <c>new-password</c>.</value>
         [Parameter]
-        public bool AutoComplete { get; set; } = true;
+        public string AutoComplete { get; set; } = ACG.NewPassword;
 
         /// <summary>
         /// Handles the <see cref="E:Change" /> event.

--- a/Radzen.Blazor/RadzenTextBox.razor
+++ b/Radzen.Blazor/RadzenTextBox.razor
@@ -2,5 +2,5 @@
 @if (Visible)
 {
     <input @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@(AutoComplete ? "on" : "off")" value="@Value" @onchange="@OnChange" id="@GetId()" />
+           placeholder="@Placeholder" maxlength="@MaxLength" autocomplete="@AutoComplete" value="@Value" @onchange="@OnChange" id="@GetId()" />
 }

--- a/Radzen.Blazor/RadzenTextBox.razor.cs
+++ b/Radzen.Blazor/RadzenTextBox.razor.cs
@@ -21,11 +21,11 @@ namespace Radzen.Blazor
         public bool ReadOnly { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating the browser built-in autocomplete is enabled.
+        /// Gets or sets a value guiding the browser on how to populate the input.
         /// </summary>
-        /// <value><c>true</c> if input automatic complete is enabled; otherwise, <c>false</c>.</value>
+        /// <value>Provide an autocomplete option to disable/configure autocomplete; otherwise, <c>on</c>.</value>
         [Parameter]
-        public bool AutoComplete { get; set; } = true;
+        public string AutoComplete { get; set; } = ACG.On;
 
         /// <summary>
         /// Gets or sets the maximum allowed text length.


### PR DESCRIPTION
This pull request replaced the boolean **AutoComplete** parameter with a string **AutoComplete** parameter. This allows developers to use the auto-complete options supported by web browsers. See the available options on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) and the [spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).

This PR also adds a new `static class` that acts as an `enum` with each option linked to the appropriate attribute string value. It serves as a shortcut to avoid typos. 

Also, the tests are updated to use the new string parameter while maintaining the same functionality.