### PR TITLE
RadzenAutoComplete - Close Popup if value is smaller than MinLength

### DIFF
--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -116,7 +116,10 @@ namespace Radzen.Blazor
             var value = await JSRuntime.InvokeAsync<string>("Radzen.getInputValue", search);
 
             if (value.Length < MinLength)
+            {
+                await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID);
                 return;
+            }
 
             if (!LoadData.HasDelegate)
             {


### PR DESCRIPTION
Close the Popup if the value is smaller than MinLength-Parameter

Example [Radzen-AutoComplete:](https://blazor.radzen.com/autocomplete)

![grafik](https://user-images.githubusercontent.com/115212774/229519756-12f9e4d2-6ec0-418d-b15a-c4f7d36aa47e.png)

Before:
![grafik](https://user-images.githubusercontent.com/115212774/229519870-7eee519d-8e8b-4310-8aab-c70a64bc9204.png)

Now:
![grafik](https://user-images.githubusercontent.com/115212774/229520014-ef55ca28-cf5c-41ef-abf4-98edbd6db815.png)
