### PR TITLE
Fix columns visibility when DataGrid Reset

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1767,7 +1767,7 @@ namespace Radzen.Blazor
         }
 
         /// <summary>
-        /// Resets the DataGrid instance to initial state with no sorting, grouping and/or filtering.
+        /// Resets the DataGrid instance to initial state with no sorting, grouping and/or filtering, column visibility.
         /// </summary>
         /// <param name="resetColumnState">if set to <c>true</c> [reset column state].</param>
         /// <param name="resetRowState">if set to <c>true</c> [reset row state].</param>
@@ -1792,7 +1792,9 @@ namespace Radzen.Blazor
                     c.ResetSortOrder();
                     c.SetOrderIndex(null);
                     c.SetWidth(null);
+                    c.SetVisible(null);
                 });
+                selectedColumns = allColumns.Where(c => c.Pickable && c.GetVisible()).ToList();
                 sorts.Clear();
            }
 
@@ -3322,10 +3324,6 @@ namespace Radzen.Blazor
                         CurrentPage = 0;
                         skip = 0;
                         Reset(true);
-                        allColumns.ToList().ForEach(c =>
-                        {
-                            c.SetVisible(true);
-                        });
                         columns = allColumns.Where(c => c.Parent == null).ToList();
                         InvokeAsync(Reload);
 


### PR DESCRIPTION
Fix columns visibility when DataGrid Reset, columns visibility returns to its default state. Now, after the reset, all columns are visible without using the Visible="" parameter, only after refresh page, the correct columns are displayed.

Before:

https://github.com/radzenhq/radzen-blazor/assets/18440948/88c9dbc6-de88-417f-a195-322d9992510a



After:


https://github.com/radzenhq/radzen-blazor/assets/18440948/5d2aa9a1-d8b2-41a7-a73c-f64a814bb6fd

