### PR TITLE
Added Filters to Query to be able to get filter data via grid.Query.Filters

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -518,10 +518,10 @@ namespace Radzen
         /// <value>The filter.</value>
         public string Filter { get; set; }
         /// <summary>
-        /// Gets or sets the filter parameters.
+        /// Gets the filter expression as a collection of filter descriptors.
         /// </summary>
         /// <value>The filter parameters.</value>
-        public object[] FilterParameters { get; set; }
+        public IEnumerable<FilterDescriptor> Filters { get; set; }
         /// <summary>
         /// Gets or sets the order by.
         /// </summary>

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -523,6 +523,11 @@ namespace Radzen
         /// <value>The filter parameters.</value>
         public IEnumerable<FilterDescriptor> Filters { get; set; }
         /// <summary>
+        /// Gets or sets the filter parameters.
+        /// </summary>
+        /// <value>The filter parameters.</value>
+        public object[] FilterParameters { get; set; }
+        /// <summary>
         /// Gets or sets the order by.
         /// </summary>
         /// <value>The order by.</value>

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1827,7 +1827,8 @@ namespace Radzen.Blazor
             var filterString = allColumns.ToList().ToFilterString<TItem>();
             Query.Filter = filterString;
 
-            filters = allColumns.ToList().Where(c => c.Filterable && c.GetVisible() && (c.GetFilterValue() != null
+            filters = allColumns.ToList()
+                .Where(c => c.Filterable && c.GetVisible() && (c.GetFilterValue() != null
                     || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
                     || c.GetFilterOperator() == FilterOperator.IsEmpty | c.GetFilterOperator() == FilterOperator.IsNotEmpty))
                 .Select(c => new FilterDescriptor()
@@ -1838,7 +1839,10 @@ namespace Radzen.Blazor
                     SecondFilterValue = c.GetSecondFilterValue(),
                     SecondFilterOperator = c.GetSecondFilterOperator(),
                     LogicalFilterOperator = c.GetLogicalFilterOperator()
-                }).ToList();
+                })
+                .ToList();
+
+            Query.Filters = filters;
 
             if (LoadData.HasDelegate)
             {

--- a/Radzen.Blazor/RadzenGrid.razor
+++ b/Radzen.Blazor/RadzenGrid.razor
@@ -799,54 +799,54 @@
         }
     }
 
-	public async override Task Reload()
-	{
-		_view = null;
+    public async override Task Reload()
+    {
+        _view = null;
 
-		if (Data != null && !LoadData.HasDelegate)
-		{
-			Count = View.Count();
-		}
+        if (Data != null && !LoadData.HasDelegate)
+        {
+            Count = View.Count();
+        }
 
-		Query.Skip = skip;
-		Query.Top = PageSize;
-		Query.OrderBy = orderBy;
+        Query.Skip = skip;
+        Query.Top = PageSize;
+        Query.OrderBy = orderBy;
 
-		var filterString = columns.ToFilterString<TItem>();
-		Query.Filter = filterString;
+        var filterString = columns.ToFilterString<TItem>();
+        Query.Filter = filterString;
 
-		if (LoadData.HasDelegate)
-		{
-			await LoadData.InvokeAsync(new Radzen.LoadDataArgs()
-			{
-				Skip = skip,
-				Top = PageSize,
-				OrderBy = orderBy,
-				Filter = IsOData() ? columns.ToODataFilterString<TItem>() : filterString,
-				Filters = columns.Where(c => c.Filterable && c.Visible && c.FilterValue != null).Select(c => new FilterDescriptor()
-				{
-					Property = c.GetFilterProperty(),
-					FilterValue = c.FilterValue,
-					FilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.FilterOperator]),
-					SecondFilterValue = c.SecondFilterValue,
-					SecondFilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.SecondFilterOperator]),
-					LogicalFilterOperator = c.LogicalFilterOperator
-				}),
-				Sorts = columns.Where(c => c.Sortable && c.Visible && (orderBy.Contains($"{c.GetSortProperty()} asc") || orderBy.Contains($"{c.GetSortProperty()} desc"))).Select(c => new SortDescriptor()
-				{
-					Property = c.GetSortProperty(),
-					SortOrder = orderBy.Contains($"{c.GetSortProperty()} asc") ? SortOrder.Ascending : SortOrder.Descending,
-				})
-			});
-		}
+        if (LoadData.HasDelegate)
+        {
+            await LoadData.InvokeAsync(new Radzen.LoadDataArgs()
+            {
+                Skip = skip,
+                Top = PageSize,
+                OrderBy = orderBy,
+                Filter = IsOData() ? columns.ToODataFilterString<TItem>() : filterString,
+                Filters = columns.Where(c => c.Filterable && c.Visible && c.FilterValue != null).Select(c => new FilterDescriptor()
+                {
+                    Property = c.GetFilterProperty(),
+                    FilterValue = c.FilterValue,
+                    FilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.FilterOperator]),
+                    SecondFilterValue = c.SecondFilterValue,
+                    SecondFilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.SecondFilterOperator]),
+                    LogicalFilterOperator = c.LogicalFilterOperator
+                }),
+                Sorts = columns.Where(c => c.Sortable && c.Visible && (orderBy.Contains($"{c.GetSortProperty()} asc") || orderBy.Contains($"{c.GetSortProperty()} desc"))).Select(c => new SortDescriptor()
+                {
+                    Property = c.GetSortProperty(),
+                    SortOrder = orderBy.Contains($"{c.GetSortProperty()} asc") ? SortOrder.Ascending : SortOrder.Descending,
+                })
+            });
+        }
 
