### PR TITLE
#885 Added AllowBothCommaAndDotAsDecimalSeparator as parameter for the RadzenNumeric component

### DIFF
--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -228,6 +228,14 @@ namespace Radzen.Blazor
         public TextAlign TextAlign { get; set; } = TextAlign.Left;
 
         /// <summary>
+        /// Gets or sets whether both a comma and a dot can be used as decimal separator
+        /// Note that the separator will be replaced by the one dictated by the format.
+        /// Default: false
+        /// </summary>
+        [Parameter]
+        public bool AllowBothCommaAndDotAsDecimalSeparator { get; set; } = false;
+
+        /// <summary>
         /// Handles the <see cref="E:Change" /> event.
         /// </summary>
         /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
@@ -257,7 +265,15 @@ namespace Radzen.Blazor
             TValue newValue;
             try
             {
-                BindConverter.TryConvertTo<TValue>(RemoveNonNumericCharacters(value), Culture, out newValue);
+                string decimalSeparator = Culture.NumberFormat.NumberDecimalSeparator;
+                string valueAsString = RemoveNonNumericCharacters(value);
+                if (this.AllowBothCommaAndDotAsDecimalSeparator)
+                {
+                    valueAsString = valueAsString.Replace(".", decimalSeparator)
+                        .Replace(",", decimalSeparator);
+                }
+
+                BindConverter.TryConvertTo<TValue>(RemoveNonNumericCharacters(valueAsString), Culture, out newValue);
             }
             catch
             {

--- a/RadzenBlazorDemos/Pages/NumericDecimalSeparator.razor
+++ b/RadzenBlazorDemos/Pages/NumericDecimalSeparator.razor
@@ -1,0 +1,7 @@
+﻿<div class="rz-p-12 rz-text-align-center">
+    <RadzenNumeric TValue="double" @bind-Value=@value Format="0.00" AllowBothCommaAndDotAsDecimalSeparator="true" />
+</div>
+
+@code {
+    double value = 0.0;
+}

--- a/RadzenBlazorDemos/Pages/NumericPage.razor
+++ b/RadzenBlazorDemos/Pages/NumericPage.razor
@@ -61,3 +61,13 @@
 <RadzenExample ComponentName="Numeric" Example="NumericAlign">
     <NumericAlign />
 </RadzenExample>
+
+<RadzenText TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
+    Allow both comma and dot as decimal separator
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Note that the separator will be replaced by the one dictated by the format.
+</RadzenText>
+<RadzenExample ComponentName="Numeric" Example="NumericDecimalSeparator">
+    <NumericDecimalSeparator />
+</RadzenExample>


### PR DESCRIPTION
Added the property which should allow for both the comma and dot to be used as decimal separator.