### PR TITLE
Update QueryableExtension.cs

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -376,6 +376,8 @@ namespace Radzen
             {
                 property = $"({property})";
             }
+            bool hasNp = property.Contains("np(");
+            string npProperty = hasNp ? property : $@"np({property})";
 
             var columnFilterOperator = !second ? column.GetFilterOperator() : column.GetSecondFilterOperator();
 
@@ -415,19 +417,19 @@ namespace Radzen
                 }
                 else if (columnFilterOperator == FilterOperator.IsNull)
                 {
-                    return $@"np({property}) == null";
+                    return npProperty + " == null";
                 }
                 else if (columnFilterOperator == FilterOperator.IsEmpty)
                 {
-                    return $@"np({property}) == """"";
+                    return npProperty + @" == """"";
                 }
                 else if (columnFilterOperator == FilterOperator.IsNotEmpty)
                 {
-                    return $@"np({property}) != """"";
+                    return npProperty + @" != """"";
                 }
                 else if (columnFilterOperator == FilterOperator.IsNotNull)
                 {
-                    return $@"np({property}) != null";
+                    return npProperty + @" != null";
                 }
             }
             else if (PropertyAccess.IsNumeric(column.FilterPropertyType))


### PR DESCRIPTION
Bug: If you use a sub-property in the Column PropertyName (ex: "Data2.Name") and the filter is isNull / IsNotNull / Empty/ NotEmtpy  -> There will be an excepction: "Error: The 'np' (null-propagation) function requires the first argument to be a MemberExpression, ParameterExpression or MethodCallExpression (at index 0) because of the double np(np(.....)) in the generated Filter property....