### PR TITLE
[PanelMenu] Show arrow icon when ChildContent exists

### DIFF
--- a/Radzen.Blazor/RadzenPanelMenuItem.razor
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor
@@ -23,7 +23,7 @@
                     {
                         <span class="rz-navigation-item-text" @onclick="@Toggle">@Text</span>
                     }
-                    @if (items.Any())
+                    @if (items.Any() || ChildContent != null)
                     {
                         <i class="rzi rz-navigation-item-icon-children" style="@getStyle()" @onclick="@Toggle" @onclick:preventDefault>keyboard_arrow_down</i>
                     }
@@ -48,7 +48,7 @@
                     {
                         <span class="rz-navigation-item-text">@Text</span>
                     }
-                    @if (items.Any())
+                    @if (items.Any() || ChildContent != null)
                     {
                         <i class="rzi rz-navigation-item-icon-children" style="@getStyle()">keyboard_arrow_down</i>
                     }


### PR DESCRIPTION
**How it's working today**
The arrow icon displays when the menu item has menu items inside.

**Proposal**
Also show the arrow icon when there is ChildContent inside, so that the menu item can be used both ways.

**Before**

![before](https://user-images.githubusercontent.com/78243998/221382448-a29fae09-77af-4649-b4cb-387ed451da7d.jpg)

**After**

![after](https://user-images.githubusercontent.com/78243998/221382456-022e0879-7bbc-4a74-99fb-7a793413ca77.jpg)