### PR TITLE
Issue #1016 - Adds input id parameter for RadzenDropDowns.

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -12,7 +12,7 @@
     <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" onmousedown="Radzen.activeElement = null" @onclick="@(args => OpenPopup("ArrowDown", false, true))" @onclick:preventDefault @onclick:stopPropagation style="@Style" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
          @onkeydown="@((args) => OnKeyPress(args))" id="@GetId()"  @onfocus="@((args) => OnFocus(args))">
         <div class="rz-helper-hidden-accessible">
-            <input disabled="@Disabled" aria-haspopup="listbox" readonly="" type="text" tabindex="-1"
+            <input disabled="@Disabled" aria-haspopup="listbox" readonly="" type="text" tabindex="-1" id="@InputId"
                    name="@Name" value="@(internalValue != null ? internalValue : "")"
                    aria-label="@(!Multiple && internalValue != null ? internalValue : "")" />
         </div>

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -60,6 +60,25 @@ namespace Radzen.Blazor
         [Parameter]
         public string FilterPlaceholder { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Gets or sets the <c>id</c> attribute value of the <c>RadzenDropDown</c> component's <c>input</c> element.
+        /// </summary>
+        /// <remarks>Form fields should be linked to their labels through the <c>input</c>'s <c>id</c> attribute and
+        /// the label's <c>for</c> attribute. The <c>Component</c> parameter of a <c>RadnzenLabel</c> should match the
+        /// <c>id</c> attribute of the <c>input</c> element it labels.</remarks>
+        /// <example>
+        /// For example:
+        /// <code>
+        /// <RadzenLabel Component="myInput" />
+        /// <RadzenDropDown InputId="myInput" />
+        /// </code>
+        /// This links the label with the input through the <c>Component</c> parameter and the <c>InputId</c> parameter.
+        /// results in <c>p</c>'s having the value (2,8).
+        /// </example>
+        /// <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/for" />
+        /// <value>The <c>id</c> attribute value of the <c>RadzenDropDown</c> component's <c>input</c> element.</value>
+        public string InputId { get; set; } = null;
+        
         private async Task OnFocus(Microsoft.AspNetCore.Components.Web.FocusEventArgs args)
         {
             if (OpenOnFocus)


### PR DESCRIPTION
Adds an `InputId` parameter to set the id attribute of the **RadzenDropDown**'s input element. See #1016.