### PR TITLE
Added the ability to display smaller segmented pie charts

### DIFF
--- a/Radzen.Blazor/RadzenDonutSeries.razor
+++ b/Radzen.Blazor/RadzenDonutSeries.razor
@@ -37,19 +37,22 @@
         var radius = CurrentRadius;
         var innerRadius = InnerRadius ?? radius / 2;
 
+        double startAngle = StartAngle.HasValue ? (double)StartAngle - 90 : -90;
+        double totalAngle = TotalAngle.HasValue ? (double)TotalAngle : 360;
+        double endAngle = startAngle + totalAngle;
+
         return
         @<g>
             <g class="@className">
                 @if (PositiveItems.Any())
                 {
                     var sum = PositiveItems.Sum(Value);
-                    double startAngle = -90;
 
                     @foreach (var data in PositiveItems)
                     {
                         var value = Value(data);
-                        var angle = (value / sum) * 360;
-                        var endAngle = startAngle + angle;
+                        var angle = (value / sum) * totalAngle;
+                        endAngle = startAngle + angle;
 
                         var d = Segment(x, y, radius, innerRadius, startAngle, endAngle);
 
@@ -68,7 +71,7 @@
                 else
                 {
                     var arcClassName = $"rz-series-item-0";
-                    var d = Segment(x, y, radius, radius - 1, -90, 270);
+                    var d = Segment(x, y, radius, radius - 1, startAngle, endAngle);
                     var fill = PickColor(0, Fills);
                     var stroke = PickColor(0, Strokes);
                     <g class="@arcClassName">

--- a/Radzen.Blazor/RadzenDonutSeries.razor
+++ b/Radzen.Blazor/RadzenDonutSeries.razor
@@ -37,8 +37,8 @@
         var radius = CurrentRadius;
         var innerRadius = InnerRadius ?? radius / 2;
 
-        double startAngle = StartAngle.HasValue ? (double)StartAngle - 90 : -90;
-        double totalAngle = TotalAngle.HasValue ? (double)TotalAngle : 360;
+        double startAngle = StartAngle - 90;
+        double totalAngle = TotalAngle;
         double endAngle = startAngle + totalAngle;
 
         return

--- a/Radzen.Blazor/RadzenDonutSeries.razor
+++ b/Radzen.Blazor/RadzenDonutSeries.razor
@@ -36,23 +36,19 @@
         var y = CenterY;
         var radius = CurrentRadius;
         var innerRadius = InnerRadius ?? radius / 2;
-
-        double startAngle = StartAngle - 90;
-        double totalAngle = TotalAngle;
-        double endAngle = startAngle + totalAngle;
-
         return
         @<g>
             <g class="@className">
                 @if (PositiveItems.Any())
                 {
                     var sum = PositiveItems.Sum(Value);
+                    var startAngle = StartAngle;
 
                     @foreach (var data in PositiveItems)
                     {
                         var value = Value(data);
-                        var angle = (value / sum) * totalAngle;
-                        endAngle = startAngle + angle;
+                        var sweepAngle = (value / sum) * TotalAngle;
+                        var endAngle = startAngle - sweepAngle;
 
                         var d = Segment(x, y, radius, innerRadius, startAngle, endAngle);
 
@@ -71,7 +67,7 @@
                 else
                 {
                     var arcClassName = $"rz-series-item-0";
-                    var d = Segment(x, y, radius, radius - 1, startAngle, endAngle);
+                    var d = Segment(x, y, radius, radius - 1,  StartAngle, StartAngle - TotalAngle);
                     var fill = PickColor(0, Fills);
                     var stroke = PickColor(0, Strokes);
                     <g class="@arcClassName">

--- a/Radzen.Blazor/RadzenPieSeries.razor
+++ b/Radzen.Blazor/RadzenPieSeries.razor
@@ -16,19 +16,22 @@
         var y = CenterY;
         var radius = CurrentRadius;
 
+        double startAngle = StartAngle.HasValue ? (double)StartAngle - 90 : -90;
+        double totalAngle = TotalAngle.HasValue ? (double)TotalAngle : 360;
+        double endAngle = startAngle + totalAngle;
+
         return
         @<g class="@className">
             @if (PositiveItems.Any())
                 {
                     var sum = PositiveItems.Sum(Value);
 
-                    double startAngle = -90;
 
                 @foreach (var data in PositiveItems)
                     {
                         var value = Value(data);
-                        var angle = sum == 0 ? 0 : (value / sum) * 360;
-                        var endAngle = startAngle + angle;
+                        var angle = sum == 0 ? 0 : (value / sum) * totalAngle;
+                        endAngle = startAngle + angle;
 
                         var d = Segment(x, y, radius, 0, startAngle, endAngle);
 
@@ -50,7 +53,7 @@
                 else
                 {
                     var arcClassName = $"rz-series-item-0";
-                    var d = Segment(x, y, radius, radius - 1, -90, 270);
+                    var d = Segment(x, y, radius, radius - 1, startAngle, endAngle);
                     var fill = PickColor(0, Fills);
                     var stroke = PickColor(0, Strokes);
                     <g class="@arcClassName">

--- a/Radzen.Blazor/RadzenPieSeries.razor
+++ b/Radzen.Blazor/RadzenPieSeries.razor
@@ -16,22 +16,18 @@
         var y = CenterY;
         var radius = CurrentRadius;
 
-        double startAngle = StartAngle - 90;
-        double totalAngle = TotalAngle;
-        double endAngle = startAngle + totalAngle;
-
         return
         @<g class="@className">
             @if (PositiveItems.Any())
                 {
                     var sum = PositiveItems.Sum(Value);
-
+                    var startAngle = StartAngle;
 
                 @foreach (var data in PositiveItems)
                     {
                         var value = Value(data);
-                        var angle = sum == 0 ? 0 : (value / sum) * totalAngle;
-                        endAngle = startAngle + angle;
+                        var sweepAngle = sum == 0 ? 0 : (value / sum) * TotalAngle;
+                        var endAngle = startAngle - sweepAngle;
 
                         var d = Segment(x, y, radius, 0, startAngle, endAngle);
 
@@ -43,7 +39,7 @@
                         var stroke = PickColor(index, Strokes);
 
                         <g class="@arcClassName">
-                            @if (angle > 0)
+                            @if (sweepAngle > 0)
                             {
                                 <Path D="@d" Fill="@fill" StrokeWidth="@StrokeWidth" Stroke="@stroke" />
                             }
@@ -53,7 +49,7 @@
                 else
                 {
                     var arcClassName = $"rz-series-item-0";
-                    var d = Segment(x, y, radius, radius - 1, startAngle, endAngle);
+                    var d = Segment(x, y, radius, radius - 1, StartAngle, StartAngle - TotalAngle);
                     var fill = PickColor(0, Fills);
                     var stroke = PickColor(0, Strokes);
                     <g class="@arcClassName">

--- a/Radzen.Blazor/RadzenPieSeries.razor
+++ b/Radzen.Blazor/RadzenPieSeries.razor
@@ -16,8 +16,8 @@
         var y = CenterY;
         var radius = CurrentRadius;
 
-        double startAngle = StartAngle.HasValue ? (double)StartAngle - 90 : -90;
-        double totalAngle = TotalAngle.HasValue ? (double)TotalAngle : 360;
+        double startAngle = StartAngle - 90;
+        double totalAngle = TotalAngle;
         double endAngle = startAngle + totalAngle;
 
         return

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -321,9 +321,9 @@ namespace Radzen.Blazor
         /// <param name="endAngle">The end angle.</param>
         protected string Segment(double x, double y, double radius, double innerRadius, double startAngle, double endAngle)
         {
-            var largeArcFlag = endAngle - startAngle <= 180 ? 0 : 1;
+            var largeArcFlag = 0;
 
-            if (Math.Abs(endAngle - startAngle) >= 360)
+            if (Math.Abs(endAngle - startAngle) >= 180)
             {
                 endAngle += 0.01;
                 largeArcFlag = 1;

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -53,13 +53,15 @@ namespace Radzen.Blazor
         public double StrokeWidth { get; set; }
 
         /// <summary>
-        /// Gets or sets the start angle of the donut, defaults to 0.
+        /// Gets or sets the start angle from which segments are rendered (clockwise). Set to <c>90</c> by default.
+        /// Top is <c>90</c>, right is <c>0</c>, bottom is <c>270</c>, left is <c>180</c>.
         /// </summary>
         [Parameter]
-        public double StartAngle { get; set; } = 0;
+        public double StartAngle { get; set; } = 90;
 
         /// <summary>
-        /// Gets or sets the total angle of the donut, defaults to 360. 
+        /// Gets or sets the total angle of the pie in degrees. Set to <c>360</c> by default which renders a full circle.
+        /// Set to <c>180</c> to render a half circle or
         /// </summary>
         [Parameter]
         public double TotalAngle { get; set; } = 360;
@@ -191,28 +193,24 @@ namespace Radzen.Blazor
                 return (null, null);
             }
 
-            var angle = 90 - Math.Atan((CenterY - y) / (x - CenterX)) * 180 / Math.PI;
+            var angle = Math.Atan2(CenterY - y, x - CenterX) * 180 / Math.PI;
 
-            if (x < CenterX)
-            {
-                angle += 180;
-            }
+            // Normalize the angle to be within [0, 360)
+            angle = (angle + 360) % 360;
 
             var sum = Items.Sum(Value);
-            double startAngle = StartAngle;
-            double totalAngle = TotalAngle;
-            //handling charts with an end point > 360 degrees
-            if (angle < startAngle && //cursor angle "behind" the start point
-                (startAngle + totalAngle) > 360 && //end of the chart past 360 degrees
-                (angle + 360) < (startAngle + totalAngle))//updated cursor angle within the range of the chart
-                angle += 360;
+            var startAngle = StartAngle;
 
             foreach (var data in Items)
             {
                 var value = Value(data);
-                var endAngle = startAngle + (value / sum) * totalAngle;
+                var endAngle = startAngle - value / sum * TotalAngle; // assuming clockwise
 
-                if (startAngle <= angle && angle <= endAngle)
+                // Normalize the endAngle
+                endAngle = (endAngle + 360) % 360;
+
+                if ((startAngle >= endAngle && angle <= startAngle && angle >= endAngle) ||
+                    (startAngle <= endAngle && (angle <= startAngle || angle >= endAngle)))
                 {
                     return (data, new Point() { X = x, Y = y });
                 }
@@ -222,6 +220,7 @@ namespace Radzen.Blazor
 
             return (null, null);
         }
+
 
         /// <inheritdoc />
         protected override string TooltipClass(TItem item)
@@ -249,18 +248,18 @@ namespace Radzen.Blazor
             return style;
         }
 
-        /// <inheritdoc />
-        internal override double TooltipX(TItem item)
+        private double TooltipAngle(TItem item)
         {
             var sum = PositiveItems.Sum(Value);
-            double startAngle = StartAngle;
-            double totalAngle = TotalAngle;
-            double endAngle = 0;
+            var startAngle = StartAngle;
+            var endAngle = 0d;
 
             foreach (var data in PositiveItems)
             {
                 var value = Value(data);
-                endAngle = startAngle + (value / sum) * totalAngle;
+                var sweepAngle = value / sum * TotalAngle;
+
+                endAngle = startAngle - sweepAngle;
 
                 if (EqualityComparer<TItem>.Default.Equals(data, item))
                 {
@@ -270,35 +269,23 @@ namespace Radzen.Blazor
                 startAngle = endAngle;
             }
 
-            var angle = startAngle + (endAngle - startAngle) / 2;
+            return startAngle + (endAngle - startAngle) / 2;
+        }
 
-            return CenterX + CurrentRadius * Math.Cos(DegToRad(90 - angle));
+        /// <inheritdoc />
+        internal override double TooltipX(TItem item)
+        {
+            var angle = TooltipAngle(item);
+
+            return CenterX + CurrentRadius * Math.Cos(DegToRad(angle));
         }
 
         /// <inheritdoc />
         internal override double TooltipY(TItem item)
         {
-            var sum = PositiveItems.Sum(Value);
-            double startAngle = StartAngle;
-            double totalAngle = TotalAngle;
-            double endAngle = 0;
+            var angle = TooltipAngle(item);
 
-            foreach (var data in Items)
-            {
-                var value = Value(data);
-                endAngle = startAngle + (value / sum) * totalAngle;
-
-                if (EqualityComparer<TItem>.Default.Equals(data, item))
-                {
-                    break;
-                }
-
-                startAngle = endAngle;
-            }
-
-            var angle = startAngle + (endAngle - startAngle) / 2;
-
-            return CenterY - CurrentRadius * Math.Sin(DegToRad(90 - angle));
+            return CenterY - CurrentRadius * Math.Sin(DegToRad(angle));
         }
 
         /// <summary>
@@ -306,9 +293,7 @@ namespace Radzen.Blazor
         /// </summary>
         protected double DegToRad(double degrees)
         {
-            var radians = (degrees) * Math.PI / 180;
-
-            return radians;
+            return degrees * Math.PI / 180;
         }
 
         /// <summary>
@@ -320,9 +305,9 @@ namespace Radzen.Blazor
         /// <param name="degrees">The degrees.</param>
         protected (double X, double Y) ToCartesian(double x, double y, double radius, double degrees)
         {
-            var radians = (degrees) * Math.PI / 180;
+            var radians = DegToRad(degrees);
 
-            return (x + radius * Math.Cos(radians), y + radius * Math.Sin(radians));
+            return (x + radius * Math.Cos(radians), y - radius * Math.Sin(radians));
         }
 
         /// <summary>
@@ -336,11 +321,12 @@ namespace Radzen.Blazor
         /// <param name="endAngle">The end angle.</param>
         protected string Segment(double x, double y, double radius, double innerRadius, double startAngle, double endAngle)
         {
-            //if its a single full segment set start angle to 180 to stop rendering off center
-            if (endAngle - startAngle == 360)
+            var largeArcFlag = endAngle - startAngle <= 180 ? 0 : 1;
+
+            if (Math.Abs(endAngle - startAngle) >= 360)
             {
-                startAngle = 180;
-                endAngle = 540;
+                endAngle += 0.01;
+                largeArcFlag = 1;
             }
 
             var start = ToCartesian(x, y, radius, startAngle);
@@ -349,7 +335,6 @@ namespace Radzen.Blazor
             var innerStart = ToCartesian(x, y, innerRadius, startAngle);
             var innerEnd = ToCartesian(x, y, innerRadius, endAngle);
 
-            var largeArcFlag = endAngle - startAngle <= 180 ? 0 : 1;
             var startX = start.X.ToInvariantString();
             var startY = start.Y.ToInvariantString();
             var endX = end.X.ToInvariantString();
@@ -361,14 +346,6 @@ namespace Radzen.Blazor
             var innerEndY = innerEnd.Y.ToInvariantString();
             var innerR = innerRadius.ToInvariantString();
 
-            if (Math.Abs(end.X - start.X) < 0.01 && Math.Abs(end.Y - start.Y) < 0.01)
-            {
-                // Full circle - SVG can't render a full circle arc
-                endX = (end.X - 0.01).ToInvariantString();
-
-                innerEndX = (innerEnd.X - 0.01).ToInvariantString();
-            }
-
             return $"M {startX} {startY} A {r} {r} 0 {largeArcFlag} 1 {endX} {endY} L {innerEndX} {innerEndY} A {innerR} {innerR} 0 {largeArcFlag} 0 {innerStartX} {innerStartY} Z";
         }
 
@@ -379,8 +356,6 @@ namespace Radzen.Blazor
 
             if(Data != null)
             {
-                //var DataGreaterZero = Data.Where(e => Value(e) > 0).ToList();
-
                 foreach (var d in PositiveItems)
                 {
                     var x = TooltipX(d) - CenterX;

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -56,13 +56,13 @@ namespace Radzen.Blazor
         /// Gets or sets the start angle of the donut, defaults to -90.
         /// </summary>
         [Parameter]
-        public double? StartAngle { get; set; }
+        public double StartAngle { get; set; } = 0;
 
         /// <summary>
         /// Gets or sets the total angle of the donut, defaults to 360. 
         /// </summary>
         [Parameter]
-        public double? TotalAngle { get; set; }
+        public double TotalAngle { get; set; } = 360;
 
         /// <summary>
         /// Returns the current radius - either a specified <see cref="Radius" /> or automatically calculated one.
@@ -199,8 +199,8 @@ namespace Radzen.Blazor
             }
 
             var sum = Items.Sum(Value);
-            double startAngle = StartAngle.HasValue ? (double)StartAngle : 0;
-            double totalAngle = TotalAngle.HasValue ? (double)TotalAngle : 360;
+            double startAngle = StartAngle;
+            double totalAngle = TotalAngle;
             //handling charts with an end point > 360 degrees
             if (angle < startAngle && //cursor angle "behind" the start point
                 (startAngle + totalAngle) > 360 && //end of the chart past 360 degrees
@@ -253,8 +253,8 @@ namespace Radzen.Blazor
         internal override double TooltipX(TItem item)
         {
             var sum = PositiveItems.Sum(Value);
-            double startAngle = StartAngle.HasValue ? (double)StartAngle : 0;
-            double totalAngle = TotalAngle.HasValue ? (double)TotalAngle : 360;
+            double startAngle = StartAngle;
+            double totalAngle = TotalAngle;
             double endAngle = 0;
 
             foreach (var data in PositiveItems)
@@ -279,8 +279,8 @@ namespace Radzen.Blazor
         internal override double TooltipY(TItem item)
         {
             var sum = PositiveItems.Sum(Value);
-            double startAngle = StartAngle.HasValue ? (double)StartAngle : 0;
-            double totalAngle = TotalAngle.HasValue ? (double)TotalAngle : 360;
+            double startAngle = StartAngle;
+            double totalAngle = TotalAngle;
             double endAngle = 0;
 
             foreach (var data in Items)

--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -53,7 +53,7 @@ namespace Radzen.Blazor
         public double StrokeWidth { get; set; }
 
         /// <summary>
-        /// Gets or sets the start angle of the donut, defaults to -90.
+        /// Gets or sets the start angle of the donut, defaults to 0.
         /// </summary>
         [Parameter]
         public double StartAngle { get; set; } = 0;

--- a/RadzenBlazorDemos/Pages/DonutChartConfig.razor
+++ b/RadzenBlazorDemos/Pages/DonutChartConfig.razor
@@ -7,13 +7,13 @@
                 <RadzenLabel Text="Show Data Labels" For="dataLabels" Style="margin-left: 8px; vertical-align: middle;" />
             </RadzenCard>
             <RadzenChart>
-                <RadzenDonutSeries Data="@revenue" CategoryProperty="Quarter" ValueProperty="Revenue">
+                <RadzenDonutSeries Data="@revenue" CategoryProperty="Quarter" ValueProperty="Revenue" TotalAngle="180" StartAngle="180">
                     <ChildContent>
                         <RadzenSeriesDataLabels Visible="@showDataLabels" />
                     </ChildContent>
                     <TitleTemplate>
                         <div class="rz-donut-content">
-                            <div>Revenue</div> 
+                            <div>Revenue</div>
                             <div>for 2020</div>
                         </div>
                     </TitleTemplate>

--- a/RadzenBlazorDemos/Pages/PieChartConfig.razor
+++ b/RadzenBlazorDemos/Pages/PieChartConfig.razor
@@ -6,17 +6,7 @@
                 <RadzenLabel Text="Show Data Labels" For="dataLabels" Style="margin-left: 8px; vertical-align: middle;" />
             </RadzenCard>
             <RadzenChart SeriesClick=@OnSeriesClick>
-                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue" StartAngle="90">
-                    <RadzenSeriesDataLabels Visible="@showDataLabels" />
-                </RadzenPieSeries>
-            </RadzenChart>
-            <RadzenChart SeriesClick=@OnSeriesClick>
-                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue" TotalAngle="180" StartAngle="180">
-                    <RadzenSeriesDataLabels Visible="@showDataLabels" />
-                </RadzenPieSeries>
-            </RadzenChart>
-            <RadzenChart SeriesClick=@OnSeriesClick>
-                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue" StartAngle="0">
+                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue">
                     <RadzenSeriesDataLabels Visible="@showDataLabels" />
                 </RadzenPieSeries>
             </RadzenChart>
@@ -42,7 +32,6 @@
     }
 
     DataItem[] revenue = new DataItem[] {
-        /*
         new DataItem
         {
             Quarter = "Q1",
@@ -51,7 +40,7 @@
         new DataItem
         {
             Quarter = "Q2",
-            Revenue = 400
+            Revenue = 40000
         },
         new DataItem
         {
@@ -63,6 +52,5 @@
             Quarter = "Q4",
             Revenue = 80000
         },
-        */
     };
 }

--- a/RadzenBlazorDemos/Pages/PieChartConfig.razor
+++ b/RadzenBlazorDemos/Pages/PieChartConfig.razor
@@ -6,7 +6,17 @@
                 <RadzenLabel Text="Show Data Labels" For="dataLabels" Style="margin-left: 8px; vertical-align: middle;" />
             </RadzenCard>
             <RadzenChart SeriesClick=@OnSeriesClick>
-                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue">
+                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue" StartAngle="90">
+                    <RadzenSeriesDataLabels Visible="@showDataLabels" />
+                </RadzenPieSeries>
+            </RadzenChart>
+            <RadzenChart SeriesClick=@OnSeriesClick>
+                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue" TotalAngle="180" StartAngle="180">
+                    <RadzenSeriesDataLabels Visible="@showDataLabels" />
+                </RadzenPieSeries>
+            </RadzenChart>
+            <RadzenChart SeriesClick=@OnSeriesClick>
+                <RadzenPieSeries Data="@revenue" Title="Revenue" CategoryProperty="Quarter" ValueProperty="Revenue" StartAngle="0">
                     <RadzenSeriesDataLabels Visible="@showDataLabels" />
                 </RadzenPieSeries>
             </RadzenChart>
@@ -32,6 +42,7 @@
     }
 
     DataItem[] revenue = new DataItem[] {
+        /*
         new DataItem
         {
             Quarter = "Q1",
@@ -40,7 +51,7 @@
         new DataItem
         {
             Quarter = "Q2",
-            Revenue = 40000
+            Revenue = 400
         },
         new DataItem
         {
@@ -52,5 +63,6 @@
             Quarter = "Q4",
             Revenue = 80000
         },
+        */
     };
 }


### PR DESCRIPTION
Added the ability to control the starting point and the size of the span for both Pie and Donut charts, functionality that could be useful for people wanting charts that don't span a full 360 degrees.

Tested across a full range of values for both the starting location and the size of the span, including checking the functionality of both the mouseover tooltip and the SeriesClick event of the chart

Screenshots:
![image](https://github.com/radzenhq/radzen-blazor/assets/147621771/c165d7b0-73a5-4ca7-829d-ca07a4f4efe7)
![image](https://github.com/radzenhq/radzen-blazor/assets/147621771/7638da10-da99-4a7e-b8c3-965d536da048)
![image](https://github.com/radzenhq/radzen-blazor/assets/147621771/d4f25c53-5930-49fc-81ff-f9d2e4c4bf6e)
