### PR TITLE
Update RadzenDataGridFilterMenu.razor

### DIFF
--- a/Radzen.Blazor/RadzenDataGridFilterMenu.razor
+++ b/Radzen.Blazor/RadzenDataGridFilterMenu.razor
@@ -164,6 +164,8 @@
     {
         Column.ClearFilters();
 
+        Grid.SaveSettings();
+
         await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}{Column.GetFilterProperty()}");
 
         await Grid.FilterCleared.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>()


### PR DESCRIPTION
If you use "FilterMode.SimpleWithMenu" and Grid Settings together, then the "Clear" button in the fitler menu, do not work, because there was not a SaveSetting() calling in the ClearFilter function. (Always loaded the "last" settings, after the Clear button has pushed.)