### PR TITLE
add ClearSelection method to RadzenTree

### DIFF
--- a/Radzen.Blazor/RadzenTree.razor.cs
+++ b/Radzen.Blazor/RadzenTree.razor.cs
@@ -274,7 +274,14 @@ namespace Radzen.Blazor
                 });
             }
         }
-
+        /// <summary>
+        /// Clear the current selection to allow re-selection by mouse click
+        /// </summary>
+        public void ClearSelection()
+        {
+            SelectedItem?.Unselect();
+            SelectedItem = null;
+        }
         internal async Task ExpandItem(RadzenTreeItem item)
         {
             var args = new TreeExpandEventArgs()


### PR DESCRIPTION
i was looking for a way to reset the internal "SelectedItem" state in RadzenTree. This is useful when the tree is used as a filter for other items (e.g. a datalist). After resetting the filter, the previously selected node can't be selected again, as in it's internal state it is still selected, therefore not triggering a change event upon mouse click.
with this PR the internal state can be cleared, and the previously node selected again.
