### PR TITLE
Change to position of Data Labels for Column and Bar charts

### DIFF
--- a/Radzen.Blazor/RadzenBarSeries.razor.cs
+++ b/Radzen.Blazor/RadzenBarSeries.razor.cs
@@ -222,12 +222,16 @@ namespace Radzen.Blazor
         {
             var list = new List<ChartDataLabel>();
 
+            (string Anchor, int Sign) position;
+
             foreach (var d in Data)
             {
-                list.Add(new ChartDataLabel 
-                { 
-                    Position = new Point() { X = TooltipX(d) + offsetX + 8, Y = TooltipY(d) + offsetY },
-                    TextAnchor = "start",
+                position = Value(d) < 0 ? ("end", -1) : Value(d) == 0 ? ("middle", 0) : ("start", 1);
+
+                list.Add(new ChartDataLabel
+                {
+                    Position = new Point() { X = TooltipX(d) + offsetX + (8 * position.Sign), Y = TooltipY(d) + offsetY },
+                    TextAnchor = position.Anchor,
                     Text = Chart.ValueAxis.Format(Chart.CategoryScale, Value(d))
                 });
             }

--- a/Radzen.Blazor/RadzenColumnSeries.razor.cs
+++ b/Radzen.Blazor/RadzenColumnSeries.razor.cs
@@ -154,11 +154,7 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         internal override double TooltipY(TItem item)
         {
-            var y = base.TooltipY(item);
-            var ticks = Chart.ValueScale.Ticks(Chart.ValueAxis.TickDistance);
-            var y0 = Chart.ValueScale.Scale(Math.Max(0, ticks.Start));
-
-            return Math.Min(y, y0);
+            return base.TooltipY(item);
         }
 
         /// <inheritdoc />
@@ -195,7 +191,23 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         public override IEnumerable<ChartDataLabel> GetDataLabels(double offsetX, double offsetY)
         {
-            return base.GetDataLabels(offsetX, offsetY - 16);
+            var list = new List<ChartDataLabel>();
+
+            int sign;
+
+            foreach (var d in Data)
+            {
+                sign = Value(d) < 0 ? -1 : Value(d) == 0 ? 0 : 1;
+
+                list.Add(new ChartDataLabel
+                {
+                    Position = new Point() { X = TooltipX(d) + offsetX, Y = TooltipY(d) - offsetY - (16 * sign) },
+                    TextAnchor = "middle",
+                    Text = Chart.ValueAxis.Format(Chart.ValueScale, Value(d))
+                });
+            }
+
+            return list;
         }
     }
 }


### PR DESCRIPTION

This is the first in a series of changes.

Test site - [radzen.delaci.co.uk](http://radzen.delaci.co.uk/)

While using negative and zero data, the labels were always positioned above (column) or to the right (bar) of the bar.

This change places the label above, level or below for column charts and left, level or right for bar charts.

