### PR TITLE
Add EmptyTemplate to RadzenDropdown

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -143,7 +143,7 @@
                 </div>
             }
             <div class="@(Multiple ? "rz-multiselect-items-wrapper" : "rz-dropdown-items-wrapper")" style="@PopupStyle">
-                @if (Count > 0)
+                @if (Data.Cast<object>().Any() && (!IsVirtualizationAllowed() || Data.Cast<object>().Any()) || LoadData.HasDelegate && Data != null && Data.Cast<object>().Any())
                 {
                     <ul @ref="list" class="@(Multiple ? "rz-multiselect-items rz-multiselect-list" : "rz-dropdown-items rz-dropdown-list")" role="listbox">
                         @if (View != null)

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -143,12 +143,19 @@
                 </div>
             }
             <div class="@(Multiple ? "rz-multiselect-items-wrapper" : "rz-dropdown-items-wrapper")" style="@PopupStyle">
-                <ul @ref="list" class="@(Multiple ? "rz-multiselect-items rz-multiselect-list" : "rz-dropdown-items rz-dropdown-list")" role="listbox">
-                    @if (View != null)
-                    {
-                        @RenderItems()
-                    }
-                </ul>
+                @if (Count > 0)
+                {
+                    <ul @ref="list" class="@(Multiple ? "rz-multiselect-items rz-multiselect-list" : "rz-dropdown-items rz-dropdown-list")" role="listbox">
+                        @if (View != null)
+                        {
+                            @RenderItems()
+                        }
+                    </ul>   
+                }
+                else
+                {
+                    @EmptyTemplate
+                }
             </div>
         </div>
         @if (AllowClear && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -143,7 +143,7 @@
                 </div>
             }
             <div class="@(Multiple ? "rz-multiselect-items-wrapper" : "rz-dropdown-items-wrapper")" style="@PopupStyle">
-                @if (Data.Cast<object>().Any() && (!IsVirtualizationAllowed() || Data.Cast<object>().Any()) || LoadData.HasDelegate && Data != null && Data.Cast<object>().Any())
+                @if (Data != null && Data.Cast<object>().Any())
                 {
                     <ul @ref="list" class="@(Multiple ? "rz-multiselect-items rz-multiselect-list" : "rz-dropdown-items rz-dropdown-list")" role="listbox">
                         @if (View != null)

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -31,6 +31,13 @@ namespace Radzen.Blazor
         /// <value>The value template.</value>
         [Parameter]
         public RenderFragment<dynamic> ValueTemplate { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the empty template.
+        /// </summary>
+        /// <value>The empty template.</value>
+        [Parameter]
+        public RenderFragment EmptyTemplate { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether popup should open on focus. Set to <c>false</c> by default.


### PR DESCRIPTION
### Resume
- Update RadzenDropdown to add the EmptyTemplate option when DataCount is equals zero.

### Evidence
> Not required

### Reference
> Add EmptyTemplate to RadzenDropDown #1181