-		CalculatePager();
+        CalculatePager();
 
-		if (!LoadData.HasDelegate)
-		{
-			StateHasChanged();
-		}
-	}
+        if (!LoadData.HasDelegate)
+        {
+            StateHasChanged();
+        }
+    }
 
     internal async Task ChangeState()
     {

--- a/Radzen.Blazor/RadzenGrid.razor
+++ b/Radzen.Blazor/RadzenGrid.razor
@@ -815,6 +815,21 @@
         var filterString = columns.ToFilterString<TItem>();
         Query.Filter = filterString;
 
+	    var filters = columns
+		    .Where(c => c.Filterable && c.Visible && c.FilterValue != null)
+		    .Select(c => new FilterDescriptor()
+		    {
+			    Property = c.GetFilterProperty(),
+			    FilterValue = c.FilterValue,
+			    FilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.FilterOperator]),
+			    SecondFilterValue = c.SecondFilterValue,
+			    SecondFilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.SecondFilterOperator]),
+			    LogicalFilterOperator = c.LogicalFilterOperator
+		    })
+		    .ToList();
+
+	    Query.Filters = filters;
+
         if (LoadData.HasDelegate)
         {
             await LoadData.InvokeAsync(new Radzen.LoadDataArgs()
@@ -823,15 +838,7 @@
                 Top = PageSize,
                 OrderBy = orderBy,
                 Filter = IsOData() ? columns.ToODataFilterString<TItem>() : filterString,
-                Filters = columns.Where(c => c.Filterable && c.Visible && c.FilterValue != null).Select(c => new FilterDescriptor()
-                {
-                    Property = c.GetFilterProperty(),
-                    FilterValue = c.FilterValue,
-                    FilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.FilterOperator]),
-                    SecondFilterValue = c.SecondFilterValue,
-                    SecondFilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.SecondFilterOperator]),
-                    LogicalFilterOperator = c.LogicalFilterOperator
-                }),
+                Filters = filters,
                 Sorts = columns.Where(c => c.Sortable && c.Visible && (orderBy.Contains($"{c.GetSortProperty()} asc") || orderBy.Contains($"{c.GetSortProperty()} desc"))).Select(c => new SortDescriptor()
                 {
                     Property = c.GetSortProperty(),

--- a/Radzen.Blazor/RadzenGrid.razor
+++ b/Radzen.Blazor/RadzenGrid.razor
@@ -799,61 +799,54 @@
         }
     }
 
