### PR TITLE
Add MaxColumnsSelectedLabels to RadzenDataGrid to expose MaxSelectedLabels of column picker RadzenDropDown

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -51,13 +51,16 @@
                 @if (AllowColumnPicking)
                 {
                     <div class="rz-column-picker">
-                        <RadzenDropDown SelectAllText="@AllColumnsText" AllowSelectAll="@AllowPickAllColumns"
-                            MaxSelectedLabels="2"
-                            SelectedItemsText="@ColumnsShowingText" Change=@ToggleColumns
+                        <RadzenDropDown 
                             @bind-Value="@selectedColumns"
+                            AllowSelectAll="@AllowPickAllColumns"
+                            Change="@ToggleColumns"
+                            Data="allPickableColumns"
+                            MaxSelectedLabels="@MaxColumnsSelectedLabels"
                             Multiple="true"
                             Placeholder="@ColumnsText"
-                            Data="allPickableColumns"
+                            SelectAllText="@AllColumnsText" 
+                            SelectedItemsText="@ColumnsShowingText" 
                             TextProperty="Title" />
                     </div>
 

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1138,6 +1138,13 @@ namespace Radzen.Blazor
         public bool AllowPickAllColumns { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the maximum number of selected column names are shown as labels in column picker.
+        /// </summary>
+        /// <value>Maximum number of labels (default: 2).</value>
+        [Parameter]
+        public int MaxColumnsSelectedLabels { get; set; } = 2;
+
+        /// <summary>
         /// Gets or sets a value indicating whether grouping is allowed.
         /// </summary>
         /// <value><c>true</c> if grouping is allowed; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
This PR is meant to be able to alter the number of selected column labels in de column picker of the RadzenDataGrid.