### PR TITLE
Add "Create" Button Functionality to RadzenDropDownDataGrid Component

### DIFF
--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -122,6 +122,12 @@
                                 <i class="rz-button-icon-left rzi">search</i>
                             </button>
                         }
+                        @if (ShowAdd)
+                        {
+                            <button class="rz-button rz-button-md rz-button-icon-only rz-primary" style="margin-left: 5px" type="button" title="" @onclick="@OnAddClick">
+                                <i class="rz-button-icon-left rzi">add</i>
+                            </button>
+                        }
                     </div>
                 }
                 @if (Template != null)

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -174,7 +174,7 @@ namespace Radzen.Blazor
         /// Gets or sets the action to be executed when the Add button is clicked.
         /// </summary>
         [Parameter]
-        public EventCallback<MouseEventArgs> OnAdd { get; set; }
+        public EventCallback<MouseEventArgs> Add { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the create button is shown.
@@ -732,7 +732,7 @@ namespace Radzen.Blazor
             {
                 clicking = true;
 
-                await OnAdd.InvokeAsync(args);
+                await Add.InvokeAsync(args);
                 if (RefreshAfterAdd)
                 {
                     await Reload();

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -170,6 +170,24 @@ namespace Radzen.Blazor
         /// <value><c>true</c> if search button is shown; otherwise, <c>false</c>.</value>
         [Parameter]
         public bool ShowSearch { get; set; } = true;
+        /// <summary>
+        /// Gets or sets the action to be executed when the Add button is clicked.
+        /// </summary>
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnAdd { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the create button is shown.
+        /// </summary>
+        /// <value><c>true</c> if the create button is shown; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ShowAdd { get; set; } = false;
+        /// <summary>
+        /// Gets or sets a value indicating whether the component should refresh after a create action.
+        /// </summary>
+        /// <value><c>true</c> if the component should refresh after a create action; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool RefreshAfterAdd { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the page numbers count.
@@ -695,6 +713,34 @@ namespace Radzen.Blazor
             if (IsJSRuntimeAvailable)
             {
                 JSRuntime.InvokeVoidAsync("Radzen.destroyPopup", PopupID);
+            }
+        }
+
+        bool clicking;
+        /// <summary>
+        /// Handles the <see cref="E:Click" /> event.
+        /// </summary>
+        /// <param name="args">The <see cref="MouseEventArgs"/> instance containing the event data.</param>
+        public async Task OnAddClick(MouseEventArgs args)
+        {
+            if (clicking)
+            {
+                return;
+            }
+
+            try
+            {
+                clicking = true;
+
+                await OnAdd.InvokeAsync(args);
+                if (RefreshAfterAdd)
+                {
+                    await Reload();
+                }
+            }
+            finally
+            {
+                clicking = false;
             }
         }
     }

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -182,12 +182,6 @@ namespace Radzen.Blazor
         /// <value><c>true</c> if the create button is shown; otherwise, <c>false</c>.</value>
         [Parameter]
         public bool ShowAdd { get; set; } = false;
-        /// <summary>
-        /// Gets or sets a value indicating whether the component should refresh after a create action.
-        /// </summary>
-        /// <value><c>true</c> if the component should refresh after a create action; otherwise, <c>false</c>.</value>
-        [Parameter]
-        public bool RefreshAfterAdd { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the page numbers count.
@@ -733,10 +727,6 @@ namespace Radzen.Blazor
                 clicking = true;
 
                 await Add.InvokeAsync(args);
-                if (RefreshAfterAdd)
-                {
-                    await Reload();
-                }
             }
             finally
             {


### PR DESCRIPTION
I have added a new feature to the RadzenDropDownDataGrid component that allows the inclusion of a "Create" button. This button enables the invocation of an external function, which provides the capability to create a new record without navigating to a different page.

Changes Made:
- Added a new parameter called `OnCreate` of type `Action` to the RadzenDropDownDataGrid component.
- Included the "Create" button next to the existing "Search" button.
- Linked the `OnCreate` function to the "Create" button's click event.

Usage Example:
```

@code {
    private async Task OnAdd()
    {
        await DialogService.OpenAsync<AddRegion>("Add Region", null);
    }
}
           <RadzenDropDownDataGrid Data="@regionsForregion" TextProperty="name" ValueProperty="id" AllowClear=true
                                            Disabled=@(hasregionValue) Placeholder="Seleccionar Comuna" style="display: block; width: 100%" @bind-Value="@comuna.region" Name="region"
                                            SearchText="Nombre Región"
                                            ShowAdd="true"
                                            RefreshAfterAdd="true"
                                        OnAdd="OnAdd">
```

With this enhancement, users can now create a new record by clicking the "Create" button directly within the dropdown grid component, offering a more convenient and efficient user experience.

Please review and merge these changes at your earliest convenience.

Thank you!


https://github.com/radzenhq/radzen-blazor/assets/6192404/81ba1edf-3d77-426d-8c90-50290c16fccc




