### PR TITLE
Various changes to Radzen Blazor Chart column and bar series

### DIFF
--- a/Radzen.Blazor/AxisBase.cs
+++ b/Radzen.Blazor/AxisBase.cs
@@ -103,6 +103,13 @@ namespace Radzen.Blazor
         public double ChartBaseValue { get; set; } = 0.0;
 
         /// <summary>
+        /// Gets or sets the buffer distance from the ChartBaseValue to adjacent chart axis labels and lines. Any that fall within will not be displayed. A value of 0.0 (default) hides the base label if not part of the calculated axis grid.
+        /// </summary>
+        /// <value>Buffer distance from the base label to adjacent chart axis labels and lines.</value>
+        [Parameter]
+        public double ChartBaseLabelSpace { get; set; } = 0.0;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="AxisBase"/> is visible.
         /// </summary>
         /// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>

--- a/Radzen.Blazor/AxisBase.cs
+++ b/Radzen.Blazor/AxisBase.cs
@@ -96,6 +96,13 @@ namespace Radzen.Blazor
         public object Step { get; set; }
 
         /// <summary>
+        /// Gets or sets the base value for the chart (defaults to 0).
+        /// </summary>
+        /// <value>The base value of the chart.</value>
+        [Parameter]
+        public double ChartBaseValue { get; set; } = 0.0;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="AxisBase"/> is visible.
         /// </summary>
         /// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>

--- a/Radzen.Blazor/AxisBase.cs
+++ b/Radzen.Blazor/AxisBase.cs
@@ -103,6 +103,13 @@ namespace Radzen.Blazor
         public double ChartBaseValue { get; set; } = 0.0;
 
         /// <summary>
+        /// Gets or sets whether the ChartBaseValue is shown
+        /// </summary>
+        /// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ShowChartBaseLabel { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the buffer distance from the ChartBaseValue to adjacent chart axis labels and lines. Any that fall within will not be displayed. A value of 0.0 (default) hides the base label if not part of the calculated axis grid.
         /// </summary>
         /// <value>Buffer distance from the base label to adjacent chart axis labels and lines.</value>

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -311,6 +311,21 @@ namespace Radzen
     }
 
     /// <summary>
+    /// Render Color Mode .
+    /// </summary>
+    public enum RenderColorMode
+    {
+        /// <summary>
+        /// Colors will be applied from css style of current theme or from Fills to each series.
+        /// </summary>
+        Series,
+        /// <summary>
+        /// First two colors will be applied from css style of current theme or from Fills to Positive and Negative values.
+        /// </summary>
+        PositiveNegative,
+    }
+
+    /// <summary>
     /// DataGrid settings class used to Save/Load settings.
     /// </summary>
     public class DataGridSettings

--- a/Radzen.Blazor/RadzenBarSeries.razor
+++ b/Radzen.Blazor/RadzenBarSeries.razor
@@ -6,16 +6,16 @@
 @implements IChartBarSeries
 
 <CascadingValue Value="@this">
