### PR TITLE
Add Close Tab Button

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -657,6 +657,21 @@ namespace Radzen
     }
 
     /// <summary>
+    /// Specify how the <see cref="RadzenTabs" /> component tab close button is displayed
+    /// </summary>
+    public enum TabCloseMode
+    {
+        /// <summary>
+        /// All Tabs
+        /// </summary>
+        All,
+        /// <summary>
+        /// Selected tab
+        /// </summary>
+        Selected
+    }
+
+    /// <summary>
     /// Specifies the ways a <see cref="RadzenTimeline" /> component renders line and content items.
     /// </summary>
     public enum LinePosition

--- a/Radzen.Blazor/RadzenTabs.razor.cs
+++ b/Radzen.Blazor/RadzenTabs.razor.cs
@@ -72,6 +72,13 @@ namespace Radzen.Blazor
         List<RadzenTabsItem> tabs = new List<RadzenTabsItem>();
 
         /// <summary>
+        /// Gets or sets tab close button event 
+        /// </summary>
+        /// <value>The close button callback.</value>
+        [Parameter]
+        public EventCallback<RadzenTabsItem> TabCloseClick { get; set; }
+
+        /// <summary>
         /// Adds the tab.
         /// </summary>
         /// <param name="tab">The tab.</param>

--- a/Radzen.Blazor/RadzenTabs.razor.cs
+++ b/Radzen.Blazor/RadzenTabs.razor.cs
@@ -76,7 +76,13 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The close button callback.</value>
         [Parameter]
-        public EventCallback<RadzenTabsItem> TabCloseClick { get; set; }
+        public EventCallback<RadzenTabsItem> TabClose { get; set; }
+
+        /// <summary>
+        /// Gets or sets tab close button display mode 
+        /// </summary>
+        [Parameter]
+        public TabCloseMode CloseMode { get; set; } = TabCloseMode.Selected;
 
         /// <summary>
         /// Adds the tab.

--- a/Radzen.Blazor/RadzenTabsItem.razor
+++ b/Radzen.Blazor/RadzenTabsItem.razor
@@ -16,7 +16,10 @@
             else
             {
                 <span class="rz-tabview-title">@Text</span>
-
+                @if (!string.IsNullOrEmpty(BadgeText))
+                {
+                    <RadzenBadge Text="@BadgeText" class="rz-ml-1" />
+                }
                 @if (Tabs.TabClose.HasDelegate)
                 {
                     <span class="rz-ml-05 @(Tabs.CloseMode==TabCloseMode.Selected?"close-botton":"")">

--- a/Radzen.Blazor/RadzenTabsItem.razor
+++ b/Radzen.Blazor/RadzenTabsItem.razor
@@ -16,15 +16,16 @@
             else
             {
                 <span class="rz-tabview-title">@Text</span>
-                @if (Tabs.TabCloseClick.HasDelegate)
+
+                @if (Tabs.TabClose.HasDelegate)
                 {
-                    <span class="rz-ml-05">
-                        <RadzenButton Click="@OnTabCloseClick" class="rz-border-radius" Icon="close" Variant="Variant.Text"
-                                      ButtonStyle="ButtonStyle.Dark" Shade="Shade.Darker" Size="ButtonSize.ExtraSmall"
-                                      Style="hover{opacity:0}" />
+                    <span class="rz-ml-05 @(Tabs.CloseMode==TabCloseMode.Selected?"close-botton":"")">
+                        <RadzenButton Click="@OnTabClose" class="rz-border-radius" Icon="close" Variant="Variant.Text"
+                                      Size="ButtonSize.ExtraSmall" />
                     </span>
                 }
             }
         </a>
+
     </li>
 }

--- a/Radzen.Blazor/RadzenTabsItem.razor
+++ b/Radzen.Blazor/RadzenTabsItem.razor
@@ -3,9 +3,9 @@
 @if (Tabs.RenderMode == TabRenderMode.Server ? Visible : true)
 {
     <li role="presentation" @attributes=@Attributes style=@Style class=@ClassList>
-    <a @onclick=@OnClick role="tab" href="javascript: void(0)" tabindex=@(Disabled? "-1" : "0") id="@($"{Tabs.Id}-tabpanel-{Index}-label")"
-        aria-selected=@(IsSelected? "true" : "false") aria-controls="@($"{Tabs.Id}-tabpanel-{Index}")">
-        @if (!string.IsNullOrEmpty(Icon))
+        <a @onclick=@OnClick role="tab" href="javascript: void(0)" tabindex=@(Disabled? "-1" : "0") id="@($"{Tabs.Id}-tabpanel-{Index}-label")"
+           aria-selected=@(IsSelected? "true" : "false") aria-controls="@($"{Tabs.Id}-tabpanel-{Index}")">
+            @if (!string.IsNullOrEmpty(Icon))
             {
                 <span class="rz-tabview-left-icon rzi">@((MarkupString)Icon)</span>
             }
@@ -16,6 +16,14 @@
             else
             {
                 <span class="rz-tabview-title">@Text</span>
+                @if (Tabs.TabCloseClick.HasDelegate)
+                {
+                    <span class="rz-ml-05">
+                        <RadzenButton Click="@OnTabCloseClick" class="rz-border-radius" Icon="close" Variant="Variant.Text"
+                                      ButtonStyle="ButtonStyle.Dark" Shade="Shade.Darker" Size="ButtonSize.ExtraSmall"
+                                      Style="hover{opacity:0}" />
+                    </span>
+                }
             }
         </a>
     </li>

--- a/Radzen.Blazor/RadzenTabsItem.razor.cs
+++ b/Radzen.Blazor/RadzenTabsItem.razor.cs
@@ -138,12 +138,9 @@ namespace Radzen.Blazor
             }
         }
 
