### PR TITLE
Htmledit on input

### DIFF
--- a/Radzen.Blazor/RadzenHtmlEditor.razor
+++ b/Radzen.Blazor/RadzenHtmlEditor.razor
@@ -13,7 +13,7 @@
             {
                 @ChildContent
             }
-            else
+            else if (!NoTools)
             {
                 <RadzenHtmlEditorUndo />
                 <RadzenHtmlEditorRedo />

--- a/Radzen.Blazor/RadzenHtmlEditor.razor.cs
+++ b/Radzen.Blazor/RadzenHtmlEditor.razor.cs
@@ -19,6 +19,12 @@ namespace Radzen.Blazor
     public partial class RadzenHtmlEditor : FormComponent<string>
     {
         /// <summary>
+        /// Allows for no-tool HTML editors.
+        /// </summary>
+        [Parameter]
+        public bool NoTools { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the mode of the editor.
         /// </summary>
         [Parameter]

--- a/Radzen.Blazor/RadzenHtmlEditor.razor.cs
+++ b/Radzen.Blazor/RadzenHtmlEditor.razor.cs
@@ -46,6 +46,13 @@ namespace Radzen.Blazor
         public IDictionary<string, string> UploadHeaders { get; set; }
 
         /// <summary>
+        /// Gets or sets the input.
+        /// </summary>
+        /// <value>The input.</value>
+        [Parameter]
+        public EventCallback<string> Input { get; set; }
+
+        /// <summary>
         /// A callback that will be invoked when the user pastes content in the editor. Commonly used to filter unwanted HTML.
         /// </summary>
         /// <example>
@@ -280,6 +287,7 @@ namespace Radzen.Blazor
         public void OnChange(string html)
         {
             Html = html;
+            Input.InvokeAsync(html);
         }
 
         /// <summary>

--- a/RadzenBlazorDemos/Pages/HtmlEditorGetSetValue.razor
+++ b/RadzenBlazorDemos/Pages/HtmlEditorGetSetValue.razor
@@ -1,4 +1,4 @@
-﻿<RadzenHtmlEditor @bind-Value=@htmlValue style="height: 300px;" Change=@OnChange Paste=@OnPaste Execute=@OnExecute UploadUrl="upload/image" />
+﻿<RadzenHtmlEditor @bind-Value=@htmlValue style="height: 300px;" Input=@OnInput Change=@OnChange Paste=@OnPaste Execute=@OnExecute UploadUrl="upload/image" />
 
 <EventConsole @ref=@console />
 
@@ -15,6 +15,11 @@
     void OnChange(string html)
     {
         console.Log($"Change: {html}");
+    }
+
+    void OnInput(string html)
+    {
+        console.Log($"Input: {html}");
     }
 
     void OnExecute(HtmlEditorExecuteEventArgs args)


### PR DESCRIPTION
Adds two parameters to the `RadzenHTMLEditor` component.

- `NoTools`: is a boolean that allows for an HTMLEditor component that doesn't have any tools.
- `Input`: is an event callback on input allowing developers to react to changes in the HTMLEditor without having to wait until blur.

I updated one of the HTMLEditor demos to include an implementation of `Input`.