-  @ChildContent
+    @ChildContent
 </CascadingValue>
 
 @code {
-   public override RenderFragment Render(ScaleBase categoryScale, ScaleBase valueScale)
-   {
+    public override RenderFragment Render(ScaleBase categoryScale, ScaleBase valueScale)
+    {
         var value = ComposeValue(categoryScale);
         var category = ComposeCategory(valueScale);
         var ticks = Chart.CategoryScale.Ticks(Chart.ValueAxis.TickDistance);
-        var x0 = Chart.CategoryScale.Scale(Math.Max(0, ticks.Start));
+        var x0 = Chart.CategoryScale.Scale(Math.Max(Chart.ValueAxis.ChartBaseValue, ticks.Start));
         var style = $"clip-path: url(#{Chart.ClipPath}); -webkit-clip-path: url(#{Chart.ClipPath});";
 
         var barSeries = VisibleBarSeries;
@@ -23,35 +23,73 @@
         var padding = Chart.BarOptions.Margin;
 
         var barHeight = BandHeight;
-        var height = barHeight / barSeries.Count() - padding + padding / barSeries.Count();;
+        var height = barHeight / barSeries.Count() - padding + padding / barSeries.Count();
         var className = $"rz-bar-series rz-series-{Chart.Series.IndexOf(this)}";
 
-        return 
-        @<g class="@className">
-            @foreach(var data in Items)
-            {
-                var y = category(data) - barHeight / 2 + index * height + index * padding;
-                var x = value(data);
-                var radius = Chart.BarOptions.Radius;
-
-                if (radius > height / 2)
+        if (RenderColorMode == RenderColorMode.Series)
+        {
+            return
+            @<g class="@className">
+                @foreach(var data in Items)
                 {
-                    radius = 0;
+                    var y = category(data) - barHeight / 2 + index * height + index * padding;
+                    var x = value(data);
+                    var radius = Chart.BarOptions.Radius;
+
+                    if ((radius > height / 2) || (radius > Math.Abs(x - x0)))
+                    {
+                        radius = 0;
+                    }
+
+                    var r = radius.ToInvariantString();
+
+                    var path = $"M {x0.ToInvariantString()} {y.ToInvariantString()} L {(x-radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 1 {x.ToInvariantString()} {(y+radius).ToInvariantString()} L {x.ToInvariantString()} {(y+height-radius).ToInvariantString()} A {r} {r} 0 0 1 {(x-radius).ToInvariantString()} {(y + height).ToInvariantString()} L {x0.ToInvariantString()} {(y+height).ToInvariantString()} Z";
+
+                    if (x <= x0)
+                    {
+                        path = $"M {x0.ToInvariantString()} {y.ToInvariantString()} L {(x+radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 0 {x.ToInvariantString()} {(y+radius).ToInvariantString()} L {x.ToInvariantString()} {(y+height-radius).ToInvariantString()} A {r} {r} 0 0 0 {(x+radius).ToInvariantString()} {(y + height).ToInvariantString()} L {x0.ToInvariantString()} {(y+height).ToInvariantString()} Z";
+                    }
+                    var fill = PickColor(Items.IndexOf(data), Fills, Fill);
+                    var stroke = PickColor(Items.IndexOf(data), Strokes, Stroke);
+
+                    <Path @key="@path" D="@path" Stroke="@stroke" StrokeWidth="@StrokeWidth" Fill="@fill" LineType="@LineType" Style="@style" />
                 }
-
-                var r = radius.ToInvariantString();
-
-                var path = $"M {x0.ToInvariantString()} {y.ToInvariantString()} L {(x-radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 1 {x.ToInvariantString()} {(y+radius).ToInvariantString()} L {x.ToInvariantString()} {(y+height-radius).ToInvariantString()} A {r} {r} 0 0 1 {(x-radius).ToInvariantString()} {(y + height).ToInvariantString()} L {x0.ToInvariantString()} {(y+height).ToInvariantString()} Z";
-
-                if (x < x0)
+            </g>;
+        }
+        else
+        {
+            return
+            @<text>
+                @foreach(var data in Items)
                 {
-                    path = $"M {x0.ToInvariantString()} {y.ToInvariantString()} L {(x+radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 0 {x.ToInvariantString()} {(y+radius).ToInvariantString()} L {x.ToInvariantString()} {(y+height-radius).ToInvariantString()} A {r} {r} 0 0 0 {(x+radius).ToInvariantString()} {(y + height).ToInvariantString()} L {x0.ToInvariantString()} {(y+height).ToInvariantString()} Z";
-                }
-                var fill = PickColor(Items.IndexOf(data), Fills, Fill);
-                var stroke = PickColor(Items.IndexOf(data), Strokes, Stroke);
+                    var y = category(data) - barHeight / 2 + index * height + index * padding;
+                    var x = value(data);
+                    var val =  Value(data);
+                    className = val <= Chart.ValueAxis.ChartBaseValue ? $"rz-column-series rz-series-0" :  $"rz-column-series rz-series-1";
+                    var radius = Chart.ColumnOptions.Radius;
 
-                <Path @key="@path" D="@path" Stroke="@stroke" StrokeWidth="@StrokeWidth" Fill="@fill" LineType="@LineType" Style="@style" />
-            }
-        </g>;
+                    if ((radius > height / 2) || (radius > Math.Abs(x - x0)))
+                    {
+                        radius = 0;
+                    }
+
+                    var r = radius.ToInvariantString();
+
+                    var path = $"M {x0.ToInvariantString()} {y.ToInvariantString()} L {(x-radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 1 {x.ToInvariantString()} {(y+radius).ToInvariantString()} L {x.ToInvariantString()} {(y+height-radius).ToInvariantString()} A {r} {r} 0 0 1 {(x-radius).ToInvariantString()} {(y + height).ToInvariantString()} L {x0.ToInvariantString()} {(y+height).ToInvariantString()} Z";
+
+                    if (x <= x0)
+                    {
+                        path = $"M {x0.ToInvariantString()} {y.ToInvariantString()} L {(x+radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 0 {x.ToInvariantString()} {(y+radius).ToInvariantString()} L {x.ToInvariantString()} {(y+height-radius).ToInvariantString()} A {r} {r} 0 0 0 {(x+radius).ToInvariantString()} {(y + height).ToInvariantString()} L {x0.ToInvariantString()} {(y+height).ToInvariantString()} Z";
+                    }
+
+                    var fill = PickColor(val <= Chart.ValueAxis.ChartBaseValue ? 0 : 1, Fills, Fill);
+                    var stroke = PickColor(val <= Chart.ValueAxis.ChartBaseValue ? 0 : 1, Strokes, Stroke);
+
+                    <g class="@className">
+                        <Path @key="@path" D="@path" Stroke="@stroke" StrokeWidth="@StrokeWidth" Fill="@fill" LineType="@LineType" Style="@style" />
+                    </g>;
+                }
+            </text>;
+        }
     }
 }

--- a/Radzen.Blazor/RadzenColumnSeries.razor
+++ b/Radzen.Blazor/RadzenColumnSeries.razor
@@ -1,3 +1,4 @@
+@using Radzen
 @using Radzen.Blazor
 @using Radzen.Blazor.Rendering
 @typeparam TItem
@@ -5,15 +6,16 @@
 @implements IChartColumnSeries
 
 <CascadingValue Value="@this">
-  @ChildContent
+    @ChildContent
 </CascadingValue>