-        async Task OnTabCloseClick()
+        async Task OnTabClose()
         {
-            if (Tabs.TabCloseClick.HasDelegate)
-            {
-                await Tabs.TabCloseClick.InvokeAsync(this);
-            }
+            await Tabs.TabClose.InvokeAsync(this);
         }
 
         /// <inheritdoc />

--- a/Radzen.Blazor/RadzenTabsItem.razor.cs
+++ b/Radzen.Blazor/RadzenTabsItem.razor.cs
@@ -54,6 +54,13 @@ namespace Radzen.Blazor
         public string Icon { get; set; }
 
         /// <summary>
+        /// Gets or sets the badge text.
+        /// </summary>
+        /// <value>The badge text.</value>
+        [Parameter]
+        public string BadgeText { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="RadzenTabsItem"/> is selected.
         /// </summary>
         /// <value><c>true</c> if selected; otherwise, <c>false</c>.</value>

--- a/Radzen.Blazor/RadzenTabsItem.razor.cs
+++ b/Radzen.Blazor/RadzenTabsItem.razor.cs
@@ -138,6 +138,14 @@ namespace Radzen.Blazor
             }
         }
 
+        async Task OnTabCloseClick()
+        {
+            if (Tabs.TabCloseClick.HasDelegate)
+            {
+                await Tabs.TabCloseClick.InvokeAsync(this);
+            }
+        }
+
         /// <inheritdoc />
         public override async Task SetParametersAsync(ParameterView parameters)
         {

--- a/Radzen.Blazor/themes/components/blazor/_tabs.scss
+++ b/Radzen.Blazor/themes/components/blazor/_tabs.scss
@@ -118,7 +118,10 @@ $tabs-transition: var(--rz-transition-all) !default;
       &:hover {
         text-decoration: none;
       }
-    }
+
+      .close-botton {
+        display: none;
+      }
 
     &.rz-state-disabled {
       opacity: 0.5;
@@ -131,8 +134,11 @@ $tabs-transition: var(--rz-transition-all) !default;
 
     a {
       color: var(--rz-tabs-tab-selected-color);
+
+      .close-botton {
+        display: inline;
+      }
     }
-  }
 
   .rz-tabview-top > & {
     flex-direction: row;

--- a/Radzen.Blazor/themes/components/blazor/_tabs.scss
+++ b/Radzen.Blazor/themes/components/blazor/_tabs.scss
@@ -88,7 +88,8 @@ $tabs-transition: var(--rz-transition-all) !default;
 
   li {
     border: var(--rz-tabs-border);
-    background-color: var(--rz-tabs-tab-background-color);;
+    background-color: var(--rz-tabs-tab-background-color);
+    ;
     transition: var(--rz-tabs-transition);
 
     &:hover {
@@ -118,13 +119,14 @@ $tabs-transition: var(--rz-transition-all) !default;
       &:hover {
         text-decoration: none;
       }
-
-      .close-botton {
-        display: none;
-      }
+    }
 
     &.rz-state-disabled {
       opacity: 0.5;
+    }
+
+    .close-botton {
+      display: none;
     }
   }
 
@@ -134,13 +136,14 @@ $tabs-transition: var(--rz-transition-all) !default;
 
     a {
       color: var(--rz-tabs-tab-selected-color);
-
-      .close-botton {
-        display: inline;
-      }
     }
 
-  .rz-tabview-top > & {
+    .close-botton {
+      display: inline;
+    }
+  }
+
+  .rz-tabview-top>& {
     flex-direction: row;
 
     li {
@@ -164,11 +167,11 @@ $tabs-transition: var(--rz-transition-all) !default;
     }
   }
 
-  .rz-tabview-top-right > & {
+  .rz-tabview-top-right>& {
     justify-content: flex-end;
   }
 
-  .rz-tabview-bottom > & {
+  .rz-tabview-bottom>& {
     flex-direction: row;
 
     li {
@@ -193,11 +196,11 @@ $tabs-transition: var(--rz-transition-all) !default;
     }
   }
 
-  .rz-tabview-bottom-right > & {
+  .rz-tabview-bottom-right>& {
     justify-content: flex-end;
   }
 
-  .rz-tabview-left > & {
+  .rz-tabview-left>& {
     flex-direction: column;
 
     li {
@@ -221,7 +224,7 @@ $tabs-transition: var(--rz-transition-all) !default;
     }
   }
 
-  .rz-tabview-right > & {
+  .rz-tabview-right>& {
     flex-direction: column;
 
     li {
@@ -254,24 +257,25 @@ $tabs-transition: var(--rz-transition-all) !default;
   flex: 1;
   overflow: auto;
 
-  .rz-tabview-top > & {
+  .rz-tabview-top>& {
     border-radius: 0 0 var(--rz-tabs-border-radius) var(--rz-tabs-border-radius);
   }
 
-  .rz-tabview-bottom > & {
+  .rz-tabview-bottom>& {
     border-radius: var(--rz-tabs-border-radius) var(--rz-tabs-border-radius) 0 0;
   }
 
-  .rz-tabview-left > & {
+  .rz-tabview-left>& {
     border-radius: 0 var(--rz-tabs-border-radius) var(--rz-tabs-border-radius) 0;
   }
 
-  .rz-tabview-right > & {
+  .rz-tabview-right>& {
     border-radius: var(--rz-tabs-border-radius) 0 0 var(--rz-tabs-border-radius);
   }
 }
 
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+@media screen and (-ms-high-contrast: active),
+(-ms-high-contrast: none) {
   .rz-tabview-panels {
     flex: auto;
   }

--- a/RadzenBlazorDemos/Pages/TabsClient.razor
+++ b/RadzenBlazorDemos/Pages/TabsClient.razor
@@ -3,7 +3,7 @@
         <RadzenTabsItem Text="Customers">
             Customers
         </RadzenTabsItem>
-        <RadzenTabsItem Text="Orders">
+        <RadzenTabsItem Text="Orders" BadgeText="5">
             Orders
         </RadzenTabsItem>
         <RadzenTabsItem Text="Order Details">

--- a/RadzenBlazorDemos/Pages/TabsModify.razor
+++ b/RadzenBlazorDemos/Pages/TabsModify.razor
@@ -1,4 +1,4 @@
-﻿<RadzenTabs @ref="tabs" RenderMode="TabRenderMode.Client" @bind-SelectedIndex=@selectedIndex>
+﻿<RadzenTabs @ref="tabs" RenderMode="TabRenderMode.Client" @bind-SelectedIndex=@selectedIndex TabCloseClick="OnTabCloseClick">
     <Tabs>
         @foreach (var item in items)
         {
@@ -31,6 +31,13 @@
     void RemoveItem()
     {
         items.RemoveAt(selectedIndex);
+        if (selectedIndex >= items.Count) selectedIndex = items.Count - 1;
+        tabs.Reload();
+    }
+
+    void OnTabCloseClick(RadzenTabsItem item)
+    {
+        items.RemoveAt(item.Index);
         if (selectedIndex >= items.Count) selectedIndex = items.Count - 1;
         tabs.Reload();
     }

--- a/RadzenBlazorDemos/Pages/TabsModify.razor
+++ b/RadzenBlazorDemos/Pages/TabsModify.razor
@@ -1,4 +1,13 @@
-﻿<RadzenTabs @ref="tabs" RenderMode="TabRenderMode.Client" @bind-SelectedIndex=@selectedIndex TabCloseClick="OnTabCloseClick">
+﻿<div class="rz-p-12 rz-text-align-center">
+    <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
+        <RadzenLabel Text="CloseMode:" />
+        <RadzenSelectBar @bind-Value="@closeMode" TextProperty="Text" ValueProperty="Value"
+                         Data="@(Enum.GetValues(typeof(TabCloseMode)).Cast<TabCloseMode>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
+    </RadzenStack>
+
+</div>
+
+<RadzenTabs @ref="tabs" RenderMode="TabRenderMode.Client" @bind-SelectedIndex=@selectedIndex TabClose="OnTabClose" CloseMode="closeMode">
     <Tabs>
         @foreach (var item in items)
         {
@@ -16,6 +25,8 @@
 
 
 @code {
+    TabCloseMode closeMode = TabCloseMode.Selected;
+
     RadzenTabs tabs;
     int selectedIndex = 0;
 
@@ -35,7 +46,7 @@
         tabs.Reload();
     }
 
-    void OnTabCloseClick(RadzenTabsItem item)
+    void OnTabClose(RadzenTabsItem item)
     {
         items.RemoveAt(item.Index);
         if (selectedIndex >= items.Count) selectedIndex = items.Count - 1;

--- a/RadzenBlazorDemos/Pages/TabsServer.razor
+++ b/RadzenBlazorDemos/Pages/TabsServer.razor
@@ -3,7 +3,7 @@
         <RadzenTabsItem Text="Customers">
             Customers
         </RadzenTabsItem>
-        <RadzenTabsItem Text="Orders">
+        <RadzenTabsItem Text="Orders" BadgeText="5">
             Orders
         </RadzenTabsItem>
         <RadzenTabsItem Text="Order Details">


### PR DESCRIPTION
Provide a tab closure event. After defining the event, the tab displays a closure button, and the control itself does not perform any logic. The closure function is implemented by the user themselves.
![tab](https://github.com/radzenhq/radzen-blazor/assets/7581981/28eb9561-d23e-41f9-bc53-2247292d8219)
