### PR TITLE
Pie and Donut render errors

### DIFF
--- a/Radzen.Blazor/CartesianSeries.cs
+++ b/Radzen.Blazor/CartesianSeries.cs
@@ -214,12 +214,6 @@ namespace Radzen.Blazor
         /// <value>The items.</value>
         protected IList<TItem> Items { get; set; } = new List<TItem>();
 
-        /// <summary>
-        /// Stores <see cref="Data" /> filtered to items greater than zero as an IList of <typeparamref name="TItem"/>.
-        /// </summary>
-        /// <value>The items.</value>
-        protected IList<TItem> ItemsGreaterZero { get; set; } = new List<TItem>();
-
         /// <inheritdoc />
         public RadzenMarkers Markers { get; set; } = new RadzenMarkers();
 
@@ -394,8 +388,6 @@ namespace Radzen.Blazor
                     {
                         Items = Items.AsQueryable().OrderBy(CategoryProperty).ToList();
                     }
-                    
-                    ItemsGreaterZero = Items.Where(e => Value(e) > 0).ToList();
                 }
 
                 await Chart.Refresh(false);

--- a/Radzen.Blazor/CartesianSeries.cs
+++ b/Radzen.Blazor/CartesianSeries.cs
@@ -214,6 +214,12 @@ namespace Radzen.Blazor
         /// <value>The items.</value>
         protected IList<TItem> Items { get; set; } = new List<TItem>();
 
+        /// <summary>
+        /// Stores <see cref="Data" /> filtered to items greater than zero as an IList of <typeparamref name="TItem"/>.
+        /// </summary>
+        /// <value>The items.</value>
+        protected IList<TItem> ItemsGreaterZero { get; set; } = new List<TItem>();
+
         /// <inheritdoc />
         public RadzenMarkers Markers { get; set; } = new RadzenMarkers();
 
@@ -388,6 +394,8 @@ namespace Radzen.Blazor
                     {
                         Items = Items.AsQueryable().OrderBy(CategoryProperty).ToList();
                     }
+                    
+                    ItemsGreaterZero = Items.Where(e => Value(e) > 0).ToList();
                 }
 
                 await Chart.Refresh(false);