+
 @code {
     public override RenderFragment Render(ScaleBase categoryScale, ScaleBase valueScale)
     {
         var category = ComposeCategory(categoryScale);
         var value = ComposeValue(valueScale);
         var ticks = Chart.ValueScale.Ticks(Chart.ValueAxis.TickDistance);
-        var y0 = Chart.ValueScale.Scale(Math.Max(0, ticks.Start));
+        var y0 = Chart.ValueScale.Scale(Math.Max(Chart.ValueAxis.ChartBaseValue, ticks.Start));
         var style = $"clip-path: url(#{Chart.ClipPath}); -webkit-clip-path: url(#{Chart.ClipPath});";
 
         var columnSeries = VisibleColumnSeries;
@@ -21,33 +23,73 @@
         var padding = Chart.ColumnOptions.Margin;
 
         var bandWidth = BandWidth;
-        var width = bandWidth / columnSeries.Count() - padding + padding / columnSeries.Count();;
+        var width = bandWidth / columnSeries.Count() - padding + padding / columnSeries.Count();
         var className = $"rz-column-series rz-series-{Chart.Series.IndexOf(this)}";
 
-        return 
-        @<g class="@className">
-            @foreach(var data in Items)
-            {
-                var x = category(data) - bandWidth / 2 + index * width + index * padding;
-                var y = value(data);
-                var radius = Chart.ColumnOptions.Radius;
-
-                if (radius > width / 2)
+        if (RenderColorMode == RenderColorMode.Series)
+        {
+            return
+            @<g class="@className">
+                @foreach(var data in Items)
                 {
-                    radius = 0;
+                    var x = category(data) - bandWidth / 2 + index * width + index * padding;
+                    var y = value(data);
+                    var radius = Chart.ColumnOptions.Radius;
+
+                    if ((radius > width / 2) || (radius > Math.Abs(y - y0)))
+                    {
+                        radius = 0;
+                    }
+
+                    var r = radius.ToInvariantString();
+
+                    var path = $"M {x.ToInvariantString()} {(y+radius).ToInvariantString()} A {r} {r} 0 0 1 {(x + radius).ToInvariantString()} {y.ToInvariantString()} L {(x + width - radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 1 {(x + width).ToInvariantString()} {(y+radius).ToInvariantString()} L {(x+width).ToInvariantString()} {y0.ToInvariantString()} L {x.ToInvariantString()} {y0.ToInvariantString()} Z";
+
+                    if (y >= y0)
+                    {
+                        path = $"M {x.ToInvariantString()} {y0.ToInvariantString()} L {(x+width).ToInvariantString()} {y0.ToInvariantString()} L {(x+width).ToInvariantString()} {(y-radius).ToInvariantString()} A {r} {r} 0 0 1 {(x + width - radius).ToInvariantString()} {y.ToInvariantString()} L {(x + radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 1 {x.ToInvariantString()} {(y-radius).ToInvariantString()} L {x.ToInvariantString()} {y0.ToInvariantString()} Z";
+                    }
+                    var fill = PickColor(Items.IndexOf(data), Fills, Fill);
+                    var stroke = PickColor(Items.IndexOf(data), Strokes, Stroke);
+
+                    <Path @key="@path" D="@path" Stroke="@stroke" StrokeWidth="@StrokeWidth" Fill="@fill" LineType="@LineType" Style="@style" />
                 }
-
-                var path = $"M {x.ToInvariantString()} {(y+radius).ToInvariantString()} A {radius.ToInvariantString()} {radius.ToInvariantString()} 0 0 1 {(x + radius).ToInvariantString()} {y.ToInvariantString()} L {(x + width - radius).ToInvariantString()} {y.ToInvariantString()} A {radius.ToInvariantString()} {radius.ToInvariantString()} 0 0 1 {(x + width).ToInvariantString()} {(y+radius).ToInvariantString()} L {(x+width).ToInvariantString()} {y0.ToInvariantString()} L {x.ToInvariantString()} {y0.ToInvariantString()} Z";
-
-                if (y > y0)
+            </g>;
+        }
+        else
+        {
+            return
+            @<text>
+                @foreach(var data in Items)
                 {
-                    path = $"M {x.ToInvariantString()} {y0.ToInvariantString()} L {(x+width).ToInvariantString()} {y0.ToInvariantString()} L {(x+width).ToInvariantString()} {(y-radius).ToInvariantString()} A {radius.ToInvariantString()} {radius.ToInvariantString()} 0 0 1 {(x + width - radius).ToInvariantString()} {y.ToInvariantString()} L {(x + radius).ToInvariantString()} {y.ToInvariantString()} A {radius.ToInvariantString()} {radius.ToInvariantString()} 0 0 1 {x.ToInvariantString()} {(y-radius).ToInvariantString()} L {x.ToInvariantString()} {y0.ToInvariantString()} Z";
-                }
-                var fill = PickColor(Items.IndexOf(data), Fills, Fill);
-                var stroke = PickColor(Items.IndexOf(data), Strokes, Stroke);
+                    var x = category(data) - bandWidth / 2 + index * width + index * padding;
+                    var y = value(data);
+                    var val =  Value(data);
+                    className = val <= Chart.ValueAxis.ChartBaseValue ? $"rz-column-series rz-series-0" :  $"rz-column-series rz-series-1";
+                    var radius = Chart.ColumnOptions.Radius;
 
-                <Path @key="@path" D="@path" Stroke="@stroke" StrokeWidth="@StrokeWidth" Fill="@fill" LineType="@LineType" Style="@style" />
-            }
-        </g>;
+                    if ((radius > width / 2) || (radius > Math.Abs(y - y0)))
+                    {
+                        radius = 0;
+                    }
+
+                    var r = radius.ToInvariantString();
+
+                    var path = $"M {x.ToInvariantString()} {(y+radius).ToInvariantString()} A {r} {r} 0 0 1 {(x + radius).ToInvariantString()} {y.ToInvariantString()} L {(x + width - radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 1 {(x + width).ToInvariantString()} {(y+radius).ToInvariantString()} L {(x+width).ToInvariantString()} {y0.ToInvariantString()} L {x.ToInvariantString()} {y0.ToInvariantString()} Z";
+
+                    if (y >= y0)
+                    {
+                        path = $"M {x.ToInvariantString()} {y0.ToInvariantString()} L {(x+width).ToInvariantString()} {y0.ToInvariantString()} L {(x+width).ToInvariantString()} {(y-radius).ToInvariantString()} A {r} {r} 0 0 1 {(x + width - radius).ToInvariantString()} {y.ToInvariantString()} L {(x + radius).ToInvariantString()} {y.ToInvariantString()} A {r} {r} 0 0 1 {x.ToInvariantString()} {(y-radius).ToInvariantString()} L {x.ToInvariantString()} {y0.ToInvariantString()} Z";
+                    }
+
+                    var fill = PickColor(val <= Chart.ValueAxis.ChartBaseValue ? 0 : 1, Fills, Fill);
+                    var stroke = PickColor(val <= Chart.ValueAxis.ChartBaseValue ? 0 : 1, Strokes, Stroke);
+
+                    <g class="@className">
+                        <Path @key="@path" D="@path" Stroke="@stroke" StrokeWidth="@StrokeWidth" Fill="@fill" LineType="@LineType" Style="@style" />
+                    </g>;
+                }
+            </text>;
+        }
     }
 }

