### PR TITLE
Add "Create" Button Functionality to RadzenDropDownDataGrid Component

### DIFF
--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -1,4 +1,4 @@
-﻿@using Radzen
+@using Radzen
 @using System.Collections
 @using System.Collections.Generic
 @using System.Linq.Dynamic.Core
@@ -121,6 +121,13 @@
                             <button class="rz-button rz-button-md rz-button-icon-only rz-primary" type="button" title="" @onclick="@((args) => OnFilter(new ChangeEventArgs()))">
                                 <i class="rz-button-icon-left rzi">search</i>
                             </button>
+
+                            @if (ShowCreate)
+                            {
+                                <button class="rz-button rz-button-md rz-button-icon-only rz-primary" style="margin-left: 5px" type="button" title="" @onclick="@OnAddClick">
+                                    <i class="rz-button-icon-left rzi">add</i>
+                                </button>
+                            }
                         }
                     </div>
                 }

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using System;
@@ -172,6 +172,19 @@ namespace Radzen.Blazor
         public bool ShowSearch { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the create button is shown.
+        /// </summary>
+        /// <value><c>true</c> if the create button is shown; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ShowCreate { get; set; } = false;
+        /// <summary>
+        /// Gets or sets a value indicating whether the component should refresh after a create action.
+        /// </summary>
+        /// <value><c>true</c> if the component should refresh after a create action; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool RefreshAfterCreate { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the page numbers count.
         /// </summary>
         /// <value>The page numbers count.</value>
@@ -219,6 +232,12 @@ namespace Radzen.Blazor
         /// <value>The columns.</value>
         [Parameter]
         public RenderFragment Columns { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action to be executed when the Add button is clicked.
+        /// </summary>
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnAdd { get; set; }
 
         RadzenDataGrid<object> grid;
         IEnumerable<object> pagedData;
@@ -333,7 +352,33 @@ namespace Radzen.Blazor
 
             return type == typeof(string);
         }
+        bool clicking;
+        /// <summary>
+        /// Handles the <see cref="E:Click" /> event.
+        /// </summary>
+        /// <param name="args">The <see cref="MouseEventArgs"/> instance containing the event data.</param>
+        public async Task OnAddClick(MouseEventArgs args)
+        {
+            if (clicking)
+            {
+                return;
+            }
 
+            try
+            {
+                clicking = true;
+
+                await OnAdd.InvokeAsync(args);
+                if (RefreshAfterCreate)
+                {
+                    await Reload();
+                }
+            }
+            finally
+            {
+                clicking = false;
+            }
+        }
         async Task OnLoadData(LoadDataArgs args)
         {
             if (!LoadData.HasDelegate)
@@ -622,7 +667,10 @@ namespace Radzen.Blazor
         protected override async Task OnFilter(ChangeEventArgs args)
         {
             await DebounceFilter();
-        }
+        }   
+        
+        
+
 
         /// <summary>
         /// Gets or sets a value indicating whether sorting is allowed.


### PR DESCRIPTION
I have added a new feature to the RadzenDropDownDataGrid component that allows the inclusion of a "Create" button. This button enables the invocation of an external function, which provides the capability to create a new record without navigating to a different page.

Changes Made:
- Added a new parameter called `OnCreate` of type `Action` to the RadzenDropDownDataGrid component.
- Included the "Create" button next to the existing "Search" button.
- Linked the `OnCreate` function to the "Create" button's click event.

Usage Example:
```

@code {
    private async Task OnAdd()
    {
        await DialogService.OpenAsync<AddRegion>("Add Region", null);
    }
}
           <RadzenDropDownDataGrid Data="@regionsForregion" TextProperty="name" ValueProperty="id" AllowClear=true
                                            Disabled=@(hasregionValue) Placeholder="Seleccionar Comuna" style="display: block; width: 100%" @bind-Value="@comuna.region" Name="region"
                                            SearchText="Nombre Región"
                                            ShowCreate="true"
                                            RefreshAfterCreate="true"
                                        OnAdd="OnAdd">
```

With this enhancement, users can now create a new record by clicking the "Create" button directly within the dropdown grid component, offering a more convenient and efficient user experience.

Please review and merge these changes at your earliest convenience.

Thank you!


https://github.com/radzenhq/radzen-blazor/assets/6192404/81ba1edf-3d77-426d-8c90-50290c16fccc




