### PR TITLE
add IsShowArrow

### DIFF
--- a/Radzen.Blazor/RadzenPanelMenu.razor.cs
+++ b/Radzen.Blazor/RadzenPanelMenu.razor.cs
@@ -48,6 +48,13 @@ namespace Radzen.Blazor
         [Parameter]
         public MenuItemDisplayStyle DisplayStyle { get; set; } = MenuItemDisplayStyle.IconAndText;
 
+        /// <summary>
+        /// Gets or sets the show arrow.
+        /// </summary>
+        [Parameter]
+        public bool IsShowArrow { get; set; } = true;
+
+
         internal List<RadzenPanelMenuItem> items = new List<RadzenPanelMenuItem>();
 
         /// <summary>

--- a/Radzen.Blazor/RadzenPanelMenu.razor.cs
+++ b/Radzen.Blazor/RadzenPanelMenu.razor.cs
@@ -52,7 +52,7 @@ namespace Radzen.Blazor
         /// Gets or sets the show arrow.
         /// </summary>
         [Parameter]
-        public bool IsShowArrow { get; set; } = true;
+        public bool ShowArrow { get; set; } = true;
 
 
         internal List<RadzenPanelMenuItem> items = new List<RadzenPanelMenuItem>();

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor
@@ -4,7 +4,7 @@
 @if (Visible)
 {
     <li @ref="@Element" id="@GetId()" style="@Style" @attributes="Attributes" class="@GetCssClass()" @onclick="@OnClick" @onclick:stopPropagation>
-        <div class=@(Selected ? "rz-navigation-item-wrapper rz-navigation-item-wrapper-active" : "rz-navigation-item-wrapper")>
+        <div class=@(Selected ? "rz-navigation-item-wrapper rz-navigation-item-wrapper-active" : "rz-navigation-item-wrapper") style="margin-right:0px">
             @if (Path != null)
             {
                 <NavLink target="@Target" class=@(Selected ? "rz-navigation-item-link rz-navigation-item-link-active" : "rz-navigation-item-link") style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" href="@Path" Match="@Match">
@@ -24,7 +24,7 @@
                     {
                         <span class="rz-navigation-item-text" @onclick="@Toggle">@Text</span>
                     }
-                    @if (items.Any())
+                    @if (items.Any() && Parent?.IsShowArrow == true)
                     {
                         <i class="rzi rz-navigation-item-icon-children" style="@getStyle()" @onclick="@Toggle" @onclick:preventDefault>keyboard_arrow_down</i>
                     }
@@ -49,7 +49,7 @@
                     {
                         <span class="rz-navigation-item-text">@Text</span>
                     }
-                    @if (items.Any())
+                    @if (items.Any() && Parent?.IsShowArrow == true)
                     {
                         <i class="rzi rz-navigation-item-icon-children" style="@getStyle()">keyboard_arrow_down</i>
                     }

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor
@@ -24,7 +24,7 @@
                     {
                         <span class="rz-navigation-item-text" @onclick="@Toggle">@Text</span>
                     }
-                    @if (items.Any() && Parent?.IsShowArrow == true)
+                    @if (items.Any() && Parent?.ShowArrow == true)
                     {
                         <i class="rzi rz-navigation-item-icon-children" style="@getStyle()" @onclick="@Toggle" @onclick:preventDefault>keyboard_arrow_down</i>
                     }
@@ -49,7 +49,7 @@
                     {
                         <span class="rz-navigation-item-text">@Text</span>
                     }
-                    @if (items.Any() && Parent?.IsShowArrow == true)
+                    @if (items.Any() && Parent?.ShowArrow == true)
                     {
                         <i class="rzi rz-navigation-item-icon-children" style="@getStyle()">keyboard_arrow_down</i>
                     }

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor
@@ -7,7 +7,7 @@
         <div class=@(Selected ? "rz-navigation-item-wrapper rz-navigation-item-wrapper-active" : "rz-navigation-item-wrapper") style="margin-right:0px">
             @if (Path != null)
             {
-                <NavLink target="@Target" class=@(Selected ? "rz-navigation-item-link rz-navigation-item-link-active" : "rz-navigation-item-link") style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" href="@Path" Match="@Match">
+                <NavLink target="@Target" class=@(Selected ? "rz-navigation-item-link rz-navigation-item-link-active" : "rz-navigation-item-link") style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px;":"")" href="@Path" Match="@Match">
                     @if (!string.IsNullOrEmpty(Icon) && (Parent?.DisplayStyle == MenuItemDisplayStyle.Icon || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
                         <i class="rzi rz-navigation-item-icon" style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>
@@ -32,7 +32,7 @@
             }
             else
             {
-                <div class="rz-navigation-item-link" style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")" @onclick="@Toggle">
+                <div class="rz-navigation-item-link" style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px;":"")" @onclick="@Toggle">
                     @if (!string.IsNullOrEmpty(Icon) && (Parent?.DisplayStyle == MenuItemDisplayStyle.Icon || Parent?.DisplayStyle == MenuItemDisplayStyle.IconAndText))
                     {
                         <i class="rzi rz-navigation-item-icon" style="@(Parent?.DisplayStyle == MenuItemDisplayStyle.Icon?"margin-right:0px":"")">@((MarkupString)Icon)</i>

--- a/RadzenBlazorDemos/Pages/LayoutIconSidebar.razor
+++ b/RadzenBlazorDemos/Pages/LayoutIconSidebar.razor
@@ -6,7 +6,7 @@
         </RadzenStack>
     </RadzenHeader>
     <RadzenSidebar Style="width:auto">
-        <RadzenPanelMenu DisplayStyle="@(sidebar1Expanded?MenuItemDisplayStyle.IconAndText:MenuItemDisplayStyle.Icon)">
+        <RadzenPanelMenu DisplayStyle="@(sidebar1Expanded?MenuItemDisplayStyle.IconAndText:MenuItemDisplayStyle.Icon)" IsShowArrow=true>
             <RadzenPanelMenuItem Text="Overview" Icon="home" />
             <RadzenPanelMenuItem Text="Dashboard" Icon="dashboard" />
             <RadzenPanelMenuItem Text="UI Fundamentals" Icon="auto_awesome">

--- a/RadzenBlazorDemos/Pages/LayoutIconSidebar.razor
+++ b/RadzenBlazorDemos/Pages/LayoutIconSidebar.razor
@@ -6,7 +6,7 @@
         </RadzenStack>
     </RadzenHeader>
     <RadzenSidebar Style="width:auto">
-        <RadzenPanelMenu DisplayStyle="@(sidebar1Expanded?MenuItemDisplayStyle.IconAndText:MenuItemDisplayStyle.Icon)" IsShowArrow=false>
+        <RadzenPanelMenu DisplayStyle="@(sidebar1Expanded?MenuItemDisplayStyle.IconAndText:MenuItemDisplayStyle.Icon)" ShowArrow=false>
             <RadzenPanelMenuItem Text="Overview" Icon="home" />
             <RadzenPanelMenuItem Text="Dashboard" Icon="dashboard" />
             <RadzenPanelMenuItem Text="UI Fundamentals" Icon="auto_awesome">

--- a/RadzenBlazorDemos/Pages/LayoutIconSidebar.razor
+++ b/RadzenBlazorDemos/Pages/LayoutIconSidebar.razor
@@ -6,7 +6,7 @@
         </RadzenStack>
     </RadzenHeader>
     <RadzenSidebar Style="width:auto">
-        <RadzenPanelMenu DisplayStyle="@(sidebar1Expanded?MenuItemDisplayStyle.IconAndText:MenuItemDisplayStyle.Icon)" IsShowArrow=true>
+        <RadzenPanelMenu DisplayStyle="@(sidebar1Expanded?MenuItemDisplayStyle.IconAndText:MenuItemDisplayStyle.Icon)" IsShowArrow=false>
             <RadzenPanelMenuItem Text="Overview" Icon="home" />
             <RadzenPanelMenuItem Text="Dashboard" Icon="dashboard" />
             <RadzenPanelMenuItem Text="UI Fundamentals" Icon="auto_awesome">

--- a/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
+++ b/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
@@ -5,10 +5,10 @@
                          Data="@(Enum.GetValues(typeof(MenuItemDisplayStyle)).Cast<MenuItemDisplayStyle>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
 
         <RadzenCheckBox @bind-Value=@isShowArrow Name="CheckBox2" TValue="bool" />
-        <RadzenLabel Text="Allow multiple expand" Component="CheckBox2" />
+        <RadzenLabel Text="Show Arrow" Component="CheckBox2" />
     </RadzenStack>
 
-    <RadzenPanelMenu DisplayStyle="@DisplayStyle" IsShowArrow="@isShowArrow" Multiple=false>
+    <RadzenPanelMenu DisplayStyle="@DisplayStyle" ShowArrow="@isShowArrow" Multiple=false>
         <RadzenPanelMenuItem Text="General" Icon="home">
             <RadzenPanelMenuItem Text="Buttons" Path="buttons" Icon="account_circle"></RadzenPanelMenuItem>
             <RadzenPanelMenuItem Text="Menu" Path="menu" Icon="line_weight"></RadzenPanelMenuItem>

--- a/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
+++ b/RadzenBlazorDemos/Pages/PanelMenuDisplayStyle.razor
@@ -3,9 +3,12 @@
         <div style="white-space:nowrap; margin-right: 16px">DisplayStyle:</div>
         <RadzenSelectBar @bind-Value="@DisplayStyle" TextProperty="Text" ValueProperty="Value"
                          Data="@(Enum.GetValues(typeof(MenuItemDisplayStyle)).Cast<MenuItemDisplayStyle>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
+
+        <RadzenCheckBox @bind-Value=@isShowArrow Name="CheckBox2" TValue="bool" />
+        <RadzenLabel Text="Allow multiple expand" Component="CheckBox2" />
     </RadzenStack>
 
-    <RadzenPanelMenu DisplayStyle="@DisplayStyle" Multiple=false>
+    <RadzenPanelMenu DisplayStyle="@DisplayStyle" IsShowArrow="@isShowArrow" Multiple=false>
         <RadzenPanelMenuItem Text="General" Icon="home">
             <RadzenPanelMenuItem Text="Buttons" Path="buttons" Icon="account_circle"></RadzenPanelMenuItem>
             <RadzenPanelMenuItem Text="Menu" Path="menu" Icon="line_weight"></RadzenPanelMenuItem>
@@ -41,4 +44,6 @@
 
 @code {
     MenuItemDisplayStyle DisplayStyle = MenuItemDisplayStyle.IconAndText;
+
+    bool isShowArrow = true;
 }


### PR DESCRIPTION
Sometimes the menu needs a look without a pull arrow, so a switch has been added to hide it.

However, when encountering hidden elements and expanding them on the style, it will cause a change in the menu width. I directly modify the style to worry about affecting other components. If this evaluation is valuable, please help to address the style issue.

![GIF 2023-9-17 15-03-12](https://github.com/radzenhq/radzen-blazor/assets/7581981/f1a5e61b-999f-40cc-bed6-b35e968fad71)