--- a/Radzen.Blazor/RadzenColumnSeries.razor.cs
+++ b/Radzen.Blazor/RadzenColumnSeries.razor.cs
@@ -27,7 +27,7 @@ namespace Radzen.Blazor
         [Parameter]
         public IEnumerable<string> Fills { get; set; }
 
-        /// <summary>
+        /// <summary>   
         /// Specifies the stroke (border color) of the column series.
         /// </summary>
         /// <value>The stroke.</value>

--- a/Radzen.Blazor/Rendering/CategoryAxis.razor
+++ b/Radzen.Blazor/Rendering/CategoryAxis.razor
@@ -11,7 +11,7 @@
             x = Chart.CategoryScale.Scale(idx, true);
             var text = XAxis.Format(Chart.CategoryScale, value);
 
-            if ((XAxis.ChartBaseLabelSpace == 0.0) || (XAxis.ChartBaseLabelSpace != 0.0 && (Math.Abs(x0 - x) > XAxis.ChartBaseLabelSpace)))
+            if ((!XAxis.ShowChartBaseLabel) || (XAxis.ShowChartBaseLabel && (Math.Abs(x0 - x) > XAxis.ChartBaseLabelSpace)))
             {
                 if (XAxis.Ticks.Template != null)
                 {
@@ -32,7 +32,7 @@
                 }
             }
         }
