### PR TITLE
Autocomplete, Numeric: display focus state

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_autocomplete.scss
+++ b/Radzen.Blazor/themes/components/blazor/_autocomplete.scss
@@ -9,6 +9,10 @@
   &:hover:not(.rz-state-disabled) {
     @extend %input-hover;
   }
+
+  &:focus-within:not(.rz-state-disabled) {
+    @extend %input-focus;
+  }
 }
 
 .rz-state-disabled.rz-autocomplete {

--- a/Radzen.Blazor/themes/components/blazor/_input.scss
+++ b/Radzen.Blazor/themes/components/blazor/_input.scss
@@ -145,5 +145,10 @@ input {
       border: none;
       box-shadow: none;
     }
+
+    &:focus-within {
+      border: none;
+      box-shadow: none;
+    }
   }
 }

--- a/Radzen.Blazor/themes/components/blazor/_numeric.scss
+++ b/Radzen.Blazor/themes/components/blazor/_numeric.scss
@@ -51,6 +51,10 @@ $numeric-button-disabled-color: var(--rz-text-disabled-color) !default;
     }
   }
 
+  &:focus-within:not(.rz-state-disabled) {
+    @extend %input-focus;
+  }
+
   &.rz-state-disabled {
     @extend %input-disabled;
 


### PR DESCRIPTION
As inputs in the autocomplete and numeric components are wrapped, `:focus` styles simply cannot work on the wrappers.