### PR TITLE
DataGrid: prevent sorting from being triggerred while resizing a reorderable column

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -93,7 +93,7 @@
                     }
                     @foreach (var column in visibleColumns)
                     {
-                        <col id=@(getColumnResizerId(visibleColumns.IndexOf(column)) + "-col") style="@column.GetStyle()">
+                        <col id=@(getColumnUniqueId(visibleColumns.IndexOf(column)) + "-col") style="@column.GetStyle()">
                     }
                 </colgroup>
                 <thead>

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1218,14 +1218,14 @@ namespace Radzen.Blazor
         [Parameter]
         public string GroupPanelText { get; set; } = "Drag a column header here and drop it to group by that column";
 
-        internal string getColumnResizerId(int columnIndex)
+        internal string getColumnUniqueId(int columnIndex)
         {
             return string.Join("", $"{UniqueID}".Split('.')) + columnIndex;
         }
 
         internal async Task StartColumnResize(MouseEventArgs args, int columnIndex)
         {
-            await JSRuntime.InvokeVoidAsync("Radzen.startColumnResize", getColumnResizerId(columnIndex), Reference, columnIndex, args.ClientX);
+            await JSRuntime.InvokeVoidAsync("Radzen.startColumnResize", getColumnUniqueId(columnIndex), Reference, columnIndex, args.ClientX);
         }
 
         int? indexOfColumnToReoder;
@@ -1233,7 +1233,7 @@ namespace Radzen.Blazor
         internal async Task StartColumnReorder(MouseEventArgs args, int columnIndex)
         {
             indexOfColumnToReoder = columnIndex;
-            await JSRuntime.InvokeVoidAsync("Radzen.startColumnReorder", getColumnResizerId(columnIndex));
+            await JSRuntime.InvokeVoidAsync("Radzen.startColumnReorder", getColumnUniqueId(columnIndex));
         }
 
         internal async Task EndColumnReorder(MouseEventArgs args, int columnIndex)
