### PR TITLE
RadzenDataGridColumn Pickable change dosnt update UI

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -450,7 +450,18 @@ namespace Radzen.Blazor
             selectedColumns = columnsList;
         }
 
-        internal void RemoveColumn(RadzenDataGridColumn<TItem> column)
+		public void UpdatePickableColumns()
+		{
+			if (allColumns.Any(c => c.Pickable))
+			{
+				if (AllowColumnPicking)
+				{
+					allPickableColumns = allColumns.Where(c => c.Pickable).OrderBy(c => c.GetOrderIndex()).ToList();
+				}
+			}
+		}
+
+		internal void RemoveColumn(RadzenDataGridColumn<TItem> column)
         {
             if (columns.Contains(column))
             {

--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -682,7 +682,20 @@ namespace Radzen.Blazor
                 }
             }
 
-            if (parameters.DidParameterChange(nameof(SortOrder), SortOrder))
+			if (parameters.DidParameterChange(nameof(Pickable), Pickable))
+			{
+				var newPickable = parameters.GetValueOrDefault<bool>(nameof(Pickable));
+
+				Pickable = newPickable;
+
+				if (Grid != null)
+				{
+					Grid.UpdatePickableColumns();
+					await Grid.ChangeState();
+				}
+			}
+
+			if (parameters.DidParameterChange(nameof(SortOrder), SortOrder))
             {
                 sortOrder = new SortOrder?[] { parameters.GetValueOrDefault<SortOrder?>(nameof(SortOrder)) };
 


### PR DESCRIPTION
Related to https://forum.radzen.com/t/radzendatagridcolumn-pickable-change-dosnt-update-ui/13917