### PR TITLE
Switch: clicking a label changes a value of the corresponding switch

### DIFF
--- a/Radzen.Blazor/RadzenSwitch.razor
+++ b/Radzen.Blazor/RadzenSwitch.razor
@@ -6,7 +6,7 @@
 <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" id="@GetId()"
      @onclick="@Toggle" @onkeypress="@(async (args) => { if (args.Code == "Space") { await Toggle(); } })" style="outline: 0 none;@Style" tabindex="@(Disabled ? "-1" : $"{TabIndex}")">
     <div class="rz-helper-hidden-accessible">
-        <input type="checkbox" name="@Name" checked=@Value value="@ValueAsString" tabindex="-1">
+        <input type="checkbox" name="@Name" id="@Name" checked="@Value" value="@ValueAsString" tabindex="-1">
     </div>
     <span class="rz-switch-circle@(Disabled ? " rz-disabled" : "")"></span>
 </div>


### PR DESCRIPTION
As you can observe in the [login ](https://blazor.radzen.com/login)demo, clicking the _Remember me_ label doesn't change the value of the switch. In case of ordinary checkboxes it would change the value.
Here's a pull request to make labels for switches behave as they do for checkboxes.