### PR TITLE
Can modify groups parameter added

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -35,9 +35,12 @@
                             {
                                 <div class="rz-group-header-item">
                                     <span class="rz-group-header-item-title">@gd.GetTitle()</span>
-                                    <a href="javascript:void(0)" @onclick=@(async args => await RemoveGroupAsync(gd)) role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">
-                                        <span class="rzi rzi-times"></span>
-                                    </a>
+                                    @if (CanModifyGroups)
+                                    {
+                                        <a href="javascript:void(0)" @onclick=@(async args => await RemoveGroupAsync(gd)) role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close">
+                                            <span class="rzi rzi-times"></span>
+                                        </a>
+                                    }
                                 </div>
                             }
                         </div>

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2659,12 +2659,7 @@ namespace Radzen.Blazor
 
         internal async Task EndColumnDropToGroup()
         {
-            if (CanModifyGroups is false)
-            {
-                return;
-            }
-
-            if (indexOfColumnToReoder == null || AllowGrouping is false)
+            if (CanModifyGroups is false || indexOfColumnToReoder == null || AllowGrouping is false)
             {
                 return;
             }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2675,21 +2675,15 @@ namespace Radzen.Blazor
 
             indexOfColumnToReoder = null;
 
-            if (column == null || column.Groupable is false || string.IsNullOrEmpty(column.GetGroupProperty()))
+            if (column == null || 
+                column.Groupable is false ||
+                string.IsNullOrEmpty(column.GetGroupProperty()) ||
+                Groups.Any(gd => gd.Property == column.GetGroupProperty()))
             {
                 return;
             }
 
-            var groupDescriptor = Groups
-                .Where(d => d.Property == column.GetGroupProperty())
-                .FirstOrDefault();
-
-            if (groupDescriptor != null)
-            {
-                return;
-            }
-
-            groupDescriptor = new GroupDescriptor() 
+            var groupDescriptor = new GroupDescriptor() 
             {
                 Property = column.GetGroupProperty(),
                 Title = column.GetTitle(),

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1215,13 +1215,6 @@ namespace Radzen.Blazor
         public bool CanModifyGroups { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether grouping is allowed.
-        /// </summary>
-        /// <value><c>true</c> if grouping is allowed; otherwise, <c>false</c>.</value>
-        [Parameter]
-        public bool AllowGroupChange { get; set; } = true;
-
-        /// <summary>
         /// Gets or sets a value indicating whether grouped column should be hidden.
         /// </summary>
         /// <value><c>true</c> if grouped columns should be hidden; otherwise, <c>false</c>.</value>

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -4,7 +4,7 @@
 {
 <th rowspan="@(Column.GetRowSpan())" colspan="@(Column.GetColSpan())" @attributes="@Attributes" class="@CssClass" scope="col" style="@GetStyle()" @onmouseup=@(args => Grid.EndColumnReorder(args, ColumnIndex))>
     <div @onclick='@((args) => Grid.OnSort(args, Column))' tabindex="@SortingTabIndex" @onkeydown="OnSortKeyPressed">
-        @if ((Grid.AllowColumnReorder && Column.Reorderable || Grid.AllowGrouping && Column.Groupable))
+        @if ((Grid.AllowColumnReorder && Column.Reorderable || Grid.AllowGrouping && Column.Groupable && Grid.CanModifyGroups))
         {
             <span id="@(Grid.getColumnUniqueId(ColumnIndex) + "-drag")" class="rz-column-drag"
                     @onclick:preventDefault="true" @onclick:stopPropagation="true"


### PR DESCRIPTION
Added CanModifyGroups parameter which is used to disable adding/removing groups but keeping Group UI.
Method EndColumnDropToGroup refactored to avoid nested if. 