### PR TITLE
[WIP] Improve clickability of chart series

### DIFF
--- a/Radzen.Blazor/RadzenChart.razor.cs
+++ b/Radzen.Blazor/RadzenChart.razor.cs
@@ -279,7 +279,7 @@ namespace Radzen.Blazor
         {
             foreach (var series in Series)
             {
-                if (series.Visible && series.Contains(mouseX - MarginLeft, mouseY - MarginTop, 5))
+                if (series.Visible && series.Contains(mouseX - MarginLeft, mouseY - MarginTop, 25))
                 {
                     var data = series.DataAt(mouseX - MarginLeft, mouseY - MarginTop);
 


### PR DESCRIPTION
This is the start of a commit series to improve clickability of chart series.

Looking specifically for feedback about approach and testing.

# Motivation
I've noticed that clicking a line series datapoint can be a bit flaky.

![image](https://user-images.githubusercontent.com/6101677/218117384-50363fcd-12f9-4092-9a91-be143b42d2a7.png)

At first I thought the hitbox was just too small, but with further testing I've noticed that sometimes you can be directly on the datapoint and a click still doesn't register. Additionally there is no user feedback on clickability, e.g. a cursor change.

The tooltip implementation feels natural and reliable.

# Current approach.
https://github.com/radzenhq/radzen-blazor/blob/master/Radzen.Blazor/RadzenChart.razor.cs#L282
It appears that the current approach is to loop through possible targets, checking if it is within a certain `tolerance`, and then triggering the `RenderTooltip` or `SeriesClick`. Right now the `tolerance`s is set to `25` and `5` respectively.

The `RenderTooltip` check also includes all overlays such as adjacent line segments, but `SeriesClick` does not.

# Solution
I would like to do two things here:

1. Fix the flakyness
2. Communicate that a click will succeed, either by changing the cursor, or highlighting a point somehow.

# Technical details
I don't yet fully understand the failure method flaky clicking. When a click doesn't register, I can click 5 times and nothing will happen. Moving over by a pixel or two and clicking will usually cause it register.

I no longer think the hitbox `tolerance` is the main concern.

One issue with expanding the hitbox: when there is lots of crowded data, you want to return the closest, not just the first matching data point.
```
foreach (var series in Series)
{
    if (series.Visible && series.Contains(mouseX - MarginLeft, mouseY - MarginTop, 5))
    {
        var data = series.DataAt(mouseX - MarginLeft, mouseY - MarginTop);

        if (data != null)
        {
            await series.InvokeClick(SeriesClick, data);
        }

        return;
    }
}
```
This is already done within a series, but not between series
```
public virtual object DataAt(double x, double y)
{
    if (Items.Any())
    {
        return Items.Select(item =>
        {
            var distance = Math.Abs(TooltipX(item) - x);
            return new { Item = item, Distance = distance };
        }).Aggregate((a, b) => a.Distance < b.Distance ? a : b).Item;
    }

    return null;
}
```

For giving feedback on clickability, we could overlay a caret opposite of the hover overlay, or alternatively, just sync the implementation of click and hover and showing empty caret if a `SeriesClick` is on but `ToolTip.Visible` is False. This informs the user of exactly which data point is about to be clicked.

https://forum.radzen.com/t/hitbox-for-seriesclick-is-tiny-on-line-charts/13087