### PR TITLE
do not hide 2 notification when clicking close

### DIFF
--- a/Radzen.Blazor/RadzenNotificationMessage.razor
+++ b/Radzen.Blazor/RadzenNotificationMessage.razor
@@ -54,7 +54,7 @@
    public void Close()
    {
       Service.Messages.Remove(Message);
-      System.Threading.Tasks.Task.Delay(0).ContinueWith(r => { Visible = false; });
+      //System.Threading.Tasks.Task.Delay(0).ContinueWith(r => { Visible = false; });
    }
 
    protected override void OnInitialized()


### PR DESCRIPTION
solving issue found on forum : https://forum.radzen.com/t/closing-a-notification-closes-two-notifications/2020

when you remove a message, blazor will rebind and the message will become invisible, so no need to set visible to false