### PR TITLE
Added expand/collapse title and aria-label attributes to panels.

### DIFF
--- a/Radzen.Blazor/RadzenPanel.razor
+++ b/Radzen.Blazor/RadzenPanel.razor
@@ -21,13 +21,17 @@
             {
                 @if (collapsed)
                 {
-                    <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler" href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content" aria-expanded="false">
+                    <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
+                       href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
+                       aria-expanded="false" aria-label="@ExpandAriaLabel" title="@ExpandTitle">
                         <span class="rzi rzi-plus"></span>
                     </a>
                 }
                 else
                 {
-                    <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler" href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content" aria-expanded="true">
+                    <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
+                       href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
+                       aria-expanded="true" aria-label="@CollapseAriaLabel" title="@CollapseTitle">
                         <span class="rzi rzi-minus"></span>
                     </a>
                 }

--- a/Radzen.Blazor/RadzenPanel.razor.cs
+++ b/Radzen.Blazor/RadzenPanel.razor.cs
@@ -102,6 +102,34 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback Collapse { get; set; }
 
+        /// <summary>
+        /// Gets or sets the title attribute of the expand button.
+        /// </summary>
+        /// <value>The title attribute value of the expand button.</value>
+        [Parameter]
+        public string ExpandTitle { get; set; } = "Expand";
+        
+        /// <summary>
+        /// Gets or sets the title attribute of the collapse button.
+        /// </summary>
+        /// <value>The title attribute value of the collapse button.</value>
+        [Parameter]
+        public string CollapseTitle { get; set; } = "Collapse";
+
+        /// <summary>
+        /// Gets or sets the aria-label attribute of the expand button.
+        /// </summary>
+        /// <value>The aria-label attribute value of the expand button.</value>
+        [Parameter]
+        public string ExpandAriaLabel { get; set; } = null;
+        
+        /// <summary>
+        /// Gets or sets the aria-label attribute of the collapse button.
+        /// </summary>
+        /// <value>The aria-label attribute value of the collapse button.</value>
+        [Parameter]
+        public string CollapseAriaLabel { get; set; } = null;
+        
         string contentStyle = "display: block;";
         string summaryContentStyle = "display: none";
 


### PR DESCRIPTION
I missed a component on PR #1204. This adds expand/collapse title and aria-label attributes to RadzenPanels.