### PR TITLE
Fix-set-filterOperator-in-DataFilter

### DIFF
--- a/Radzen.Blazor/RadzenDataFilterItem.razor
+++ b/Radzen.Blazor/RadzenDataFilterItem.razor
@@ -148,7 +148,19 @@ else
         Filter.FilterValue = null;
 
         var defaultOperator = typeof(System.Collections.IEnumerable).IsAssignableFrom(property.FilterPropertyType) ? FilterOperator.Contains : default(FilterOperator);
-        Filter.FilterOperator = property.GetFilterOperators().Contains(defaultOperator) ? defaultOperator : property.GetFilterOperators().FirstOrDefault();
+	    
+	    if (property.GetFilterOperators().Any(o => o == property.FilterOperator))
+	    {
+		    Filter.FilterOperator = property.FilterOperator;
+	    }
+	    else if (property.GetFilterOperators().Contains(defaultOperator))
+	    {
+		    Filter.FilterOperator = defaultOperator;
+	    }
+	    else
+	    {
+		    Filter.FilterOperator = property.GetFilterOperators().FirstOrDefault();
+	    }
 
         await ApplyFilter();
     }


### PR DESCRIPTION
Set the filter operator specified in the code when adding a filter in DataFilter.

Before:

https://github.com/radzenhq/radzen-blazor/assets/18440948/d3b0a66c-fc7d-43ac-84ed-5f70fa569e77

After:

https://github.com/radzenhq/radzen-blazor/assets/18440948/14222817-8c36-42d5-b91c-0dc1fc91ffde

