### PR TITLE
Fix JSDisconnectedException in RadzenContextMenu.razor.cs

### DIFF
--- a/Radzen.Blazor/RadzenContextMenu.razor.cs
+++ b/Radzen.Blazor/RadzenContextMenu.razor.cs
@@ -139,7 +139,13 @@ namespace Radzen.Blazor
 
             if (IsJSRuntimeAvailable)
             {
-                await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", UniqueID);
+                try {
+                    await JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", UniqueID);
+                }
+                catch (JSDisconnectedException ex)
+                {
+                     // Ignore
+                }
             }
 
             Service.OnOpen -= OnOpen;


### PR DESCRIPTION
On page refresh, the SignalR connection is already disrupted resulting in a JSDisconnectedExcepion. This will suppress the error in the console.