### PR TITLE
Add ReadOnly property to CheckBoxList and CheckBoxListItem

### DIFF
--- a/Radzen.Blazor/RadzenCheckBox.razor
+++ b/Radzen.Blazor/RadzenCheckBox.razor
@@ -5,7 +5,7 @@
 @inherits FormComponent<TValue>
 @if (Visible)
 {
-    <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" @onkeypress=@OnKeyPress @onkeypress:preventDefault style="@Style" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()">
+    <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" @onkeypress=@OnKeyPress @onkeypress:preventDefault style="@Style" tabindex="@(Disabled || ReadOnly ? "-1" : $"{TabIndex}")" id="@GetId()">
     <div class="rz-helper-hidden-accessible">
         <input type="checkbox" @onchange=@Toggle value=@CheckBoxValue name=@Name id=@Name checked=@CheckBoxChecked
             tabindex="-1" readonly="@ReadOnly">

--- a/Radzen.Blazor/RadzenCheckBoxList.razor
+++ b/Radzen.Blazor/RadzenCheckBoxList.razor
@@ -18,16 +18,16 @@
         @if (AllowSelectAll)
         {
             <div class="rz-multiselect-header rz-helper-clearfix" @onclick:preventDefault>
-                <RadzenCheckBox Name="SelectAll" TValue="bool?" Value="@IsAllSelected()" Change="@SelectAll" />
+                <RadzenCheckBox ReadOnly="@ReadOnly" Disabled="@Disabled" Name="SelectAll" TValue="bool?" Value="@IsAllSelected()" Change="@SelectAll" />
                 <RadzenLabel Component="SelectAll" Text="@SelectAllText" class="rz-chkbox-label" />
             </div>
         }
         @foreach (var item in allItems.Where(i => i.Visible))
         {
             <div @ref="@item.Element" id="@item.GetItemId()" @onclick="@(args => SelectItem(item))" @attributes="item.Attributes" class="@item.GetItemCssClass()" style="@item.Style">
-                <div class="rz-chkbox " @onkeypress="@(async args => { if (args.Code == "Space") { await SelectItem(item); } })" tabindex="@(Disabled || item.Disabled ? "-1" : $"{TabIndex}")">
+                <div class="rz-chkbox " @onkeypress="@(async args => { if (args.Code == "Space") { await SelectItem(item); } })" tabindex="@(Disabled || ReadOnly || item.Disabled || item.ReadOnly ? "-1" : $"{TabIndex}")">
                     <div class="rz-helper-hidden-accessible">
-                        <input type="checkbox" name="@Name" value="@item.Value" disabled="@Disabled" tabindex="-1">
+                        <input type="checkbox" name="@Name" value="@item.Value" disabled="@Disabled" readonly="@ReadOnly" tabindex="-1">
                     </div>
                     <div class=@ItemClassList(item)>
                         <span class=@IconClassList(item)></span>

--- a/Radzen.Blazor/RadzenCheckBoxList.razor.cs
+++ b/Radzen.Blazor/RadzenCheckBoxList.razor.cs
@@ -76,7 +76,7 @@ namespace Radzen.Blazor
 
         async Task SelectAll(bool? value)
         {
-            if (Disabled)
+            if (Disabled || ReadOnly)
             {
                 return;
             }
@@ -114,6 +114,7 @@ namespace Radzen.Blazor
         }
 
         IEnumerable _data = null;
+
         /// <summary>
         /// Gets or sets the data used to generate items.
         /// </summary>
@@ -134,6 +135,13 @@ namespace Radzen.Blazor
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether is read only.
+        /// </summary>
+        /// <value><c>true</c> if is read only; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ReadOnly { get; set; }
 
         /// <inheritdoc />
         protected override string GetComponentCssClass()
@@ -214,7 +222,7 @@ namespace Radzen.Blazor
         /// <param name="item">The item.</param>
         protected async System.Threading.Tasks.Task SelectItem(RadzenCheckBoxListItem<TValue> item)
         {
-            if (Disabled || item.Disabled)
+            if (Disabled || item.Disabled || ReadOnly || item.ReadOnly)
                 return;
 
             List<TValue> selectedValues = new List<TValue>(Value != null ? Value : Enumerable.Empty<TValue>());
@@ -235,11 +243,6 @@ namespace Radzen.Blazor
             await Change.InvokeAsync(Value);
 
             StateHasChanged();
-        }
-
-        private string getDisabledState(RadzenCheckBoxListItem<TValue> item)
-        {
-            return Disabled || item.Disabled ? " rz-state-disabled" : "";
         }
     }
 }

