### PR TITLE
Add `EditTemplate` to `RadzenDataGrid` 

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1125,6 +1125,13 @@ namespace Radzen.Blazor
         public RenderFragment EmptyTemplate { get; set; }
 
         /// <summary>
+        /// Gets or sets the edit template.
+        /// </summary>
+        /// <value>The template.</value>
+        [Parameter]
+        public RenderFragment<TItem> EditTemplate { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this instance loading indicator is shown.
         /// </summary>
         /// <value><c>true</c> if this instance loading indicator is shown; otherwise, <c>false</c>.</value>

--- a/Radzen.Blazor/RadzenDataGridRow.razor
+++ b/Radzen.Blazor/RadzenDataGridRow.razor
@@ -130,15 +130,30 @@
 </tr>
 }
 
-@if (Grid.Template != null && Grid.expandedItems.Keys.Contains(Item))
+@if (Grid.expandedItems.Keys.Contains(Item))
 {
-    <tr class="rz-expanded-row-content">
-        <td colspan="@(Columns.Sum(c => c.GetColSpan()) + (Grid.ShowExpandColumn ? 1 : 0) + Grid.Groups.Count)">
-            <div class="rz-expanded-row-template" style="position:sticky">
-                @Grid.Template(Item)
-            </div>
-        </td>
-    </tr>
+    @if (Grid.IsRowInEditMode(Item) && Grid.EditTemplate != null)
+    {
+        <tr class="rz-expanded-row-content">
+            <td colspan="@(Columns.Sum(c => c.GetColSpan()) + (Grid.ShowExpandColumn ? 1 : 0) + Grid.Groups.Count)">
+                <div class="rz-expanded-row-template" style="position:sticky">
+                    <CascadingValue Value=@EditContext>
+                        @Grid.EditTemplate(Item)
+                    </CascadingValue>
+                </div>
+            </td>
+        </tr>
+    }
+    else if (Grid.Template != null)
+    {
+        <tr class="rz-expanded-row-content">
+            <td colspan="@(Columns.Sum(c => c.GetColSpan()) + (Grid.ShowExpandColumn ? 1 : 0) + Grid.Groups.Count)">
+                <div class="rz-expanded-row-template" style="position:sticky">
+                    @Grid.Template(Item)
+                </div>
+            </td>
+        </tr>
+    }
 }
 @code {
         [Parameter]

--- a/RadzenBlazorDemos/Pages/DataGridInLineEdit.razor
+++ b/RadzenBlazorDemos/Pages/DataGridInLineEdit.razor
@@ -67,6 +67,25 @@
             </EditTemplate>
         </RadzenDataGridColumn>
     </Columns>
+
+    <Template Context="order">
+        <RadzenCard Style="margin-bottom:20px">
+            <b>Address</b>: <br />
+            @order.ShipAddress <br />
+            @order.ShipCity @order.ShipRegion @order.ShipPostalCode @order.ShipCountry
+        </RadzenCard>
+    </Template>
+
+    <EditTemplate Context="order">
+        <RadzenCard Style="margin-bottom:20px">
+            <b>Address</b>: <br />
+            <RadzenTextBox @bind-Value="order.ShipAddress" Style="width:100%;" /> <br />
+            <RadzenTextBox @bind-Value="order.ShipCity" />
+            <RadzenTextBox @bind-Value="order.ShipRegion" />
+            <RadzenTextBox @bind-Value="order.ShipPostalCode" />
+            <RadzenTextBox @bind-Value="order.ShipCountry" />
+        </RadzenCard>
+    </EditTemplate>
 </RadzenDataGrid>
 
 @code {


### PR DESCRIPTION
This PR adds an `EditTemplate` to the `RadzenDataGrid`, with a cascading `EditContext`, so that the child elements can participate in the same edit context as the parent row. 

NB: commit 7e4d037 is only added to prove that the change works as intended; the UI is not polished. I can remove this commit upon request.

Fixes #1167