### PR TITLE
panel menu item add display style

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -2996,4 +2996,23 @@ namespace Radzen
         /// </summary>
         Polar
     }
+
+    /// <summary>
+    /// Menu Item display style enum
+    /// </summary>
+    public enum MenuItemDisplayStyle
+    {
+        /// <summary>
+        /// Show text only
+        /// </summary>
+        Text,
+        /// <summary>
+        /// Show only icons
+        /// </summary>
+        Icon,
+        /// <summary>
+        /// Both icons and text are displayed
+        /// </summary>
+        IconAndText
+    }
 }

--- a/Radzen.Blazor/RadzenPanelMenu.razor.cs
+++ b/Radzen.Blazor/RadzenPanelMenu.razor.cs
@@ -42,6 +42,12 @@ namespace Radzen.Blazor
         [Parameter]
         public NavLinkMatch Match { get; set; }
 
+        /// <summary>
+        /// Gets or sets the display style.
+        /// </summary>
+        [Parameter]
+        public MenuItemDisplayStyle DisplayStyle { get; set; } = MenuItemDisplayStyle.IconAndText;
+
         internal List<RadzenPanelMenuItem> items = new List<RadzenPanelMenuItem>();
 
         /// <summary>

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor
@@ -7,12 +7,12 @@
         <div class=@(Selected ? "rz-navigation-item-wrapper rz-navigation-item-wrapper-active" : "rz-navigation-item-wrapper")>
             @if (Path != null)
             {
-                <NavLink target="@Target" class=@(Selected ? "rz-navigation-item-link rz-navigation-item-link-active" : "rz-navigation-item-link") style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" href="@Path" Match="@Match">
-                    @if (!string.IsNullOrEmpty(Icon) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
+                <NavLink target="@Target" class=@(Selected ? "rz-navigation-item-link rz-navigation-item-link-active" : "rz-navigation-item-link") style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" href="@Path" Match="@Match">
+                    @if (!string.IsNullOrEmpty(Icon) && (Parent?.DisplayStyle == MenuItemDisplayStyle.Icon || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
-                        <i class="rzi rz-navigation-item-icon" style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>
+                        <i class="rzi rz-navigation-item-icon" style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>
                     }
-                    @if (!string.IsNullOrEmpty(Image) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
+                    @if (!string.IsNullOrEmpty(Image) && (Parent?.DisplayStyle == MenuItemDisplayStyle.Icon || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
                         <img class="rz-navigation-item-icon" src="@Image" />
                     }
@@ -20,7 +20,7 @@
                     {
                         @Template
                     }
-                    else if (DisplayStyle == MenuItemDisplayStyle.Text || DisplayStyle == MenuItemDisplayStyle.IconAndText)
+                    else if (Parent?.DisplayStyle == MenuItemDisplayStyle.Text || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText)
                     {
                         <span class="rz-navigation-item-text" @onclick="@Toggle">@Text</span>
                     }
@@ -32,12 +32,12 @@
             }
             else
             {
-                <div class="rz-navigation-item-link" style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" @onclick="@Toggle">
-                    @if (!string.IsNullOrEmpty(Icon) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
+                <div class="rz-navigation-item-link" style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" @onclick="@Toggle">
+                    @if (!string.IsNullOrEmpty(Icon) && (Parent?.DisplayStyle == MenuItemDisplayStyle.Icon || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
-                        <i class="rzi rz-navigation-item-icon" style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>
+                        <i class="rzi rz-navigation-item-icon" style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>
                     }
-                    @if (!string.IsNullOrEmpty(Image) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
+                    @if (!string.IsNullOrEmpty(Image) && (Parent?.DisplayStyle == MenuItemDisplayStyle.Icon || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
                         <img class="rz-navigation-item-icon" src="@Image" />
                     }
@@ -45,7 +45,7 @@
                     {
                         @Template
                     }
-                    else if (DisplayStyle == MenuItemDisplayStyle.Text || DisplayStyle == MenuItemDisplayStyle.IconAndText)
+                    else if (Parent?.DisplayStyle == MenuItemDisplayStyle.Text || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText)
                     {
                         <span class="rz-navigation-item-text">@Text</span>
                     }

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor
@@ -7,12 +7,12 @@
         <div class=@(Selected ? "rz-navigation-item-wrapper rz-navigation-item-wrapper-active" : "rz-navigation-item-wrapper")>
             @if (Path != null)
             {
-                <NavLink target="@Target" class=@(Selected ? "rz-navigation-item-link rz-navigation-item-link-active" : "rz-navigation-item-link") href="@Path" Match="@Match">
-                    @if (!string.IsNullOrEmpty(Icon))
+                <NavLink target="@Target" class=@(Selected ? "rz-navigation-item-link rz-navigation-item-link-active" : "rz-navigation-item-link") style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" href="@Path" Match="@Match">
+                    @if (!string.IsNullOrEmpty(Icon) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
-                        <i class="rzi rz-navigation-item-icon">@((MarkupString)Icon)</i>
+                        <i class="rzi rz-navigation-item-icon" style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>
                     }
-                    @if (!string.IsNullOrEmpty(Image))
+                    @if (!string.IsNullOrEmpty(Image) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
                         <img class="rz-navigation-item-icon" src="@Image" />
                     }
@@ -20,7 +20,7 @@
                     {
                         @Template
                     }
-                    else
+                    else if (DisplayStyle == MenuItemDisplayStyle.Text || DisplayStyle == MenuItemDisplayStyle.IconAndText)
                     {
                         <span class="rz-navigation-item-text" @onclick="@Toggle">@Text</span>
                     }
@@ -32,12 +32,12 @@
             }
             else
             {
-                <div class="rz-navigation-item-link" @onclick="@Toggle">
-                    @if (!string.IsNullOrEmpty(Icon))
+                <div class="rz-navigation-item-link" style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" @onclick="@Toggle">
+                    @if (!string.IsNullOrEmpty(Icon) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
-                        <i class="rzi rz-navigation-item-icon">@((MarkupString)Icon)</i>
+                        <i class="rzi rz-navigation-item-icon" style="@(DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>
                     }
-                    @if (!string.IsNullOrEmpty(Image))
+                    @if (!string.IsNullOrEmpty(Image) && (DisplayStyle == MenuItemDisplayStyle.Icon || DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
                         <img class="rz-navigation-item-icon" src="@Image" />
                     }
@@ -45,7 +45,7 @@
                     {
                         @Template
                     }
-                    else
+                    else if (DisplayStyle == MenuItemDisplayStyle.Text || DisplayStyle == MenuItemDisplayStyle.IconAndText)
                     {
                         <span class="rz-navigation-item-text">@Text</span>
                     }

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor.cs
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor.cs
@@ -75,13 +75,6 @@ namespace Radzen.Blazor
         public string Image { get; set; }
 
         /// <summary>
-        /// Gets or sets the display style.
-        /// </summary>
-        [CascadingParameter]
-        public MenuItemDisplayStyle DisplayStyle { get; set; } = MenuItemDisplayStyle.IconAndText;
-
-
-        /// <summary>
         /// Gets or sets the template.
         /// </summary>
         /// <value>The template.</value>
@@ -259,8 +252,6 @@ namespace Radzen.Blazor
             {
                 expanded = parameters.GetValueOrDefault<bool>(nameof(Expanded));
             }
-
-            DisplayStyle = Parent?.DisplayStyle ?? DisplayStyle;
 
             await base.SetParametersAsync(parameters);
         }

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor.cs
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor.cs
@@ -75,6 +75,13 @@ namespace Radzen.Blazor
         public string Image { get; set; }
 
         /// <summary>
+        /// Gets or sets the display style.
+        /// </summary>
+        [CascadingParameter]
+        public MenuItemDisplayStyle DisplayStyle { get; set; } = MenuItemDisplayStyle.IconAndText;
+
+
+        /// <summary>
         /// Gets or sets the template.
         /// </summary>
         /// <value>The template.</value>
@@ -149,7 +156,7 @@ namespace Radzen.Blazor
         }
 
         RadzenPanelMenu _parent;
-        
+
         /// <summary>
         /// Gets or sets the click callback.
         /// </summary>
@@ -253,9 +260,11 @@ namespace Radzen.Blazor
                 expanded = parameters.GetValueOrDefault<bool>(nameof(Expanded));
             }
 
+            DisplayStyle = Parent?.DisplayStyle ?? DisplayStyle;
+
             await base.SetParametersAsync(parameters);
         }
-        
+
         /// <summary>
         /// Handles the <see cref="E:Click" /> event.
         /// </summary>

--- a/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
+++ b/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
@@ -1,0 +1,44 @@
+﻿<RadzenStack AlignItems="AlignItems.Center" Class="rz-p-12">
+    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+        <div style="white-space:nowrap; margin-right: 16px">Density:</div>
+        <RadzenSelectBar @bind-Value="@DisplayStyle" TextProperty="Text" ValueProperty="Value"
+                         Data="@(Enum.GetValues(typeof(MenuItemDisplayStyle)).Cast<MenuItemDisplayStyle>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
+    </RadzenStack>
+
+    <RadzenPanelMenu DisplayStyle="@DisplayStyle" Multiple=false>
+        <RadzenPanelMenuItem Text="General" Icon="home">
+            <RadzenPanelMenuItem Text="Buttons" Path="buttons" Icon="account_circle"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Menu" Path="menu" Icon="line_weight"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="FileInput" Path="fileinput" Icon="attach_file"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Dialog" Path="dialog" Icon="perm_media"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Notification" Path="notification" Icon="announcement"></RadzenPanelMenuItem>
+        </RadzenPanelMenuItem>
+        <RadzenPanelMenuItem Text="Inputs" Icon="payment">
+            <RadzenPanelMenuItem Text="CheckBox" Path="checkbox" Icon="check_circle"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="TextBox" Path="textbox" Icon="input"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="TextArea" Path="textarea" Icon="description"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Password" Path="password" Icon="payment"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Numeric" Path="numeric" Icon="aspect_ratio"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="DatePicker" Path="datepicker" Icon="date_range"></RadzenPanelMenuItem>
+        </RadzenPanelMenuItem>
+        <RadzenPanelMenuItem Text="Data" Icon="save">
+            <RadzenPanelMenuItem Text="DataGrid" Path="datagrid" Icon="grid_on"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="DataList" Path="datalist" Icon="list"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="DropDown" Path="dropdown" Icon="dns"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="DropDownDataGrid" Path="dropdown-datagrid" Icon="receipt"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="ListBox" Path="listbox" Icon="view_list"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="TemplateForm" Path="templateform" Icon="line_style"></RadzenPanelMenuItem>
+        </RadzenPanelMenuItem>
+        <RadzenPanelMenuItem Text="Containers" Icon="account_box">
+            <RadzenPanelMenuItem Text="Tabs" Path="tabs" Icon="tab"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Panel" Path="panel" Icon="content_paste"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Fieldset" Path="fieldset" Icon="account_balance_wallet"></RadzenPanelMenuItem>
+            <RadzenPanelMenuItem Text="Card" Path="card" Icon="line_style"></RadzenPanelMenuItem>
+        </RadzenPanelMenuItem>
+    </RadzenPanelMenu>
+
+</RadzenStack>
+
+@code {
+    MenuItemDisplayStyle DisplayStyle = MenuItemDisplayStyle.IconAndText;
+}

--- a/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
+++ b/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
@@ -1,6 +1,6 @@
 ﻿<RadzenStack AlignItems="AlignItems.Center" Class="rz-p-12">
     <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
-        <div style="white-space:nowrap; margin-right: 16px">Density:</div>
+        <div style="white-space:nowrap; margin-right: 16px">DisplayStyle:</div>
         <RadzenSelectBar @bind-Value="@DisplayStyle" TextProperty="Text" ValueProperty="Value"
                          Data="@(Enum.GetValues(typeof(MenuItemDisplayStyle)).Cast<MenuItemDisplayStyle>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
     </RadzenStack>

--- a/RadzenBlazorDemos/Pages/PanelMenuPage.razor
+++ b/RadzenBlazorDemos/Pages/PanelMenuPage.razor
@@ -20,3 +20,10 @@
 <RadzenExample ComponentName="PanelMenu" Example="PanelMenuProgrammatic">
      <PanelMenuProgrammatic />
 </RadzenExample>
+
+<RadzenText Anchor="panelmenu#panelmenu-panelmenudisplaystyle" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
+    Set the display style of menu items
+</RadzenText>
+<RadzenExample ComponentName="PanelMenu" Example="PanelMenuDisplayStyle">
+    <PanelMenuDisplayStyle />
+</RadzenExample>


### PR DESCRIPTION
Three display methods are provided for RadzenPanelMenu.
Usage 1: Provide a way to display only icons for subsequent RadzenSidebar folding
Expected effect

![1](https://github.com/radzenhq/radzen-blazor/assets/7581981/7a181859-6194-4bea-8510-e62429056ac2)
![2](https://github.com/radzenhq/radzen-blazor/assets/7581981/b94050a8-6b9c-4a14-97e2-b94ec5ae1ddc)

Usage 2: The MenuItemDisplayStyle enumeration can also be used in Menu to achieve flexible use of screen space