### PR TITLE
Fix search with quotes in RadzenDataGrid filter

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -304,6 +304,7 @@ namespace Radzen
 
             var value = !second ? (string)Convert.ChangeType(column.FilterValue, typeof(string)) :
                 (string)Convert.ChangeType(column.SecondFilterValue, typeof(string));
+            value = value?.Replace("\"", "\\\"");
 
             var columnType = column.Type;
             var columnFormat = column.Format;
@@ -393,7 +394,8 @@ namespace Radzen
             if (column.FilterPropertyType == typeof(string))
             {
                 string filterCaseSensitivityOperator = column.Grid.FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? ".ToLower()" : "";
-
+                value = value?.Replace("\"", "\\\"");
+                
                 if (!string.IsNullOrEmpty(value) && columnFilterOperator == FilterOperator.Contains)
                 {
                     return $@"({property} == null ? """" : {property}){filterCaseSensitivityOperator}.Contains(""{value}""{filterCaseSensitivityOperator})";


### PR DESCRIPTION
![chrome_2023-07-07_13-47-47](https://github.com/radzenhq/radzen-blazor/assets/18440948/82699d5d-c11f-478b-9d34-1d87592d87f7)

Fix search with quotes in RadzenDataGrid filter
Maybe more testing is needed or an additional fix in other methods that work with filters.