@@ -687,7 +695,7 @@ namespace Radzen.Blazor
         public virtual IEnumerable<ChartDataLabel> GetDataLabels(double offsetX, double offsetY)
         {
             var list = new List<ChartDataLabel>();
-            
+
             foreach (var d in Data)
             {
                 list.Add(new ChartDataLabel 

--- a/Radzen.Blazor/RadzenDonutSeries.razor
+++ b/Radzen.Blazor/RadzenDonutSeries.razor
@@ -25,11 +25,12 @@
 
       return @<div style="position: absolute;left: @(left)px;top: @(top)px;width: @(width.ToInvariantString())px; height: @(height.ToInvariantString())px;">
                 @TitleTemplate
-            </div>;
-      }
+          </div>
+      ;
+    }
 
-   public override RenderFragment Render(ScaleBase categoryScale, ScaleBase valueScale)
-   {
+    public override RenderFragment Render(ScaleBase categoryScale, ScaleBase valueScale)
+    {
         var className = $"rz-donut-series rz-series-{Chart.Series.IndexOf(this)}";
         var x = CenterX;
         var y = CenterY;
@@ -39,49 +40,39 @@
         return 
         @<g>
             <g class="@className">
-                @if (Items.Any())
+                @if (ItemsGreaterZero.Any())
                 {
-                    var sum = Items.Sum(Value);
+                    var sum = ItemsGreaterZero.Sum(Value);
+                    double startAngle = -90;
 
-                    if(sum == 0)
+                    @foreach (var data in ItemsGreaterZero)
                     {
-                        var arcClassName = $"rz-series-item-0";
-                        var d = Segment(x, y, radius, radius - 1, -90, 270);
+                        var value = Value(data);
+                        var angle = (value / sum) * 360;
+                        var endAngle = startAngle + angle;
+
+                        var d = Segment(x, y, radius, innerRadius, startAngle, endAngle);
+
+                        startAngle = endAngle;
+
+                        var index = Items.IndexOf(data);
+                        var arcClassName = $"rz-series-item-{index}";
+                        var fill = PickColor(index, Fills);
+                        var stroke = PickColor(index, Strokes);
+
                         <g class="@arcClassName">
-                            <Path D="@d" StrokeWidth="@StrokeWidth" />
+                            <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
                         </g>
-                    }
-                    else
-                    {
-                        double startAngle = -90;
-
-                        @foreach(var data in Items)
-                        {
-                            var value = Value(data);
-                            var angle = (value / sum) * 360;
-                            var endAngle = startAngle + angle;
-
-                            var d = Segment(x, y, radius, innerRadius, startAngle, endAngle);
-
-                            startAngle = endAngle;
-                        
-                            var index = Items.IndexOf(data);
-                            var arcClassName = $"rz-series-item-{index}";
-                            var fill = PickColor(index, Fills);
-                            var stroke = PickColor(index, Strokes);
-
-                            <g class="@arcClassName">
-                                <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
-                            </g>
-                        }
                     }
                 }
                 else
                 {
                     var arcClassName = $"rz-series-item-0";
                     var d = Segment(x, y, radius, radius - 1, -90, 270);
+                    var fill = PickColor(0, Fills);
+                    var stroke = PickColor(0, Strokes);
                     <g class="@arcClassName">
-                        <Path D="@d" StrokeWidth="@StrokeWidth" />
+                        <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
                     </g>
                 }
             </g>

--- a/Radzen.Blazor/RadzenDonutSeries.razor
+++ b/Radzen.Blazor/RadzenDonutSeries.razor
@@ -42,27 +42,47 @@
                 @if (Items.Any())
                 {
                     var sum = Items.Sum(Value);
-                    double startAngle = -90;
 
-                    @foreach(var data in Items)
+                    if(sum == 0)
                     {
-                        var value = Value(data);
-                        var angle = (value / sum) * 360;
-                        var endAngle = startAngle + angle;
-
-                        var d = Segment(x, y, radius, innerRadius, startAngle, endAngle);
-
-                        startAngle = endAngle;
-                        
-                        var index = Items.IndexOf(data);
-                        var arcClassName = $"rz-series-item-{index}";
-                        var fill = PickColor(index, Fills);
-                        var stroke = PickColor(index, Strokes);
-
+                        var arcClassName = $"rz-series-item-0";
+                        var d = Segment(x, y, radius, radius - 1, -90, 270);
                         <g class="@arcClassName">
-                            <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
+                            <Path D="@d" StrokeWidth="@StrokeWidth" />
                         </g>
                     }
+                    else
+                    {
+                        double startAngle = -90;
+
+                        @foreach(var data in Items)
+                        {
+                            var value = Value(data);
+                            var angle = (value / sum) * 360;
+                            var endAngle = startAngle + angle;
+
+                            var d = Segment(x, y, radius, innerRadius, startAngle, endAngle);
+
+                            startAngle = endAngle;
+                        
+                            var index = Items.IndexOf(data);
+                            var arcClassName = $"rz-series-item-{index}";
+                            var fill = PickColor(index, Fills);
+                            var stroke = PickColor(index, Strokes);
+
+                            <g class="@arcClassName">
+                                <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
+                            </g>
+                        }
+                    }
+                }
+                else
+                {
+                    var arcClassName = $"rz-series-item-0";
+                    var d = Segment(x, y, radius, radius - 1, -90, 270);
+                    <g class="@arcClassName">
+                        <Path D="@d" StrokeWidth="@StrokeWidth" />
+                    </g>
                 }
             </g>
        

--- a/Radzen.Blazor/RadzenDonutSeries.razor
+++ b/Radzen.Blazor/RadzenDonutSeries.razor
@@ -37,15 +37,15 @@
         var radius = CurrentRadius;
         var innerRadius = InnerRadius ?? radius / 2;
 
-        return 
+        return
         @<g>
             <g class="@className">
-                @if (ItemsGreaterZero.Any())
+                @if (PositiveItems.Any())
                 {
-                    var sum = ItemsGreaterZero.Sum(Value);
+                    var sum = PositiveItems.Sum(Value);
                     double startAngle = -90;
 
-                    @foreach (var data in ItemsGreaterZero)
+                    @foreach (var data in PositiveItems)
                     {
                         var value = Value(data);
                         var angle = (value / sum) * 360;
@@ -76,7 +76,7 @@
                     </g>
                 }
             </g>
-       
+
         @if (!string.IsNullOrEmpty(Title) && TitleTemplate == null)
         {
             <g class="rz-donut-title">

--- a/Radzen.Blazor/RadzenPieSeries.razor
+++ b/Radzen.Blazor/RadzenPieSeries.razor
@@ -22,30 +22,49 @@
             {
                 var sum = Items.Sum(Value);
 
-                double startAngle = -90;
-
-                @foreach(var data in Items)
+                if(sum == 0)
                 {
-                    var value = Value(data);
-                    var angle = sum == 0 ? 0 : (value / sum) * 360;
-                    var endAngle = startAngle + angle;
-
-                    var d = Segment(x, y, radius, 0, startAngle, endAngle);
-
-                    startAngle = endAngle;
-                    
-                    var index = Items.IndexOf(data);
-                    var arcClassName = $"rz-series-item-{index}";
-                    var fill = PickColor(index, Fills);
-                    var stroke = PickColor(index, Strokes);
-
+                    var arcClassName = $"rz-series-item-0";
+                    var d = Segment(x, y, radius, radius - 1, -90, 270);
                     <g class="@arcClassName">
-                        @if (angle > 0)
-                        {
-                            <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
-                        }
+                        <Path D="@d" StrokeWidth="@StrokeWidth" />
                     </g>
                 }
+                else
+                {
+                    double startAngle = -90;
+
+                    @foreach(var data in Items)
+                    {
+                        var value = Value(data);
+                        var angle = sum == 0 ? 0 : (value / sum) * 360;
+                        var endAngle = startAngle + angle;
+
+                        var d = Segment(x, y, radius, 0, startAngle, endAngle);
+
+                        startAngle = endAngle;
+                    
+                        var index = Items.IndexOf(data);
+                        var arcClassName = $"rz-series-item-{index}";
+                        var fill = PickColor(index, Fills);
+                        var stroke = PickColor(index, Strokes);
+
+                        <g class="@arcClassName">
+                            @if (angle > 0)
+                            {
+                                <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
+                            }
+                        </g>
+                    }                        
+                }
+            }
+            else
+            {
+                var arcClassName = $"rz-series-item-0";
+                var d = Segment(x, y, radius, radius - 1, -90, 270);
+                <g class="@arcClassName">
+                    <Path D="@d" StrokeWidth="@StrokeWidth" />
+                </g>
             }
         </g>;
     }

--- a/Radzen.Blazor/RadzenPieSeries.razor
+++ b/Radzen.Blazor/RadzenPieSeries.razor
@@ -18,23 +18,13 @@
 
         return 
         @<g class="@className">
-            @if (Items.Any())
-            {
-                var sum = Items.Sum(Value);
+            @if (ItemsGreaterZero.Any())
+                {
+                    var sum = ItemsGreaterZero.Sum(Value);
 
-                if(sum == 0)
-                {
-                    var arcClassName = $"rz-series-item-0";
-                    var d = Segment(x, y, radius, radius - 1, -90, 270);
-                    <g class="@arcClassName">
-                        <Path D="@d" StrokeWidth="@StrokeWidth" />
-                    </g>
-                }
-                else
-                {
                     double startAngle = -90;
 
-                    @foreach(var data in Items)
+                @foreach (var data in ItemsGreaterZero)
                     {
                         var value = Value(data);
                         var angle = sum == 0 ? 0 : (value / sum) * 360;
@@ -43,7 +33,7 @@
                         var d = Segment(x, y, radius, 0, startAngle, endAngle);
 
                         startAngle = endAngle;
-                    
+
                         var index = Items.IndexOf(data);
                         var arcClassName = $"rz-series-item-{index}";
                         var fill = PickColor(index, Fills);
@@ -57,15 +47,16 @@
                         </g>
                     }                        
                 }
-            }
-            else
-            {
-                var arcClassName = $"rz-series-item-0";
-                var d = Segment(x, y, radius, radius - 1, -90, 270);
-                <g class="@arcClassName">
-                    <Path D="@d" StrokeWidth="@StrokeWidth" />
-                </g>
-            }
+                else
+                {
+                    var arcClassName = $"rz-series-item-0";
+                    var d = Segment(x, y, radius, radius - 1, -90, 270);
+                    var fill = PickColor(0, Fills);
+                    var stroke = PickColor(0, Strokes);
+                    <g class="@arcClassName">
+                        <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
+                    </g>
+                }
         </g>;
     }
 }

--- a/Radzen.Blazor/RadzenPieSeries.razor
+++ b/Radzen.Blazor/RadzenPieSeries.razor
@@ -16,15 +16,15 @@
         var y = CenterY;
         var radius = CurrentRadius;
 
-        return 
+        return
         @<g class="@className">
-            @if (ItemsGreaterZero.Any())
+            @if (PositiveItems.Any())
                 {
-                    var sum = ItemsGreaterZero.Sum(Value);
+                    var sum = PositiveItems.Sum(Value);
 
                     double startAngle = -90;
 
-                @foreach (var data in ItemsGreaterZero)
+                @foreach (var data in PositiveItems)
                     {
                         var value = Value(data);
                         var angle = sum == 0 ? 0 : (value / sum) * 360;
@@ -45,7 +45,7 @@
                                 <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
                             }
                         </g>
-                    }                        
+                    }
                 }
                 else
                 {

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -324,31 +324,34 @@ namespace Radzen.Blazor
         {
             var list = new List<ChartDataLabel>();
 
-            foreach (var d in Data)
+            if(Data != null)
             {
-                var x = TooltipX(d) - CenterX;
-                var y = TooltipY(d) - CenterY;
+                foreach (var d in Data)
+                {
+                    var x = TooltipX(d) - CenterX;
+                    var y = TooltipY(d) - CenterY;
 
-                // find angle and add offset
-                var phi = Math.Atan2(y, x);
+                    // find angle and add offset
+                    var phi = Math.Atan2(y, x);
 
-                phi += Polar.ToRadian(offsetY % 360);
+                    phi += Polar.ToRadian(offsetY % 360);
 
-                var textAnchor = phi >= -1.5 && phi <= 1.5 ? "start" : "end";
+                    var textAnchor = phi >= -1.5 && phi <= 1.5 ? "start" : "end";
 
-                // find radius
-                var hyp = Math.Sqrt(x * x + y * y) + offsetX + 16;
+                    // find radius
+                    var hyp = Math.Sqrt(x * x + y * y) + offsetX + 16;
 
-                // move along the radius and rotate
-                x = CenterX + hyp * Math.Cos(phi);
-                y = CenterY + hyp * Math.Sin(phi);
+                    // move along the radius and rotate
+                    x = CenterX + hyp * Math.Cos(phi);
+                    y = CenterY + hyp * Math.Sin(phi);
 
-                list.Add(new ChartDataLabel 
-                { 
-                    TextAnchor = textAnchor, 
-                    Position = new Point { X = x, Y = y },
-                    Text = Chart.ValueAxis.Format(Chart.ValueScale, Value(d))
-                });
+                    list.Add(new ChartDataLabel
+                    {
+                        TextAnchor = textAnchor,
+                        Position = new Point { X = x, Y = y },
+                        Text = Chart.ValueAxis.Format(Chart.ValueScale, Value(d))
+                    });
+                }
             }
 
             return list;

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -97,19 +97,20 @@ namespace Radzen.Blazor
         /// Stores <see cref="Data" /> filtered to items greater than zero as an IList of <typeparamref name="TItem"/>.
         /// </summary>
         /// <value>The items.</value>
-        protected IList<TItem> ItemsGreaterZero 
-        { 
-            get
-            {
+        protected IList<TItem> PositiveItems { get; set; }
 
-                if (Items != null)
-                {
-                    return Items.Where(e => Value(e) > 0).ToList();
-                }
-                else
-                {
-                    return new List<TItem>();
-                }
+        /// <inheritdoc />
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            await base.SetParametersAsync(parameters);
+
+            if (Items != null)
+            {
+                PositiveItems = Items.Where(e => Value(e) > 0).ToList();
+            }
+            else
+            {
+                PositiveItems = new List<TItem>();
             }
         }
 
@@ -228,11 +229,11 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         internal override double TooltipX(TItem item)
         {
-            var sum = ItemsGreaterZero.Sum(Value);
+            var sum = PositiveItems.Sum(Value);
             double startAngle = 0;
             double endAngle = 0;
 
-            foreach (var data in ItemsGreaterZero)
+            foreach (var data in PositiveItems)
             {
                 var value = Value(data);
                 endAngle = startAngle + (value / sum) * 360;
@@ -253,7 +254,7 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         internal override double TooltipY(TItem item)
         {
-            var sum = ItemsGreaterZero.Sum(Value);
+            var sum = PositiveItems.Sum(Value);
             double startAngle = 0;
             double endAngle = 0;
 
@@ -330,7 +331,7 @@ namespace Radzen.Blazor
 
             if (Math.Abs(end.X - start.X) < 0.01 && Math.Abs(end.Y - start.Y) < 0.01)
             {
-                // Full circle - SVG can't render a full circle arc 
+                // Full circle - SVG can't render a full circle arc
                 endX = (end.X - 0.01).ToInvariantString();
 
                 innerEndX = (innerEnd.X - 0.01).ToInvariantString();
@@ -348,7 +349,7 @@ namespace Radzen.Blazor
             {
                 //var DataGreaterZero = Data.Where(e => Value(e) > 0).ToList();
 
-                foreach (var d in ItemsGreaterZero)
+                foreach (var d in PositiveItems)
                 {
                     var x = TooltipX(d) - CenterX;
                     var y = TooltipY(d) - CenterY;

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -93,6 +93,26 @@ namespace Radzen.Blazor
             }
         }
 
+        /// <summary>
+        /// Stores <see cref="Data" /> filtered to items greater than zero as an IList of <typeparamref name="TItem"/>.
+        /// </summary>
+        /// <value>The items.</value>
+        protected IList<TItem> ItemsGreaterZero 
+        { 
+            get
+            {
+
+                if (Items != null)
+                {
+                    return Items.Where(e => Value(e) > 0).ToList();
+                }
+                else
+                {
+                    return new List<TItem>();
+                }
+            }
+        }
+
         /// <inheritdoc />
         public override double MeasureLegend()
         {

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -208,11 +208,11 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         internal override double TooltipX(TItem item)
         {
-            var sum = Items.Sum(Value);
+            var sum = ItemsGreaterZero.Sum(Value);
             double startAngle = 0;
             double endAngle = 0;
 
-            foreach (var data in Items)
+            foreach (var data in ItemsGreaterZero)
             {
                 var value = Value(data);
                 endAngle = startAngle + (value / sum) * 360;
@@ -233,7 +233,7 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         internal override double TooltipY(TItem item)
         {
-            var sum = Items.Sum(Value);
+            var sum = ItemsGreaterZero.Sum(Value);
             double startAngle = 0;
             double endAngle = 0;
 
@@ -326,7 +326,9 @@ namespace Radzen.Blazor
 
             if(Data != null)
             {
-                foreach (var d in Data)
+                //var DataGreaterZero = Data.Where(e => Value(e) > 0).ToList();
+
+                foreach (var d in ItemsGreaterZero)
                 {
                     var x = TooltipX(d) - CenterX;
                     var y = TooltipY(d) - CenterY;

--- a/Radzen.Blazor/RadzenSeriesDataLabels.razor
+++ b/Radzen.Blazor/RadzenSeriesDataLabels.razor
@@ -29,12 +29,15 @@
             builder.OpenRegion(0);
             foreach (var label in series.GetDataLabels(OffsetX, OffsetY))
             {
-                builder.AddContent(1,
-                    @<g>
-                        <Text @key="@($"{label.Position}-{Chart.Series.IndexOf(series)}")" 
-                            Value="@label.Text" Position="@label.Position" TextAnchor="@label.TextAnchor" Class="rz-series-data-label" />
-                    </g>
+                if (!(double.IsNaN(label.Position.X) || double.IsNaN(label.Position.Y)))
+                {
+                    builder.AddContent(1,
+                            @<g>
+                                <Text @key="@($"{label.Position}-{Chart.Series.IndexOf(series)}")" 
+                                    Value="@label.Text" Position="@label.Position" TextAnchor="@label.TextAnchor" Class="rz-series-data-label" />
+                            </g>
                     );
+                }
             }
             builder.CloseRegion();
         };


### PR DESCRIPTION
As per issue [Issue](https://github.com/radzenhq/radzen-blazor/issues/810#issue-1581898242) / [Forum Entry](https://forum.radzen.com/t/radzendonut-series-display-error-when-items-in-collection-are-zero/13007)

[Working demo](http://radzen.delaci.co.uk/)

Checks for instances where sum of data = 0 and draws an empty circle rather than nothing (this was causing rendering errors in the browser where some of the values were NaN).

Whilst looking at this, there were also render errors when drawing data labels. These have been resolved.

Also found an error during testing when Data was set to a null object, i.e. DataItem[] revenue; These will also render as an empty circle rather crashing (crashing, not browser rendering error).

Regards

Paul Ruston