-        @if (XAxis.ChartBaseLabelSpace != 0.0)
+        @if (XAxis.ShowChartBaseLabel)
         {
             var value = Chart.CategoryScale.Value(XAxis.ChartBaseValue);
             var text = XAxis.Format(Chart.CategoryScale, value);

--- a/Radzen.Blazor/Rendering/CategoryAxis.razor
+++ b/Radzen.Blazor/Rendering/CategoryAxis.razor
@@ -3,36 +3,49 @@
 @if (XAxis.Visible)
 {
     <g class="rz-axis rz-category-axis">
-    <Line Class="rz-line" X1="@x1" Y1="@y1" X2="@x2" Y2="@y1" Stroke="@XAxis.Stroke" StrokeWidth="@XAxis.StrokeWidth" LineType="@XAxis.LineType" />
-    @for (var idx = start; idx <= end; idx += step)
-    {
-        var value = Chart.CategoryScale.Value((double)idx);
-        var x = Chart.CategoryScale.Scale((double)idx, true);
-
-        var text = XAxis.Format(Chart.CategoryScale, value);
-
-        if (XAxis.Ticks.Template != null)
+        <Line Class="rz-line" X1="@x1" Y1="@y1" X2="@x2" Y2="@y1" Stroke="@XAxis.Stroke" StrokeWidth="@XAxis.StrokeWidth" LineType="@XAxis.LineType" />
+        @for (var idx = start; idx <= end; idx += step)
         {
-            var context = new TickTemplateContext { Text = text, Value = value, X = x, Y = y1 } ;
+            var value = Chart.CategoryScale.Value((double)idx);
+            var x = Chart.CategoryScale.Scale((double)idx, true);
 
-            <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType">
-                @XAxis.Ticks.Template(context)
-            </CategoryAxisTick>
-        } 
-        else if (!String.IsNullOrEmpty(text))
-        {
-            <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType"/>
+            var text = XAxis.Format(Chart.CategoryScale, value);
+
+            if (XAxis.Ticks.Template != null)
+            {
+                var context = new TickTemplateContext { Text = text, Value = value, X = x, Y = y1 };
+
+                <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType">
+                    @XAxis.Ticks.Template(context)
+                </CategoryAxisTick>
+            }
+            else if (!String.IsNullOrEmpty(text))
+            {
+                <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType" />
+            }
+
+            if (XAxis.GridLines.Visible && idx > start)
+            {
+                <Line Class="rz-grid-line" X1="@x" Y1="@y1" X2="@x" Y2="@y2" Stroke="@XAxis.GridLines.Stroke" StrokeWidth="@XAxis.GridLines.StrokeWidth" LineType="@XAxis.GridLines.LineType" />
+            }
+
+            if (!basedrawn && (double)idx == Chart.ValueAxis.ChartBaseValue) basedrawn = true;
+
         }
 
-        if (XAxis.GridLines.Visible && idx > start)
+        @if (!basedrawn)
         {
-            <Line Class="rz-grid-line" X1="@x" Y1="@y1" X2="@x" Y2="@y2" Stroke="@XAxis.GridLines.Stroke" StrokeWidth="@XAxis.GridLines.StrokeWidth" LineType="@XAxis.GridLines.LineType" />
+            var x = Chart.CategoryScale.Scale(Chart.ValueAxis.ChartBaseValue);
+            if (XAxis.GridLines.Visible)
+            {
+                <Line Class="rz-grid-line" X1="@x" Y1="@y1" X2="@x" Y2="@y2" Stroke="@XAxis.GridLines.Stroke" StrokeWidth="@XAxis.GridLines.StrokeWidth" LineType="@XAxis.GridLines.LineType" />
+            }
         }
-    }
-    @if (!String.IsNullOrEmpty(XAxis.Title.Text))
-    {
-        <CategoryAxisTitle X="@((x2 - x1)/2)" Y="@(y1 + Chart.CategoryAxis.Size - XAxis.Title.Size)" Text="@XAxis.Title.Text" />
-    }
+
+        @if (!String.IsNullOrEmpty(XAxis.Title.Text))
+        {
+            <CategoryAxisTitle X="@((x2 - x1)/2)" Y="@(y1 + Chart.CategoryAxis.Size - XAxis.Title.Size)" Text="@XAxis.Title.Text" />
+        }
     </g>
 }
 @code {
@@ -46,6 +59,8 @@
 
     private AxisBase XAxis { get; set; }
     private AxisBase YAxis { get; set; }
+
+    bool basedrawn;
 
     protected override void OnParametersSet()
     {
@@ -69,5 +84,7 @@
         var valueTicks = Chart.ValueScale.Ticks(YAxis.TickDistance);
         y1 = Chart.ValueScale.Scale(valueTicks.Start);
         y2 = Chart.ValueScale.Scale(valueTicks.End);
+
+        basedrawn = false;
     }
 }

--- a/Radzen.Blazor/Rendering/CategoryAxis.razor
+++ b/Radzen.Blazor/Rendering/CategoryAxis.razor
@@ -4,42 +4,56 @@
 {
     <g class="rz-axis rz-category-axis">
         <Line Class="rz-line" X1="@x1" Y1="@y1" X2="@x2" Y2="@y1" Stroke="@XAxis.Stroke" StrokeWidth="@XAxis.StrokeWidth" LineType="@XAxis.LineType" />
+
         @for (var idx = start; idx <= end; idx += step)
         {
-            var value = Chart.CategoryScale.Value((double)idx);
-            var x = Chart.CategoryScale.Scale((double)idx, true);
+            var value = Chart.CategoryScale.Value(idx);
+            x = Chart.CategoryScale.Scale(idx, true);
+            var text = XAxis.Format(Chart.CategoryScale, value);
 
+            if ((XAxis.ChartBaseLabelSpace == 0.0) || (XAxis.ChartBaseLabelSpace != 0.0 && (Math.Abs(x0 - x) > XAxis.ChartBaseLabelSpace)))
+            {
+                if (XAxis.Ticks.Template != null)
+                {
+                    var context = new TickTemplateContext { Text = text, Value = value, X = x, Y = y1 };
+
+                    <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType">
+                        @XAxis.Ticks.Template(context)
+                    </CategoryAxisTick>
+                }
+                else if (!String.IsNullOrEmpty(text))
+                {
+                    <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType" />
+                }
+
+                if (XAxis.GridLines.Visible && idx > start)
+                {
+                    <Line Class="rz-grid-line" X1="@x" Y1="@y1" X2="@x" Y2="@y2" Stroke="@XAxis.GridLines.Stroke" StrokeWidth="@XAxis.GridLines.StrokeWidth" LineType="@XAxis.GridLines.LineType" />
+                }
+            }
+        }
+        @if (XAxis.ChartBaseLabelSpace != 0.0)
+        {
+            var value = Chart.CategoryScale.Value(XAxis.ChartBaseValue);
             var text = XAxis.Format(Chart.CategoryScale, value);
 
             if (XAxis.Ticks.Template != null)
             {
                 var context = new TickTemplateContext { Text = text, Value = value, X = x, Y = y1 };
 
-                <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType">
+                <CategoryAxisTick X="@x0" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType">
                     @XAxis.Ticks.Template(context)
                 </CategoryAxisTick>
             }
-            else if (!String.IsNullOrEmpty(text))
+            else
             {
-                <CategoryAxisTick X="@x" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType" />
+                <CategoryAxisTick X="@x0" Y="@y1" Text="@text" Stroke="@(XAxis.Ticks.Stroke ?? XAxis.Stroke)" StrokeWidth="@XAxis.Ticks.StrokeWidth" LineType="@XAxis.Ticks.LineType" />
             }
-
-            if (XAxis.GridLines.Visible && idx > start)
-            {
-                <Line Class="rz-grid-line" X1="@x" Y1="@y1" X2="@x" Y2="@y2" Stroke="@XAxis.GridLines.Stroke" StrokeWidth="@XAxis.GridLines.StrokeWidth" LineType="@XAxis.GridLines.LineType" />
-            }
-
-            if (!basedrawn && (double)idx == Chart.ValueAxis.ChartBaseValue) basedrawn = true;
-
         }
 
-        @if (!basedrawn)
+        @if (XAxis.GridLines.Visible)
         {
-            var x = Chart.CategoryScale.Scale(Chart.ValueAxis.ChartBaseValue);
-            if (XAxis.GridLines.Visible)
-            {
-                <Line Class="rz-grid-line" X1="@x" Y1="@y1" X2="@x" Y2="@y2" Stroke="@XAxis.GridLines.Stroke" StrokeWidth="@XAxis.GridLines.StrokeWidth" LineType="@XAxis.GridLines.LineType" />
-            }
+            <Line Class="rz-grid-line" X1="@x0" Y1="@y1" X2="@x0" Y2="@y2" Stroke="@XAxis.GridLines.Stroke" StrokeWidth="@XAxis.GridLines.StrokeWidth" LineType="@XAxis.GridLines.LineType" />
         }
 
         @if (!String.IsNullOrEmpty(XAxis.Title.Text))
@@ -49,9 +63,9 @@
     </g>
 }
 @code {
-    decimal start;
-    decimal end;
-    decimal step;
+    double start;
+    double end;
+    double step;
     double x1;
     double x2;
     double y1;
@@ -60,7 +74,8 @@
     private AxisBase XAxis { get; set; }
     private AxisBase YAxis { get; set; }
 
-    bool basedrawn;
+    double x;
+    double x0;
 
     protected override void OnParametersSet()
     {
@@ -74,9 +89,9 @@
         }
 
         var ticks = Chart.CategoryScale.Ticks(XAxis.TickDistance);
-        start = (decimal)ticks.Start;
-        end = (decimal)ticks.End;
-        step = (decimal)ticks.Step;
+        start = ticks.Start;
+        end = ticks.End;
+        step = ticks.Step;
 
         x1 = Chart.CategoryScale.Scale(ticks.Start);
         x2 = Chart.CategoryScale.Scale(ticks.End);
@@ -85,6 +100,6 @@
         y1 = Chart.ValueScale.Scale(valueTicks.Start);
         y2 = Chart.ValueScale.Scale(valueTicks.End);
 
-        basedrawn = false;
+        x0 = Chart.CategoryScale.Scale(XAxis.ChartBaseValue);
     }
 }

