### PR TITLE
Added custom text for null enum value in filter. 

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -281,7 +281,7 @@
                                                         {
                                                             <RadzenDropDown Style="width:100%" AllowClear="true" AllowFiltering="false" TValue="@object"
                                                     Value=@column.GetFilterValue() Multiple="false" Placeholder="@EnumFilterSelectText" TextProperty="Text" ValueProperty="Value"
-                                                    Data=@((PropertyAccess.IsNullableEnum(column.FilterPropertyType) ? new object[]{ new { Value = -1, Text = "<null>"}} : Enumerable.Empty<object>()).Concat(EnumExtensions.EnumAsKeyValuePair(Nullable.GetUnderlyingType(column.FilterPropertyType) ?? column.FilterPropertyType)))
+                                                                            Data=@((PropertyAccess.IsNullableEnum(column.FilterPropertyType) ? new object[]{ new { Value = -1, Text = EnumNullFilterText}} : Enumerable.Empty<object>()).Concat(EnumExtensions.EnumAsKeyValuePair(Nullable.GetUnderlyingType(column.FilterPropertyType) ?? column.FilterPropertyType)))
                                                     Change="@(args => {column.SetFilterValue(args);column.SetFilterOperator(object.Equals(args, -1) ? FilterOperator.IsNull : FilterOperator.Equals);ApplyFilter(column, true);})" />
                                                         }
                                                         else if (PropertyAccess.IsNumeric(column.FilterPropertyType))

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -855,6 +855,13 @@ namespace Radzen.Blazor
         public string EnumFilterSelectText { get; set; } = "Select...";
 
         /// <summary>
+        /// Gets or sets the nullable enum for null value filter text.
+        /// </summary>
+        /// <value>The enum filter select text.</value>
+        [Parameter]
+        public string EnumNullFilterText { get; set; } = "No value";
+
+        /// <summary>
         /// Gets or sets the and operator text.
         /// </summary>
         /// <value>The and operator text.</value>


### PR DESCRIPTION
Added custom text for null enum value in filter. 
Default value "No value" instead of "<null>".

Before:
![chrome_2023-07-13_19-42-35](https://github.com/radzenhq/radzen-blazor/assets/18440948/b86bd7dc-d93d-4d59-bab5-e77186f6660e)

After:
![chrome_2023-07-13_19-36-23](https://github.com/radzenhq/radzen-blazor/assets/18440948/95d55503-a907-4920-a2cb-e2f3927d8e0a)



