### PR TITLE
Update RadzenDataGridColumn.cs

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -230,7 +230,10 @@ namespace Radzen.Blazor
             return _title ?? Title;
         }
 
-        internal void SetTitle(string value)
+        /// <summary>
+        /// Sets the column title.
+        /// </summary>
+        public void SetTitle(string value)
         {
             _title = value;
         }


### PR DESCRIPTION
Change the SetTitle() method to public.
Why? It's easier for developers because there are fewer properties in the source code, and if you have a common localization process for example:
```
    protected override async Task OnAfterRenderAsync(bool firstRender)
    {
        if (firstRender)
        {
            foreach (var col in grd.ColumnsCollection.Where(x => x.Property != null && string.IsNullOrEmpty(x.Title)).ToList())
            {
                col.SetTitle(LocalizationHelper.Localizer( col.Property));        // out localization process
            }
        }
    }
```
...then all properties can be managed together in the system ("Name" = "Név" ,etc)
(ps:Unfortonatelly the "Title" property is not good, bevaous of "Component parameter should not be set outside of its component")