### PR TITLE
Add property to SplitterPane to be able to show / hide splitter bar

### DIFF
--- a/Radzen.Blazor/RadzenSplitterPane.razor
+++ b/Radzen.Blazor/RadzenSplitterPane.razor
@@ -9,7 +9,7 @@
     </div>
 
 
-    @if (!IsLast)
+    @if (!IsLast && BarVisible)
     {
         <div class="@GetComponentBarCssClass()"
              @onclick:preventDefault="true"

--- a/Radzen.Blazor/RadzenSplitterPane.razor.cs
+++ b/Radzen.Blazor/RadzenSplitterPane.razor.cs
@@ -151,6 +151,13 @@ namespace Radzen.Blazor
         }
 
         /// <summary>
+        /// Gets or sets the visibility of the splitter bar.
+        /// </summary>
+        /// <value>The visibility of the splitter bar.</value>
+        [Parameter]
+        public bool BarVisible { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the splitter.
         /// </summary>
         /// <value>The splitter.</value>


### PR DESCRIPTION
Where there is a requirement to have all the functionality of the RadzenSplitter, but the "Bar" is moved programmatically.