### PR TITLE
Numeric Issue with Leading Zeros

### DIFF
--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -378,5 +378,36 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains($" value=\"{valueToTest.ToString(format)}\"", component.Markup);
         }
+        
+        public static TheoryData<decimal, decimal> NumericFormatterPreservesLeadingZerosData =>
+            new()
+            {
+                { 10.000m, 100.000m },
+                { 100.000m, 10.000m }
+            };
+        
+        [Theory]
+        [MemberData(nameof(NumericFormatterPreservesLeadingZerosData))]
+        public void Numeric_Formatted_PreservesLeadingZeros(decimal oldValue, decimal newValue)
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            string format = "0.000";
+
+            var component = ctx.RenderComponent<RadzenNumeric<decimal>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<decimal>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<decimal>.Value), oldValue)
+            );
+
+            component.Render();
+            
+            Assert.Contains($" value=\"{oldValue.ToString(format)}\"", component.Markup);
+
+            component.Find("input").Change(newValue);
+            
+            Assert.Contains($" value=\"{newValue.ToString(format)}\"", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -388,7 +388,7 @@ namespace Radzen.Blazor.Tests
         
         [Theory]
         [MemberData(nameof(NumericFormatterPreservesLeadingZerosData))]
-        public void Numeric_Formatted_PreservesLeadingZeros(decimal oldValue, decimal newValue)
+        public void Numeric_Formatter_PreservesLeadingZeros(decimal oldValue, decimal newValue)
         {
             using var ctx = new TestContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -266,7 +266,19 @@ namespace Radzen.Blazor
 
             if (!string.IsNullOrEmpty(Format))
             {
-                valueStr = valueStr.Replace(Format.Replace("#", "").Trim(), "");
+                string formattedStringWithoutPlaceholder = Format.Replace("#", "").Trim();
+                
+                if (valueStr.Contains(Format))
+                {
+                    string currencyDecimalSeparator = Culture.NumberFormat.CurrencyDecimalSeparator;
+
+                    string[] splitFormatString = formattedStringWithoutPlaceholder.Split(currencyDecimalSeparator);
+                    string[] splitValueString = valueStr.Split(currencyDecimalSeparator);
+                    int lengthDifference = splitValueString[0].Length - splitFormatString[0].Length;
+                    formattedStringWithoutPlaceholder = formattedStringWithoutPlaceholder.PadLeft(formattedStringWithoutPlaceholder.Length + lengthDifference, '0');
+                }
+                
+                valueStr = valueStr.Replace(formattedStringWithoutPlaceholder, "");
             }
 
             return new string(valueStr.Where(c => char.IsDigit(c) || char.IsPunctuation(c)).ToArray()).Replace("%", "");


### PR DESCRIPTION
There is a formatting issue using a formatting template such as 0.0000. Updating the value from 10.0000 to 100.0000 is resetting to 10.000.

![ezgif-5-a5e08e35bf](https://github.com/radzenhq/radzen-blazor/assets/33861884/75c585f6-cfae-4f11-bc75-34636bb61469)

I've added a unit test that fails without the fix included

![Screenshot 2023-11-14 094120](https://github.com/radzenhq/radzen-blazor/assets/33861884/041f0334-4356-46f4-99a1-d4b04dd061d8)

It passes successfully with the included fix.
