### PR TITLE
Color Picker: HSV picker base color fix + alpha resetting fix

### DIFF
--- a/Radzen.Blazor/RadzenColorPicker.razor
+++ b/Radzen.Blazor/RadzenColorPicker.razor
@@ -6,7 +6,7 @@
 @if (Visible)
 {
     <div @ref=@Element style=@Style @onclick=@Toggle @attributes=@Attributes class=@GetCssClass() id=@GetId()>
-        @if(Icon != null)
+        @if (Icon != null)
         {
             <i class="rzi">@Icon</i>
         }
@@ -15,10 +15,10 @@
         <Popup Lazy=@(PopupRenderMode == PopupRenderMode.OnDemand) @ref=@Popup class="rz-colorpicker-popup" Close=@Close Open=@Open>
             @if (ShowHSV)
             {
-                <Draggable class="rz-saturation-picker rz-colorpicker-section" style=@($"background-color: {HSV.ToRGB().ToCSS()}") Drag=@OnSaturationMove>
+                <Draggable class="rz-saturation-picker rz-colorpicker-section" style=@($"background-color: hsl({Math.Round(HSV.Hue * 360)}, 100%, 50%)") Drag=@OnSaturationMove>
                     <div class="rz-saturation-white">
                         <div class="rz-saturation-black"></div>
-                        <div class="rz-saturation-handle" style=@($"top: {(SaturationHandleTop*100).ToInvariantString()}%; left: {(SaturationHandleLeft * 100).ToInvariantString()}%")></div>
+                        <div class="rz-saturation-handle" style=@($"top: {(SaturationHandleTop * 100).ToInvariantString()}%; left: {(SaturationHandleLeft * 100).ToInvariantString()}%")></div>
                     </div>
                 </Draggable>
                 <div class="rz-colorpicker-preview-area rz-colorpicker-section">
@@ -107,7 +107,7 @@
                 </div>
 
             }
-            @if(ShowButton)
+            @if (ShowButton)
             {
                 <div class="rz-colorpicker-button rz-colorpicker-section">
                     <RadzenButton ButtonStyle="ButtonStyle.Primary" Click=@OnClick Text=@ButtonText @onclick:preventDefault />

--- a/Radzen.Blazor/RadzenColorPicker.razor
+++ b/Radzen.Blazor/RadzenColorPicker.razor
@@ -15,7 +15,7 @@
         <Popup Lazy=@(PopupRenderMode == PopupRenderMode.OnDemand) @ref=@Popup class="rz-colorpicker-popup" Close=@Close Open=@Open>
             @if (ShowHSV)
             {
-                <Draggable class="rz-saturation-picker rz-colorpicker-section" style=@($"background-color: hsl({Math.Round(HSV.Hue * 360)}, 100%, 50%)") Drag=@OnSaturationMove>
+                <Draggable class="rz-saturation-picker rz-colorpicker-section" style=@($"background-color: hsl({(HueHandleLeft * 360).ToInvariantString()}, 100%, 50%)") Drag=@OnSaturationMove>
                     <div class="rz-saturation-white">
                         <div class="rz-saturation-black"></div>
                         <div class="rz-saturation-handle" style=@($"top: {(SaturationHandleTop * 100).ToInvariantString()}%; left: {(SaturationHandleLeft * 100).ToInvariantString()}%")></div>

--- a/Radzen.Blazor/RadzenColorPicker.razor.cs
+++ b/Radzen.Blazor/RadzenColorPicker.razor.cs
@@ -379,8 +379,6 @@ namespace Radzen.Blazor
                 HSV = RGB.Parse(Color).ToHSV();
                 SaturationHandleLeft = HSV.Saturation;
                 SaturationHandleTop = 1 - HSV.Value;
-                HSV.Saturation = 1;
-                HSV.Value = 1;
                 HueHandleLeft = HSV.Hue;
 
                 if (value.StartsWith("rgba"))

--- a/Radzen.Blazor/RadzenColorPicker.razor.cs
+++ b/Radzen.Blazor/RadzenColorPicker.razor.cs
@@ -151,16 +151,24 @@ namespace Radzen.Blazor
             }
         }
 
+        void UpdateColorUsingHsvHandles()
+        {
+            var hsv = new HSV {
+                Hue = HueHandleLeft,
+                Saturation = SaturationHandleLeft,
+                Value = 1 - SaturationHandleTop,
+                Alpha = AlphaHandleLeft
+            };
+            Color = hsv.ToRGB().ToCSS();
+            TriggerChange();
+        }
+
         void OnSaturationMove(DraggableEventArgs args)
         {
             SaturationHandleLeft = Math.Clamp((args.ClientX - args.Rect.Left) / args.Rect.Width, 0, 1);
             SaturationHandleTop = Math.Clamp((args.ClientY - args.Rect.Top) / args.Rect.Height, 0, 1);
 
-            var hsv = new HSV { Hue = HSV.Hue, Saturation = SaturationHandleLeft, Value = 1 - SaturationHandleTop, Alpha = AlphaHandleLeft };
-
-            Color = hsv.ToRGB().ToCSS();
-
-            TriggerChange();
+            UpdateColorUsingHsvHandles();
         }
 
         void TriggerChange()
@@ -176,23 +184,17 @@ namespace Radzen.Blazor
 
         void ChangeRGB(object value)
         {
-            SetValue(value as string);
-        }
-
-        void SetValue(string value)
-        {
-            var rgb = RGB.Parse(value);
-
+            var rgb = RGB.Parse(value as string);
             if (rgb != null)
             {
-                Color = rgb.ToCSS();
+                rgb.Alpha = AlphaHandleLeft;
                 UpdateColor(rgb);
             }
         }
 
         internal async Task SelectColor(string value)
         {
-            SetValue(value);
+            UpdateColor(RGB.Parse(value));
 
             if (!ShowButton)
             {
@@ -204,11 +206,12 @@ namespace Radzen.Blazor
         {
             Color = rgb.ToCSS();
 
-            HSV = rgb.ToHSV();
+            var hsv = rgb.ToHSV();
 
-            SaturationHandleLeft = HSV.Saturation;
-            SaturationHandleTop = 1 - HSV.Value;
-            HueHandleLeft = HSV.Hue;
+            SaturationHandleLeft = hsv.Saturation;
+            SaturationHandleTop = 1 - hsv.Value;
+            HueHandleLeft = hsv.Hue;
+            AlphaHandleLeft = hsv.Alpha;
 
             TriggerChange();
         }
@@ -258,25 +261,14 @@ namespace Radzen.Blazor
         {
             AlphaHandleLeft = Math.Round(Math.Clamp((args.ClientX - args.Rect.Left) / args.Rect.Width, 0, 1), 2);
 
-            HSV.Alpha = AlphaHandleLeft;
-
-            var hsv = new HSV { Hue = HSV.Hue, Saturation = SaturationHandleLeft, Value = 1 - SaturationHandleTop, Alpha = AlphaHandleLeft };
-
-            Color = hsv.ToRGB().ToCSS();
-
-            TriggerChange();
+            UpdateColorUsingHsvHandles();
         }
 
         void OnHueMove(DraggableEventArgs args)
         {
             HueHandleLeft = Math.Clamp((args.ClientX - args.Rect.Left) / args.Rect.Width, 0, 1);
 
-            HSV.Hue = HueHandleLeft;
-            var hsv = new HSV { Hue = HSV.Hue, Saturation = SaturationHandleLeft, Value = 1 - SaturationHandleTop, Alpha = AlphaHandleLeft };
-
-            Color = hsv.ToRGB().ToCSS();
-
-            TriggerChange();
+            UpdateColorUsingHsvHandles();
         }
 
         async Task OnClick()
@@ -328,11 +320,10 @@ namespace Radzen.Blazor
         [Parameter]
         public PopupRenderMode PopupRenderMode { get; set; } = PopupRenderMode.Initial;
 
-        double SaturationHandleLeft { get; set; }
-        double HueHandleLeft { get; set; }
+        double SaturationHandleLeft { get; set; } = 0;
+        double SaturationHandleTop { get; set; } = 0;
+        double HueHandleLeft { get; set; } = 0;
         double AlphaHandleLeft { get; set; } = 1;
-        double SaturationHandleTop { get; set; }
-        HSV HSV { get; set; } = new HSV { Hue = 0, Saturation = 1, Value = 1 };
         string Color { get; set; } = "rgb(255, 255, 255)";
 
         async Task Toggle()
@@ -376,15 +367,11 @@ namespace Radzen.Blazor
             {
                 Color = value;
 
-                HSV = RGB.Parse(Color).ToHSV();
-                SaturationHandleLeft = HSV.Saturation;
-                SaturationHandleTop = 1 - HSV.Value;
-                HueHandleLeft = HSV.Hue;
-
-                if (value.StartsWith("rgba"))
-                {
-                    AlphaHandleLeft = HSV.Alpha;
-                }
+                var hsv = RGB.Parse(Color).ToHSV();
+                SaturationHandleLeft = hsv.Saturation;
+                SaturationHandleTop = 1 - hsv.Value;
+                HueHandleLeft = hsv.Hue;
+                AlphaHandleLeft = hsv.Alpha;
             }
         }
 


### PR DESCRIPTION
The color in the top right corner of the HSV stauration/value picker should be always the most saturated. Once you choose a predefined color or enter RGB values, it becomes the chosen color, not the most saturated one:
![color picker hue issue](https://user-images.githubusercontent.com/44393502/235375254-bcb015dc-df14-4e04-85e9-3434c001888c.gif)

Here's a fix for this issue.