### PR TITLE
RadzenDataGrid/RadzenDataList - Add text to loading indicator

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -397,13 +397,7 @@
                 }
             </table>
 
-            @if (IsLoading)
-            {
-                <div class="rz-datatable-loading"></div>
-                <div class="rz-datatable-loading-content">
-                    <i class="rzi-circle-o-notch"></i>
-                </div>
-            }
+            <RadzenLoadingIndicator IsLoading="@IsLoading" LoadingText="@LoadingText" />
         </div>
 
         @if (AllowPaging && (PagerPosition == PagerPosition.Bottom || PagerPosition == PagerPosition.TopAndBottom))

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1132,6 +1132,13 @@ namespace Radzen.Blazor
         public bool IsLoading { get; set; }
 
         /// <summary>
+        /// Gets or sets a value of the text while loading indicator is shown
+        /// </summary>
+        /// <value>Value of the loading indicator text; default: string.Empty</value>
+        [Parameter]
+        public string LoadingText { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets a value indicating whether sorting is allowed.
         /// </summary>
         /// <value><c>true</c> if sorting is allowed; otherwise, <c>false</c>.</value>

--- a/Radzen.Blazor/RadzenDataList.razor
+++ b/Radzen.Blazor/RadzenDataList.razor
@@ -21,13 +21,9 @@
                 </div>
             }
         }
-        @if (IsLoading)
-        {
-            <div class="rz-datatable-loading"></div>
-            <div class="rz-datatable-loading-content">
-                <i class="rzi-circle-o-notch"></i>
-            </div>
-        }
+
+        <RadzenLoadingIndicator IsLoading="@IsLoading" LoadingText="@LoadingText" />
+        
         @if (AllowPaging && (PagerPosition == PagerPosition.Bottom || PagerPosition == PagerPosition.TopAndBottom))
         {
             <RadzenPager HorizontalAlign="@PagerHorizontalAlign" AlwaysVisible="@PagerAlwaysVisible" @ref="bottomPager" Count="@Count" PageSize="@PageSize" PageNumbersCount="@PageNumbersCount" PageChanged="@OnPageChanged" PageSizeChanged="@OnPageSizeChanged" PageSizeOptions="@PageSizeOptions" ShowPagingSummary="@ShowPagingSummary" PagingSummaryFormat="@PagingSummaryFormat" PageSizeText="@PageSizeText" class="rz-paginator-bottom" Density="@Density" />

--- a/Radzen.Blazor/RadzenDataList.razor.cs
+++ b/Radzen.Blazor/RadzenDataList.razor.cs
@@ -155,5 +155,12 @@ namespace Radzen.Blazor
         /// <value><c>true</c> if this instance loading indicator is shown; otherwise, <c>false</c>.</value>
         [Parameter]
         public bool IsLoading { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value of the text while loading indicator is shown
+        /// </summary>
+        /// <value>Value of the loading indicator text; default: string.Empty</value>
+        [Parameter]
+        public string LoadingText { get; set; } = string.Empty;
     }
 }

--- a/Radzen.Blazor/RadzenLoadingIndicator.razor
+++ b/Radzen.Blazor/RadzenLoadingIndicator.razor
@@ -1,0 +1,13 @@
+﻿@if (IsLoading)
+{
+    <div class="rz-datatable-loading"></div>
+    <div class="rz-datatable-loading-content text-center">
+        <i class="rzi-circle-o-notch"></i>
+        @if (!string.IsNullOrWhiteSpace(LoadingText))
+        {
+            <div>
+                <span>@LoadingText</span>
+            </div>
+        }
+    </div>
+}

