### PR TITLE
Added SetFilterValueAsync method

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -530,7 +530,8 @@ namespace Radzen.Blazor
                 var visibleColumns = Grid.ColumnsCollection.Where(c => c.GetVisible()).ToList();
                 var left = visibleColumns
                     .Where((c, i) => visibleColumns.IndexOf(this) > i && c.IsFrozen())
-                    .Sum(c => {
+                    .Sum(c =>
+                    {
                         var w = !string.IsNullOrEmpty(c.GetWidth()) ? c.GetWidth() : Grid.ColumnWidth;
                         var cw = 200;
                         if (!string.IsNullOrEmpty(w) && w.Contains("px"))
@@ -711,20 +712,20 @@ namespace Radzen.Blazor
                 }
             }
 
-			if (parameters.DidParameterChange(nameof(Pickable), Pickable))
-			{
-				var newPickable = parameters.GetValueOrDefault<bool>(nameof(Pickable));
+            if (parameters.DidParameterChange(nameof(Pickable), Pickable))
+            {
+                var newPickable = parameters.GetValueOrDefault<bool>(nameof(Pickable));
 
-				Pickable = newPickable;
+                Pickable = newPickable;
 
-				if (Grid != null)
-				{
-					Grid.UpdatePickableColumns();
-					await Grid.ChangeState();
-				}
-			}
+                if (Grid != null)
+                {
+                    Grid.UpdatePickableColumns();
+                    await Grid.ChangeState();
+                }
+            }
 
-			if (parameters.DidParameterChange(nameof(SortOrder), SortOrder))
+            if (parameters.DidParameterChange(nameof(SortOrder), SortOrder))
             {
                 sortOrder = new SortOrder?[] { parameters.GetValueOrDefault<SortOrder?>(nameof(SortOrder)) };
 
@@ -883,11 +884,23 @@ namespace Radzen.Blazor
             }
         }
 
+        /// <summary>
+        /// Set column filter value and reload grid.
+        /// </summary>
+        /// <param name="value">Filter value.</param>
+        /// <param name="isFirst"><c>true</c> if FilterValue; <c>false</c> for SecondFilterValue</param>
+        public async Task SetFilterValueAsync(object value, bool isFirst = true)
+        {
+            SetFilterValue(value, isFirst);
+            Grid.SaveSettings();
+            await Grid.Reload();
+        }
+
         internal bool CanSetFilterValue()
         {
             return GetFilterOperator() == FilterOperator.IsNull
                     || GetFilterOperator() == FilterOperator.IsNotNull
-                    ||  GetFilterOperator() == FilterOperator.IsEmpty
+                    || GetFilterOperator() == FilterOperator.IsEmpty
                     || GetFilterOperator() == FilterOperator.IsNotEmpty;
         }
 
@@ -999,8 +1012,9 @@ namespace Radzen.Blazor
             if (PropertyAccess.IsNullableEnum(FilterPropertyType))
                 return new FilterOperator[] { FilterOperator.Equals, FilterOperator.NotEquals, FilterOperator.IsNull, FilterOperator.IsNotNull };
 
-            return Enum.GetValues(typeof(FilterOperator)).Cast<FilterOperator>().Where(o => {
-                var isStringOperator = o == FilterOperator.Contains ||  o == FilterOperator.DoesNotContain
+            return Enum.GetValues(typeof(FilterOperator)).Cast<FilterOperator>().Where(o =>
+            {
+                var isStringOperator = o == FilterOperator.Contains || o == FilterOperator.DoesNotContain
                     || o == FilterOperator.StartsWith || o == FilterOperator.EndsWith || o == FilterOperator.IsEmpty || o == FilterOperator.IsNotEmpty;
                 return FilterPropertyType == typeof(string) || QueryableExtension.IsEnumerable(FilterPropertyType) ? isStringOperator
                       || o == FilterOperator.Equals || o == FilterOperator.NotEquals
@@ -1026,7 +1040,7 @@ namespace Radzen.Blazor
                     return Grid?.EqualsText;
                 case FilterOperator.GreaterThan:
                     return Grid?.GreaterThanText;
-                case FilterOperator. GreaterThanOrEquals:
+                case FilterOperator.GreaterThanOrEquals:
                     return Grid?.GreaterThanOrEqualsText;
                 case FilterOperator.LessThan:
                     return Grid?.LessThanText;
@@ -1139,7 +1153,7 @@ namespace Radzen.Blazor
             {
                 return Grid.sorts.IndexOf(descriptor);
             }
-            
+
             return null;
         }
 


### PR DESCRIPTION
Added SetFilterValueAsync method set column filter value and reload grid. Allows you to use the FilterTemplate without initializing an additional property.
**And also allows save the value of FilterTemplate when saving settings.**

Example:
![devenv_2023-07-25_01-14-00](https://github.com/radzenhq/radzen-blazor/assets/18440948/a0122711-5827-492a-859d-9b5ab7948a91)

https://github.com/radzenhq/radzen-blazor/assets/18440948/20482534-3a9f-40a3-bde0-c9eb1f86b7d3




Example with IEnumerable<string>
![devenv_2023-07-24_21-35-50](https://github.com/radzenhq/radzen-blazor/assets/18440948/fb2915a8-2cbe-4f67-822d-9b6fad6f779e)

https://github.com/radzenhq/radzen-blazor/assets/18440948/79dbd888-f292-4a1a-817b-e48fed6d962a


_and code formatting fix._
