### PR TITLE
Reset DataGrid in Settings.set

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2936,25 +2936,24 @@ namespace Radzen.Blazor
             {
                 if (settings != value)
                 {
+                    canSaveSettings = false;
+
+                    Groups.Clear();
+                    CurrentPage = 0;
+                    skip = 0;
+                    Reset(true);
+                    allColumns.ToList().ForEach(c =>
+                    {
+                        c.SetVisible(true);
+
+                    });
+                    columns = allColumns.Where(c => c.Parent == null).ToList();
+
                     settings = value;
 
-                    if (settings == null)
-                    {
-                        canSaveSettings = false;
+                    InvokeAsync(Reload);
 
-                        Groups.Clear();
-                        CurrentPage = 0;
-                        skip = 0;
-                        Reset(true);
-                        allColumns.ToList().ForEach(c =>
-                        {
-                            c.SetVisible(true);
-                        });
-                        columns = allColumns.Where(c => c.Parent == null).ToList();
-                        InvokeAsync(Reload);
-
-                        canSaveSettings = true;
-                    }
+                    canSaveSettings = true;
                 }
             }
         }

--- a/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
+++ b/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
@@ -15,7 +15,7 @@
 <p>This example shows how to save/load DataGrid state using Settings property when binding using LoadData event.</p>
 <p>The state includes current page index, page size, groups and columns filter, sort, order, width and visibility.</p>
 <RadzenButton Click="@(args => Settings = null)" Text="Clear saved settings" Style="margin-bottom: 16px" />
-<RadzenButton Click="@(args => NavigationManager.NavigateTo("/datagrid-save-settings", true))" Text="Reload" Style="margin-bottom: 16px" />
+<RadzenButton Click="@(args => NavigationManager.NavigateTo("/datagrid-save-settings-loaddata", true))" Text="Reload" Style="margin-bottom: 16px" />
 <RadzenDataGrid @ref=grid @bind-Settings="@Settings" AllowFiltering="true" AllowColumnPicking="true" AllowGrouping="true" AllowPaging="true" PageSize="4"
                 AllowSorting="true" AllowMultiColumnSorting="true" ShowMultiColumnSortingIndex="true" 
                 AllowColumnResize="true" AllowColumnReorder="true" ColumnWidth="200px"

--- a/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
+++ b/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
@@ -109,16 +109,16 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender || loaded)
+        if (firstRender)
         {
             await LoadStateAsync();
-            
-            if (loaded)
-            {
-                await Task.Yield();
-                await grid.Reload();
-                loaded = false;
-            }
         }
+
+        if (loaded)
+        {
+            await Task.Yield();
+            await grid.Reload();
+            loaded = false;
+        }        
     }
 }


### PR DESCRIPTION
Currently the DataGrid Settings are only reset if the Settings property is called with null. If an application is developed with multiple DataGridSettings that can be saved and loaded, any secondary set is loaded in addition to the first for column sorting.

This branch resets the DataGrid each time the Settings setter is called prior to the updated value being applied and Reload being called meaning the new Settings will be applied from fresh.

As highlighted by **enchev** in my first pull request, this caused a loop issue in the [LoadData Demo](https://blazor.radzen.com/datagrid-save-settings-loaddata).  The `DataGridSettings` were being deserialized and loaded on every `OnAfterRenderAsync` once Data has been `loaded`.  This only needs to happen on `firstRender` to avoid continual loop.

I also noted that the Reload button was targeting the IQueryable page.