### PR TITLE
Removed unnecessary curly brace in RadzenLink component

### DIFF
--- a/Radzen.Blazor/RadzenLink.razor
+++ b/Radzen.Blazor/RadzenLink.razor
@@ -7,5 +7,6 @@
         {
             <i class="rzi">@((MarkupString)Icon)</i>
         }
-        <span @ref="@Element" class="rz-link-text">@if (ChildContent != null) {@ChildContent} else {@Text}</span></NavLink>}
+        <span @ref="@Element" class="rz-link-text">@if (ChildContent != null) {@ChildContent} else {@Text}</span>
+    </NavLink>
 }


### PR DESCRIPTION
There was an additional curly brace in the RadzenLink component:
![grafik](https://user-images.githubusercontent.com/3940036/227950048-5ff69fac-1ee3-4c68-9b5c-94644283e4d0.png)
