### PR TITLE
Reset DataGrid in Settings.set

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2936,25 +2936,24 @@ namespace Radzen.Blazor
             {
                 if (settings != value)
                 {
+                    canSaveSettings = false;
+
+                    Groups.Clear();
+                    CurrentPage = 0;
+                    skip = 0;
+                    Reset(true);
+                    allColumns.ToList().ForEach(c =>
+                    {
+                        c.SetVisible(true);
+
+                    });
+                    columns = allColumns.Where(c => c.Parent == null).ToList();
+
                     settings = value;
 
-                    if (settings == null)
-                    {
-                        canSaveSettings = false;
+                    InvokeAsync(Reload);
 
-                        Groups.Clear();
-                        CurrentPage = 0;
-                        skip = 0;
-                        Reset(true);
-                        allColumns.ToList().ForEach(c =>
-                        {
-                            c.SetVisible(true);
-                        });
-                        columns = allColumns.Where(c => c.Parent == null).ToList();
-                        InvokeAsync(Reload);
-
-                        canSaveSettings = true;
-                    }
+                    canSaveSettings = true;
                 }
             }
         }


### PR DESCRIPTION
Currently the DataGrid Settings are only reset if the Settings property is called with null.  If an application is developed with multiple `DataGridSettings` that can be saved and loaded, any secondary set is loaded in addition to the first for column sorting.

This commit resets the DataGrid each time the Settings setter is called prior to the updated value being applied and Reload being called meaning the new Settings will be applied from fresh.