--- a/Radzen.Blazor/RadzenLoadingIndicator.razor.cs
+++ b/Radzen.Blazor/RadzenLoadingIndicator.razor.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor
+{
+    /// <summary>
+    /// A component to show the loading indicator
+    /// </summary>
+    public partial class RadzenLoadingIndicator
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance loading indicator is shown.
+        /// </summary>
+        /// <value><c>true</c> if this instance loading indicator is shown; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool IsLoading { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value of the text while loading indicator is shown
+        /// </summary>
+        /// <value>Value of the loading indicator text; default: string.Empty</value>
+        [Parameter]
+        public string LoadingText { get; set; } = string.Empty;
+    }
+}

--- a/RadzenBlazorDemos/Pages/DataGridLoadData.razor
+++ b/RadzenBlazorDemos/Pages/DataGridLoadData.razor
@@ -5,7 +5,7 @@
 @inherits DbContextPage
 
 <RadzenButton Text="Reset" Click="@Reset" Style="margin-bottom: 20px;" />
-<RadzenDataGrid style="height: 335px" @ref="grid" IsLoading=@isLoading Count="@count" Data="@employees" LoadData="@LoadData" AllowSorting="true" AllowFiltering="true" AllowPaging="true" PageSize="4" PagerHorizontalAlign="HorizontalAlign.Center" TItem="Employee" ColumnWidth="200px">
+<RadzenDataGrid style="height: 335px" @ref="grid" IsLoading=@isLoading LoadingText="Loading..." Count="@count" Data="@employees" LoadData="@LoadData" AllowSorting="true" AllowFiltering="true" AllowPaging="true" PageSize="4" PagerHorizontalAlign="HorizontalAlign.Center" TItem="Employee" ColumnWidth="200px">
     <Columns>
         <RadzenDataGridColumn TItem="Employee" Property="EmployeeID" Filterable="false" Title="ID" Frozen="true" Width="80px" TextAlign="TextAlign.Center" />
         <RadzenDataGridColumn TItem="Employee" Title="Photo" Frozen="true" Sortable="false" Filterable="false" Width="80px" TextAlign="TextAlign.Center" >
@@ -87,7 +87,7 @@ void LoadData(LoadDataArgs args)
         {
             selectedTitles = null;  
         }
-        
+
         await grid.FirstPage();
     }
 

--- a/RadzenBlazorDemos/Pages/DataListLoadData.razor
+++ b/RadzenBlazorDemos/Pages/DataListLoadData.razor
@@ -11,7 +11,7 @@
 </RadzenStack>
 
 <RadzenDataList AllowVirtualization=@allowVirtualization Style="@(allowVirtualization ? "height:400px;overflow:auto;" : "")" 
-                WrapItems="@(!allowVirtualization)" AllowPaging="@(!allowVirtualization)" IsLoading=@isLoading LoadData=@LoadData
+                WrapItems="@(!allowVirtualization)" AllowPaging="@(!allowVirtualization)" IsLoading=@isLoading LoadingText="Loading..." LoadData=@LoadData
                 Data="@products" Count=@count TItem="Product" PageSize="5" PagerHorizontalAlign="HorizontalAlign.Left" ShowPagingSummary="true">
     <Template Context="product">
         <RadzenCard Style="width: 100%; padding: 0;">
@@ -59,7 +59,7 @@
 }
 </style>
 
-@code {
+    @code {
     bool allowVirtualization;
     int count;
     bool isLoading;


### PR DESCRIPTION
1. Add class "RadzenLoadingIndicator" to use the class in RadzenDataGrid/RadzenDataList instead of copy paste the code
2. Add property "LoadingText" to RadzenDataGrid/RadzenDataList 

![grafik](https://github.com/radzenhq/radzen-blazor/assets/115212774/177beed5-2f55-4c20-afb9-1c89f2426452)

Maybe you can explain me, why i cant see the new property in the "Edit Source"-Tab:
![grafik](https://github.com/radzenhq/radzen-blazor/assets/115212774/56fa7002-c3a8-42dd-9e23-ced842a53bf8)

![grafik](https://github.com/radzenhq/radzen-blazor/assets/115212774/b5d9848f-2218-4f8a-955d-857949398408)

