### PR TITLE
access to SelectedTab

### DIFF
--- a/Radzen.Blazor/RadzenTabs.razor.cs
+++ b/Radzen.Blazor/RadzenTabs.razor.cs
@@ -105,7 +105,7 @@ namespace Radzen.Blazor
             }
         }
 
-        RadzenTabsItem SelectedTab
+        public RadzenTabsItem SelectedTab
         {
             get
             {


### PR DESCRIPTION
Access is given to the selected Tab so that logic can be applied, for example

  async Task ChangeTab()
  {

      if (TabsOT is null) return;
     
      if (TabsOT.SelectedTab.Text.Equals("Actividades"))
      {
          

          if (listadoSolInsumos is null)
          {
              await SolicitudInsumosLoadData();
          }
          if (planesMantencionList is null || planesMantencionList.Count().Equals(0))
          {
              planesMantencionList = await comgesotdbService.GetPlanDeMantencion(new Query
              {
                  Filter = "x=>x.versionid == @0",
                  FilterParameters = new object[] { ot.Vehiculo.VersionAuto.id },
                  Expand = "VersionAuto.ModeloAuto.MarcaVehiculo",
              });
          }

      }
  }

Currently it can be done by obtaining the index at the change of each Tab, but if there are dynamic Tabs, it does not work correctly