--- a/Radzen.Blazor/Rendering/ValueAxis.razor
+++ b/Radzen.Blazor/Rendering/ValueAxis.razor
@@ -1,37 +1,48 @@
-
 @inherits RadzenChartComponentBase
+
 @if (YAxis.Visible)
 {
     <g class="rz-axis rz-value-axis">
-    <Line Class="rz-line" X1="@x1" Y1="@y1" X2="@x1" Y2="@y2" Stroke="@YAxis.Stroke" StrokeWidth="@YAxis.StrokeWidth" LineType="@YAxis.LineType" />
-    @for (var idx = start; idx <= end; idx += step)
-    {
-        var value = Chart.ValueScale.Value(idx);
-        var y = Chart.ValueScale.Scale(idx);
-        var text = YAxis.Format(Chart.ValueScale, value);
-
-        if (YAxis.Ticks.Template != null)
+        <Line Class="rz-line" X1="@x1" Y1="@y1" X2="@x1" Y2="@y2" Stroke="@YAxis.Stroke" StrokeWidth="@YAxis.StrokeWidth" LineType="@YAxis.LineType" />
+        @for (var idx = start; idx <= end; idx += step)
         {
-            var context = new TickTemplateContext { Text = text, Value = value, X = x1, Y = y } ;
+            var value = Chart.ValueScale.Value(idx);
+            var y = Chart.ValueScale.Scale(idx);
+            var text = YAxis.Format(Chart.ValueScale, value);
 
-            <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType">
-                @YAxis.Ticks.Template(context)
-            </ValueAxisTick>
-        } 
-        else
-        {
-            <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType"/>
+            if (YAxis.Ticks.Template != null)
+            {
+                var context = new TickTemplateContext { Text = text, Value = value, X = x1, Y = y } ;
+
+                <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType">
+                    @YAxis.Ticks.Template(context)
+                </ValueAxisTick>
+            }
+            else
+            {
+                <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType"/>
+            }
+
+            if (YAxis.GridLines.Visible && idx > start)
+            {
+                <Line Class="rz-grid-line" X1="@x1" Y1="@y" X2="@x2" Y2="@y" Stroke="@YAxis.GridLines.Stroke" StrokeWidth="@YAxis.GridLines.StrokeWidth" LineType="@YAxis.GridLines.LineType" />
+            }
+
+            if (!basedrawn && idx == Chart.ValueAxis.ChartBaseValue) basedrawn = true;
         }
 
-        if (YAxis.GridLines.Visible && idx > start)
+        @if (!basedrawn)
         {
-            <Line Class="rz-grid-line" X1="@x1" Y1="@y" X2="@x2" Y2="@y" Stroke="@YAxis.GridLines.Stroke" StrokeWidth="@YAxis.GridLines.StrokeWidth" LineType="@YAxis.GridLines.LineType" />
+            var y = Chart.ValueScale.Scale(Chart.ValueAxis.ChartBaseValue);
+            if (YAxis.GridLines.Visible)
+            {
+                <Line Class="rz-grid-line" X1="@x1" Y1="@y" X2="@x2" Y2="@y" Stroke="@YAxis.GridLines.Stroke" StrokeWidth="@YAxis.GridLines.StrokeWidth" LineType="@YAxis.GridLines.LineType" />
+            }
         }
-    }
-    @if (!String.IsNullOrEmpty(YAxis.Title.Text))
-    {
-        <ValueAxisTitle X="@(x1 - Chart.ValueAxis.Size + YAxis.Title.Size)" Y="@((y1 - y2)/2)" Text="@YAxis.Title.Text" />
-    }
+        @if (!String.IsNullOrEmpty(YAxis.Title.Text))
+        {
+            <ValueAxisTitle X="@(x1 - Chart.ValueAxis.Size + YAxis.Title.Size)" Y="@((y1 - y2)/2)" Text="@YAxis.Title.Text" />
+        }
     </g>
 }
 @code {
@@ -44,6 +55,8 @@
     double y2;
     private AxisBase XAxis { get; set; }
     private AxisBase YAxis { get; set; }
+
+    bool basedrawn;
 
     protected override void OnParametersSet()
     {
@@ -66,5 +79,7 @@
         x2 = Chart.CategoryScale.Scale(categoryTicks.End);
         y1 = Chart.ValueScale.Scale(start);
         y2 = Chart.ValueScale.Scale(end);
+
+        basedrawn = false;
     }
 }

