### PR TITLE
DataGrid: fix headers and footers of frozen columns

### DIFF
--- a/Radzen.Blazor/RadzenDataGridFooterCell.razor
+++ b/Radzen.Blazor/RadzenDataGridFooterCell.razor
@@ -38,13 +38,21 @@ else
     [Parameter]
     public string Style { get; set; }
 
-    string GetStyle()
+    private string GetStyle()
     {
-        if (Attributes != null && Attributes.TryGetValue("style", out var style) == true && !string.IsNullOrEmpty(Convert.ToString(style)))
+        var styles = new List<string>() { Column.GetStyle(true, true), Style };
+
+        if (Attributes?.TryGetValue("style", out var styleAttribute) == true)
         {
-            return String.IsNullOrEmpty(Style) ? $"{style}" : $"{Style.TrimEnd(';')};{style}";
+            styles.Add(Convert.ToString(styleAttribute));
         }
 
-        return Style;
+        var finalStyle = string.Join(";",
+                styles
+                .Select(x => x?.Trim().TrimEnd(';'))
+                .Where(x => !string.IsNullOrEmpty(x))
+            );
+
+        return finalStyle;
     }
 }

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -2,7 +2,7 @@
 @using Radzen.Blazor.Rendering
 @if (RowIndex == Column.GetLevel())
 {
-    <th rowspan="@(Column.GetRowSpan())" colspan="@(Column.GetColSpan())" @attributes="@Attributes" class="@CssClass" scope="col" style="@GetStyle()" @onmouseup=@(args => Grid.EndColumnReorder(args, ColumnIndex))>
+<th rowspan="@(Column.GetRowSpan())" colspan="@(Column.GetColSpan())" @attributes="@Attributes" class="@CssClass" scope="col" style="@GetStyle()" @onmouseup=@(args => Grid.EndColumnReorder(args, ColumnIndex))>
     <div @onclick='@((args) => Grid.OnSort(args, Column))' tabindex="@SortingTabIndex" @onkeydown="OnSortKeyPressed">
         @if ((Grid.AllowColumnReorder && Column.Reorderable || Grid.AllowGrouping && Column.Groupable))
         {
@@ -212,14 +212,22 @@ else
     [Parameter]
     public string Style { get; set; }
 
-    string GetStyle()
+    private string GetStyle()
     {
-        if (Attributes != null && Attributes.TryGetValue("style", out var style) == true && !string.IsNullOrEmpty(Convert.ToString(style)))
+        var styles = new List<string>() { Column.GetStyle(true, true), Style };
+
+        if (Attributes?.TryGetValue("style", out var styleAttribute) == true)
         {
-            return String.IsNullOrEmpty(Style) ? $"{style}" : $"{Style.TrimEnd(';')};{style}";
+            styles.Add(Convert.ToString(styleAttribute));
         }
 
-        return Style;
+        var finalStyle = string.Join(";",
+                styles
+                .Select(x => x?.Trim().TrimEnd(';'))
+                .Where(x => !string.IsNullOrEmpty(x))
+            );
+
+        return finalStyle;
     }
 
     private int SortingTabIndex => Grid.AllowSorting && Column.Sortable ? 0 : -1;


### PR DESCRIPTION
Since 4.15.0 headers and footers haven't been frozen:

![image](https://github.com/radzenhq/radzen-blazor/assets/44393502/33103d75-a410-4239-86b9-9b343d7a1eda)
