### PR TITLE
Add support for `EditTemplate`

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1125,6 +1125,13 @@ namespace Radzen.Blazor
         public RenderFragment EmptyTemplate { get; set; }
 
         /// <summary>
+        /// Gets or sets the edit template.
+        /// </summary>
+        /// <value>The template.</value>
+        [Parameter]
+        public RenderFragment<TItem> EditTemplate { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this instance loading indicator is shown.
         /// </summary>
         /// <value><c>true</c> if this instance loading indicator is shown; otherwise, <c>false</c>.</value>

--- a/Radzen.Blazor/RadzenDataGridRow.razor
+++ b/Radzen.Blazor/RadzenDataGridRow.razor
@@ -130,15 +130,32 @@
 </tr>
 }
 
-@if (Grid.Template != null && Grid.expandedItems.Keys.Contains(Item))
+@if (Grid.expandedItems.Keys.Contains(Item))
 {
-    <tr class="rz-expanded-row-content">
-        <td colspan="@(Columns.Sum(c => c.GetColSpan()) + (Grid.ShowExpandColumn ? 1 : 0) + Grid.Groups.Count)">
-            <div class="rz-expanded-row-template" style="position:sticky">
-                @Grid.Template(Item)
-            </div>
-        </td>
-    </tr>
+    @if (Grid.IsRowInEditMode(Item) && Grid.EditTemplate != null)
+    {
+        <tr class="rz-expanded-row-content">
+            <td colspan="@(Columns.Sum(c => c.GetColSpan()) + (Grid.ShowExpandColumn ? 1 : 0) + Grid.Groups.Count)">
+                <div class="rz-expanded-row-template" style="position:sticky">
+                    <CascadingValue Value=@EditContext>
+                        <CascadingValue Value=this>
+                            @Grid.EditTemplate(Item)
+                        </CascadingValue>
+                    </CascadingValue>
+                </div>
+            </td>
+        </tr>
+    }
+    else if (Grid.Template != null)
+    {
+        <tr class="rz-expanded-row-content">
+            <td colspan="@(Columns.Sum(c => c.GetColSpan()) + (Grid.ShowExpandColumn ? 1 : 0) + Grid.Groups.Count)">
+                <div class="rz-expanded-row-template" style="position:sticky">
+                    @Grid.Template(Item)
+                </div>
+            </td>
+        </tr>
+    }
 }
 @code {
         [Parameter]


### PR DESCRIPTION
This PR adds an `EditTemplate` to the `RadzenDataGrid`, with a cascading `EditContext`, so that the child elements can participate in the same edit context as the parent row. 

Fixes #1167