--- a/Radzen.Blazor/Rendering/ValueAxis.razor
+++ b/Radzen.Blazor/Rendering/ValueAxis.razor
@@ -4,44 +4,62 @@
 {
     <g class="rz-axis rz-value-axis">
         <Line Class="rz-line" X1="@x1" Y1="@y1" X2="@x1" Y2="@y2" Stroke="@YAxis.Stroke" StrokeWidth="@YAxis.StrokeWidth" LineType="@YAxis.LineType" />
+
         @for (var idx = start; idx <= end; idx += step)
         {
             var value = Chart.ValueScale.Value(idx);
-            var y = Chart.ValueScale.Scale(idx);
+            y = Chart.ValueScale.Scale(idx);
+            var text = YAxis.Format(Chart.ValueScale, value);
+
+            if ((YAxis.ChartBaseLabelSpace == 0.0) || (YAxis.ChartBaseLabelSpace != 0.0 && (Math.Abs(y0 - y) > YAxis.ChartBaseLabelSpace)))
+            {
+                if (YAxis.Ticks.Template != null)
+                {
+                    var context = new TickTemplateContext { Text = text, Value = value, X = x1, Y = y } ;
+
+                    <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType">
+                        @YAxis.Ticks.Template(context)
+                    </ValueAxisTick>
+                }
+                else
+                {
+                    <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType"/>
+                }
+
+                if (YAxis.GridLines.Visible && idx > start)
+                {
+                    <Line Class="rz-grid-line" X1="@x1" Y1="@y" X2="@x2" Y2="@y" Stroke="@YAxis.GridLines.Stroke" StrokeWidth="@YAxis.GridLines.StrokeWidth" LineType="@YAxis.GridLines.LineType" />
+                }
+            }
+        }
+
+        @if (YAxis.ChartBaseLabelSpace != 0.0)
+        {
+            var value = Chart.ValueScale.Value(YAxis.ChartBaseValue);
             var text = YAxis.Format(Chart.ValueScale, value);
 
             if (YAxis.Ticks.Template != null)
             {
-                var context = new TickTemplateContext { Text = text, Value = value, X = x1, Y = y } ;
+                var context = new TickTemplateContext { Text = text, Value = value, X = x1, Y = y };
 
-                <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType">
+                <ValueAxisTick X="@x1" Y="@y0" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType">
                     @YAxis.Ticks.Template(context)
                 </ValueAxisTick>
             }
             else
             {
-                <ValueAxisTick X="@x1" Y="@y" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType"/>
+                <ValueAxisTick X="@x1" Y="@y0" Text="@text" Stroke="@(YAxis.Ticks.Stroke ?? YAxis.Stroke)" StrokeWidth="@YAxis.Ticks.StrokeWidth" LineType="@YAxis.Ticks.LineType" />
             }
-
-            if (YAxis.GridLines.Visible && idx > start)
-            {
-                <Line Class="rz-grid-line" X1="@x1" Y1="@y" X2="@x2" Y2="@y" Stroke="@YAxis.GridLines.Stroke" StrokeWidth="@YAxis.GridLines.StrokeWidth" LineType="@YAxis.GridLines.LineType" />
-            }
-
-            if (!basedrawn && idx == Chart.ValueAxis.ChartBaseValue) basedrawn = true;
         }
 
-        @if (!basedrawn)
+        @if (YAxis.GridLines.Visible)
         {
-            var y = Chart.ValueScale.Scale(Chart.ValueAxis.ChartBaseValue);
-            if (YAxis.GridLines.Visible)
-            {
-                <Line Class="rz-grid-line" X1="@x1" Y1="@y" X2="@x2" Y2="@y" Stroke="@YAxis.GridLines.Stroke" StrokeWidth="@YAxis.GridLines.StrokeWidth" LineType="@YAxis.GridLines.LineType" />
-            }
+            <Line Class="rz-grid-line" X1="@x1" Y1="@y0" X2="@x2" Y2="@y0" Stroke="@YAxis.GridLines.Stroke" StrokeWidth="@YAxis.GridLines.StrokeWidth" LineType="@YAxis.GridLines.LineType" />
         }
+
         @if (!String.IsNullOrEmpty(YAxis.Title.Text))
         {
-            <ValueAxisTitle X="@(x1 - Chart.ValueAxis.Size + YAxis.Title.Size)" Y="@((y1 - y2)/2)" Text="@YAxis.Title.Text" />
+            <ValueAxisTitle X="@(x1 - YAxis.Size + YAxis.Title.Size)" Y="@((y1 - y2)/2)" Text="@YAxis.Title.Text" />
         }
     </g>
 }
