### PR TITLE
Create context menu separators without RenderFragment

### DIFF
--- a/Radzen.Blazor/ContextMenuService.cs
+++ b/Radzen.Blazor/ContextMenuService.cs
@@ -215,4 +215,9 @@ namespace Radzen
         /// <value>The image.</value>
         public string Image { get; set; }
     }
+
+    /// <summary>
+    /// Class ContextMenuSeparator.
+    /// </summary>
+    public class ContextMenuSeparator : ContextMenuItem { }
 }

--- a/Radzen.Blazor/RadzenContextMenu.razor
+++ b/Radzen.Blazor/RadzenContextMenu.razor
@@ -17,7 +17,11 @@
                 <RadzenMenu Click="@(args => { if (menu.Options.Click != null) { menu.Options.Click(args); } })" Responsive="false">
                     @foreach (var item in menu.Options.Items)
                     {
-                        <RadzenMenuItem Text="@item.Text" Value="@item.Value" Icon="@item.Icon" IconColor="@item.IconColor" Image="@item.Image"></RadzenMenuItem>
+                        if(item is ContextMenuSeparator) {
+                            <hr />
+                        } else {
+                            <RadzenMenuItem Text="@item.Text" Value="@item.Value" Icon="@item.Icon" IconColor="@item.IconColor" Image="@item.Image"></RadzenMenuItem>
+                        }
                     }
                 </RadzenMenu>
             </div>


### PR DESCRIPTION
I created a ContextMenuSeparator class that extends ContextMenuItem and modified RadzenContextMenu to distinguish between those to types. I feels a litte bit more "natural" to me than the following approaches.

Another approach would be to create a simple "IsSeparator" property which RadzenContextMenu checks against. Yet another approach could be to create the properties "InsertSeparatorAfter" or "InsertSeparatorBefore".

I am happy to contribute any approach, if you want me to.

Someone created an issue 5 days ago (#1201)