### PR TITLE
Use method to get classes for RadzenStepsItem

### DIFF
--- a/Radzen.Blazor/RadzenSteps.razor
+++ b/Radzen.Blazor/RadzenSteps.razor
@@ -43,7 +43,7 @@
         var step = steps[i];
         @if (step.Visible)
         {
-            @if (i == SelectedIndex)
+            @if (IsSelected(i, step))
             {
                 <div class="rz-widget-content">
                     @if (step.ChildContent != null)

--- a/Radzen.Blazor/RadzenSteps.razor
+++ b/Radzen.Blazor/RadzenSteps.razor
@@ -21,7 +21,7 @@
             var step = steps[i];
             @if (step.Visible)
             {
-                <li class='@($"rz-steps-item {(IsSelected(i, step) ? "rz-state-highlight rz-steps-current" : step.Disabled ? "rz-state-disabled" : "")}")' @attributes="step.Attributes" style="@step.Style">
+                <li class="@step.GetItemCssClass()" @attributes="step.Attributes" style="@step.Style">
                     <a @onclick="@(async (args) => { if (!step.Disabled) { await SelectStep(step, true); } })" href="javascript:void(0)" class="rz-menuitem-link">
                         <span class="rz-steps-number">@(steps.Where(s => s.Visible).ToList().IndexOf(step) + 1)</span>
                         @if (step.Template != null)
@@ -43,7 +43,7 @@
         var step = steps[i];
         @if (step.Visible)
         {
-            @if (IsSelected(i, step))
+            @if (i == SelectedIndex)
             {
                 <div class="rz-widget-content">
                     @if (step.ChildContent != null)

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -257,17 +257,6 @@ namespace Radzen.Blazor
             StateHasChanged();
         }
 
-        /// <summary>
-        /// Determines whether the specified index is selected.
-        /// </summary>
-        /// <param name="index">The index.</param>
-        /// <param name="step">The step.</param>
-        /// <returns><c>true</c> if the specified index is selected; otherwise, <c>false</c>.</returns>
-        protected bool IsSelected(int index, RadzenStepsItem step)
-        {
-            return SelectedIndex == index;
-        }
-
         internal async System.Threading.Tasks.Task SelectStep(RadzenStepsItem step, bool raiseChange = false)
         {
             var valid = true;

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -257,6 +257,17 @@ namespace Radzen.Blazor
             StateHasChanged();
         }
 
+        /// <summary>
+        /// Determines whether the specified index is selected.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <param name="step">The step.</param>
+        /// <returns><c>true</c> if the specified index is selected; otherwise, <c>false</c>.</returns>
+        protected bool IsSelected(int index, RadzenStepsItem step)
+        {
+            return SelectedIndex == index;
+        }
+
         internal async System.Threading.Tasks.Task SelectStep(RadzenStepsItem step, bool raiseChange = false)
         {
             var valid = true;

--- a/Radzen.Blazor/RadzenStepsItem.cs
+++ b/Radzen.Blazor/RadzenStepsItem.cs
@@ -25,10 +25,7 @@ namespace Radzen.Blazor
                 if (_text != value)
                 {
                     _text = value;
-                    if (Steps != null)
-                    {
-                        Steps.Refresh();
-                    }
+                    Steps?.Refresh();
                 }
             }
         }
@@ -64,10 +61,7 @@ namespace Radzen.Blazor
                 if (_visible != value)
                 {
                     _visible = value;
-                    if (Steps != null)
-                    {
-                        Steps.Refresh();
-                    }
+                    Steps?.Refresh();
                 }
             }
         }
@@ -89,10 +83,7 @@ namespace Radzen.Blazor
                 if (_disabled != value)
                 {
                     _disabled = value;
-                    if (Steps != null)
-                    {
-                        Steps.Refresh();
-                    }
+                    Steps?.Refresh();
                 }
             }
         }
@@ -148,6 +139,17 @@ namespace Radzen.Blazor
             }
 
             await base.SetParametersAsync(parameters);
+        }
+
+        internal string GetItemCssClass()
+        {
+            return GetCssClass();
+        }
+
+        /// <inheritdoc />
+        protected override string GetComponentCssClass()
+        {
+            return $"rz-steps-item {(Steps.StepsCollection.IndexOf(this) == Steps.SelectedIndex ? "rz-state-highlight rz-steps-current" : string.Empty)} {(Disabled ? "rz-state-disabled" : string.Empty)}";
         }
 
         /// <summary>


### PR DESCRIPTION
In our own project we want to add some classes to the RadzenStepsItem based on some extra parameters we addedin our own project. In order to achieve this, it is necessary that the classes for the RadzenStepsItem are determined via a method, so we can override the method 'GetComponentCssClass' for the RadzenStepsItem.