### PR TITLE
access to SelectedTab

### DIFF
--- a/Radzen.Blazor/RadzenTabs.razor.cs
+++ b/Radzen.Blazor/RadzenTabs.razor.cs
@@ -105,7 +105,7 @@ namespace Radzen.Blazor
             }
         }
 
-        RadzenTabsItem SelectedTab
+        public RadzenTabsItem SelectedTab
         {
             get
             {


### PR DESCRIPTION
[#1165
](https://github.com/radzenhq/radzen-blazor/pull/1165)

The object of this change is to be able to select the tab, if you see the example based on the fact that the tab is tengo, you will have other information, so you don't have to load all the information on the page from one principle

```
            <RadzenTabs @ref=@TabsOT TabPosition="TabPosition.Top" RenderMode="TabRenderMode.Client" Change="ChangeTab">
                <Tabs>

                    <RadzenTabsItem Text="Información Vehículo">
</RadzenTabsItem>
</Tabs>
</RadzenTabs>

async Task ChangeTab()
{

  if (TabsOT is null) return;
 
  if (TabsOT.SelectedTab.Text.Equals("Actividades"))
  {
      

      if (listadoSolInsumos is null)
      {
          await SolicitudInsumosLoadData();
      }
      if (planesMantencionList is null || planesMantencionList.Count().Equals(0))
      {
          planesMantencionList = await comgesotdbService.GetPlanDeMantencion(new Query
          {
              Filter = "x=>x.versionid == @0",
              FilterParameters = new object[] { ot.Vehiculo.VersionAuto.id },
              Expand = "VersionAuto.ModeloAuto.MarcaVehiculo",
          });
      }

  }
}
```

In the example presented solo is to create tabs in a foreach, but that is where you hold tabs with distinct information and you can recognize which tab is active.

Is there any reason to access SelectedTab?