@@ -56,7 +74,8 @@
     private AxisBase XAxis { get; set; }
     private AxisBase YAxis { get; set; }
 
-    bool basedrawn;
+    double y;
+    double y0;
 
     protected override void OnParametersSet()
     {
@@ -80,6 +99,6 @@
         y1 = Chart.ValueScale.Scale(start);
         y2 = Chart.ValueScale.Scale(end);
 
-        basedrawn = false;
+        y0 = Chart.ValueScale.Scale(YAxis.ChartBaseValue);
     }
 }

--- a/Radzen.Blazor/Rendering/ValueAxis.razor
+++ b/Radzen.Blazor/Rendering/ValueAxis.razor
@@ -11,7 +11,7 @@
             y = Chart.ValueScale.Scale(idx);
             var text = YAxis.Format(Chart.ValueScale, value);
 
-            if ((YAxis.ChartBaseLabelSpace == 0.0) || (YAxis.ChartBaseLabelSpace != 0.0 && (Math.Abs(y0 - y) > YAxis.ChartBaseLabelSpace)))
+            if ((!YAxis.ShowChartBaseLabel) || (YAxis.ShowChartBaseLabel && (Math.Abs(y0 - y) > YAxis.ChartBaseLabelSpace)))
             {
                 if (YAxis.Ticks.Template != null)
                 {
@@ -33,7 +33,7 @@
             }
         }
 
-        @if (YAxis.ChartBaseLabelSpace != 0.0)
+        @if (YAxis.ShowChartBaseLabel)
         {
             var value = Chart.ValueScale.Value(YAxis.ChartBaseValue);
             var text = YAxis.Format(Chart.ValueScale, value);


### PR DESCRIPTION
Initial requirement: I needed a chart that displayed only profit / loss or increase / decrease. I needed it to show one color for positive and one color for negative as opposed to different colors for each series. I did begin by creating a new series type, but the reality is all I needed was a different way of coloring. So I created a Property and an Enum for selecting a 'ColorMode', and the Render method of each column and bar acts on this appropriately.
However, as much as I would prefer to change one thing a time, it did give rise to other, related items (fixes and features). 
I've created a demo app at [radzen.delaci.co.uk](http://radzen.delaci.co.uk/) to show these changes. Along the top are numbered controls to highlight each item listed below.
(1) Sets the enum of the ColorMode to 'Series' or 'PositiveNegative' to show the different color render modes.
(2) Uses custom Fills as opposed to using the theme.
(3) The way data labels were rendered didn't seem right. Whether the value was positive or negative, it rendered above (column) or to the right (bar) of the rendered bar. It now renders above if positive, below if negative and on the line if 0 (or base value, see next items).
(4) Gives the ability to set the base of the chart to something other than zero.
(5) Sets whether the base label is shown on the chart.
(6) Because of the differences in rendering based on Chart Size, Steps and Font Size, this setting gives 'breathing space' for the base label so adjacent labels can be hidden.

Below the example column and bar series, there is a copy of the "Radzen Blazor Chart column series" from the Radzen demo site to show that, on the face of it, there are no breaking changes.

Hope this is of interest and look forward to your feedback.

Regards

Paul
