### PR TITLE
Right side frozen columns for RadzenDataGrid

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -3308,9 +3308,18 @@ namespace Radzen
         IconAndText
     }
 
-    public enum FrozenPosition
+    /// <summary>
+    /// Frozen Column Position enum
+    /// </summary>
+    public enum FrozenColumnPosition
     {
+        /// <summary>
+        /// Freeze column to the left
+        /// </summary>
         Left,
+        /// <summary>
+        /// Freeze column to the right
+        /// </summary>
         Right
     }
 }

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -3307,4 +3307,10 @@ namespace Radzen
         /// </summary>
         IconAndText
     }
+
+    public enum FrozenPosition
+    {
+        Left,
+        Right
+    }
 }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -325,7 +325,52 @@ namespace Radzen.Blazor
 
         internal string getFrozenColumnClass(RadzenDataGridColumn<TItem> column, IList<RadzenDataGridColumn<TItem>> visibleColumns)
         {
-            return column.IsFrozen() ? (column.FrozenPosition == FrozenPosition.Left ? "rz-frozen-cell rz-frozen-cell-left" : "rz-frozen-cell rz-frozen-cell-right") : "";
+            if(!column.IsFrozen())
+            {
+                return "";
+            }
+
+            if(column.FrozenPosition == FrozenPosition.Left)
+            {
+                for(var i=0; i<ColumnsCollection.Count; i++)
+                {
+                    if (ColumnsCollection[i] == column)
+                    {
+                        if (i + 1 < ColumnsCollection.Count && (!ColumnsCollection[i + 1].IsFrozen() || ColumnsCollection[i + 1].FrozenPosition == FrozenPosition.Right))
+                        {
+                            return "rz-frozen-cell rz-frozen-cell-left rz-frozen-cell-left-end";
+                        }
+                        else
+                        {
+                            return "rz-frozen-cell rz-frozen-cell-left";
+                        }
+                    }
+                    if(!ColumnsCollection[i].IsFrozen())
+                    {
+                        break;
+                    }
+                }
+                return "rz-frozen-cell rz-frozen-cell-left-inner";
+            }
+            for (var i = ColumnsCollection.Count-1; i >=0; i--)
+            {
+                if (ColumnsCollection[i] == column)
+                {
+                    if (i - 1 >=0 && (!ColumnsCollection[i-1].IsFrozen() || ColumnsCollection[i-1].FrozenPosition == FrozenPosition.Left))
+                    {
+                        return "rz-frozen-cell rz-frozen-cell-right rz-frozen-cell-right-end";
+                    }
+                    else
+                    {
+                        return "rz-frozen-cell rz-frozen-cell-right";
+                    }
+                }
+                if (!ColumnsCollection[i].IsFrozen())
+                {
+                    break;
+                }
+            }
+            return "rz-frozen-cell rz-frozen-cell-right-inner";
         }
 
         internal string getColumnAlignClass(RadzenDataGridColumn<TItem> column)

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -325,7 +325,7 @@ namespace Radzen.Blazor
 
         internal string getFrozenColumnClass(RadzenDataGridColumn<TItem> column, IList<RadzenDataGridColumn<TItem>> visibleColumns)
         {
-            return column.IsFrozen() ? "rz-frozen-cell" : "";
+            return column.IsFrozen() ? (column.FrozenPosition == FrozenPosition.Left ? "rz-frozen-cell rz-frozen-cell-left" : "rz-frozen-cell rz-frozen-cell-right") : "";
         }
 
         internal string getColumnAlignClass(RadzenDataGridColumn<TItem> column)

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -325,18 +325,37 @@ namespace Radzen.Blazor
 
         internal string getFrozenColumnClass(RadzenDataGridColumn<TItem> column, IList<RadzenDataGridColumn<TItem>> visibleColumns)
         {
-            if(!column.IsFrozen())
+            if (!column.IsFrozen())
             {
                 return "";
             }
 
-            if(column.FrozenPosition == FrozenPosition.Left)
+            // Frozen columns are grouped to:
+            // - left frozen columns: all of the frozen columns marked by FrozenColumnPosition.Left from left till the first not frozen column
+            // - left inner frozen columns: any frozen column marked by FrozenColumnPosition.Left which are not "left frozen columns"
+            // - right frozen columns: all of the frozen columns marked by FrozenColumnPosition.Right from right till the first not frozen column
+            // - right inner frozen columns: any frozen column marked by FrozenColumnPosition.Right which are not "right frozen columns"
+
+            // According to https://github.com/w3c/csswg-drafts/issues/1656 stucked columns cannot be detected by pseudo classes, so the stucked state had to be managed somehow.
+
+            // A good solution for the problem, might be:
+            // https://stackoverflow.com/questions/25308823/targeting-positionsticky-elements-that-are-currently-in-a-stuck-state
+            // https://codepen.io/TomAnthony/pen/qBqgErK
+            // It seemed too complicated, so left + right frozen columns problme has been solved by following css classes:
+            // - rz-frozen-cell-left            all of the "left frozen columns" get this class 
+            // - rz-frozen-cell-left-end        the most right column of the "left frozen columns" get this class to draw the shadow for it
+            // - rz-frozen-cell-left-inner      all of the "left inner frozen columns" get this class
+            // - rz-frozen-cell-right           all of the "right frozen columns" get this class
+            // - rz-frozen-cell-right-end       the most left column of the "right frozen columns" get this class to draw the shadow for it
+            // - rz-frozen-cell-right-inner     all of the "right inner frozen columns" get this class
+
+            if (column.FrozenPosition == FrozenColumnPosition.Left)
             {
                 for(var i=0; i<ColumnsCollection.Count; i++)
                 {
                     if (ColumnsCollection[i] == column)
                     {
-                        if (i + 1 < ColumnsCollection.Count && (!ColumnsCollection[i + 1].IsFrozen() || ColumnsCollection[i + 1].FrozenPosition == FrozenPosition.Right))
+                        if (i + 1 < ColumnsCollection.Count && (!ColumnsCollection[i + 1].IsFrozen() || ColumnsCollection[i + 1].FrozenPosition == FrozenColumnPosition.Right))
                         {
                             return "rz-frozen-cell rz-frozen-cell-left rz-frozen-cell-left-end";
                         }
@@ -352,11 +371,12 @@ namespace Radzen.Blazor
                 }
                 return "rz-frozen-cell rz-frozen-cell-left-inner";
             }
+
             for (var i = ColumnsCollection.Count-1; i >=0; i--)
             {
                 if (ColumnsCollection[i] == column)
                 {
-                    if (i - 1 >=0 && (!ColumnsCollection[i-1].IsFrozen() || ColumnsCollection[i-1].FrozenPosition == FrozenPosition.Left))
+                    if (i - 1 >=0 && (!ColumnsCollection[i-1].IsFrozen() || ColumnsCollection[i-1].FrozenPosition == FrozenColumnPosition.Left))
                     {
                         return "rz-frozen-cell rz-frozen-cell-right rz-frozen-cell-right-end";
                     }

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -581,6 +581,10 @@ namespace Radzen.Blazor
             return string.Join(";", style);
         }
 
+        // https://stackoverflow.com/questions/25308823/targeting-positionsticky-elements-that-are-currently-in-a-stuck-state
+        // https://codepen.io/TomAnthony/pen/qBqgErK
+        // https://github.com/w3c/csswg-drafts/issues/1656
+
         private string GetStackedStyleForFrozen()
         {
             var visibleFrozenColumns = Grid.ColumnsCollection.Where(c => c.GetVisible() && c.IsFrozen() && c.FrozenPosition == FrozenPosition).ToList();

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -395,6 +395,9 @@ namespace Radzen.Blazor
         [Parameter]
         public bool Frozen { get; set; }
 
+        [Parameter]
+        public FrozenPosition FrozenPosition { get; set; } = FrozenPosition.Left;
+
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="RadzenDataGridColumn{TItem}"/> is resizable.
         /// </summary>
@@ -580,12 +583,26 @@ namespace Radzen.Blazor
 
         private string GetStackedStyleForFrozen()
         {
-            var visibleFrozenColumns = Grid.ColumnsCollection.Where(c => c.GetVisible() && c.IsFrozen()).ToList();
-            var stackColumns = visibleFrozenColumns.Where((c, i) => visibleFrozenColumns.IndexOf(this) > i);
+            var visibleFrozenColumns = Grid.ColumnsCollection.Where(c => c.GetVisible() && c.IsFrozen() && c.FrozenPosition == FrozenPosition).ToList();
+            if (FrozenPosition == FrozenPosition.Left)
+            {
+                var stackColumns = visibleFrozenColumns.Where((c, i) => visibleFrozenColumns.IndexOf(this) > i);
 
+                return GetStackedStyleForFrozen(stackColumns, "left");
+            }
+            else
+            {
+                var stackColumns = visibleFrozenColumns.Where((c, i) => visibleFrozenColumns.IndexOf(this) < i);
+
+                return GetStackedStyleForFrozen(stackColumns, "right");
+            }
+        }
+
+        private static string GetStackedStyleForFrozen(IEnumerable<RadzenDataGridColumn<TItem>> stackColumns, string position)
+        {
             if (!stackColumns.Any())
             {
-                return "left:0";
+                return $"{position}:0";
             }
 
             var widths = new List<string>();
@@ -611,10 +628,10 @@ namespace Radzen.Blazor
 
             if (widths.Count == 1)
             {
-                return $"left:{widths.First()}";
+                return $"{position}:{widths.First()}";
             }
 
-            return $"left:calc({string.Join(" + ", widths)})";
+            return $"{position}:calc({string.Join(" + ", widths)})";
         }
 
         internal bool IsFrozen()

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -395,6 +395,10 @@ namespace Radzen.Blazor
         [Parameter]
         public bool Frozen { get; set; }
 
+        /// <summary>
+        /// Gets or sets the frozen position this <see cref="RadzenDataGridColumn{TItem}"/>
+        /// </summary>
+        /// <value><see cref="FrozenColumnPosition.Left"/> or <see cref="FrozenColumnPosition.Right"/>.</value>
         [Parameter]
         public FrozenColumnPosition FrozenPosition { get; set; } = FrozenColumnPosition.Left;
 
@@ -580,10 +584,6 @@ namespace Radzen.Blazor
 
             return string.Join(";", style);
         }
-
-        // https://stackoverflow.com/questions/25308823/targeting-positionsticky-elements-that-are-currently-in-a-stuck-state
-        // https://codepen.io/TomAnthony/pen/qBqgErK
-        // https://github.com/w3c/csswg-drafts/issues/1656
 
         private string GetStackedStyleForFrozen()
         {

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -396,7 +396,7 @@ namespace Radzen.Blazor
         public bool Frozen { get; set; }
 
         [Parameter]
-        public FrozenPosition FrozenPosition { get; set; } = FrozenPosition.Left;
+        public FrozenColumnPosition FrozenPosition { get; set; } = FrozenColumnPosition.Left;
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="RadzenDataGridColumn{TItem}"/> is resizable.
@@ -588,7 +588,7 @@ namespace Radzen.Blazor
         private string GetStackedStyleForFrozen()
         {
             var visibleFrozenColumns = Grid.ColumnsCollection.Where(c => c.GetVisible() && c.IsFrozen() && c.FrozenPosition == FrozenPosition).ToList();
-            if (FrozenPosition == FrozenPosition.Left)
+            if (FrozenPosition == FrozenColumnPosition.Left)
             {
                 var stackColumns = visibleFrozenColumns.Where((c, i) => visibleFrozenColumns.IndexOf(this) > i);
 

--- a/Radzen.Blazor/themes/components/blazor/_grid.scss
+++ b/Radzen.Blazor/themes/components/blazor/_grid.scss
@@ -117,7 +117,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
   --rz-grid-cell-color: #{$grid-cell-color};
   --rz-grid-cell-font-size: #{$grid-cell-font-size};
   --rz-grid-cell-line-height: #{$grid-cell-line-height};
-
+ 
   --rz-grid-hover-background-color: #{$grid-hover-background-color};
   --rz-grid-hover-color: #{$grid-hover-color};
 
@@ -139,10 +139,10 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
   --rz-grid-header-title-padding: #{$grid-header-title-padding};
   --rz-grid-header-sorted-background-color: #{$grid-header-sorted-background-color};
   --rz-grid-header-padding: #{$grid-header-padding};
-
+  
   --rz-grid-foot-cell-color: #{$grid-foot-cell-color};
   --rz-grid-foot-background-color: #{$grid-foot-background-color};
-
+  
   --rz-grid-filter-background-color: #{$grid-filter-background-color};
   --rz-grid-filter-padding: #{$grid-filter-padding};
   --rz-grid-filter-margin: #{$grid-filter-margin};
@@ -152,57 +152,57 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
   --rz-grid-filter-icon-height: #{$grid-filter-icon-height};
   --rz-grid-filter-icon-margin: #{$grid-filter-icon-margin};
   --rz-grid-filter-icon-font-size: #{$grid-filter-icon-font-size};
-
+  
   --rz-grid-filter-color: #{$grid-filter-color};
   --rz-grid-filter-focus-color: #{$grid-filter-focus-color};
   --rz-grid-filter-gap: #{$grid-filter-gap};
   --rz-grid-filter-buttons-padding: #{$grid-filter-buttons-padding};
   --rz-grid-filter-buttons-border: #{$grid-filter-buttons-border};
   --rz-grid-filter-buttons-background-color: #{$grid-filter-buttons-background-color};
-
+  
   --rz-grid-clear-filter-button-background-color: #{$grid-clear-filter-button-background-color};
   --rz-grid-clear-filter-button-color: #{$grid-clear-filter-button-color};
   --rz-grid-clear-filter-button-shadow: #{$grid-clear-filter-button-shadow};
   --rz-grid-apply-filter-button-background-color: #{$grid-apply-filter-button-background-color};
   --rz-grid-apply-filter-button-color: #{$grid-apply-filter-button-color};
   --rz-grid-apply-filter-button-shadow: #{$grid-apply-filter-button-shadow};
-
-
+ 
+  
   --rz-grid-header-filter-icon-margin: #{$grid-header-filter-icon-margin};
   --rz-grid-header-filter-icon-hover-color: #{$grid-header-filter-icon-hover-color};
   --rz-grid-header-filter-icon-active-color: #{$grid-header-filter-icon-active-color};
   --rz-grid-header-filter-icon-font-size: #{$grid-header-filter-icon-font-size};
-
+  
   --rz-grid-border: #{$grid-border};
   --rz-grid-border-radius: #{$grid-border-radius};
-
+  
   --rz-grid-sort-icon-width: #{$grid-sort-icon-width};
   --rz-grid-sort-icon-height: #{$grid-sort-icon-height};
   --rz-grid-sort-icon-color: #{$grid-sort-icon-color};
-
+  
   --rz-grid-shadow: #{$grid-shadow};
   --rz-grid-background-color: #{$grid-background-color};
-
+  
   --rz-grid-column-resizer-width: #{$grid-column-resizer-width};
   --rz-grid-column-resizer-helper-width: #{$grid-column-resizer-helper-width};
   --rz-grid-column-resizer-helper-background-color: #{$grid-column-resizer-helper-background-color};
-
+  
   --rz-grid-column-icon-width: #{$grid-column-icon-width};
   --rz-grid-column-icon-padding: #{$grid-column-icon-padding};
-
+  
   --rz-grid-detail-template-border: #{$grid-detail-template-border};
   --rz-grid-detail-template-border-radius: #{$grid-detail-template-border-radius};
   --rz-grid-detail-template-padding: #{$grid-detail-template-padding};
   --rz-grid-detail-template-background-color: #{$grid-detail-template-background-color};
-
+  
   --rz-grid-loading-indicator-color: #{$grid-loading-indicator-color};
   --rz-grid-loading-indicator-background-color: #{$grid-loading-indicator-background-color};
-
+  
   --rz-grid-frozen-cell-border: #{$grid-frozen-cell-border};
   --rz-grid-frozen-cell-background-color: #{$grid-frozen-cell-background-color};
-
+  
   --rz-grid-state-transition: #{$grid-state-transition};
-
+  
   --rz-grid-group-header-padding: #{$grid-group-header-padding};
   --rz-grid-group-header-item-background-color: #{$grid-group-header-item-background-color};
   --rz-grid-group-header-item-padding: #{$grid-group-header-item-padding};
@@ -210,7 +210,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
   --rz-grid-group-header-item-border: #{$grid-group-header-item-border};
   --rz-grid-group-header-item-border-radius: #{$grid-group-header-item-border-radius};
   --rz-grid-group-header-items-margin: #{$grid-group-header-items-margin};
-
+  
   --rz-column-drag-handle-color: #{$column-drag-handle-color};
   --rz-column-drag-handle-hover-color: #{$column-drag-handle-hover-color};
   --rz-column-drag-handle-margin: #{$column-drag-handle-margin};
@@ -341,104 +341,104 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 .rz-datatable-thead,
 .rz-grid-table thead {
 
-    th {
-        background-color: var(--rz-grid-header-background-color);
-        padding: 0;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        border-bottom: var(--rz-grid-header-cell-border-bottom);
+  th {
+    background-color: var(--rz-grid-header-background-color);
+    padding: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-bottom: var(--rz-grid-header-cell-border-bottom);
 
-        &:not(:last-child) {
-            border-right: var(--rz-grid-header-cell-border);
-        }
-
-        > div:not(.rz-cell-filter) {
-            display: flex;
-            justify-content: flex-start;
-            align-items: center;
-            width: 100%;
-            outline: none;
-            padding: var(--rz-grid-header-cell-padding);
-        }
-
-        .rz-column-title {
-            display: inline-flex;
-            flex: auto;
-            width: 100%;
-            align-items: center;
-            font-size: var(--rz-grid-header-font-size);
-            line-height: var(--rz-grid-header-line-height);
-            text-transform: var(--rz-grid-header-text-transform);
-            color: var(--rz-grid-header-color);
-            padding: var(--rz-grid-header-title-padding);
-            font-weight: var(--rz-grid-header-font-weight);
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-
-        .rz-column-title-content {
-            display: inline-block;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-
-            &:has(.rz-chkbox) {
-                overflow: visible;
-            }
-        }
-
-        &.rz-text-align-center {
-            .rz-column-title {
-                justify-content: center;
-                padding-left: 0;
-            }
-            &.rz-sortable-column {
-                .rz-column-title {
-                    padding-left: var(--rz-grid-sort-icon-width);
-                }
-            }
-        }
-
-        &.rz-text-align-right {
-            .rz-column-title {
-                justify-content: right;
-            }
-            &.rz-sortable-column {
-                .rz-column-title {
-                    padding-left: var(--rz-grid-sort-icon-width);
-                }
-            }
-        }
-
-        .rz-column-drag {
-            + .rz-column-title {
-                padding-left: 0;
-            }
-        }
+    &:not(:last-child) {
+      border-right: var(--rz-grid-header-cell-border);
     }
+
+    > div:not(.rz-cell-filter) {
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      width: 100%;
+      outline: none;
+      padding: var(--rz-grid-header-cell-padding);
+    }
+
+    .rz-column-title {
+      display: inline-flex;
+      flex: auto;
+      width: 100%;
+      align-items: center;
+      font-size: var(--rz-grid-header-font-size);
+      line-height: var(--rz-grid-header-line-height);
+      text-transform: var(--rz-grid-header-text-transform);
+      color: var(--rz-grid-header-color);
+      padding: var(--rz-grid-header-title-padding);
+      font-weight: var(--rz-grid-header-font-weight);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .rz-column-title-content {
+      display: inline-block;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      &:has(.rz-chkbox) {
+        overflow: visible;
+      }
+    }
+
+    &.rz-text-align-center {
+      .rz-column-title {
+        justify-content: center;
+        padding-left: 0;
+      }
+      &.rz-sortable-column {
+        .rz-column-title {
+          padding-left: var(--rz-grid-sort-icon-width);
+        }
+      }
+    }
+
+    &.rz-text-align-right {
+      .rz-column-title {
+        justify-content: right;
+      }
+      &.rz-sortable-column {
+        .rz-column-title {
+          padding-left: var(--rz-grid-sort-icon-width);
+        }
+      }
+    }
+
+    .rz-column-drag {
+      + .rz-column-title {
+        padding-left: 0;
+      }
+    }
+  }
 }
 
 .rz-datatable-tfoot, .rz-grid-table tfoot {
-    td {
-        background-color: var(--rz-grid-foot-background-color);
-        font-size: var(--rz-grid-cell-font-size);
-        line-height: var(--rz-grid-cell-line-height);
-        color: var(--rz-grid-foot-cell-color);
-        padding: var(--rz-grid-cell-padding);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+  td {
+    background-color: var(--rz-grid-foot-background-color);
+    font-size: var(--rz-grid-cell-font-size);
+    line-height: var(--rz-grid-cell-line-height);
+    color: var(--rz-grid-foot-cell-color);
+    padding: var(--rz-grid-cell-padding);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
-        &:not(:last-child) {
-            border-right: var(--rz-grid-right-cell-border);
-        }
-
-        &.rz-composite-cell {
-            border-right: var(--rz-grid-right-cell-border);
-        }
+    &:not(:last-child) {
+      border-right: var(--rz-grid-right-cell-border);
     }
+
+    &.rz-composite-cell {
+      border-right: var(--rz-grid-right-cell-border);
+    }
+  }
 }
 
 .rz-datatable-scrollable-header {
@@ -532,7 +532,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
   &.rz-grid-table thead {
     th {
       border-bottom: var(--rz-grid-header-cell-border);
-  
+
       &.rz-composite-cell {
         border-right: var(--rz-grid-header-cell-border);
       }
@@ -542,115 +542,115 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 
 .rz-datatable-data,
 .rz-grid-table {
+  td {
+    padding: var(--rz-grid-cell-padding);
+    border-bottom: var(--rz-grid-bottom-cell-border);
+
+    &:not(:last-child) {
+      border-right: var(--rz-grid-right-cell-border);
+    }
+
+    &.rz-composite-cell {
+      border-right: var(--rz-grid-right-cell-border);
+    }
+
+    .rz-cell-data {
+      color: var(--rz-grid-cell-color);
+      font-size: var(--rz-grid-cell-font-size);
+      line-height: var(--rz-grid-cell-line-height);
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      &:has(.rz-chkbox),
+      &:has(.rz-button) {
+        overflow: visible;
+      }
+    }
+
+    .rz-cell-toggle {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+  }
+
+  tr {
     td {
-        padding: var(--rz-grid-cell-padding);
-        border-bottom: var(--rz-grid-bottom-cell-border);
-
-        &:not(:last-child) {
-            border-right: var(--rz-grid-right-cell-border);
-        }
-
-        &.rz-composite-cell {
-            border-right: var(--rz-grid-right-cell-border);
-        }
-
-        .rz-cell-data {
-            color: var(--rz-grid-cell-color);
-            font-size: var(--rz-grid-cell-font-size);
-            line-height: var(--rz-grid-cell-line-height);
-            display: block;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-
-            &:has(.rz-chkbox),
-            &:has(.rz-button) {
-                overflow: visible;
-            }
-        }
-
-        .rz-cell-toggle {
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-        }
+      &:first-child {
+        border-left: none;
+      }
+      &:last-child:not(.rz-composite-cell) {
+        border-right: none;
+      }
     }
 
-    tr {
-        td {
-            &:first-child {
-                border-left: none;
-            }
-            &:last-child:not(.rz-composite-cell) {
-                border-right: none;
-            }
-        }
-
-        &:first-child {
-            > td {
-                border-top: none;
-            }
-        }
-
-        &:last-child {
-            > td {
-                border-bottom: none;
-            }
-        }
+    &:first-child {
+      > td {
+        border-top: none;
+      }
     }
+
+    &:last-child {
+      > td {
+        border-bottom: none;
+      }
+    }
+  }
 }
 
 // GridLines
 .rz-grid-table {
-    // GridLines.Both
-    &.rz-grid-gridlines-both {
-        > thead > tr > th,
-        > thead > tr > th.rz-composite-cell,
-        > tbody > tr > td,
-        > tfoot > tr > td {
-            border-bottom: var(--rz-grid-cell-border);
+  // GridLines.Both
+  &.rz-grid-gridlines-both {
+    > thead > tr > th,
+    > thead > tr > th.rz-composite-cell,
+    > tbody > tr > td,
+    > tfoot > tr > td {
+      border-bottom: var(--rz-grid-cell-border);
 
-            &:not(:last-child) {
-                border-right: var(--rz-grid-cell-border);
-            }
-        }
+      &:not(:last-child) {
+        border-right: var(--rz-grid-cell-border);
+      }
     }
+  }
 
-    // GridLines.None
-    &.rz-grid-gridlines-none {
-        > thead > tr > th,
-        > thead > tr > th.rz-composite-cell,
-        > tbody > tr > td,
-        > tfoot > tr > td {
-            border-bottom: none;
-            border-right: none;
-        }
+  // GridLines.None
+  &.rz-grid-gridlines-none {
+    > thead > tr > th,
+    > thead > tr > th.rz-composite-cell,
+    > tbody > tr > td,
+    > tfoot > tr > td {
+      border-bottom: none;
+      border-right: none;
     }
+  }
 
-    // GridLines.Horizontal
-    &.rz-grid-gridlines-horizontal {
-        > thead > tr > th,
-        > thead > tr > th.rz-composite-cell,
-        > tbody > tr > td,
-        > tfoot > tr > td {
-            border-bottom: var(--rz-grid-cell-border);
-            border-right: none;
-        }
+  // GridLines.Horizontal
+  &.rz-grid-gridlines-horizontal {
+    > thead > tr > th,
+    > thead > tr > th.rz-composite-cell,
+    > tbody > tr > td,
+    > tfoot > tr > td {
+      border-bottom: var(--rz-grid-cell-border);
+      border-right: none;
     }
+  }
 
-    // GridLines.Vertical
-    &.rz-grid-gridlines-vertical {
-        > thead > tr > th,
-        > thead > tr > th.rz-composite-cell,
-        > tbody > tr > td,
-        > tfoot > tr > td {
-            border-bottom: none;
+  // GridLines.Vertical
+  &.rz-grid-gridlines-vertical {
+    > thead > tr > th,
+    > thead > tr > th.rz-composite-cell,
+    > tbody > tr > td,
+    > tfoot > tr > td {
+      border-bottom: none;
 
-            &:not(:last-child) {
-                border-right: var(--rz-grid-cell-border);
-            }
-        }
+      &:not(:last-child) {
+        border-right: var(--rz-grid-cell-border);
+      }
     }
+  }
 }
 
 .rz-datatable-reflow {
@@ -716,21 +716,21 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
   font-weight: normal;
 
   .rz-cell-filter-label {
-      display: flex;
-      flex: auto;
-      align-items: center;
+    display: flex;
+    flex: auto;
+    align-items: center;
 
-      > .rzi {
-        width: var(--rz-grid-filter-icon-width);
-        height: var(--rz-grid-filter-icon-height);
-        font-size: var(--rz-grid-filter-icon-font-size);
-        margin: var(--rz-grid-filter-icon-margin);
-        color: var(--rz-grid-filter-color);
+    > .rzi {
+      width: var(--rz-grid-filter-icon-width);
+      height: var(--rz-grid-filter-icon-height);
+      font-size: var(--rz-grid-filter-icon-font-size);
+      margin: var(--rz-grid-filter-icon-margin);
+      color: var(--rz-grid-filter-color);
 
-        &.rz-cell-filter-clear {
-          margin-left: auto;
-        }
+      &.rz-cell-filter-clear {
+        margin-left: auto;
       }
+    }
 
     .rz-current-filter {
       margin-left: 0.5rem;
@@ -739,101 +739,101 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 }
 
 .rz-selectable {
-    tbody {
-        tr.rz-data-row {
-            td,
-            .rz-cell-data {
-                transition: background-color var(--rz-transition), color var(--rz-transition);
+  tbody {
+    tr.rz-data-row {
+      td,
+      .rz-cell-data {
+        transition: background-color var(--rz-transition), color var(--rz-transition);
 
-                &.rz-frozen-cell {
-                    &:before,
-                    &:after {
-                        content: "";
-                        position: absolute;
-                        inset: 0;
-                        transition: background-color var(--rz-transition), color var(--rz-transition);
-                    }
-                }
-
-                &.rz-frozen-cell-left {
-                    &:before {
-                        z-index: -1;
-                    }
-
-                    &:after {
-                        z-index: -2;
-                        background-color: var(--rz-grid-frozen-cell-background-color);
-                    }
-                }
-
-                &.rz-frozen-cell-right {
-                    &:before {
-                        z-index: -2;
-                        background-color: var(--rz-grid-frozen-cell-background-color);
-                    }
-
-                    &:after {
-                        z-index: -1;
-                    }
-                }
-            }
-
-            &.rz-state-highlight {
-                > td {
-                    background-color: var(--rz-grid-selected-background-color);
-
-                    &.rz-frozen-cell-left {
-                        &:before {
-                            background-color: var(--rz-grid-selected-background-color);
-                        }
-                    }
-
-                    &.rz-frozen-cell-right {
-                        &:after {
-                            background-color: var(--rz-grid-selected-background-color);
-                        }
-                    }
-                }
-
-                .rz-cell-data {
-                    color: var(--rz-grid-selected-color);
-                }
-
-                > .rzi {
-                    color: var(--rz-grid-selected-color);
-                }
-            }
-
-            &.rz-state-disabled {
-                opacity: 0.5;
-                pointer-events: none;
-            }
-
-            &:hover {
-                &:not(.rz-state-highlight) {
-                    > td {
-                        background-color: var(--rz-grid-hover-background-color);
-
-                        &.rz-frozen-cell-left {
-                            &:before {
-                                background-color: var(--rz-grid-hover-background-color);
-                            }
-                        }
-
-                        &.rz-frozen-cell-right {
-                            &:after {
-                                background-color: var(--rz-grid-hover-background-color);
-                            }
-                        }
-                    }
-
-                    .rz-cell-data {
-                        color: var(--rz-grid-hover-color);
-                    }
-                }
-            }
+        &.rz-frozen-cell {
+          &:before,
+          &:after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            transition: background-color var(--rz-transition), color var(--rz-transition);
+          }
         }
+
+        &.rz-frozen-cell-left {
+          &:before {
+            z-index: -1;
+          }
+
+          &:after {
+            z-index: -2;
+            background-color: var(--rz-grid-frozen-cell-background-color);
+          }
+        }
+
+        &.rz-frozen-cell-right {
+          &:before {
+            z-index: -2;
+            background-color: var(--rz-grid-frozen-cell-background-color);
+          }
+
+          &:after {
+            z-index: -1;
+          }
+        }
+      }
+
+      &.rz-state-highlight {
+        > td {
+          background-color: var(--rz-grid-selected-background-color);
+
+          &.rz-frozen-cell-left {
+            &:before {
+              background-color: var(--rz-grid-selected-background-color);
+            }
+          }
+
+          &.rz-frozen-cell-right {
+            &:after {
+              background-color: var(--rz-grid-selected-background-color);
+            }
+          }
+        }
+
+        .rz-cell-data {
+          color: var(--rz-grid-selected-color);
+        }
+
+        > .rzi {
+          color: var(--rz-grid-selected-color);
+        }
+      }
+
+      &.rz-state-disabled {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+
+      &:hover {
+        &:not(.rz-state-highlight) {
+          > td {
+            background-color: var(--rz-grid-hover-background-color);
+
+            &.rz-frozen-cell-left {
+              &:before {
+                background-color: var(--rz-grid-hover-background-color);
+              }
+            }
+
+            &.rz-frozen-cell-right {
+              &:after {
+                background-color: var(--rz-grid-hover-background-color);
+              }
+            }
+          }
+
+          .rz-cell-data {
+            color: var(--rz-grid-hover-color);
+          }
+        }
+      }
     }
+  }
 }
 
 .rz-cell-filter-content {
@@ -1077,27 +1077,27 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 }
 
 .rz-grid-table-fixed {
-    table-layout: fixed;
+  table-layout: fixed;
 
-    .rz-frozen-cell {
-        position: -webkit-sticky;
-        position: sticky;
-    }
+  .rz-frozen-cell {
+    position: -webkit-sticky;
+    position: sticky;
+  }
 
-    .rz-frozen-cell-left, .rz-frozen-cell-right {
-        background: var(--rz-grid-frozen-cell-background-color);
-        z-index: 1;
-    }
+  .rz-frozen-cell-left, .rz-frozen-cell-right {
+    background: var(--rz-grid-frozen-cell-background-color);
+    z-index: 1;
+  }
 
-    .rz-frozen-cell-left.rz-frozen-cell-left-end {
-        box-shadow: 5px 0 5px -5px rgba(0,0,0,0.12);
-        border-right: var(--rz-grid-frozen-cell-border) !important;
-    }
+  .rz-frozen-cell-left.rz-frozen-cell-left-end {
+    box-shadow: 5px 0 5px -5px rgba(0,0,0,0.12);
+    border-right: var(--rz-grid-frozen-cell-border) !important;
+  }
 
-    .rz-frozen-cell-right.rz-frozen-cell-right-end {
-        box-shadow: -5px 0 5px -5px rgba(0,0,0,0.12);
-        border-left: var(--rz-grid-frozen-cell-border) !important;
-    }
+  .rz-frozen-cell-right.rz-frozen-cell-right-end {
+    box-shadow: -5px 0 5px -5px rgba(0,0,0,0.12);
+    border-left: var(--rz-grid-frozen-cell-border) !important;
+  }
 }
 
 .rz-grid-table tfoot, .rz-grid-table tfoot td {
@@ -1124,7 +1124,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 }
 
 .rz-grid-table tbody > div {
-    display: table-row;
+  display: table-row;
 }
 
 .rz-column-drag {

--- a/Radzen.Blazor/themes/components/blazor/_grid.scss
+++ b/Radzen.Blazor/themes/components/blazor/_grid.scss
@@ -341,104 +341,114 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 .rz-datatable-thead,
 .rz-grid-table thead {
 
-  th {
-    background-color: var(--rz-grid-header-background-color);
-    padding: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    border-bottom: var(--rz-grid-header-cell-border-bottom);
+    th {
+        background-color: var(--rz-grid-header-background-color);
+        padding: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-bottom: var(--rz-grid-header-cell-border-bottom);
 
-    &:not(:last-child) {
-      border-right: var(--rz-grid-header-cell-border);
-    }
+        &:not(:last-child) {
+            border-right: var(--rz-grid-header-cell-border);
 
-    > div:not(.rz-cell-filter) {
-      display: flex;
-      justify-content: flex-start;
-      align-items: center;
-      width: 100%;
-      outline: none;
-      padding: var(--rz-grid-header-cell-padding);
-    }
-
-    .rz-column-title {
-      display: inline-flex;
-      flex: auto;
-      width: 100%;
-      align-items: center;
-      font-size: var(--rz-grid-header-font-size);
-      line-height: var(--rz-grid-header-line-height);
-      text-transform: var(--rz-grid-header-text-transform);
-      color: var(--rz-grid-header-color);
-      padding: var(--rz-grid-header-title-padding);
-      font-weight: var(--rz-grid-header-font-weight);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .rz-column-title-content {
-      display: inline-block;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-
-      &:has(.rz-chkbox) {
-        overflow: visible;
-      }
-    }
-
-    &.rz-text-align-center {
-      .rz-column-title {
-        justify-content: center;
-        padding-left: 0;
-      }
-      &.rz-sortable-column {
-        .rz-column-title {
-          padding-left: var(--rz-grid-sort-icon-width);
+            &.rz-frozen-cell-right {
+                border-right: var(--rz-grid-frozen-cell-border);
+            }
         }
-      }
-    }
 
-    &.rz-text-align-right {
-      .rz-column-title {
-        justify-content: right;
-      }
-      &.rz-sortable-column {
-        .rz-column-title {
-          padding-left: var(--rz-grid-sort-icon-width);
+        > div:not(.rz-cell-filter) {
+            display: flex;
+            justify-content: flex-start;
+            align-items: center;
+            width: 100%;
+            outline: none;
+            padding: var(--rz-grid-header-cell-padding);
         }
-      }
-    }
 
-    .rz-column-drag {
-        + .rz-column-title {
-        padding-left: 0;
-      }
+        .rz-column-title {
+            display: inline-flex;
+            flex: auto;
+            width: 100%;
+            align-items: center;
+            font-size: var(--rz-grid-header-font-size);
+            line-height: var(--rz-grid-header-line-height);
+            text-transform: var(--rz-grid-header-text-transform);
+            color: var(--rz-grid-header-color);
+            padding: var(--rz-grid-header-title-padding);
+            font-weight: var(--rz-grid-header-font-weight);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .rz-column-title-content {
+            display: inline-block;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+
+            &:has(.rz-chkbox) {
+                overflow: visible;
+            }
+        }
+
+        &.rz-text-align-center {
+            .rz-column-title {
+                justify-content: center;
+                padding-left: 0;
+            }
+
+            &.rz-sortable-column {
+                .rz-column-title {
+                    padding-left: var(--rz-grid-sort-icon-width);
+                }
+            }
+        }
+
+        &.rz-text-align-right {
+            .rz-column-title {
+                justify-content: right;
+            }
+
+            &.rz-sortable-column {
+                .rz-column-title {
+                    padding-left: var(--rz-grid-sort-icon-width);
+                }
+            }
+        }
+
+        .rz-column-drag {
+            + .rz-column-title {
+                padding-left: 0;
+            }
+        }
     }
-  }
 }
 
 .rz-datatable-tfoot, .rz-grid-table tfoot {
-  td {
-    background-color: var(--rz-grid-foot-background-color);
-    font-size: var(--rz-grid-cell-font-size);
-    line-height: var(--rz-grid-cell-line-height);
-    color: var(--rz-grid-foot-cell-color);
-    padding: var(--rz-grid-cell-padding);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    td {
+        background-color: var(--rz-grid-foot-background-color);
+        font-size: var(--rz-grid-cell-font-size);
+        line-height: var(--rz-grid-cell-line-height);
+        color: var(--rz-grid-foot-cell-color);
+        padding: var(--rz-grid-cell-padding);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
 
-    &:not(:last-child) {
-      border-right: var(--rz-grid-right-cell-border);
-    }
+        &:not(:last-child) {
+            border-right: var(--rz-grid-right-cell-border);
 
-    &.rz-composite-cell {
-      border-right: var(--rz-grid-right-cell-border);
+            &.rz-frozen-cell-right {
+                border-right: var(--rz-grid-frozen-cell-border);
+            }
+        }
+
+        &.rz-composite-cell {
+            border-right: var(--rz-grid-right-cell-border);
+        }
     }
-  }
 }
 
 .rz-datatable-scrollable-header {
@@ -542,62 +552,67 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 
 .rz-datatable-data,
 .rz-grid-table {
-  td {
-    padding: var(--rz-grid-cell-padding);
-    border-bottom: var(--rz-grid-bottom-cell-border);
-
-    &:not(:last-child) {
-      border-right: var(--rz-grid-right-cell-border);
-    }
-
-    &.rz-composite-cell {
-      border-right: var(--rz-grid-right-cell-border);
-    }
-
-    .rz-cell-data {
-      color: var(--rz-grid-cell-color);
-      font-size: var(--rz-grid-cell-font-size);
-      line-height: var(--rz-grid-cell-line-height);
-      display: block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-
-      &:has(.rz-chkbox),
-      &:has(.rz-button) {
-        overflow: visible;
-      }
-    }
-
-    .rz-cell-toggle {
-      display: flex;
-      align-items: center;
-      gap: 0.25rem;
-    }
-  }
-
-  tr {
     td {
-      &:first-child {
-        border-left: none;
-      }
-      &:last-child:not(.rz-composite-cell) {
-        border-right: none;
-      }
+        padding: var(--rz-grid-cell-padding);
+        border-bottom: var(--rz-grid-bottom-cell-border);
+
+        &:not(:last-child) {
+            border-right: var(--rz-grid-right-cell-border);
+
+            &.rz-frozen-cell-right {
+                border-right: var(--rz-grid-frozen-cell-border);
+            }
+        }
+
+        &.rz-composite-cell {
+            border-right: var(--rz-grid-right-cell-border);
+        }
+
+        .rz-cell-data {
+            color: var(--rz-grid-cell-color);
+            font-size: var(--rz-grid-cell-font-size);
+            line-height: var(--rz-grid-cell-line-height);
+            display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+
+            &:has(.rz-chkbox),
+            &:has(.rz-button) {
+                overflow: visible;
+            }
+        }
+
+        .rz-cell-toggle {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+        }
     }
 
-    &:first-child {
-      > td {
-        border-top: none;
-      }
-    }
+    tr {
+        td {
+            &:first-child {
+                border-left: none;
+            }
 
-    &:last-child {
-      > td {
-        border-bottom: none;
-      }
+            &:last-child:not(.rz-composite-cell) {
+                border-right: none;
+            }
+        }
+
+        &:first-child {
+            > td {
+                border-top: none;
+            }
+        }
+
+        &:last-child {
+            > td {
+                border-bottom: none;
+            }
+        }
     }
-  }
 }
 
 // GridLines
@@ -739,76 +754,101 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 }
 
 .rz-selectable {
-  tbody {
-    tr.rz-data-row {
-      td,
-      .rz-cell-data {
-        transition: background-color var(--rz-transition), color var(--rz-transition);
+    tbody {
+        tr.rz-data-row {
+            td,
+            .rz-cell-data {
+                transition: background-color var(--rz-transition), color var(--rz-transition);
 
-        &.rz-frozen-cell {
-          &:before,
-          &:after {
-            content: "";
-            position: absolute;
-            inset: 0;
-            transition: background-color var(--rz-transition), color var(--rz-transition);
-          }
+                &.rz-frozen-cell {
+                    &:before,
+                    &:after {
+                        content: "";
+                        position: absolute;
+                        inset: 0;
+                        transition: background-color var(--rz-transition), color var(--rz-transition);
+                    }
+                }
 
-          &:before {
-            z-index: -1;
-          }
+                &.rz-frozen-cell-left {
+                    &:before {
+                        z-index: -1;
+                    }
 
-          &:after {
-            z-index: -2;
-            background-color: var(--rz-grid-frozen-cell-background-color);
-          }
-        }
-      }
+                    &:after {
+                        z-index: -2;
+                        background-color: var(--rz-grid-frozen-cell-background-color);
+                    }
+                }
 
-      &.rz-state-highlight {
-        > td {
-          background-color: var(--rz-grid-selected-background-color);
+                &.rz-frozen-cell-right {
+                    &:before {
+                        z-index: -2;
+                        background-color: var(--rz-grid-frozen-cell-background-color);
+                    }
 
-          &.rz-frozen-cell {
-            &:before {
-              background-color: var(--rz-grid-selected-background-color);
+                    &:after {
+                        z-index: -1;
+                    }
+                }
             }
-          }
-        }
 
-        .rz-cell-data {
-          color: var(--rz-grid-selected-color);
-        }
+            &.rz-state-highlight {
+                > td {
+                    background-color: var(--rz-grid-selected-background-color);
 
-        > .rzi {
-          color: var(--rz-grid-selected-color);
-        }
-      }
+                    &.rz-frozen-cell-left {
+                        &:before {
+                            background-color: var(--rz-grid-selected-background-color);
+                        }
+                    }
 
-      &.rz-state-disabled {
-        opacity: 0.5;
-        pointer-events: none;
-      }
+                    &.rz-frozen-cell-right {
+                        &:after {
+                            background-color: var(--rz-grid-selected-background-color);
+                        }
+                    }
+                }
 
-      &:hover {
-        &:not(.rz-state-highlight) {
-          > td {
-            background-color: var(--rz-grid-hover-background-color);
+                .rz-cell-data {
+                    color: var(--rz-grid-selected-color);
+                }
 
-            &.rz-frozen-cell {
-              &:before {
-                background-color: var(--rz-grid-hover-background-color);
-              }
+                > .rzi {
+                    color: var(--rz-grid-selected-color);
+                }
             }
-          }
 
-          .rz-cell-data {
-            color: var(--rz-grid-hover-color);
-          }
+            &.rz-state-disabled {
+                opacity: 0.5;
+                pointer-events: none;
+            }
+
+            &:hover {
+                &:not(.rz-state-highlight) {
+                    > td {
+                        background-color: var(--rz-grid-hover-background-color);
+
+                        &.rz-frozen-cell-left {
+                            &:before {
+                                background-color: var(--rz-grid-hover-background-color);
+                            }
+                        }
+
+                        &.rz-frozen-cell-right {
+                            &:after {
+                                background-color: var(--rz-grid-hover-background-color);
+                            }
+                        }
+                    }
+
+                    .rz-cell-data {
+                        color: var(--rz-grid-hover-color);
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .rz-cell-filter-content {
@@ -1052,16 +1092,24 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 }
 
 .rz-grid-table-fixed {
-  table-layout: fixed;
+    table-layout: fixed;
 
-  .rz-frozen-cell {
-    position: -webkit-sticky;
-    position: sticky;
-    background: var(--rz-grid-frozen-cell-background-color);
-    border-right: var(--rz-grid-frozen-cell-border) !important;
-    box-shadow: 1px 0 2px 0 rgba(0,0,0,0.12);
-    z-index: 1;
-  }
+    .rz-frozen-cell {
+        position: -webkit-sticky;
+        position: sticky;
+        background: var(--rz-grid-frozen-cell-background-color);
+        z-index: 1;
+    }
+
+    .rz-frozen-cell-left {
+        box-shadow: 1px 0 5px 0 rgba(0,0,0,0.12);
+        border-right: var(--rz-grid-frozen-cell-border) !important;
+    }
+
+    .rz-frozen-cell-right {
+        box-shadow: -1px 0 5px 0 rgba(0,0,0,0.12);
+        border-left: var(--rz-grid-frozen-cell-border) !important;
+    }
 }
 
 .rz-grid-table tfoot, .rz-grid-table tfoot td {

--- a/Radzen.Blazor/themes/components/blazor/_grid.scss
+++ b/Radzen.Blazor/themes/components/blazor/_grid.scss
@@ -351,10 +351,6 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 
         &:not(:last-child) {
             border-right: var(--rz-grid-header-cell-border);
-
-/*            &.rz-frozen-cell-right {
-                border-right: var(--rz-grid-frozen-cell-border);
-            }*/
         }
 
         > div:not(.rz-cell-filter) {
@@ -439,10 +435,6 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 
         &:not(:last-child) {
             border-right: var(--rz-grid-right-cell-border);
-
-/*            &.rz-frozen-cell-right {
-                border-right: var(--rz-grid-frozen-cell-border);
-            }*/
         }
 
         &.rz-composite-cell {
@@ -558,11 +550,9 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 
         &:not(:last-child) {
             border-right: var(--rz-grid-right-cell-border);
-
-/*            &.rz-frozen-cell-right {
-                border-right: var(--rz-grid-frozen-cell-border);
-            }*/
         }
+
+
 
         &.rz-composite-cell {
             border-right: var(--rz-grid-right-cell-border);
@@ -617,55 +607,58 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 
 // GridLines
 .rz-grid-table {
-  // GridLines.Both
-  &.rz-grid-gridlines-both {
-    > thead > tr > th,
-    > thead > tr > th.rz-composite-cell,
-    > tbody > tr > td,
-    > tfoot > tr > td {
-      border-bottom: var(--rz-grid-cell-border);
+    // GridLines.Both
+    &.rz-grid-gridlines-both {
+        > thead > tr > th,
+        > thead > tr > th.rz-composite-cell,
+        > tbody > tr > td,
+        > tfoot > tr > td {
+            border-bottom: var(--rz-grid-cell-border);
 
-      &:not(:last-child) {
-        border-right: var(--rz-grid-cell-border);
-      }
-    }
-  }
+            &:not(:last-child) {
+                border-right: var(--rz-grid-cell-border);
+            }
+        }
 
-  // GridLines.None
-  &.rz-grid-gridlines-none {
-    > thead > tr > th,
-    > thead > tr > th.rz-composite-cell,
-    > tbody > tr > td,
-    > tfoot > tr > td {
-      border-bottom: none;
-      border-right: none;
+        > tbody > tr > td {
+            &.rz-frozen-cell {
+                background: var(--rz-grid-frozen-cell-background-color);
+            }
+        }
     }
-  }
+    // GridLines.None
+    &.rz-grid-gridlines-none {
+        > thead > tr > th,
+        > thead > tr > th.rz-composite-cell,
+        > tbody > tr > td,
+        > tfoot > tr > td {
+            border-bottom: none;
+            border-right: none;
+        }
+    }
+    // GridLines.Horizontal
+    &.rz-grid-gridlines-horizontal {
+        > thead > tr > th,
+        > thead > tr > th.rz-composite-cell,
+        > tbody > tr > td,
+        > tfoot > tr > td {
+            border-bottom: var(--rz-grid-cell-border);
+            border-right: none;
+        }
+    }
+    // GridLines.Vertical
+    &.rz-grid-gridlines-vertical {
+        > thead > tr > th,
+        > thead > tr > th.rz-composite-cell,
+        > tbody > tr > td,
+        > tfoot > tr > td {
+            border-bottom: none;
 
-  // GridLines.Horizontal
-  &.rz-grid-gridlines-horizontal {
-    > thead > tr > th,
-    > thead > tr > th.rz-composite-cell,
-    > tbody > tr > td,
-    > tfoot > tr > td {
-      border-bottom: var(--rz-grid-cell-border);
-      border-right: none;
+            &:not(:last-child) {
+                border-right: var(--rz-grid-cell-border);
+            }
+        }
     }
-  }
-
-  // GridLines.Vertical
-  &.rz-grid-gridlines-vertical {
-    > thead > tr > th,
-    > thead > tr > th.rz-composite-cell,
-    > tbody > tr > td,
-    > tfoot > tr > td {
-      border-bottom: none;
-      
-      &:not(:last-child) {
-        border-right: var(--rz-grid-cell-border);
-      }
-    }
-  }
 }
 
 .rz-datatable-reflow {
@@ -1097,7 +1090,6 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
     .rz-frozen-cell {
         position: -webkit-sticky;
         position: sticky;
-        background: var(--rz-grid-frozen-cell-background-color);
     }
 
     .rz-frozen-cell-left, .rz-frozen-cell-right {

--- a/Radzen.Blazor/themes/components/blazor/_grid.scss
+++ b/Radzen.Blazor/themes/components/blazor/_grid.scss
@@ -394,7 +394,6 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
                 justify-content: center;
                 padding-left: 0;
             }
-
             &.rz-sortable-column {
                 .rz-column-title {
                     padding-left: var(--rz-grid-sort-icon-width);
@@ -406,7 +405,6 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
             .rz-column-title {
                 justify-content: right;
             }
-
             &.rz-sortable-column {
                 .rz-column-title {
                     padding-left: var(--rz-grid-sort-icon-width);
@@ -552,8 +550,6 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
             border-right: var(--rz-grid-right-cell-border);
         }
 
-
-
         &.rz-composite-cell {
             border-right: var(--rz-grid-right-cell-border);
         }
@@ -585,7 +581,6 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
             &:first-child {
                 border-left: none;
             }
-
             &:last-child:not(.rz-composite-cell) {
                 border-right: none;
             }
@@ -619,13 +614,8 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
                 border-right: var(--rz-grid-cell-border);
             }
         }
-
-        > tbody > tr > td {
-            &.rz-frozen-cell {
-                background: var(--rz-grid-frozen-cell-background-color);
-            }
-        }
     }
+
     // GridLines.None
     &.rz-grid-gridlines-none {
         > thead > tr > th,
@@ -636,6 +626,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
             border-right: none;
         }
     }
+
     // GridLines.Horizontal
     &.rz-grid-gridlines-horizontal {
         > thead > tr > th,
@@ -646,6 +637,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
             border-right: none;
         }
     }
+
     // GridLines.Vertical
     &.rz-grid-gridlines-vertical {
         > thead > tr > th,
@@ -1093,6 +1085,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
     }
 
     .rz-frozen-cell-left, .rz-frozen-cell-right {
+        background: var(--rz-grid-frozen-cell-background-color);
         z-index: 1;
     }
 

--- a/Radzen.Blazor/themes/components/blazor/_grid.scss
+++ b/Radzen.Blazor/themes/components/blazor/_grid.scss
@@ -352,9 +352,9 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
         &:not(:last-child) {
             border-right: var(--rz-grid-header-cell-border);
 
-            &.rz-frozen-cell-right {
+/*            &.rz-frozen-cell-right {
                 border-right: var(--rz-grid-frozen-cell-border);
-            }
+            }*/
         }
 
         > div:not(.rz-cell-filter) {
@@ -440,9 +440,9 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
         &:not(:last-child) {
             border-right: var(--rz-grid-right-cell-border);
 
-            &.rz-frozen-cell-right {
+/*            &.rz-frozen-cell-right {
                 border-right: var(--rz-grid-frozen-cell-border);
-            }
+            }*/
         }
 
         &.rz-composite-cell {
@@ -559,9 +559,9 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
         &:not(:last-child) {
             border-right: var(--rz-grid-right-cell-border);
 
-            &.rz-frozen-cell-right {
+/*            &.rz-frozen-cell-right {
                 border-right: var(--rz-grid-frozen-cell-border);
-            }
+            }*/
         }
 
         &.rz-composite-cell {
@@ -1098,16 +1098,19 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
         position: -webkit-sticky;
         position: sticky;
         background: var(--rz-grid-frozen-cell-background-color);
+    }
+
+    .rz-frozen-cell-left, .rz-frozen-cell-right {
         z-index: 1;
     }
 
-    .rz-frozen-cell-left {
-        box-shadow: 1px 0 5px 0 rgba(0,0,0,0.12);
+    .rz-frozen-cell-left.rz-frozen-cell-left-end {
+        box-shadow: 5px 0 5px -5px rgba(0,0,0,0.12);
         border-right: var(--rz-grid-frozen-cell-border) !important;
     }
 
-    .rz-frozen-cell-right {
-        box-shadow: -1px 0 5px 0 rgba(0,0,0,0.12);
+    .rz-frozen-cell-right.rz-frozen-cell-right-end {
+        box-shadow: -5px 0 5px -5px rgba(0,0,0,0.12);
         border-left: var(--rz-grid-frozen-cell-border) !important;
     }
 }

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumns.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumns.razor
@@ -27,7 +27,7 @@
             </FooterTemplate>
         </RadzenDataGridColumn>
         <RadzenDataGridColumn TItem="Employee" Property="Title" Title="Title" Width="200px" />
-        <RadzenDataGridColumn TItem="Employee" Property="BirthDate" Title="Birth Date" FormatString="{0:d}" Frozen="true" FrozenPosition="FrozenPosition.Left"/>
+        <RadzenDataGridColumn TItem="Employee" Property="BirthDate" Title="Birth Date" FormatString="{0:d}" Frozen="true" FrozenPosition="FrozenColumnPosition.Left"/>
         <RadzenDataGridColumn TItem="Employee" Property="HireDate" Title="Hire Date" FormatString="{0:d}" />
         <RadzenDataGridColumn TItem="Employee" Property="Address" Title="Address" />
         <RadzenDataGridColumn TItem="Employee" Property="City" Title="City" />
@@ -35,8 +35,8 @@
         <RadzenDataGridColumn TItem="Employee" Property="PostalCode" Title="Postal Code" />
         <RadzenDataGridColumn TItem="Employee" Property="Country" Title="Country" />
         <RadzenDataGridColumn TItem="Employee" Property="HomePhone" Title="Home Phone" />
-        <RadzenDataGridColumn TItem="Employee" Property="Extension" Title="Extension" Frozen="true" FrozenPosition="FrozenPosition.Right" />
-        <RadzenDataGridColumn TItem="Employee" Property="Notes" Title="Notes" Frozen="true" FrozenPosition="FrozenPosition.Right" />
+        <RadzenDataGridColumn TItem="Employee" Property="Extension" Title="Extension" Frozen="true" FrozenPosition="FrozenColumnPosition.Right" />
+        <RadzenDataGridColumn TItem="Employee" Property="Notes" Title="Notes" Frozen="true" FrozenPosition="FrozenColumnPosition.Right" />
     </Columns>
 </RadzenDataGrid>
 

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumns.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumns.razor
@@ -27,7 +27,7 @@
             </FooterTemplate>
         </RadzenDataGridColumn>
         <RadzenDataGridColumn TItem="Employee" Property="Title" Title="Title" Width="200px" />
-        <RadzenDataGridColumn TItem="Employee" Property="BirthDate" Title="Birth Date" FormatString="{0:d}" Frozen="true" />
+        <RadzenDataGridColumn TItem="Employee" Property="BirthDate" Title="Birth Date" FormatString="{0:d}" Frozen="true" FrozenPosition="FrozenPosition.Left"/>
         <RadzenDataGridColumn TItem="Employee" Property="HireDate" Title="Hire Date" FormatString="{0:d}" />
         <RadzenDataGridColumn TItem="Employee" Property="Address" Title="Address" />
         <RadzenDataGridColumn TItem="Employee" Property="City" Title="City" />
@@ -36,7 +36,7 @@
         <RadzenDataGridColumn TItem="Employee" Property="Country" Title="Country" />
         <RadzenDataGridColumn TItem="Employee" Property="HomePhone" Title="Home Phone" />
         <RadzenDataGridColumn TItem="Employee" Property="Extension" Title="Extension" />
-        <RadzenDataGridColumn TItem="Employee" Property="Notes" Title="Notes" />
+        <RadzenDataGridColumn TItem="Employee" Property="Notes" Title="Notes" Frozen="true" FrozenPosition="FrozenPosition.Right" />
     </Columns>
 </RadzenDataGrid>
 

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumns.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumns.razor
@@ -35,7 +35,7 @@
         <RadzenDataGridColumn TItem="Employee" Property="PostalCode" Title="Postal Code" />
         <RadzenDataGridColumn TItem="Employee" Property="Country" Title="Country" />
         <RadzenDataGridColumn TItem="Employee" Property="HomePhone" Title="Home Phone" />
-        <RadzenDataGridColumn TItem="Employee" Property="Extension" Title="Extension" />
+        <RadzenDataGridColumn TItem="Employee" Property="Extension" Title="Extension" Frozen="true" FrozenPosition="FrozenPosition.Right" />
         <RadzenDataGridColumn TItem="Employee" Property="Notes" Title="Notes" Frozen="true" FrozenPosition="FrozenPosition.Right" />
     </Columns>
 </RadzenDataGrid>

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumns2.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumns2.razor
@@ -68,31 +68,31 @@
     class FrozenInfo{
         public string PropertyName { get; set; }
         public bool Frozen { get; set; }
-        public FrozenPosition FrozenPosition { get; set; }
+        public FrozenColumnPosition FrozenPosition { get; set; }
     }
     Radzen.DataGridGridLines GridLines = Radzen.DataGridGridLines.Default;
     IEnumerable<Employee> employees;
-    List<FrozenPosition> frozenPositions = new List<FrozenPosition>
+    List<FrozenColumnPosition> frozenPositions = new List<FrozenColumnPosition>
     {
-        FrozenPosition.Left,
-        FrozenPosition.Right
+        FrozenColumnPosition.Left,
+        FrozenColumnPosition.Right
     };
     List<FrozenInfo> frozenInfos = new List<FrozenInfo>
     {
-        new FrozenInfo{PropertyName = "EmployeeID", Frozen = true, FrozenPosition = FrozenPosition.Left },
-        new FrozenInfo{PropertyName = "Photo", Frozen = true, FrozenPosition = FrozenPosition.Left },
-        new FrozenInfo{PropertyName = "FirstName", Frozen = true, FrozenPosition = FrozenPosition.Left },
+        new FrozenInfo{PropertyName = "EmployeeID", Frozen = true, FrozenPosition = FrozenColumnPosition.Left },
+        new FrozenInfo{PropertyName = "Photo", Frozen = true, FrozenPosition = FrozenColumnPosition.Left },
+        new FrozenInfo{PropertyName = "FirstName", Frozen = true, FrozenPosition = FrozenColumnPosition.Left },
         new FrozenInfo{PropertyName = "LastName", Frozen = false },
         new FrozenInfo{PropertyName = "Title", Frozen = false },
-        new FrozenInfo{PropertyName = "BirthDate", Frozen = true, FrozenPosition = FrozenPosition.Left },
+        new FrozenInfo{PropertyName = "BirthDate", Frozen = true, FrozenPosition = FrozenColumnPosition.Left },
         new FrozenInfo{PropertyName = "HireDate", Frozen = false },
         new FrozenInfo{PropertyName = "Address", Frozen = false },
         new FrozenInfo{PropertyName = "City", Frozen = false },
         new FrozenInfo{PropertyName = "Region", Frozen = false },
         new FrozenInfo{PropertyName = "Country", Frozen = false },
         new FrozenInfo{PropertyName = "HomePhone", Frozen = false },
-        new FrozenInfo{PropertyName = "Extension", Frozen = true, FrozenPosition = FrozenPosition.Right },
-        new FrozenInfo{PropertyName = "Notes", Frozen = true, FrozenPosition = FrozenPosition.Right },
+        new FrozenInfo{PropertyName = "Extension", Frozen = true, FrozenPosition = FrozenColumnPosition.Right },
+        new FrozenInfo{PropertyName = "Notes", Frozen = true, FrozenPosition = FrozenColumnPosition.Right },
     };
 
     protected override async Task OnInitializedAsync()
@@ -114,13 +114,13 @@
         return frozenInfo.Frozen;
     }
 
-    private FrozenPosition frozenPosition(string propertyName)
+    private FrozenColumnPosition frozenPosition(string propertyName)
     {
         var frozenInfo = frozenInfos.FirstOrDefault(i => i.PropertyName == propertyName);
 
         if (frozenInfo == null)
         {
-            return FrozenPosition.Left;
+            return FrozenColumnPosition.Left;
         }
 
         return frozenInfo.FrozenPosition;

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumns2.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumns2.razor
@@ -1,0 +1,121 @@
+﻿@using RadzenBlazorDemos.Data
+@using RadzenBlazorDemos.Models.Northwind
+@using Microsoft.EntityFrameworkCore
+
+@inherits DbContextPage
+
+<RadzenDataGrid Data="@frozenInfos" TItem="FrozenInfo" AllowAlternatingRows="false">
+    <Columns>
+        <RadzenDataGridColumn TItem="FrozenInfo" Property="PropertyName" Title="Title" />
+        <RadzenDataGridColumn TItem="FrozenInfo" Title="Frozen">
+            <Template Context="data">
+                <RadzenCheckBox @bind-Value=@data.Frozen Name="FrozenCheckbox" />
+            </Template>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn TItem="FrozenInfo" Title="Position">
+            <Template Context="data">
+                <RadzenDropDown @bind-Value=@data.FrozenPosition Data=@frozenPositions>
+                    <Template Context="postion">
+                        @postion
+                    </Template>
+                </RadzenDropDown>
+            </Template>
+        </RadzenDataGridColumn>
+    </Columns>
+</RadzenDataGrid>
+
+<RadzenDataGrid AllowFiltering="true" AllowColumnResize="true" FilterMode="FilterMode.Advanced" AllowPaging="true" AllowSorting="true" Data="@employees" TItem="Employee" 
+    ColumnWidth="140px" LogicalFilterOperator="LogicalFilterOperator.Or">
+    <Columns>
+        <RadzenDataGridColumn TItem="Employee" Property="EmployeeID" Filterable="false" Title="ID" Width="5rem" TextAlign="TextAlign.Center" Frozen="@isFrozen("EmployeeID")" FrozenPosition="@frozenPosition("EmployeeID")" />
+        <RadzenDataGridColumn TItem="Employee" Title="Photo" Sortable="false" Filterable="false" Width="80px" TextAlign="TextAlign.Center" Frozen="@isFrozen("Photo")" FrozenPosition="@frozenPosition("Photo")">
+            <Template Context="data">
+                <RadzenImage Path="@data.Photo" class="rz-gravatar" />
+            </Template>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn TItem="Employee" Property="FirstName" Title="First Name" Frozen="@isFrozen("FirstName")" FrozenPosition="@frozenPosition("FirstName")">
+            <FooterTemplate>
+                Total employees: <b>@employees.Count()</b>
+            </FooterTemplate>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn TItem="Employee" Property="LastName" Title="Last Name" Frozen="@isFrozen("LastName")" FrozenPosition="@frozenPosition("LastName")">
+                <FooterTemplate>
+                Footer
+            </FooterTemplate>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn TItem="Employee" Property="Title" Title="Title" Width="200px" Frozen="@isFrozen("Title")" FrozenPosition="@frozenPosition("Title")" />
+        <RadzenDataGridColumn TItem="Employee" Property="BirthDate" Title="Birth Date" FormatString="{0:d}" Frozen="@isFrozen("BirthDate")" FrozenPosition="@frozenPosition("BirthDate")" />
+        <RadzenDataGridColumn TItem="Employee" Property="HireDate" Title="Hire Date" FormatString="{0:d}" Frozen="@isFrozen("HireDate")" FrozenPosition="@frozenPosition("HireDate")" />
+        <RadzenDataGridColumn TItem="Employee" Property="Address" Title="Address" Frozen="@isFrozen("Address")" FrozenPosition="@frozenPosition("Address")" />
+        <RadzenDataGridColumn TItem="Employee" Property="City" Title="City" Frozen="@isFrozen("City")" FrozenPosition="@frozenPosition("City")" />
+        <RadzenDataGridColumn TItem="Employee" Property="Region" Title="Region" Frozen="@isFrozen("Region")" FrozenPosition="@frozenPosition("Region")" />
+        <RadzenDataGridColumn TItem="Employee" Property="PostalCode" Title="Postal Code" Frozen="@isFrozen("PostalCode")" FrozenPosition="@frozenPosition("PostalCode")" />
+        <RadzenDataGridColumn TItem="Employee" Property="Country" Title="Country" Frozen="@isFrozen("Country")" FrozenPosition="@frozenPosition("Country")" />
+        <RadzenDataGridColumn TItem="Employee" Property="HomePhone" Title="Home Phone" Frozen="@isFrozen("HomePhone")" FrozenPosition="@frozenPosition("HomePhone")" />
+        <RadzenDataGridColumn TItem="Employee" Property="Extension" Title="Extension" Frozen="@isFrozen("Extension")" FrozenPosition="@frozenPosition("Extension")" />
+        <RadzenDataGridColumn TItem="Employee" Property="Notes" Title="Notes" Frozen="@isFrozen("Notes")" FrozenPosition="@frozenPosition("Notes")" />
+    </Columns>
+</RadzenDataGrid>
+
+@code {
+    class FrozenInfo{
+        public string PropertyName { get; set; }
+        public bool Frozen { get; set; }
+        public FrozenPosition FrozenPosition { get; set; }
+    }
+
+    IEnumerable<Employee> employees;
+    List<FrozenPosition> frozenPositions = new List<FrozenPosition>
+    {
+        FrozenPosition.Left,
+        FrozenPosition.Right
+    };
+    List<FrozenInfo> frozenInfos = new List<FrozenInfo>
+    {
+        new FrozenInfo{PropertyName = "EmployeeID", Frozen = true, FrozenPosition = FrozenPosition.Left },
+        new FrozenInfo{PropertyName = "Photo", Frozen = true, FrozenPosition = FrozenPosition.Left },
+        new FrozenInfo{PropertyName = "FirstName", Frozen = true, FrozenPosition = FrozenPosition.Left },
+        new FrozenInfo{PropertyName = "LastName", Frozen = false },
+        new FrozenInfo{PropertyName = "Title", Frozen = false },
+        new FrozenInfo{PropertyName = "BirthDate", Frozen = true, FrozenPosition = FrozenPosition.Left },
+        new FrozenInfo{PropertyName = "HireDate", Frozen = false },
+        new FrozenInfo{PropertyName = "Address", Frozen = false },
+        new FrozenInfo{PropertyName = "City", Frozen = false },
+        new FrozenInfo{PropertyName = "Region", Frozen = false },
+        new FrozenInfo{PropertyName = "Country", Frozen = false },
+        new FrozenInfo{PropertyName = "HomePhone", Frozen = false },
+        new FrozenInfo{PropertyName = "Extension", Frozen = true, FrozenPosition = FrozenPosition.Right },
+        new FrozenInfo{PropertyName = "Notes", Frozen = true, FrozenPosition = FrozenPosition.Right },
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        employees = dbContext.Employees;
+    }
+
+    private bool isFrozen(string propertyName)
+    {
+        var frozenInfo = frozenInfos.FirstOrDefault(i => i.PropertyName == propertyName);
+
+        if(frozenInfo == null)
+        {
+            return false;
+        }
+
+        return frozenInfo.Frozen;
+    }
+
+    private FrozenPosition frozenPosition(string propertyName)
+    {
+        var frozenInfo = frozenInfos.FirstOrDefault(i => i.PropertyName == propertyName);
+
+        if (frozenInfo == null)
+        {
+            return FrozenPosition.Left;
+        }
+
+        return frozenInfo.FrozenPosition;
+    }
+}

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumns2.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumns2.razor
@@ -4,28 +4,35 @@
 
 @inherits DbContextPage
 
-<RadzenDataGrid Data="@frozenInfos" TItem="FrozenInfo" AllowAlternatingRows="false">
-    <Columns>
-        <RadzenDataGridColumn TItem="FrozenInfo" Property="PropertyName" Title="Title" />
-        <RadzenDataGridColumn TItem="FrozenInfo" Title="Frozen">
-            <Template Context="data">
-                <RadzenCheckBox @bind-Value=@data.Frozen Name="FrozenCheckbox" />
-            </Template>
-        </RadzenDataGridColumn>
-        <RadzenDataGridColumn TItem="FrozenInfo" Title="Position">
-            <Template Context="data">
-                <RadzenDropDown @bind-Value=@data.FrozenPosition Data=@frozenPositions>
-                    <Template Context="postion">
-                        @postion
-                    </Template>
-                </RadzenDropDown>
-            </Template>
-        </RadzenDataGridColumn>
-    </Columns>
-</RadzenDataGrid>
+<RadzenCard class="my-4" style="display: flex; align-items: center; gap: 0.5rem">
+    <div style="white-space:nowrap; margin-right: 16px">GridLines:</div>
+    <RadzenSelectBar @bind-Value="@GridLines" TextProperty="Text" ValueProperty="Value"
+                     Data="@(Enum.GetValues(typeof(Radzen.DataGridGridLines)).Cast<Radzen.DataGridGridLines>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
+</RadzenCard>
+<RadzenCard class="my-4" style="display: flex; align-items: center; gap: 0.5rem">
+    <RadzenDataGrid Data="@frozenInfos" TItem="FrozenInfo" AllowAlternatingRows="false">
+        <Columns>
+            <RadzenDataGridColumn TItem="FrozenInfo" Property="PropertyName" Title="Title" Width="150px" />
+            <RadzenDataGridColumn TItem="FrozenInfo" Title="Frozen" Width="60px">
+                <Template Context="data">
+                    <RadzenCheckBox @bind-Value=@data.Frozen Name="FrozenCheckbox" />
+                </Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="FrozenInfo" Title="Position" Width="140px">
+                <Template Context="data">
+                    <RadzenDropDown @bind-Value=@data.FrozenPosition Data=@frozenPositions Style="width: 120px">
+                        <Template Context="postion">
+                            @postion
+                        </Template>
+                    </RadzenDropDown>
+                </Template>
+            </RadzenDataGridColumn>
+        </Columns>
+    </RadzenDataGrid>
+</RadzenCard>
 
-<RadzenDataGrid AllowFiltering="true" AllowColumnResize="true" FilterMode="FilterMode.Advanced" AllowPaging="true" AllowSorting="true" Data="@employees" TItem="Employee" 
-    ColumnWidth="140px" LogicalFilterOperator="LogicalFilterOperator.Or">
+<RadzenDataGrid AllowFiltering="true" AllowColumnResize="true" FilterMode="FilterMode.Advanced" AllowPaging="true" AllowSorting="true" Data="@employees" TItem="Employee"
+                GridLines="@GridLines" ColumnWidth="140px" LogicalFilterOperator="LogicalFilterOperator.Or">
     <Columns>
         <RadzenDataGridColumn TItem="Employee" Property="EmployeeID" Filterable="false" Title="ID" Width="5rem" TextAlign="TextAlign.Center" Frozen="@isFrozen("EmployeeID")" FrozenPosition="@frozenPosition("EmployeeID")" />
         <RadzenDataGridColumn TItem="Employee" Title="Photo" Sortable="false" Filterable="false" Width="80px" TextAlign="TextAlign.Center" Frozen="@isFrozen("Photo")" FrozenPosition="@frozenPosition("Photo")">
@@ -63,7 +70,7 @@
         public bool Frozen { get; set; }
         public FrozenPosition FrozenPosition { get; set; }
     }
-
+    Radzen.DataGridGridLines GridLines = Radzen.DataGridGridLines.Default;
     IEnumerable<Employee> employees;
     List<FrozenPosition> frozenPositions = new List<FrozenPosition>
     {

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumnsPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumnsPage.razor
@@ -3,10 +3,19 @@
 <RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
     DataGrid <strong>Frozen Columns</strong>
 </RadzenText>
+
 <RadzenText TextStyle="TextStyle.Subtitle1" class="rz-pb-4">
     Lock columns to prevent them from scrolling out of view via the <code>Frozen</code> property.
 </RadzenText>
 
 <RadzenExample ComponentName="DataGrid" Example="DataGridFrozenColumns">
     <DataGridFrozenColumns />
+</RadzenExample>
+
+<RadzenText TextStyle="TextStyle.Subtitle1" class="rz-pb-4">
+    Lock columns to prevent them from scrolling out of view via the <code>Frozen</code> property.
+</RadzenText>
+
+<RadzenExample ComponentName="DataGrid" Example="DataGridFrozenColumns2">
+    <DataGridFrozenColumns2 />
 </RadzenExample>

--- a/RadzenBlazorDemos/Pages/DataGridFrozenColumnsPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridFrozenColumnsPage.razor
@@ -13,7 +13,7 @@
 </RadzenExample>
 
 <RadzenText TextStyle="TextStyle.Subtitle1" class="rz-pb-4">
-    Lock columns to prevent them from scrolling out of view via the <code>Frozen</code> property.
+    Lock columns to prevent them from scrolling out of view via the <code>Frozen</code> property. <code>FrozenPosition</code> property can be used to lock the column either on left or on right.
 </RadzenText>
 
 <RadzenExample ComponentName="DataGrid" Example="DataGridFrozenColumns2">


### PR DESCRIPTION
Right side frozen columns for `RadzenDataGrid` has been implemented.

`RadzenDataGridColumn` introduces the new `FrozenPosition` property, which can either be `FrozenColumnPosition.Left` (default) or `FrozenColumnPosition.Right`. 

RadzenBlazorDemos/Pages/DataGridFrozenColumnsPage.razor has been extended to show usage.

Implemented issue:
- #750