-    public async override Task Reload()
-    {
-        _view = null;
+	public async override Task Reload()
+	{
+		_view = null;
 
-        if (Data != null && !LoadData.HasDelegate)
-        {
-            Count = View.Count();
-        }
+		if (Data != null && !LoadData.HasDelegate)
+		{
+			Count = View.Count();
+		}
 
-        Query.Skip = skip;
-        Query.Top = PageSize;
-        Query.OrderBy = orderBy;
+		Query.Skip = skip;
+		Query.Top = PageSize;
+		Query.OrderBy = orderBy;
 
-        var filterString = columns.ToFilterString<TItem>();
-        Query.Filter = filterString;
+		var filterString = columns.ToFilterString<TItem>();
+		Query.Filter = filterString;
 
-	    var filters = columns
-		    .Where(c => c.Filterable && c.Visible && c.FilterValue != null)
-		    .Select(c => new FilterDescriptor()
-		    {
-			    Property = c.GetFilterProperty(),
-			    FilterValue = c.FilterValue,
-			    FilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.FilterOperator]),
-			    SecondFilterValue = c.SecondFilterValue,
-			    SecondFilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.SecondFilterOperator]),
-			    LogicalFilterOperator = c.LogicalFilterOperator
-		    })
-		    .ToList();
+		if (LoadData.HasDelegate)
+		{
+			await LoadData.InvokeAsync(new Radzen.LoadDataArgs()
+			{
+				Skip = skip,
+				Top = PageSize,
+				OrderBy = orderBy,
+				Filter = IsOData() ? columns.ToODataFilterString<TItem>() : filterString,
+				Filters = columns.Where(c => c.Filterable && c.Visible && c.FilterValue != null).Select(c => new FilterDescriptor()
+				{
+					Property = c.GetFilterProperty(),
+					FilterValue = c.FilterValue,
+					FilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.FilterOperator]),
+					SecondFilterValue = c.SecondFilterValue,
+					SecondFilterOperator = (FilterOperator)Enum.Parse(typeof(FilterOperator), QueryableExtension.FilterOperators[c.SecondFilterOperator]),
+					LogicalFilterOperator = c.LogicalFilterOperator
+				}),
+				Sorts = columns.Where(c => c.Sortable && c.Visible && (orderBy.Contains($"{c.GetSortProperty()} asc") || orderBy.Contains($"{c.GetSortProperty()} desc"))).Select(c => new SortDescriptor()
+				{
+					Property = c.GetSortProperty(),
+					SortOrder = orderBy.Contains($"{c.GetSortProperty()} asc") ? SortOrder.Ascending : SortOrder.Descending,
+				})
+			});
+		}
 
-	    Query.Filters = filters;
+		CalculatePager();
 
-        if (LoadData.HasDelegate)
-        {
-            await LoadData.InvokeAsync(new Radzen.LoadDataArgs()
-            {
-                Skip = skip,
-                Top = PageSize,
-                OrderBy = orderBy,
-                Filter = IsOData() ? columns.ToODataFilterString<TItem>() : filterString,
-                Filters = filters,
-                Sorts = columns.Where(c => c.Sortable && c.Visible && (orderBy.Contains($"{c.GetSortProperty()} asc") || orderBy.Contains($"{c.GetSortProperty()} desc"))).Select(c => new SortDescriptor()
-                {
-                    Property = c.GetSortProperty(),
-                    SortOrder = orderBy.Contains($"{c.GetSortProperty()} asc") ? SortOrder.Ascending : SortOrder.Descending,
-                })
-            });
-        }
-
-        CalculatePager();
-
-        if (!LoadData.HasDelegate)
-        {
-            StateHasChanged();
-        }
-    }
+		if (!LoadData.HasDelegate)
+		{
+			StateHasChanged();
+		}
+	}
 
     internal async Task ChangeState()
     {


### PR DESCRIPTION
Added to get data `Filters` list Grid and DataGrid through Query.
Need for custom processing of `Filters` list Grid/DataGrid example during export.

![devenv_2023-10-02_17-14-32](https://github.com/radzenhq/radzen-blazor/assets/18440948/b8858684-2383-4d36-b1ad-f9ba7f6b7f82)

`object[] FilterParameters` has been removed due to not being used in the code. Maybe it's need returning?