### PR TITLE
enabled scroll in tabs

### DIFF
--- a/Radzen.Blazor/RadzenTabs.razor
+++ b/Radzen.Blazor/RadzenTabs.razor
@@ -5,7 +5,7 @@
 @if (Visible)
 {
     <div @ref=@Element style=@Style @attributes=@Attributes class=@GetCssClass() id=@GetId()>
-        <ul role="tablist" class="rz-tabview-nav">
+        <ul role="tablist" class="rz-tabview-nav" style=@(Scrollable ? "overflow-x: scroll;": "")>
             @Tabs
         </ul>
         <div class="rz-tabview-panels">

--- a/Radzen.Blazor/RadzenTabs.razor.cs
+++ b/Radzen.Blazor/RadzenTabs.razor.cs
@@ -69,6 +69,12 @@ namespace Radzen.Blazor
         [Parameter]
         public RenderFragment Tabs { get; set; }
 
+        /// <summary>
+        /// Enabled Scroll in Tabs
+        /// </summary>
+        [Parameter]
+        public bool Scrollable { get; set; }
+
         List<RadzenTabsItem> tabs = new List<RadzenTabsItem>();
 
         /// <summary>


### PR DESCRIPTION
allows adding a scroll to the tabs when there are many elements and they are viewed from a mobile device

<img width="275" alt="image" src="https://github.com/radzenhq/radzen-blazor/assets/6192404/7fcb5df6-58e7-426e-8af5-fe091694591b">

<img width="280" alt="image" src="https://github.com/radzenhq/radzen-blazor/assets/6192404/4f81fce6-697b-4e2b-ba5f-2d5712bc60e1">

