### PR TITLE
Added Password with Reveal Eye option

### DIFF
--- a/Radzen.Blazor.Tests/PasswordTests.cs
+++ b/Radzen.Blazor.Tests/PasswordTests.cs
@@ -113,6 +113,23 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Password_Renders_AllowPasswordRevealParameter()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenPassword>();
+
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AllowPasswordReveal, true));
+
+            Assert.Contains(@$"rz-button-icon-left", component.Markup);
+
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AllowPasswordReveal, false));
+
+            Assert.DoesNotContain(@$"rz-button-icon-left", component.Markup);
+        }
+
+
+        [Fact]
         public void Password_Renders_AutoCompleteParameter()
         {
             using var ctx = new TestContext();
@@ -139,7 +156,7 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains(@$"autofocus", component.Markup);
         }
-        
+
         [Fact]
         public void Password_Raises_ChangedEvent()
         {

--- a/Radzen.Blazor.Tests/PasswordTests.cs
+++ b/Radzen.Blazor.Tests/PasswordTests.cs
@@ -113,7 +113,7 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
-        public void Password_Renders_AllowPasswordRevealParameter()
+        public void Password_Renders_ShowPasswordRevealParameter()
         {
             using var ctx = new TestContext();
 

--- a/Radzen.Blazor.Tests/PasswordTests.cs
+++ b/Radzen.Blazor.Tests/PasswordTests.cs
@@ -119,11 +119,11 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenPassword>();
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AllowPasswordReveal, true));
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.ShowPasswordReveal, true));
 
             Assert.Contains(@$"rz-button-icon-left", component.Markup);
 
-            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AllowPasswordReveal, false));
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.ShowPasswordReveal, false));
 
             Assert.DoesNotContain(@$"rz-button-icon-left", component.Markup);
         }

--- a/Radzen.Blazor.Tests/PasswordTests.cs
+++ b/Radzen.Blazor.Tests/PasswordTests.cs
@@ -127,7 +127,24 @@ namespace Radzen.Blazor.Tests
 
             Assert.DoesNotContain(@$"rz-button-icon-left", component.Markup);
         }
+        //rz-state-disabled
+        [Fact]
+        public void Password_Renders_AllowRevealWhenDisabledParameter()
+        {
+            using var ctx = new TestContext();
 
+            var component = ctx.RenderComponent<RadzenPassword>();
+
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.ShowPasswordReveal, true));
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.Disabled, true));
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AllowRevealWhenDisabled, true));
+
+            Assert.DoesNotContain(@$"rz-button-icon-only rz-state-disabled", component.Markup);
+
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AllowRevealWhenDisabled, false));
+
+            Assert.Contains(@$"rz-button-icon-only rz-state-disabled", component.Markup);
+        }
 
         [Fact]
         public void Password_Renders_AutoCompleteParameter()

--- a/Radzen.Blazor/RadzenPassword.razor
+++ b/Radzen.Blazor/RadzenPassword.razor
@@ -4,6 +4,22 @@
 @implements IRadzenFormComponent
 @if (Visible)
 {
-    <input @ref="@Element" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="password" @attributes="Attributes" class="@GetCssClass()"
-           placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()"/>
+    if(AllowPasswordReveal)
+    {
+        <span class="@($"rz-calendar rz-calendar-w-btn{(Disabled ? " rz-state-disabled" : "")}")" style="width:100%">
+            <input @ref="@Element" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="@InputType" @attributes="Attributes" class="@GetCssClass()"
+           placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()" />
+           <button  @onclick=@ToggleShowPassword class="@($"rz-datepicker-trigger rz-calendar-button rz-button rz-button-icon-only{(Disabled ? " rz-state-disabled" : "")}")" tabindex="-1" type="button">
+                <span aria-hidden="true" class="rz-button-icon-left">
+                    <i class="rzi">@((MarkupString)(InputType == "password" ? "visibility" : "visibility_off"))</i>
+                </span><span class="rz-button-text"></span>
+            </button>
+        </span>
+    }
+    else
+    {
+        <input @ref="@Element" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="password" @attributes="Attributes" class="@GetCssClass()"
+       placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()" />
+    }
+    
 }

