### PR TITLE
Update RadzenDataGridColumn.cs

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -560,17 +560,12 @@ namespace Radzen.Blazor
                 descriptor = new SortDescriptor() { Property = GetSortProperty() };
             }
 
-            if (GetSortOrder() == null)
+            if (order.HasValue)
             {
-                SetSortOrderInternal(Radzen.SortOrder.Ascending);
-                descriptor.SortOrder = Radzen.SortOrder.Ascending;
+                SetSortOrderInternal(order.Value);
+                descriptor.SortOrder = order.Value;
             }
-            else if (GetSortOrder() == Radzen.SortOrder.Ascending)
-            {
-                SetSortOrderInternal(Radzen.SortOrder.Descending);
-                descriptor.SortOrder = Radzen.SortOrder.Descending;
-            }
-            else if (GetSortOrder() == Radzen.SortOrder.Descending)
+            else
             {
                 SetSortOrderInternal(null);
                 if (Grid.sorts.Where(d => d.Property == GetSortProperty()).Any())


### PR DESCRIPTION
This method has only one reference, in the RadzenDataGrid.razor.cs.  It has to change the ordering of the column based on the parameter. So, checking the SortOrder value by GetSortOrder() isn't good, because it is the "past". The "order" value is the right SortOrder value. See: https://forum.radzen.com/t/radzendatagrid-and-default-sortorder-and-datagridsettings-bug/13938