### PR TITLE
Fix Regression where previously StrokeWidth=0 allowed for "Scatterplots" without lines

### DIFF
--- a/Radzen.Blazor/Rendering/Path.razor
+++ b/Radzen.Blazor/Rendering/Path.razor
@@ -18,7 +18,7 @@
             style.Append($"fill: {Fill};");
         }
 
-        if (StrokeWidth > 0)
+        if (StrokeWidth >= 0)
         {
             style.Append($"stroke-width: {StrokeWidth.ToInvariantString()};");
         }


### PR DESCRIPTION
Change last week prevents 0 width stroke: https://github.com/radzenhq/radzen-blazor/commit/82010353c69099056e3990873673162ed70d91dd

It is sometimes useful to set `StrokeWidth` to zero (default is 2) to make "Scatterplot" style plots.

![image](https://user-images.githubusercontent.com/6101677/221645210-42b6f0c7-c598-4878-9893-983c8953edad.png)
![image](https://user-images.githubusercontent.com/6101677/221652041-3b0ad40d-1201-429b-b0b6-56236229ceed.png)


As far as i'm concerned this one is ready to merge.
