### PR TITLE
Add DataGrid Item Editing

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -70,13 +70,13 @@ namespace Radzen.Blazor
             var view = AllowPaging ? PagedView : View;
             var top = request.Count;
 
-            if(top <= 0)
+            if (top <= 0)
             {
                 top = PageSize;
             }
 
             await InvokeLoadData(request.StartIndex, top);
-            
+
             var totalItemsCount = LoadData.HasDelegate ? Count : view.Count();
 
             virtualDataItems = (LoadData.HasDelegate ? Data : itemToInsert != null ? (new[] { itemToInsert }).Concat(view.Skip(request.StartIndex).Take(top)) : view.Skip(request.StartIndex).Take(top))?.ToList();
@@ -88,7 +88,7 @@ namespace Radzen.Blazor
         {
             var top = request.Count;
 
-            if(top <= 0)
+            if (top <= 0)
             {
                 top = PageSize;
             }
@@ -102,7 +102,7 @@ namespace Radzen.Blazor
             return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<GroupResult>(_groupedPagedView.Skip(request.StartIndex).Take(top), totalItemsCount);
         }
 #endif
-       
+
         RenderFragment DrawRows(IList<RadzenDataGridColumn<TItem>> visibleColumns)
         {
             return new RenderFragment(builder =>
@@ -110,7 +110,7 @@ namespace Radzen.Blazor
 #if NET5_0_OR_GREATER
                 if (AllowVirtualization)
                 {
-                    if(AllowGrouping && Groups.Any() && !LoadData.HasDelegate)
+                    if (AllowGrouping && Groups.Any() && !LoadData.HasDelegate)
                     {
                         builder.OpenComponent(0, typeof(Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<GroupResult>));
                         builder.AddAttribute(1, "ItemsProvider", new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<GroupResult>(LoadGroups));
@@ -135,7 +135,7 @@ namespace Radzen.Blazor
                     {
                         builder.OpenComponent(0, typeof(Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>));
                         builder.AddAttribute(1, "ItemsProvider", new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem>(LoadItems));
-                    
+
                         builder.AddAttribute(2, "ChildContent", (RenderFragment<TItem>)((context) =>
                         {
                             return (RenderFragment)((b) =>
@@ -158,7 +158,7 @@ namespace Radzen.Blazor
                             });
                         }));
 
-                        if(VirtualizationOverscanCount != default(int))
+                        if (VirtualizationOverscanCount != default(int))
                         {
                             builder.AddAttribute(1, "OverscanCount", VirtualizationOverscanCount);
                         }
@@ -267,7 +267,7 @@ namespace Radzen.Blazor
 
         internal async Task RemoveGroupAsync(GroupDescriptor gd)
         {
-            Groups.Remove(gd); 
+            Groups.Remove(gd);
             _groupedPagedView = null;
 
             var column = columns.Where(c => c.GetGroupProperty() == gd.Property).FirstOrDefault();
@@ -355,7 +355,7 @@ namespace Radzen.Blazor
         /// Gives the grid a custom header, allowing the adding of components to create custom tool bars in addtion to column grouping and column picker
         /// </summary>
         [Parameter]
-        public RenderFragment HeaderTemplate { get; set; } 
+        public RenderFragment HeaderTemplate { get; set; }
 
         internal object selectedColumns;
 
@@ -439,7 +439,7 @@ namespace Radzen.Blazor
                     columnsList.Add(column);
                 }
             }
-            else 
+            else
             {
                 if (columnsList.Contains(column))
                 {
@@ -450,18 +450,18 @@ namespace Radzen.Blazor
             selectedColumns = columnsList;
         }
 
-		public void UpdatePickableColumns()
-		{
-			if (allColumns.Any(c => c.Pickable))
-			{
-				if (AllowColumnPicking)
-				{
-					allPickableColumns = allColumns.Where(c => c.Pickable).OrderBy(c => c.GetOrderIndex()).ToList();
-				}
-			}
-		}
+        public void UpdatePickableColumns()
+        {
+            if (allColumns.Any(c => c.Pickable))
+            {
+                if (AllowColumnPicking)
+                {
+                    allPickableColumns = allColumns.Where(c => c.Pickable).OrderBy(c => c.GetOrderIndex()).ToList();
+                }
+            }
+        }
 
-		internal void RemoveColumn(RadzenDataGridColumn<TItem> column)
+        internal void RemoveColumn(RadzenDataGridColumn<TItem> column)
         {
             if (columns.Contains(column))
             {
@@ -720,9 +720,9 @@ namespace Radzen.Blazor
 
             SaveSettings();
 
-            await FilterCleared.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>() 
-            { 
-                Column = column, 
+            await FilterCleared.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>()
+            {
+                Column = column,
                 FilterValue = column.GetFilterValue(),
                 SecondFilterValue = column.GetSecondFilterValue(),
                 FilterOperator = column.GetFilterOperator(),
@@ -973,14 +973,14 @@ namespace Radzen.Blazor
         /// <value>The null text.</value>
         [Parameter]
         public string IsNullText { get; set; } = "Is null";
-        
+
         /// <summary>
         /// Gets or sets the is empty text.
         /// </summary>
         /// <value>The empty text.</value>
         [Parameter]
         public string IsEmptyText { get; set; } = "Is empty";
-        
+
         /// <summary>
         /// Gets or sets the is not empty text.
         /// </summary>
@@ -1433,11 +1433,11 @@ namespace Radzen.Blazor
 
         internal bool IsVirtualizationAllowed()
         {
-    #if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
             return AllowVirtualization;
-    #else
+#else
             return false;
-    #endif
+#endif
         }
 
         IList<TItem> _value;
@@ -1631,15 +1631,15 @@ namespace Radzen.Blazor
 
             if (resetColumnState)
             {
-                allColumns.ToList().ForEach(c => 
-                { 
-                    c.ClearFilters(); 
+                allColumns.ToList().ForEach(c =>
+                {
+                    c.ClearFilters();
                     c.ResetSortOrder();
                     c.SetOrderIndex(null);
                     c.SetWidth(null);
                 });
                 sorts.Clear();
-           }
+            }
 
             if (!LoadData.HasDelegate)
             {
@@ -1662,14 +1662,14 @@ namespace Radzen.Blazor
 #if NET5_0_OR_GREATER
             if (AllowVirtualization)
             {
-                if(!LoadData.HasDelegate)
+                if (!LoadData.HasDelegate)
                 {
-                    if(virtualize != null)
+                    if (virtualize != null)
                     {
                         await virtualize.RefreshDataAsync();
                     }
 
-                    if(groupVirtualize != null)
+                    if (groupVirtualize != null)
                     {
                         await groupVirtualize.RefreshDataAsync();
                     }
@@ -1693,13 +1693,13 @@ namespace Radzen.Blazor
 #if NET5_0_OR_GREATER
                 if (AllowVirtualization)
                 {
-                    if(virtualize != null)
+                    if (virtualize != null)
                     {
                         await virtualize.RefreshDataAsync();
                         await virtualize.RefreshDataAsync();
                     }
 
-                    if(groupVirtualize != null)
+                    if (groupVirtualize != null)
                     {
                         await groupVirtualize.RefreshDataAsync();
                     }
@@ -1894,8 +1894,10 @@ namespace Radzen.Blazor
         {
             bool emptyTextChanged = false, allowColumnPickingChanged = false, valueChanged = false, allGroupsExpandedChanged = false;
 
-            foreach (var parameter in parameters) {
-                switch (parameter.Name) {
+            foreach (var parameter in parameters)
+            {
+                switch (parameter.Name)
+                {
                     case nameof(EmptyText):
                         emptyTextChanged = HasChanged(parameter.Value, EmptyText); break;
 
@@ -2290,7 +2292,7 @@ namespace Radzen.Blazor
         /// <param name="item">The item.</param>
         public async System.Threading.Tasks.Task EditRow(TItem item)
         {
-            if(itemToInsert != null)
+            if (itemToInsert != null)
             {
                 CancelEditRow(itemToInsert);
             }
@@ -2385,7 +2387,7 @@ namespace Radzen.Blazor
         {
             if (object.Equals(itemToInsert, item))
             {
-                if(!IsVirtualizationAllowed())
+                if (!IsVirtualizationAllowed())
                 {
                     var list = this.PagedView.ToList();
                     list.Remove(item);
@@ -2398,12 +2400,12 @@ namespace Radzen.Blazor
                 {
 #if NET5_0_OR_GREATER
                     itemToInsert = default(TItem);
-                    if(virtualize != null)
+                    if (virtualize != null)
                     {
                         virtualize.RefreshDataAsync();
                     }
 
-                    if(groupVirtualize != null)
+                    if (groupVirtualize != null)
                     {
                         groupVirtualize.RefreshDataAsync();
                     }
@@ -2460,7 +2462,7 @@ namespace Radzen.Blazor
         public async System.Threading.Tasks.Task InsertRow(TItem item)
         {
             itemToInsert = item;
-            if(!IsVirtualizationAllowed())
+            if (!IsVirtualizationAllowed())
             {
                 var list = this.PagedView.ToList();
                 list.Insert(0, item);
@@ -2470,12 +2472,12 @@ namespace Radzen.Blazor
             else
             {
 #if NET5_0_OR_GREATER
-                if(virtualize != null)
+                if (virtualize != null)
                 {
                     await virtualize.RefreshDataAsync();
                 }
 
-                if(groupVirtualize != null)
+                if (groupVirtualize != null)
                 {
                     await groupVirtualize.RefreshDataAsync();
                 }
@@ -2485,12 +2487,51 @@ namespace Radzen.Blazor
             await EditRowInternal(item);
         }
 
+        /// <summary>
+        /// Inserts Item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        public async Task InsertItem(TItem item)
+        {
+            var list = this.PagedView.ToList();
+            list.Insert(0, item);
+            this._view = list.AsQueryable();
+            this.Count++;
+        }
+
+        /// <summary>
+        /// Inserts Item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        public async Task UpdateItem(TItem item)
+        {
+            var list = this.PagedView.ToList();
+            var itemIndex= list.FindIndex(i => ItemEquals(i, item));
+            if (itemIndex < 0) return;
+            list.RemoveAt(itemIndex);
+            list.Insert(itemIndex, item);
+            this._view = list.AsQueryable();
+        }
+
+        /// <summary>
+        /// Delete Item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        public async Task DeleteItem(TItem item)
+        {
+            var list = this.PagedView.ToList();
+            var itemIndex = list.FindIndex(i => ItemEquals(i, item));
+            if (itemIndex < 0) return;
+            list.RemoveAt(itemIndex);
+            this._view = list.AsQueryable();
+        }
+
 
         bool? isOData;
 
         internal bool IsOData()
         {
-            if(isOData == null && Data != null)
+            if (isOData == null && Data != null)
             {
                 isOData = typeof(ODataEnumerable<TItem>).IsAssignableFrom(Data.GetType());
             }
@@ -2550,9 +2591,9 @@ namespace Radzen.Blazor
                 RadzenDataGridColumn<TItem> column;
                 column = columns.Where(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems[0]).Property).FirstOrDefault();
 
-                if(column == null)
+                if (column == null)
                 {
-                   column = allColumns.Where(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems[0]).Property).FirstOrDefault();
+                    column = allColumns.Where(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems[0]).Property).FirstOrDefault();
                 }
 
                 if (HideGroupedColumn)
@@ -2602,8 +2643,8 @@ namespace Radzen.Blazor
         /// Gets or sets the group descriptors.
         /// </summary>
         /// <value>The groups.</value>
-        public ObservableCollection<GroupDescriptor> Groups 
-        { 
+        public ObservableCollection<GroupDescriptor> Groups
+        {
             get
             {
                 if (groups == null)
@@ -2625,15 +2666,15 @@ namespace Radzen.Blazor
 
         internal async Task EndColumnDropToGroup()
         {
-            if(indexOfColumnToReoder != null && AllowGrouping)
+            if (indexOfColumnToReoder != null && AllowGrouping)
             {
                 var functionName = $"Radzen['{getColumnResizerId(indexOfColumnToReoder.Value)}end']";
                 await JSRuntime.InvokeVoidAsync("eval", $"{functionName} && {functionName}()");
 
                 RadzenDataGridColumn<TItem> column;
-                
+
                 column = columns.Where(c => c.GetVisible()).ElementAtOrDefault(indexOfColumnToReoder.Value);
-               
+
                 //may be its a child column
                 if (column == null)
                     column = allColumns.Where(c => c.GetVisible()).ElementAtOrDefault(indexOfColumnToReoder.Value);
@@ -2643,7 +2684,7 @@ namespace Radzen.Blazor
                     var descriptor = Groups.Where(d => d.Property == column.GetGroupProperty()).FirstOrDefault();
                     if (descriptor == null)
                     {
-                        descriptor = new GroupDescriptor() { Property = column.GetGroupProperty(), Title = column.GetTitle(), SortOrder = column.GetSortOrder() ?? SortOrder.Ascending  };
+                        descriptor = new GroupDescriptor() { Property = column.GetGroupProperty(), Title = column.GetTitle(), SortOrder = column.GetSortOrder() ?? SortOrder.Ascending };
                         Groups.Add(descriptor);
                         _groupedPagedView = null;
 
@@ -2657,7 +2698,7 @@ namespace Radzen.Blazor
                 }
 
                 indexOfColumnToReoder = null;
-            }  
+            }
         }
 
         /// <summary>
@@ -2900,8 +2941,8 @@ namespace Radzen.Blazor
             if (SettingsChanged.HasDelegate)
             {
                 var shouldUpdateState = false;
-                var hasFilter = settings.Columns != null && settings.Columns.Any(c => 
-                    c.FilterValue != null || c.SecondFilterValue != null || 
+                var hasFilter = settings.Columns != null && settings.Columns.Any(c =>
+                    c.FilterValue != null || c.SecondFilterValue != null ||
                     c.FilterOperator == FilterOperator.IsNull || c.FilterOperator == FilterOperator.IsNotNull ||
                     c.FilterOperator == FilterOperator.IsEmpty || c.FilterOperator == FilterOperator.IsNotEmpty ||
                     c.SecondFilterOperator == FilterOperator.IsNull || c.SecondFilterOperator == FilterOperator.IsNotNull ||

--- a/RadzenBlazorDemos/Pages/DataGridItemEdit.razor
+++ b/RadzenBlazorDemos/Pages/DataGridItemEdit.razor
@@ -1,0 +1,140 @@
+﻿@using System.Linq.Dynamic.Core
+@using RadzenBlazorDemos.Data
+@using RadzenBlazorDemos.Models.Northwind
+
+@inherits DbContextPage
+
+<RadzenButton Text="Reset" Click="@Reset" Style="margin-bottom: 20px;" />
+<RadzenButton Text="InsertRow" Click="@InsertItem" Style="margin-bottom: 20px;" />
+<RadzenDataGrid @ref="grid" ColumnWidth="200px" LoadData="@LoadData" IsLoading=@isLoading Count="@count" PageSize="10"
+                TItem="Customer" Data="@Customers" KeyProperty="CustomerID">
+    <Columns>
+        <RadzenDataGridColumn TItem="Customer" Property="CustomerID" Filterable="false" Title="ID" Frozen="true" Width="80px" TextAlign="TextAlign.Center" />
+        <RadzenDataGridColumn TItem="Customer" Property="CompanyName" Title="Company Name" Frozen="true" Width="160px" />
+        <RadzenDataGridColumn TItem="Customer" Property="Address" Title="Address" Width="200px" />
+        <RadzenDataGridColumn TItem="Customer" Property="City" Title="City" Width="160px" />
+        <RadzenDataGridColumn TItem="Customer" Context="customer" TextAlign="TextAlign.Center" Width="320px">
+            <Template Context="customer">
+                <RadzenButton Text="UpdateByObject" Size="ButtonSize.Small" Variant="Variant.Text"
+                              ButtonStyle="ButtonStyle.Primary"
+                              Click=@(args => UpdateItemByObject(customer)) @onclick:stopPropagation="true" />
+                <RadzenButton Text="UpdateByObject" Size="ButtonSize.Small" Variant="Variant.Text"
+                              ButtonStyle="ButtonStyle.Primary"
+                              Click=@(args => UpdateItemByID(customer.CustomerID)) @onclick:stopPropagation="true" />
+                <RadzenButton Text="Delete" Size="ButtonSize.Small" Variant="Variant.Text"
+                              ButtonStyle="ButtonStyle.Danger"
+                              Click=@(args => DeleteItem(customer)) @onclick:stopPropagation="true" />
+            </Template>
+        </RadzenDataGridColumn>
+    </Columns>
+</RadzenDataGrid>
+
+@code {
+    RadzenDataGrid<Customer> grid;
+    int count;
+    IEnumerable<Customer> Customers;
+    bool isLoading = false;
+
+    List<string> titles = new List<string> { "Sales Representative", "Vice President, Sales", "Sales Manager", "Inside Sales Coordinator" };
+    IEnumerable<string> selectedTitles;
+
+    async Task OnSelectedTitlesChange(object value)
+    {
+        if (selectedTitles != null && !selectedTitles.Any())
+        {
+            selectedTitles = null;
+        }
+
+        await grid.FirstPage();
+    }
+
+    async Task Reset()
+    {
+        grid.Reset(true);
+        await grid.FirstPage(true);
+    }
+
+    /// <summary>
+    /// Create a random object
+    /// </summary>
+    /// <returns></returns>
+    async Task InsertItem()
+    {
+        var customerID = Guid.NewGuid().ToString().Substring(0, 5).ToUpper();
+        var r = new Random();
+        await grid.InsertItem(new Customer()
+            {
+                CustomerID = customerID,
+                CompanyName = $"Name {customerID}",
+                Address = $"Address {r.Next(1000)}",
+                City = $"City {r.Next(1000)}",
+            });
+
+    }
+
+    /// <summary>
+    /// Update records using Object
+    /// </summary>
+    /// <returns></returns>
+    async Task UpdateItemByObject(Customer customer)
+    {
+        var r = new Random();
+        customer.Address = $"Address {r.Next(1000)}";
+        customer.City = $"City {r.Next(1000)}";
+    }
+
+    /// <summary>
+    /// Update records using ID matching
+    /// </summary>
+    /// <returns></returns>
+    async Task UpdateItemByID(string customerID)
+    {
+        var r = new Random();
+        await grid.UpdateItem(new Customer()
+            {
+                CustomerID = customerID,
+                CompanyName = $"Name {customerID}",
+                Address = $"Address {r.Next(1000)}",
+                City = $"City {r.Next(1000)}",
+            });
+    }
+
+    /// <summary>
+    /// Delete a piece of data directly from the list
+    /// </summary>
+    /// <returns></returns>
+    async Task DeleteItem(Customer customer)
+    {
+        await grid.DeleteItem(customer);
+    }
+
+    async Task LoadData(LoadDataArgs args)
+    {
+        isLoading = true;
+
+        await Task.Yield();
+
+        // This demo is using https://dynamic-linq.net
+        var query = dbContext.Customers.AsQueryable();
+
+        if (!string.IsNullOrEmpty(args.Filter))
+        {
+            // Filter via the Where method
+            query = query.Where(args.Filter);
+        }
+
+        if (!string.IsNullOrEmpty(args.OrderBy))
+        {
+            // Sort via the OrderBy method
+            query = query.OrderBy(args.OrderBy);
+        }
+
+        // Important!!! Make sure the Count property of RadzenDataGrid is set.
+        count = query.Count();
+
+        // Perform paging via Skip and Take.
+        Customers = query.Skip(args.Skip.Value).Take(args.Top.Value).ToList();
+
+        isLoading = false;
+    }
+}

--- a/RadzenBlazorDemos/Pages/DataGridItemEditPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridItemEditPage.razor
@@ -1,0 +1,12 @@
+﻿@page "/datagrid-item-edit"
+
+<RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
+    DataGrid Item Edit
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" class="rz-pb-4">
+    This page demonstrates how to modify the row displayed on the current page in the Razden Blazor DataGrid
+</RadzenText>
+
+<RadzenExample ComponentName="DataGrid" Example="DataGridRowsEdit">
+    <DataGridItemEdit />
+</RadzenExample>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -538,6 +538,15 @@ namespace RadzenBlazorDemos
 
                 new Example()
                 {
+                    Name = "Rows Editing",
+                    Path = "datagrid-item-edit",
+                    Title = "Blazor DataGrid item editing",
+                    Icon = "&#xe22b",
+                    Tags = new [] { "item", "row", "editor", "datagrid", "table", "dataview" }
+                },
+
+                new Example()
+                {
                     Name = "Conditional formatting",
                     Path = "datagrid-conditional-template",
                     Title = "Blazor DataGrid conditional template",


### PR DESCRIPTION
In many business scenarios, programs need to add, edit, and remove items in the DataGrid. This operation only requires adjustments to the data, does not require user editing, nor does it require reloading data, which is usually triggered by other operations.

The InsertRow and UpdateRow in the current DataGrid will enter row editing mode and are not applicable.

So I added three simple methods

InsertItem: Insert a row of data

UpdateItem: Updates a row of data. If the KeyProperty property is configured, it will be matched through the Key. The updated object data can come from a new object

DeleteItem: Remove a row of data

They only make adjustments to the current data


Other questions: Why are there many formats in the source code with some extra or missing spaces, such as after "if"