### PR TITLE
Selected column count issue after setting the grid settings to null

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -194,7 +194,7 @@ namespace Radzen.Blazor
         {
             _visible = value;
 
-            if (Grid != null)
+            if (Grid != null && Pickable)
             {
                 Grid.UpdatePickableColumn(this, _visible == true);
             }


### PR DESCRIPTION
Setting the grid settings to null causes the selected column count to display a wrong number. https://forum.radzen.com/t/radzen-datagrid-settings/13408