--- a/Radzen.Blazor/RadzenCheckBoxList.razor.cs
+++ b/Radzen.Blazor/RadzenCheckBoxList.razor.cs
@@ -46,6 +46,20 @@ namespace Radzen.Blazor
         [Parameter]
         public string TextProperty { get; set; }
 
+        /// <summary>
+        /// Gets or sets the disabled property.
+        /// </summary>
+        /// <value>The disabled property.</value>
+        [Parameter]
+        public string DisabledProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the read-only property.
+        /// </summary>
+        /// <value>The read-only property.</value>
+        [Parameter]
+        public string ReadOnlyProperty { get; set; }
+
         IEnumerable<RadzenCheckBoxListItem<TValue>> allItems
         {
             get
@@ -55,6 +69,17 @@ namespace Radzen.Blazor
                     var item = new RadzenCheckBoxListItem<TValue>();
                     item.SetText((string)PropertyAccess.GetItemOrValueFromProperty(i, TextProperty));
                     item.SetValue((TValue)PropertyAccess.GetItemOrValueFromProperty(i, ValueProperty));
+
+                    if (DisabledProperty != null && PropertyAccess.TryGetItemOrValueFromProperty<bool>(i, DisabledProperty, out var disabledResult))
+                    {
+                        item.SetDisabled(disabledResult);
+                    }
+
+                    if (ReadOnlyProperty != null && PropertyAccess.TryGetItemOrValueFromProperty<bool>(i, ReadOnlyProperty, out var readOnlyResult))
+                    {
+                        item.SetReadOnly(readOnlyResult);
+                    }
+
                     return item;
                 }));
             }

--- a/Radzen.Blazor/RadzenCheckBoxListItem.cs
+++ b/Radzen.Blazor/RadzenCheckBoxListItem.cs
@@ -77,6 +77,17 @@ namespace Radzen.Blazor
         {
             Value = value;
         }
+
+        internal void SetDisabled(bool value)
+        {
+            Disabled = value;
+        }
+
+        internal void SetReadOnly(bool value)
+        {
+            ReadOnly = value;
+        }
+
         internal string GetItemId()
         {
             return GetId();

--- a/Radzen.Blazor/RadzenCheckBoxListItem.cs
+++ b/Radzen.Blazor/RadzenCheckBoxListItem.cs
@@ -29,6 +29,13 @@ namespace Radzen.Blazor
         [Parameter]
         public virtual bool Disabled { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether is read only.
+        /// </summary>
+        /// <value><c>true</c> if is read only; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ReadOnly { get; set; }
+
         RadzenCheckBoxList<TValue> _checkBoxList;
 
         /// <summary>


### PR DESCRIPTION
Here is my pull request which adds the ReadOnly property to the CheckBoxList and the CheckBoxListItem. Additionally I added a commit to set the tabindex of the single CheckBox to -1 if the CheckBox is ReadOnly.

I have a few remaining questions about this approach.
1. Should the method 'SelectAll' ignore read-only and disabled checkboxes in the list?
2. Should the method 'IsAllSelected' ignore read-only and disabled checkboxes in the list?
3. How to handle CheckBoxListItems which are gerenated through the data-property. The CheckBoxList has parameters for the TextProperty and a ValueProperty, should we add similar properties for Disabled and ReadOnly?

I look forward to your reaction.