### PR TITLE
Fix calling DataGrid Reload when loading settings with filter and page greater than 1

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3032,7 +3032,7 @@ namespace Radzen.Blazor
                 {
                     skip = CurrentPage * GetPageSize();
 
-                    if (hasFilter ? skip <= View.Count() : true)
+                    if (hasFilter && View.Any() ? skip <= View.Count() : true)
                     {
                         CalculatePager();
                         UpdateColumnsOrder();


### PR DESCRIPTION
Added a check View.Any() before call View.Count() otherwise it will always be "**false**".
This fixes the problem of loading data after loading settings with filters set and the page is greater than 1, if DataGrid was no data then the check "`skip <= View.Count()`" is always "**False**" and `Reload`() not called.

If the settings are loaded after the initial data load (both demo settings), the fix do not affect them, all work,

Before:
![chrome_2023-09-06_13-46-10](https://github.com/radzenhq/radzen-blazor/assets/18440948/017700e6-6e26-45ce-8a70-30137fe0c8be)

After:
![chrome_2023-09-06_13-54-48](https://github.com/radzenhq/radzen-blazor/assets/18440948/8e336c71-dd96-47b1-869f-185dd9f22b45)


Code for test:
(suppose the settings are stored in the db/redis/json etc. and are loaded before DataGrid render)
```
@using Radzen
@using RadzenBlazorDemos.Data
@using RadzenBlazorDemos.Models.Northwind
@using Microsoft.EntityFrameworkCore
@using RadzenBlazorDemos.Services
@using Microsoft.JSInterop
@using System.Text.Json
@using System.Linq.Dynamic.Core

@inject IJSRuntime JSRuntime
@inject NavigationManager NavigationManager

@inherits DbContextPage

<p>This example shows how to save/load DataGrid state using Settings property when binding using LoadData event.</p>
<p>The state includes current page index, page size, groups and columns filter, sort, order, width and visibility.</p>
<RadzenButton Click="@(args => Settings = null)" Text="Clear saved settings" Style="margin-bottom: 16px" />
<RadzenButton Click="@(args => NavigationManager.NavigateTo("/datagrid-save-settings", true))" Text="Reload" Style="margin-bottom: 16px" />
<RadzenDataGrid @ref=grid @bind-Settings="@Settings" AllowFiltering="true" AllowColumnPicking="true" AllowGrouping="true" AllowPaging="true" PageSize="4"
                AllowSorting="true" AllowMultiColumnSorting="true" ShowMultiColumnSortingIndex="true"
                AllowColumnResize="true" AllowColumnReorder="true" ColumnWidth="200px"
                FilterPopupRenderMode="PopupRenderMode.OnDemand" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                Data="@employees" IsLoading=@isLoading Count="@count" LoadData=@LoadData TItem="Employee">
    <Columns>
        <RadzenDataGridColumn TItem="Employee" Property="Photo" Title="Employee" Sortable="false" Filterable="false">
            <Template Context="data">
                <RadzenImage Path="@data.Photo" style="width: 40px; height: 40px; border-radius: 8px; margin-right: 8px;" />
                @data.FirstName @data.LastName
            </Template>
        </RadzenDataGridColumn>
        <RadzenDataGridColumn TItem="Employee" Property="Title" Title="Title" />
        <RadzenDataGridColumn TItem="Employee" Property="EmployeeID" Title="Employee ID" />
        <RadzenDataGridColumn TItem="Employee" Property="HireDate" Title="Hire Date" FormatString="{0:d}" />
        <RadzenDataGridColumn TItem="Employee" Property="City" Title="City" />
        <RadzenDataGridColumn TItem="Employee" Property="Country" Title="Country" />
    </Columns>
</RadzenDataGrid>

<EventConsole @ref=@console />

@code {
    RadzenDataGrid<Employee> grid;
    IEnumerable<Employee> employees;
    EventConsole console;

    int count;
    bool isLoading = false;
    bool loaded;
    async Task LoadData(LoadDataArgs args)
    {
        console.Log("LoadData");
        isLoading = true;

        await Task.Yield();

        var query = dbContext.Employees.AsQueryable();

        if (!string.IsNullOrEmpty(args.Filter))
        {
            query = query.Where(args.Filter);
        }

        if (!string.IsNullOrEmpty(args.OrderBy))
        {
            query = query.OrderBy(args.OrderBy);
        }

        count = query.Count();

        // Simulate async data loading
        await Task.Delay(2000);

        employees = await Task.FromResult(query.Skip(args.Skip.Value).Take(args.Top.Value).ToList());

        isLoading = false;

        loaded = true;
    }

    DataGridSettings _settings;
    public DataGridSettings Settings
    {
        get
        {
            return _settings;
        }
        set
        {
            if (_settings != value)
            {
                _settings = value;
                console.Log("Set");
            }
        }
    }


	protected override Task OnParametersSetAsync()
	{
		var setting = $$"""{"Columns":[{"UniqueID":null,"Property":"Photo","Visible":true,"Width":null,"OrderIndex":null,"SortOrder":null,"SortIndex":null,"FilterValue":null,"FilterOperator":6,"SecondFilterValue":null,"SecondFilterOperator":0,"LogicalFilterOperator":0},{"UniqueID":null,"Property":"Title","Visible":true,"Width":null,"OrderIndex":null,"SortOrder":null,"SortIndex":null,"FilterValue":null,"FilterOperator":6,"SecondFilterValue":null,"SecondFilterOperator":0,"LogicalFilterOperator":0},{"UniqueID":null,"Property":"EmployeeID","Visible":true,"Width":null,"OrderIndex":null,"SortOrder":1,"SortIndex":0,"FilterValue":2,"FilterOperator":4,"SecondFilterValue":null,"SecondFilterOperator":0,"LogicalFilterOperator":0},{"UniqueID":null,"Property":"HireDate","Visible":true,"Width":null,"OrderIndex":null,"SortOrder":null,"SortIndex":null,"FilterValue":null,"FilterOperator":0,"SecondFilterValue":null,"SecondFilterOperator":0,"LogicalFilterOperator":0},{"UniqueID":null,"Property":"City","Visible":true,"Width":null,"OrderIndex":null,"SortOrder":null,"SortIndex":null,"FilterValue":null,"FilterOperator":6,"SecondFilterValue":null,"SecondFilterOperator":0,"LogicalFilterOperator":0},{"UniqueID":null,"Property":"Country","Visible":true,"Width":null,"OrderIndex":null,"SortOrder":null,"SortIndex":null,"FilterValue":null,"FilterOperator":6,"SecondFilterValue":null,"SecondFilterOperator":0,"LogicalFilterOperator":0}],"Groups":[],"CurrentPage":1,"PageSize":4}""";
		//console.Log("LoadStateAsync");
        _settings = JsonSerializer.Deserialize<DataGridSettings>(setting);
		return base.OnParametersSetAsync();
	}
}
```