@@ -2637,7 +2637,7 @@ namespace Radzen.Blazor
         {
             if(indexOfColumnToReoder != null && AllowGrouping)
             {
-                var functionName = $"Radzen['{getColumnResizerId(indexOfColumnToReoder.Value)}end']";
+                var functionName = $"Radzen['{getColumnUniqueId(indexOfColumnToReoder.Value)}end']";
                 await JSRuntime.InvokeVoidAsync("eval", $"{functionName} && {functionName}()");
 
                 RadzenDataGridColumn<TItem> column;

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -6,7 +6,7 @@
     <div @onclick='@((args) => Grid.OnSort(args, Column))' tabindex="@SortingTabIndex" @onkeydown="OnSortKeyPressed">
         @if ((Grid.AllowColumnReorder && Column.Reorderable || Grid.AllowGrouping && Column.Groupable))
         {
-            <span id="@Grid.getColumnUniqueId(ColumnIndex)-drag" class="rz-column-drag"
+            <span id="@(Grid.getColumnUniqueId(ColumnIndex) + "-drag")" class="rz-column-drag"
                     @onclick:preventDefault="true" @onclick:stopPropagation="true"
                     @onmousedown:preventDefault="true"
                     @onmousedown=@(args => Grid.StartColumnReorder(args, ColumnIndex))></span>

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -6,7 +6,7 @@
     <div @onclick='@((args) => Grid.OnSort(args, Column))' tabindex="@SortingTabIndex" @onkeydown="OnSortKeyPressed">
         @if ((Grid.AllowColumnReorder && Column.Reorderable || Grid.AllowGrouping && Column.Groupable))
         {
-            <span id="@Grid.getColumnResizerId(ColumnIndex)" class="rz-column-drag"
+            <span id="@Grid.getColumnUniqueId(ColumnIndex)-drag" class="rz-column-drag"
                     @onclick:preventDefault="true" @onclick:stopPropagation="true"
                     @onmousedown:preventDefault="true"
                     @onmousedown=@(args => Grid.StartColumnReorder(args, ColumnIndex))></span>
@@ -47,7 +47,7 @@
         </span>
         @if (Grid.AllowColumnResize && Column.Resizable && Column.Parent == null)
         {
-            <div id="@Grid.getColumnResizerId(ColumnIndex)" style="cursor:col-resize;float:right;"
+            <div id="@(Grid.getColumnUniqueId(ColumnIndex) + "-resizer")" style="cursor:col-resize;float:right;"
                     @onclick:preventDefault="true" @onclick:stopPropagation="true" class="rz-column-resizer"
                     @onmousedown:preventDefault="true"
                     @onmousedown=@(args => Grid.StartColumnResize(args, ColumnIndex))>&nbsp;</div>

--- a/Radzen.Blazor/RadzenGrid.razor
+++ b/Radzen.Blazor/RadzenGrid.razor
@@ -34,7 +34,7 @@
                             }
                             @foreach (var column in visibleColumns)
                             {
-                                <col id=@(getColumnResizerId(visibleColumns.IndexOf(column)) + "-col") style="@column.GetStyle()">
+                                <col id=@(getColumnUniqueId(visibleColumns.IndexOf(column)) + "-col") style="@column.GetStyle()">
                             }
                         </colgroup>
                         <thead class="rz-datatable-thead">
@@ -79,7 +79,7 @@
                                             @if (AllowColumnResize)
                                             {
                                                 var columnIndex = visibleColumns.IndexOf(column);
-                                                <div id="@getColumnResizerId(columnIndex)" style="cursor:col-resize;float:right;"
+                                                <div id="@(getColumnUniqueId(columnIndex) + "-resizer")" style="cursor:col-resize;float:right;"
                                                      @onclick:preventDefault="true" @onclick:stopPropagation="true"
                                                      @onmousedown=@(args => StartColumnResize(args, columnIndex))>&nbsp;</div>
                                             }
@@ -273,7 +273,7 @@
                             }
                             @foreach (var column in visibleColumns)
                             {
-                                <col id=@(getColumnResizerId(visibleColumns.IndexOf(column)) + "-data-col") style="@column.GetStyle()">
+                                <col id=@(getColumnUniqueId(visibleColumns.IndexOf(column)) + "-data-col") style="@column.GetStyle()">
                             }
                         </colgroup>
                         <tbody class="rz-datatable-data  rz-datatable-hoverable-rows">
@@ -449,7 +449,7 @@
                                     }
                                     @foreach (var column in visibleColumns)
                                     {
-                                        <col id=@(getColumnResizerId(visibleColumns.IndexOf(column)) + "-footer-col") style="@column.GetStyle()">
+                                        <col id=@(getColumnUniqueId(visibleColumns.IndexOf(column)) + "-footer-col") style="@column.GetStyle()">
                                     }
                                 </colgroup>
                                 <tfoot class="rz-datatable-tfoot">
@@ -646,14 +646,14 @@
     [Parameter]
     public bool AllowColumnResize { get; set; }
 
-    string getColumnResizerId(int columnIndex)
+    string getColumnUniqueId(int columnIndex)
     {
         return string.Join("", $"{UniqueID}".Split('.')) + columnIndex;
     }
 
     async Task StartColumnResize(MouseEventArgs args, int columnIndex)
     {
-        await JSRuntime.InvokeVoidAsync("Radzen.startColumnResize", getColumnResizerId(columnIndex), Reference, columnIndex, args.ClientX);
+        await JSRuntime.InvokeVoidAsync("Radzen.startColumnResize", getColumnUniqueId(columnIndex), Reference, columnIndex, args.ClientX);
     }
 
     [JSInvokable("RadzenGrid.OnColumnResized")]

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -1514,7 +1514,7 @@ window.Radzen = {
     document.removeEventListener('touchend', ref.mouseUpHandler);
   },
   startColumnReorder: function(id) {
-      var el = document.getElementById(id);
+      var el = document.getElementById(id + '-drag');
       var cell = el.parentNode.parentNode;
       var visual = document.createElement("th");
       visual.className = cell.className + ' rz-column-draggable';
@@ -1560,7 +1560,7 @@ window.Radzen = {
       document.addEventListener('mousemove', Radzen[id + 'move']);
   },
   startColumnResize: function(id, grid, columnIndex, clientX) {
-      var el = document.getElementById(id);
+      var el = document.getElementById(id + '-resizer');
       var cell = el.parentNode.parentNode;
       var col = document.getElementById(id + '-col');
       var dataCol = document.getElementById(id + '-data-col');


### PR DESCRIPTION
It turned out that both resizer and dragger of a column share the element ID. Therefore, the resizer JS function uses a wrong element when a column is both resizable and reorderable. It leads to this odd behavior of both moving column titles and accidental sorting:

![datagrid-reorder-resize-bug](https://github.com/radzenhq/radzen-blazor/assets/44393502/f8097d91-a067-4691-a3d8-48dae69750b4)

This pull request gives those elements unique IDs to avoid such situations.