### PR TITLE
method GetFilterOperatorText() changed from internal to public

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.cs
@@ -990,7 +990,10 @@ namespace Radzen.Blazor
             });
         }
 
-        internal string GetFilterOperatorText(FilterOperator filterOperator)
+        /// <summary>
+        /// Get filter operator text
+        /// </summary>
+        public string GetFilterOperatorText(FilterOperator filterOperator)
         {
             switch (filterOperator)
             {


### PR DESCRIPTION
I create my own filter template in advanced mode. I cannot get filter operator text because its internal.

![image](https://user-images.githubusercontent.com/55174695/236983101-16613afb-2af3-4f6c-b192-cc3d8907fd93.png)
