### PR TITLE
partial validation is supported

### DIFF
--- a/Radzen.Blazor/RadzenStepsItem.cs
+++ b/Radzen.Blazor/RadzenStepsItem.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Radzen.Blazor
@@ -41,6 +43,12 @@ namespace Radzen.Blazor
         /// </summary>
         [Parameter]
         public string PreviousText { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets validation field names which must be valid in this step
+        /// </summary>
+        [Parameter]
+        public IEnumerable<string> ValidationFieldNames { get; set; }
 
         /// <summary>
         /// Gets or sets the template.

--- a/RadzenBlazorDemos/Models/UserInput.cs
+++ b/RadzenBlazorDemos/Models/UserInput.cs
@@ -1,0 +1,8 @@
+﻿namespace RadzenBlazorDemos.Models;
+
+public class UserInput
+{
+    public string FirstName { get; set; } = null;
+    public string Surename { get; set; } = null;
+    public string Email { get; set; }
+}

--- a/RadzenBlazorDemos/Pages/StepsPage.razor
+++ b/RadzenBlazorDemos/Pages/StepsPage.razor
@@ -10,3 +10,14 @@
 <RadzenExample ComponentName="Steps" Example="StepsConfig">
     <StepsConfig />
 </RadzenExample>
+
+<RadzenText TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
+    Allow partial validaton in Radzen Steps
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    With property ValidationFieldNames you can set which properties of the model must be valid in current steps to continue.
+</RadzenText>
+
+<RadzenExample ComponentName="StepsPartialValidation" Example="StepsPartialValidation">
+    <StepsPartialValidation />
+</RadzenExample>

--- a/RadzenBlazorDemos/Pages/StepsPartialValidation.razor
+++ b/RadzenBlazorDemos/Pages/StepsPartialValidation.razor
@@ -1,0 +1,32 @@
+﻿@using RadzenBlazorDemos.Models;
+
+<RadzenTemplateForm TItem="UserInput" Data="@_userInput" >
+    <RadzenSteps>
+        <Steps>
+            <RadzenStepsItem ValidationFieldNames="@(new List<string>() { nameof(UserInput.FirstName), nameof(UserInput.Surename) })">
+                <RadzenText Text="Enter User Name!" />
+                <RadzenRow>
+                    <RadzenTextBox Name="FirstName" Placeholder="First name" @bind-Value="@_userInput.FirstName"/>
+                    <RadzenRequiredValidator Component="FirstName" Text="First name is required"/>
+                </RadzenRow>
+                <RadzenRow>
+                    <RadzenTextBox Name="Surname" Placeholder="Surname" @bind-Value="@_userInput.Surename" />
+                    <RadzenRequiredValidator Component="Surname" Text="Surname is required"/>
+                </RadzenRow>
+            </RadzenStepsItem>
+            <RadzenStepsItem>
+                <RadzenText Text="Enter Email Address" />
+                <RadzenRow>
+                    <RadzenTextBox Name="EmailAddress" Placeholder="Email address" @bind-Value="@_userInput.Email" />
+                    <RadzenRequiredValidator Component="EmailAddress" Text="Email address is required"/>
+                </RadzenRow>
+                <RadzenButton Icon="save" Text="Save" />
+            </RadzenStepsItem>
+        </Steps>
+    </RadzenSteps>
+
+</RadzenTemplateForm>
+
+@code {
+    public UserInput _userInput = new();
+}


### PR DESCRIPTION
Before that, RadzenStep could not be moved to next if Validation failed. This feature allows to validate only part of model in each step.

Limitations - Model is still validated and if the user moves to the next step, he will see validation messages. It would be nice to improve in the future somehow.