### PR TITLE
Add PanelTogglerPosition + Demo

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -1826,6 +1826,21 @@ namespace Radzen
     }
 
     /// <summary>
+    /// Specifies the display style of a <see cref="RadzenPanel" />. Affects the visual styling of panel-titlebar toggler.
+    /// </summary>
+    public enum PanelTogglerPosition
+    {
+        /// <summary>
+        /// Toggler position before the icon and text on the left side of the panel-titlebar
+        /// </summary>
+        Left,
+        /// <summary>
+        /// Toggler default position on the right side of the panel-titlebar
+        /// </summary>
+        Right,       
+    }
+
+    /// <summary>
     /// Supplies information about a <see cref="RadzenDataGrid{TItem}.PickedColumnsChanged" /> event that is being raised.
     /// </summary>
     /// <typeparam name="T"></typeparam>

--- a/Radzen.Blazor/RadzenPanel.razor
+++ b/Radzen.Blazor/RadzenPanel.razor
@@ -1,8 +1,41 @@
 ﻿@inherits RadzenComponentWithChildren
+
+@{
+    string panelTitlebarStyle = "";
+
+    if (PanelTogglerPosition == PanelTogglerPosition.Left)
+    {
+        panelTitlebarStyle = "justify-content: start";
+    }
+}
+
 @if (Visible)
 {
     <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
-        <div class="rz-panel-titlebar">
+        <div class="rz-panel-titlebar" style="@panelTitlebarStyle">
+            @if (PanelTogglerPosition == PanelTogglerPosition.Left)
+            {
+                @if (AllowCollapse)
+                {
+                    @if (collapsed)
+                    {
+                        <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
+                           href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
+                           aria-expanded="false" aria-label="@ExpandAriaLabel" title="@ExpandTitle">
+                            <span class="rzi rzi-plus"></span>
+                        </a>
+                    }
+                    else
+                    {
+                        <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
+                           href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
+                           aria-expanded="true" aria-label="@CollapseAriaLabel" title="@CollapseTitle">
+                            <span class="rzi rzi-minus"></span>
+                        </a>
+                    }
+                }
+            }
+
             @if (!string.IsNullOrEmpty(Text) || !string.IsNullOrEmpty(Icon))
             {
                 <div>
@@ -17,23 +50,27 @@
                 </div>
             }
             @HeaderTemplate
-            @if (AllowCollapse)
+
+            @if (PanelTogglerPosition == PanelTogglerPosition.Right)
             {
-                @if (collapsed)
+                @if (AllowCollapse)
                 {
-                    <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
-                       href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
-                       aria-expanded="false" aria-label="@ExpandAriaLabel" title="@ExpandTitle">
-                        <span class="rzi rzi-plus"></span>
-                    </a>
-                }
-                else
-                {
-                    <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
-                       href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
-                       aria-expanded="true" aria-label="@CollapseAriaLabel" title="@CollapseTitle">
-                        <span class="rzi rzi-minus"></span>
-                    </a>
+                    @if (collapsed)
+                    {
+                        <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
+                           href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
+                           aria-expanded="false" aria-label="@ExpandAriaLabel" title="@ExpandTitle">
+                            <span class="rzi rzi-plus"></span>
+                        </a>
+                    }
+                    else
+                    {
+                        <a @onclick=@Toggle class="rz-panel-titlebar-icon rz-panel-titlebar-toggler"
+                           href="javascript:void(0)" role="tab" id="rz-panel-0-label" aria-controls="rz-panel-0-content"
+                           aria-expanded="true" aria-label="@CollapseAriaLabel" title="@CollapseTitle">
+                            <span class="rzi rzi-minus"></span>
+                        </a>
+                    }
                 }
             }
         </div>

--- a/Radzen.Blazor/RadzenPanel.razor.cs
+++ b/Radzen.Blazor/RadzenPanel.razor.cs
@@ -129,11 +129,19 @@ namespace Radzen.Blazor
         /// <value>The aria-label attribute value of the collapse button.</value>
         [Parameter]
         public string CollapseAriaLabel { get; set; } = null;
-        
+
+        /// <summary>
+        /// Gets or sets the toggler position at the panel-titlebar. 
+        /// </summary>
+        /// <value>The toggler position attribute value. Default <c>PanelTogglerPosition.Right</c></value>
+        [Parameter]
+        public PanelTogglerPosition PanelTogglerPosition { get; set; } = PanelTogglerPosition.Right;
+
+
         string contentStyle = "display: block;";
         string summaryContentStyle = "display: none";
 
-        async System.Threading.Tasks.Task Toggle(MouseEventArgs args)
+        async Task Toggle(MouseEventArgs args)
         {
             collapsed = !collapsed;
             contentStyle = collapsed ? "display: none;" : "display: block;";

--- a/RadzenBlazorDemos/Pages/PanelConfig.razor
+++ b/RadzenBlazorDemos/Pages/PanelConfig.razor
@@ -4,8 +4,14 @@
 
 @inherits DbContextPage
 
+<div style="display: flex; align-items: center; margin-bottom: 16px">
+    <div style="white-space:nowrap; margin-right: 16px">Panel Toggler Position:</div>
+    <RadzenDropDown @bind-Value="@panelTogglerPosition" TextProperty="Text" ValueProperty="Value"
+                    Data="@(Enum.GetValues(typeof(PanelTogglerPosition)).Cast<PanelTogglerPosition>().Select(t => new { Text = $"{t}", Value = t }))" />
+</div>
+
 <RadzenPanel AllowCollapse="true" Class="rz-my-10 rz-mx-auto" Style="width: 700px;"
-                Expand=@(() => Change("Panel expanded")) Collapse=@(() => Change("Panel collapsed")) >
+             Expand=@(() => Change("Panel expanded")) Collapse=@(() => Change("Panel collapsed")) PanelTogglerPosition="@panelTogglerPosition">
     <HeaderTemplate>
         <RadzenText TextStyle="TextStyle.H6" Class="rz-display-flex rz-align-items-center rz-m-0">
             <RadzenIcon Icon="account_box" class="rz-mr-1" /><b>Orders</b>
@@ -53,6 +59,8 @@
     EventConsole console;
 
     IEnumerable<Order> orders;
+
+    PanelTogglerPosition panelTogglerPosition = PanelTogglerPosition.Right;
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
Add PanelTogglerPosition to RadzenPanel

Included a demo:
![grafik](https://github.com/radzenhq/radzen-blazor/assets/115212774/d971efe7-30c9-4cc4-aa6a-4b76bd9c785f)

Wasnt sure how to deal with the css `rz-panel-titlebar`. I override the `justify-content`, if toggler position `PanelTogglerPosition.Left` is set.

The `<a>` tag of the togglers could probably be a component too. With a component there is no need of copy paste the `<a>` tag as i did. I wasnt able to intgrate them.