### PR TITLE
Dialog wrapper class option.

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -253,6 +253,7 @@ namespace Radzen
                 CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
                 CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
                 CssClass = options != null ? options.CssClass : "",
+                WrapperCssClass = options != null ? options.WrapperCssClass : "",
                 CloseTabIndex = options != null ? options.CloseTabIndex : 0,
             });
         }
@@ -315,6 +316,7 @@ namespace Radzen
                 CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
                 CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
                 CssClass = options != null ? $"rz-dialog-confirm {options.CssClass}" : "rz-dialog-confirm",
+                WrapperCssClass = options != null ? $"rz-dialog-wrapper {options.WrapperCssClass}" : "rz-dialog-wrapper",
                 CloseTabIndex = options != null ? options.CloseTabIndex : 0,
             };
 
@@ -374,6 +376,7 @@ namespace Radzen
                 CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
                 CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
                 CssClass = options != null ? $"rz-dialog-alert {options.CssClass}" : "rz-dialog-alert",
+                WrapperCssClass = options != null ? $"rz-dialog-wrapper {options.WrapperCssClass}" : "rz-dialog-wrapper",
                 CloseTabIndex = options != null ? options.CloseTabIndex : 0,
             };
 
@@ -444,6 +447,11 @@ namespace Radzen
         /// Gets or sets dialog box custom class
         /// </summary>
         public string CssClass { get; set; }
+
+        /// <summary>
+        /// Gets or sets the CSS classes added to the dialog's wrapper element.
+        /// </summary>
+        public string WrapperCssClass { get; set; }
         
         /// <summary>
         /// Gets or sets a value the dialog escape tabindex. Set to <c>0</c> by default.

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -138,7 +138,8 @@
     {
         get
         {
-            return string.IsNullOrWhiteSpace(Dialog.Options.WrapperCssClass) ? "" : Dialog.Options.WrapperCssClass;
+            var baseCss = "rz-dialog-wrapper";
+            return string.IsNullOrWhiteSpace(Dialog.Options.WrapperCssClass) ? baseCss : $"{baseCss} {Dialog.Options.WrapperCssClass}";
         }
     }
 

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -2,7 +2,7 @@
 @using System.Reflection;
 @inject IJSRuntime JSRuntime
 @implements IDisposable
-<div class="rz-dialog-wrapper">
+<div class="@WrapperCssClass">
     <div @ref="dialog" class="@CssClass" role="dialog" aria-labelledby="rz-dialog-0-label" style=@Style>
         @if (Dialog.Options.ShowTitle)
         {
@@ -131,6 +131,14 @@
         {
             var baseCss = "rz-dialog";
             return string.IsNullOrEmpty(Dialog.Options.CssClass) ? baseCss : $"{baseCss} {Dialog.Options.CssClass}";
+        }
+    }
+
+    string WrapperCssClass
+    {
+        get
+        {
+            return string.IsNullOrWhiteSpace(Dialog.Options.WrapperCssClass) ? "" : Dialog.Options.WrapperCssClass;
         }
     }
 

--- a/RadzenBlazorDemos/Pages/DialogCss.razor
+++ b/RadzenBlazorDemos/Pages/DialogCss.razor
@@ -1,0 +1,19 @@
+﻿@inject DialogService DialogService
+
+<div class="rz-p-12 rz-text-align-center">
+    <RadzenButton Text="Dialog with custom CSS classes" ButtonStyle="ButtonStyle.Secondary"
+                  Click=@ShowDialogWithCustomCssClasses />
+</div>
+
+@code {
+    async Task ShowDialogWithCustomCssClasses()
+    {
+        await DialogService.OpenAsync("Dialog with custom CSS classes", ds =>
+        @<div>
+            This dialog has custom CSS classes.
+        </div>, new DialogOptions() {
+                  CssClass = "custom-dialog-class",
+                  WrapperCssClass = "custom-dialog-wrapper-class"
+              });
+    }
+}

--- a/RadzenBlazorDemos/Pages/DialogPage.razor
+++ b/RadzenBlazorDemos/Pages/DialogPage.razor
@@ -57,3 +57,10 @@
 <RadzenExample ComponentName="Dialog" Example="DialogSide">
     <DialogSide />
 </RadzenExample>
+
+<RadzenText TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
+    Dialog with custom CSS classes
+</RadzenText>
+<RadzenExample ComponentName="Dialog" Example="DialogCss">
+    <DialogCss />
+</RadzenExample>


### PR DESCRIPTION
**Problem:** I wanted to inject custom CSS classes on the dialog (already supported) and the dialog wrapper (not supported.)

**Solution:** I added a `WrapperCssClass` field on the `DialogOptions` class and mimicked the existing functionality for the `CssClass` field but on the wrapper markup.

I didn't see any existing unit tests for dialogs, and it looks complicated to add dialog service unit tests, so instead, I added a new demo to the dialog page showing a dialog with a custom CSS class on the dialog and the wrapper.

Of course, the code view of the new demo will only work once/if the code is merged.