### PR TITLE
Gets the currently selected RadzenTabsItem based on the selectedIndex

### DIFF
--- a/Radzen.Blazor/RadzenTabs.razor.cs
+++ b/Radzen.Blazor/RadzenTabs.razor.cs
@@ -105,7 +105,11 @@ namespace Radzen.Blazor
             }
         }
 
-        RadzenTabsItem SelectedTab
+        /// <summary>
+        /// Gets the currently selected RadzenTabsItem based on the selectedIndex.
+        /// </summary>
+
+        public RadzenTabsItem SelectedTab
         {
             get
             {


### PR DESCRIPTION
The purpose of being able to access the currently selected RadzenTabsItem is to solve this problem.

```
<RadzenTabs @ref=RefTab RenderMode="TabRenderMode.Client" 
    <Tabs >
        <RadzenTabsItem Text="Title1">

        </RadzenTabsItem>
        @if (Condicion)
        {
            <RadzenTabsItem Text="Title2" >
            </RadzenTabsItem>
        }

        <RadzenTabsItem Text="Title3">
        </RadzenTabsItem>
    </Tabs>
</RadzenTabs>
```

In this example, the SelectedIndex, if Title2 is hidden, and I press Title3, it will be 1, but if Title2 is visible, when I press Title3 it will be 2

By leaving it public you can access, for example, the title to be able to make some type of filter

```
        public async Task GetDataSelectedTab()
        {
            if (RefTab.SelectedTab.Text == "Title1")
            {
                await LoadTitle1();
            }
            if (RefTab.SelectedTab.Text == "Title2")
            {
                await LoadTitle2();
            }
            if (RefTab.SelectedTab.Text == "Title3")
            {
                await LoadTitle3();
            }
        }
```
If there is an alternative that I cannot detect, please comment.

