### PR TITLE
Make DataGridColumn GetOrderIndex method from internal to public.

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -135,7 +135,7 @@ namespace Radzen.Blazor
         [Parameter]
         public int? OrderIndex { get; set; }
 
-        internal int? GetOrderIndex()
+        public int? GetOrderIndex()
         {
             return orderIndex ?? OrderIndex;
         }


### PR DESCRIPTION
So i can access 'orderIndex' variable, in case of discrepancy compared to 'OrderIndex' variable.
This is the only Get-Method that still with 'internal' as accessibility 
Ex: 
![image](https://user-images.githubusercontent.com/50449423/235675372-f2f2114b-2905-4969-b016-f64ccbda8182.png)

As u can i need to retrive the correct orderIndex but i cant due to accessibility
