### PR TITLE
Add ability to configure AutoComplete input type

### DIFF
--- a/Radzen.Blazor/RadzenAutoComplete.razor
+++ b/Radzen.Blazor/RadzenAutoComplete.razor
@@ -24,7 +24,7 @@
                 oninput="@OpenScript()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" @onchange="@OnChange"
                 aria-autocomplete="list" aria-haspopup="true" autocomplete="off" role="combobox"
                 class="@InputClassList" onblur="Radzen.activeElement = null"
-                type="@Type" id="@Name" aria-expanded="true" placeholder="@CurrentPlaceholder" />
+                type="@InputType" id="@Name" aria-expanded="true" placeholder="@CurrentPlaceholder" />
         }
         <div id="@PopupID" class="rz-autocomplete-panel" style="@PopupStyle">
             <ul @ref="@list" class="rz-autocomplete-items rz-autocomplete-list" role="listbox">

--- a/Radzen.Blazor/RadzenAutoComplete.razor
+++ b/Radzen.Blazor/RadzenAutoComplete.razor
@@ -24,7 +24,7 @@
                 oninput="@OpenScript()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" @onchange="@OnChange"
                 aria-autocomplete="list" aria-haspopup="true" autocomplete="off" role="combobox"
                 class="@InputClassList" onblur="Radzen.activeElement = null"
-                type="text" id="@Name" aria-expanded="true" placeholder="@CurrentPlaceholder" />
+                type="@Type" id="@Name" aria-expanded="true" placeholder="@CurrentPlaceholder" />
         }
         <div id="@PopupID" class="rz-autocomplete-panel" style="@PopupStyle">
             <ul @ref="@list" class="rz-autocomplete-items rz-autocomplete-list" role="listbox">

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -73,7 +73,7 @@ namespace Radzen.Blazor
         /// </remarks>
         /// <value>The input type.</value>
         [Parameter]
-        public string Type { get; set; } = "text";
+        public string InputType { get; set; } = "text";
 
         /// <summary>
         /// Gets search input reference.

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -66,6 +66,16 @@ namespace Radzen.Blazor
         public int FilterDelay { get; set; } = 500;
 
         /// <summary>
+        /// Gets or sets the underlying input type.
+        /// </summary>
+        /// <remarks>
+        /// This does not apply when <see cref="Multiline"/> is <c>true</c>.
+        /// </remarks>
+        /// <value>The input type.</value>
+        [Parameter]
+        public string Type { get; set; } = "text";
+
+        /// <summary>
         /// Gets search input reference.
         /// </summary>
         protected ElementReference search;


### PR DESCRIPTION
We're using the AutoComplete component as a search box in an internal application, and users have recently requested a clear button. Since setting `type="search"` would be the most straightforward solution for us, we needed a way to be able to configure the underlying input type.