### PR TITLE
Change RadzenComponent.Element setter to protected internal

### DIFF
--- a/Radzen.Blazor/RadzenComponent.cs
+++ b/Radzen.Blazor/RadzenComponent.cs
@@ -22,7 +22,7 @@ namespace Radzen
         /// <summary>
         /// Gets a reference to the HTML element rendered by the component.
         /// </summary>
-        public ElementReference Element { get; internal set; }
+        public ElementReference Element { get; protected set; }
 
         /// <summary>
         /// A callback that will be invoked when the user hovers the component. Commonly used to display a tooltip via 

--- a/Radzen.Blazor/RadzenComponent.cs
+++ b/Radzen.Blazor/RadzenComponent.cs
@@ -22,7 +22,7 @@ namespace Radzen
         /// <summary>
         /// Gets a reference to the HTML element rendered by the component.
         /// </summary>
-        public ElementReference Element { get; protected set; }
+        public ElementReference Element { get; protected internal set; }
 
         /// <summary>
         /// A callback that will be invoked when the user hovers the component. Commonly used to display a tooltip via 


### PR DESCRIPTION
#857 
Changing this setter allows custom components inheriting the RadzenComponent class to reference the html element in @ref tags.