### PR TITLE
docs: Add note about pre-requirements when using certain controls

### DIFF
--- a/RadzenBlazorDemos/Pages/ContextMenuPage.razor
+++ b/RadzenBlazorDemos/Pages/ContextMenuPage.razor
@@ -6,6 +6,9 @@
 <RadzenText TextStyle="TextStyle.Subtitle1" class="rz-pb-4">
     Demonstration and configuration of the Radzen Blazor <strong>ContextMenu</strong> component.
 </RadzenText>
+
+<HelpPrerequirements />
+
 <RadzenText TextStyle="TextStyle.Subtitle1" class="rz-pb-4">
     Use <code>ContextMenuService</code> to open and close context menus.
 </RadzenText>

--- a/RadzenBlazorDemos/Pages/DialogPage.razor
+++ b/RadzenBlazorDemos/Pages/DialogPage.razor
@@ -7,6 +7,8 @@
     Demonstration and configuration of the Radzen Blazor Dialog component.
 </RadzenText>
 
+<HelpPrerequirements/>
+
 <RadzenText TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
     Open page as a dialog
 </RadzenText>

--- a/RadzenBlazorDemos/Pages/NotificationPage.razor
+++ b/RadzenBlazorDemos/Pages/NotificationPage.razor
@@ -7,6 +7,9 @@
     Demonstration and configuration of the Radzen Blazor <strong>Notification</strong> component.
 </RadzenText>
 
+<HelpPrerequirements />
+
+
 <RadzenExample ComponentName="Notification" Example="NotificationConfig" Source="https://github.com/radzenhq/radzen-blazor/blob/master/Radzen.Blazor/NotificationService.cs">
     <NotificationConfig />
 </RadzenExample>

--- a/RadzenBlazorDemos/Pages/TooltipPage.razor
+++ b/RadzenBlazorDemos/Pages/TooltipPage.razor
@@ -3,9 +3,12 @@
 <RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
     Tooltip
 </RadzenText>
+
 <RadzenText TextStyle="TextStyle.Subtitle1" class="rz-pb-4">
     The <strong>Tooltip</strong> component is a small pop-up box that appears when the user hovers or clicks on a UI element. It is commonly used to provide additional information or context to the user.
 </RadzenText>
+
+<HelpPrerequirements />
 
 <RadzenText Anchor="tooltip#tooltip-string-message" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
     Show tooltip with string message

--- a/RadzenBlazorDemos/Shared/HelpPrerequirements.razor
+++ b/RadzenBlazorDemos/Shared/HelpPrerequirements.razor
@@ -1,0 +1,9 @@
+﻿<RadZenText TextStyle="TextStyle.Body1">
+    <p>
+        <strong>NOTE:</strong> Please ensure you have reviewed the instructions in <a href="/get-started">Get Started</a> , as there are pre-requirements when using this component.
+    </p>
+</RadZenText>
+
+@code {
+
+}


### PR DESCRIPTION
Add a note about referring to the `Get Started` page for controls that require setup dependencies.

I fell for this initially, and was not able to locate the required information easily, searched the forum and found someone with the answer, which is outlined on the "Get started".  

This change just makes it contextually more accessible.
