### PR TITLE
Fix-loading-datagrid-filter-settings-with-quotes

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3215,7 +3215,7 @@ namespace Radzen.Blazor
                     }
                     else
                     {
-                        return element.GetRawText().Replace("\"", "");
+                        return element.GetString();
                     }
                 }
             }


### PR DESCRIPTION
Fixed loading DataGrid filter settings with quotes. When loading the filter value from json, get the string value of the element.

Not sure why use `.GetRawText().Replace("\"", "");` but most likely after fix https://github.com/radzenhq/radzen-blazor/pull/1051 this is not necessary.


Before:

https://github.com/radzenhq/radzen-blazor/assets/18440948/9bebbcfb-081d-453a-a991-6678496cd5c1

After:

https://github.com/radzenhq/radzen-blazor/assets/18440948/edc8d3ff-856e-4124-96f8-8e6dc1815504


