### PR TITLE
Update OrderIndex for all Columns

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1179,8 +1179,7 @@ namespace Radzen.Blazor
                     columns.Remove(columnToReorder);
                     columns.Insert(actualColumnIndexTo, columnToReorder);
 
-                    columnToReorder.SetOrderIndex(columns.IndexOf(columnToReorder));
-                    columnToReorderTo.SetOrderIndex(columns.IndexOf(columnToReorderTo));
+                    columns.ForEach(c => c.SetOrderIndex(columns.IndexOf(c)));
 
                     UpdateColumnsOrder();
 


### PR DESCRIPTION
The `OrderIndex` of all columns should be updated following the Delete / Insert to ensure everything to the right of the drop location has the correct index