--- a/Radzen.Blazor/RadzenPassword.razor
+++ b/Radzen.Blazor/RadzenPassword.razor
@@ -4,17 +4,24 @@
 @implements IRadzenFormComponent
 @if (Visible)
 {
-    if(AllowPasswordReveal)
+    if(ShowPasswordReveal)
     {
-        <span class="@($"rz-calendar rz-calendar-w-btn{(Disabled ? " rz-state-disabled" : "")}")" style="width:100%">
-            <input @ref="@Element" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="@InputType" @attributes="Attributes" class="@GetCssClass()"
-           placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()" />
-           <button  @onclick=@ToggleShowPassword class="@($"rz-datepicker-trigger rz-calendar-button rz-button rz-button-icon-only{(Disabled ? " rz-state-disabled" : "")}")" tabindex="-1" type="button">
-                <span aria-hidden="true" class="rz-button-icon-left">
-                    <i class="rzi">@((MarkupString)(InputType == "password" ? "visibility" : "visibility_off"))</i>
-                </span><span class="rz-button-text"></span>
-            </button>
-        </span>
+        <div @ref="@Element" @attributes="Attributes" class="@GetComponentCssClass()" style="@getStyle()" id="@GetId()">
+            <span class="@($"rz-calendar rz-calendar-w-btn{(Disabled ? " rz-state-disabled" : "")}")" style="width:100%;" >
+                <input @ref="@input" name="@Name" disabled="@Disabled" readonly="@ReadOnly" type="@InputType" id="@Name"
+                    placeholder="@Placeholder" autocomplete="@(AutoComplete ? "on" : "new-password")" value="@Value"
+                    style="@Style"
+                    class="rz-inputtext @InputClass @(ReadOnly ? "rz-readonly" : "")"
+                    @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"  />
+                <button  @onclick=@OnToggle class="@($"rz-datepicker-trigger rz-calendar-button rz-button rz-button-icon-only{((Disabled && !AllowRevealWhenDisabled) ? " rz-state-disabled" : "")}")" disabled="@(Disabled && !AllowRevealWhenDisabled)" tabindex="-1" type="button">
+                    <span aria-hidden="true" class="rz-button-icon-left">
+                        <i class="rzi">@((MarkupString)(InputType == "password" ? "visibility" : "visibility_off"))</i>
+                    </span>
+                    <span class="rz-button-text"></span>
+                </button>
+            </span>
+        </div>
+
     }
     else
     {

--- a/Radzen.Blazor/RadzenPassword.razor.cs
+++ b/Radzen.Blazor/RadzenPassword.razor.cs
@@ -34,7 +34,26 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value><c>true</c> if password reveal icon is allowed otherwise, <c>fasle</c>.</value>
         [Parameter]
-        public bool AllowPasswordReveal { get; set; }
+        public bool ShowPasswordReveal { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable Password Reveal if the Input is disabled
+        /// </summary>
+        /// <value><c>true</c> if password reveal icon is allowed and the input is disabled otherwise, <c>fasle</c>.</value>
+        [Parameter]
+        public bool AllowRevealWhenDisabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the input CSS class.
+        /// </summary>
+        /// <value>The input CSS class.</value>
+        [Parameter]
+        public string InputClass { get; set; }
+
+        /// <summary>
+        /// Gets input reference.
+        /// </summary>
+        protected ElementReference input;
 
         /// <summary>
         /// Handles the <see cref="E:Change" /> event.
@@ -58,10 +77,16 @@ namespace Radzen.Blazor
         /// <summary>
         /// Handles the Show Password toggle
         /// </summary>
-        protected System.Threading.Tasks.Task ToggleShowPassword()
+        protected System.Threading.Tasks.Task OnToggle()
         {
             InputType = InputType == "password" ? "text" : "password";
             return Task.CompletedTask;
         }
+
+        private string getStyle()
+        {
+            return $"display: inline-block; border:none; margin:0; padding:0; width:100%;{(Style != null ? Style : "")}";
+        }
+
     }
 }

--- a/Radzen.Blazor/RadzenPassword.razor.cs
+++ b/Radzen.Blazor/RadzenPassword.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
 
 namespace Radzen.Blazor
 {
@@ -12,6 +13,8 @@ namespace Radzen.Blazor
     /// </example>
     public partial class RadzenPassword : FormComponent<string>, IRadzenFormComponent
     {
+        private string InputType = "password";
+
         /// <summary>
         /// Gets or sets a value indicating whether is read only.
         /// </summary>
@@ -25,6 +28,13 @@ namespace Radzen.Blazor
         /// <value><c>true</c> if input automatic complete is allowed; otherwise, <c>false</c>.</value>
         [Parameter]
         public bool AutoComplete { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show Eye icon in password input
+        /// </summary>
+        /// <value><c>true</c> if password reveal icon is allowed otherwise, <c>fasle</c>.</value>
+        [Parameter]
+        public bool AllowPasswordReveal { get; set; }
 
         /// <summary>
         /// Handles the <see cref="E:Change" /> event.
@@ -43,6 +53,15 @@ namespace Radzen.Blazor
         protected override string GetComponentCssClass()
         {
             return GetClassList("rz-textbox").ToString();
+        }
+
+        /// <summary>
+        /// Handles the Show Password toggle
+        /// </summary>
+        protected System.Threading.Tasks.Task ToggleShowPassword()
+        {
+            InputType = InputType == "password" ? "text" : "password";
+            return Task.CompletedTask;
         }
     }
 }

--- a/RadzenBlazorDemos/Pages/PasswordConfig.razor
+++ b/RadzenBlazorDemos/Pages/PasswordConfig.razor
@@ -18,6 +18,24 @@
                 <RadzenPassword Disabled="true" Placeholder="Enter password..." class="w-100" />
             </RadzenCard>
         </div>
+        <div class="col-md-4 p-3">
+            <RadzenCard>
+                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Password with Show Password Reveal</RadzenText>
+                <RadzenPassword ShowPasswordReveal="true" Placeholder="Enter password..." Change=@(args => OnChange(args, "Password Allow Password Reveal")) class="w-100" />
+            </RadzenCard>
+        </div>
+        <div class="col-md-4 p-3">
+            <RadzenCard>
+                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Disabled Password with Show Password Reveal</RadzenText>
+                <RadzenPassword ShowPasswordReveal="true" Class="w-100" Disabled="true" Value="Radzen" />
+            </RadzenCard>
+        </div>
+        <div class="col-md-4 p-3">
+            <RadzenCard>
+                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Disabled Password with Allow Reveal When Disabled</RadzenText>
+                <RadzenPassword ShowPasswordReveal="true" AllowRevealWhenDisabled="true" Class="w-100" Disabled="true" Value="Radzen" />
+            </RadzenCard>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Hi,

I've added a Reveal Password option to the RadzenPassword class. 

A couple things to note: 
I could not figure out the CSS structure so I re-used some classes from rz-calendar. I would be happy to fix/update this if I knew how.
I tried to follow Radzen's naming conventions.
I added a test as well as updated the components demo page.

Also, if you don't like this or the way it was done, I will not take it personally. Just trying to contribute.
Thanks for any consideration!