### PR TITLE
Change DatePicker icon based on TimeOnly parameter.

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -505,5 +505,32 @@ namespace Radzen.Blazor.Tests
             Assert.Equal(kind, (component.Instance.Value as DateTime?)?.Kind);
             Assert.Equal(valueUtc.UtcDateTime.ToString(CultureInfo.InvariantCulture), (component.Instance.Value as DateTime?)?.ToString(CultureInfo.InvariantCulture));
         }
+
+        [Fact]
+        public void DatePicker_Displays_Calender_Icon()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>();
+
+            Assert.Contains(@$"rzi-calendar", component.Markup);
+        }
+
+        [Fact]
+        public void DatePicker_Displays_Schedule_Icon()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameters =>
+            {
+                parameters.Add(p => p.TimeOnly, true);
+            });
+
+            Assert.Contains(@$"rzi-time", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -18,7 +18,7 @@
                        @onchange="@ParseDate" autocomplete="off" type="text" name="@Name"
                        class="rz-inputtext @InputClass @(IsReadonly ? "rz-readonly" : "")" id="@Name" placeholder="@Placeholder" onclick="@getOpenPopupForInput()"/>
                 <button @onmousedown=@OnToggle onclick="@getOpenPopup()" class="@($"rz-datepicker-trigger rz-calendar-button rz-button rz-button-icon-only{(Disabled ? " rz-state-disabled" : "")}")" tabindex="-1" type="button">
-                    <span aria-hidden="true" class="rz-button-icon-left  rzi rzi-calendar"></span><span class="rz-button-text"></span>
+                    <span aria-hidden="true" class="@ButtonClasses"></span><span class="rz-button-text"></span>
                 </button>
                 @if (AllowClear && HasValue)
                 {

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -559,6 +559,11 @@ namespace Radzen.Blazor
             StateHasChanged();
         }
 
+        private string ButtonClasses
+        {
+            get => $"rz-button-icon-left rzi rzi-{(TimeOnly ? "time" : "calendar")}";
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="RadzenDatePicker{TValue}"/> is inline - only Calender.
         /// </summary>

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -175,12 +175,18 @@ $timepicker-border: none !default;
     }
   }
 
-  .rzi-calendar {
+  .rzi-calendar,
+  .rzi-time {
     font-size: inherit;
     vertical-align: top;
-    &:before {
-      content: 'calendar_today';
-    }
+  }
+
+  .rzi-calendar:before {
+    content: 'calendar_today';
+  }
+
+  .rzi-time:before {
+    content: 'schedule';
   }
 
   .rz-button-text {


### PR DESCRIPTION
**Issue:** The **DatePicker's** button icon is `calendar_today` even if the **DatePicker's** `TimeOnly` parameter is set to `true`.

**Proposed Solution:** Substitute the `calendar_today` icon with the `schedule` icon when the **DatePicker's** `TimeOnly` parameter is set to `true`.

This PR updates the DatePicker's CSS, code and template to support the icon logic. I've also included two new unit tests in this PR to test which icon is displayed.