### PR TITLE
Added FilterOperator.Custom check to GetColumnFilter.

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -387,6 +387,11 @@ namespace Radzen
 
             var columnFilterOperator = !second ? column.GetFilterOperator() : column.GetSecondFilterOperator();
 
+            if (columnFilterOperator == FilterOperator.Custom)
+            {
+                return "";
+            }
+
             var linqOperator = LinqFilterOperators[columnFilterOperator];
             if (linqOperator == null)
             {


### PR DESCRIPTION
Added FilterOperator.Custom check to GetColumnFilter.
With FilterOperator.Custom there is no need to generate a "filterString", otherwise it throws an error.