### PR TITLE
functionality is added so that when the filter is clicked a function is executed

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -132,7 +132,7 @@
                                 var columnIndex = visibleColumns.IndexOf(column);
                                 var sortableClass = AllowSorting && column.Sortable ? "rz-sortable-column" : "";
 
-                                <RadzenDataGridHeaderCell RowIndex="@i" Grid="@this" Column="@column" ColumnIndex="@columnIndex" CssClass="@($"rz-unselectable-text {sortableClass} {column.HeaderCssClass} {getFrozenColumnClass(column, visibleColumns)} {getCompositeCellCSSClass(column)} {getColumnAlignClass(column)}".Trim())" Attributes="@(cellAttr)" />
+                                <RadzenDataGridHeaderCell CustomFilterEvent=@CustomFilterEvent RowIndex="@i" Grid="@this" Column="@column" ColumnIndex="@columnIndex" CssClass="@($"rz-unselectable-text {sortableClass} {column.HeaderCssClass} {getFrozenColumnClass(column, visibleColumns)} {getCompositeCellCSSClass(column)} {getColumnAlignClass(column)}".Trim())" Attributes="@(cellAttr)" />
                             }
                         </tr>
                     }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -520,6 +520,10 @@ namespace Radzen.Blazor
 
             return FilterDateFormat;
         }
+        /// <summary>
+        /// Execute a function when the filter icon is clicked when using FilterMode.Advanced
+        [Parameter]
+        public EventCallback<RadzenDataGridColumn<TItem>> CustomFilterEvent { get; set; }
 
         internal RenderFragment DrawNumericFilter(RadzenDataGridColumn<TItem> column, bool force = true, bool isFirst = true)
         {

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -167,6 +167,10 @@ else
 
     async Task ToggleFilter()
     {
+        if (CustomFilterEvent.HasDelegate)
+        {
+            await CustomFilterEvent.InvokeAsync(Column);
+        }
         if (Grid.FilterPopupRenderMode == PopupRenderMode.OnDemand)
         {
             await popup.ToggleAsync(filterButton);
@@ -196,6 +200,8 @@ else
 
     [Parameter]
     public RadzenDataGridColumn<TItem> Column { get; set; }
+    [Parameter]
+    public EventCallback<RadzenDataGridColumn<TItem>> CustomFilterEvent { get; set; }
 
     [Parameter]
     public int ColumnIndex { get; set; }


### PR DESCRIPTION
With the new template filter functionality it happens that if one has many filters, since the table has many columns, the site takes a long time to load, so I added a functionality so that every time the filter is clicked it can be call a custom function and thus achieve the following


```
 public async Task FuncionX(RadzenDataGridColumn<Comgesot.Models.comgesotdb.Ot> prueba)
        {
            if (prueba.Property.Equals("TipocargoOt.nombre"))
            {
                if(tipoCargoOt is null)
                {
                    tipoCargoOt = await comgesotdbService.GetTipocargoOt();

                }
            }
}
```

So when the filter is called, if I don't have the data, it will search the database, and I only bring the information I need and not all when loading the page


Example

```
            <RadzenDataGrid @ref="grid0" ColumnWidth="200px" AllowFiltering="true" FilterMode="FilterMode.Advanced" AllowPaging="true" AllowSorting="true" ShowPagingSummary="true" PageSizeOptions=@(new int[]{5, 10, 20, 30})
                               Data="@ot"  CustomFilterEvent="@FuncionX">

```


**when trying to run the unit tests with the code that is in MAIN they are not executed, even without modifying the source code**