### PR TITLE
ColorPicker opens and immediately closes #990

### DIFF
--- a/Radzen.Blazor/Rendering/Popup.razor
+++ b/Radzen.Blazor/Rendering/Popup.razor
@@ -43,10 +43,9 @@
         {
             if (shouldToggle)
             {
+                shouldToggle = false;
                 await JSRuntime.InvokeVoidAsync("Radzen.togglePopup", target, GetId(), false, Reference, nameof(OnClose));
             }
-
-            shouldToggle = false;
         }
     }
 


### PR DESCRIPTION
As proposed, `shouldToggle = false;` is moved before `await JSRuntime.InvokeVoidAsync` to prevent closing of popup in case the next redraw was triggered before the previous one was not completed.