### PR TITLE
Indication for isNull/isNotNull in simple datagrid filter

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -174,9 +174,15 @@
                                                                     <i class="rzi">date_range</i>
                                                                 </button>
                                                                 var filterValue = column.GetFilterValue();
+                                                                var filterOperator = column.GetFilterOperator();
                                                                 @if (filterValue != null && filters.Any(d => d.Property == column.GetFilterProperty()))
                                                                 {
                                                                     <span class="rz-current-filter">@string.Format("{0:" + getFilterDateFormat(column) + "}", filterValue)</span>
+                                                                    <i @onclick="@((args) => ClearFilter(column))" class="rzi rz-cell-filter-clear">close</i>
+                                                                }
+                                                                else if ((filterOperator == FilterOperator.IsNull || filterOperator == FilterOperator.IsNotNull) && filters.Any(d => d.Property == column.GetFilterProperty()))
+                                                                {
+                                                                    <span class="rz-current-filter">@column.GetFilterOperatorText(filterOperator)</span>
                                                                     <i @onclick="@((args) => ClearFilter(column))" class="rzi rz-cell-filter-clear">close</i>
                                                                 }
                                                                 <div id="@($"{PopupID}{column.GetFilterProperty()}")" class="rz-overlaypanel"


### PR DESCRIPTION
Current Datagrid, when in simple filter mode, does not provide any clue to whether a filter is applied or not to a date column if either isNull or isNotNull is selected. In the screenshot below I have applied a filter of "is null" to the birth date column:
 
![image](https://github.com/radzenhq/radzen-blazor/assets/108884442/af791c16-dd88-47a7-91e2-04680e70bdcb)

Changed functionality has either the text "is null" or "is not null" appearing in the same manner as a filtered date in the screenshot below:

![image](https://github.com/radzenhq/radzen-blazor/assets/108884442/b63b41d8-671e-4fa2-8515-5bf684022b9e)
