### PR TITLE
Added support for translation of DisplayAttribute Description properties in RadzenDataGrid Enum filters

### DIFF
--- a/Radzen.Blazor/Extensions.cs
+++ b/Radzen.Blazor/Extensions.cs
@@ -18,20 +18,24 @@ namespace Radzen.Blazor
         /// <summary>
         /// Gets enum description.
         /// </summary>
-        public static string GetDisplayDescription(this Enum enumValue)
+        public static string GetDisplayDescription(this Enum enumValue, Func<string, string> translationFunction = null)
         {
             var enumValueAsString = enumValue.ToString();
             var val = enumValue.GetType().GetMember(enumValueAsString).FirstOrDefault();
+            var enumVal = val?.GetCustomAttribute<DisplayAttribute>()?.GetDescription() ?? enumValueAsString;
 
-            return val?.GetCustomAttribute<DisplayAttribute>()?.GetDescription() ?? enumValueAsString;
+            if (translationFunction != null)
+                return translationFunction(enumVal);
+
+            return enumVal;
         }
 
         /// <summary>
         /// Converts Enum to IEnumerable of Value/Text.
         /// </summary>
-        public static IEnumerable<object> EnumAsKeyValuePair(Type enumType)
+        public static IEnumerable<object> EnumAsKeyValuePair(Type enumType, Func<string, string> translationFunction = null)
         {
-            return Enum.GetValues(enumType).Cast<Enum>().Distinct().Select(val => new { Value = Convert.ToInt32(val), Text = val.GetDisplayDescription() });
+            return Enum.GetValues(enumType).Cast<Enum>().Distinct().Select(val => new { Value = Convert.ToInt32(val), Text = val.GetDisplayDescription(translationFunction) });
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -293,6 +293,13 @@ namespace Radzen.Blazor
         public bool Responsive { get; set; }
 
         /// <summary>
+        /// Allows to define a custom function for enums DisplayAttribute Description property value translation in datagrid 
+        /// Enum filters.
+        /// </summary>
+        [Parameter]
+        public Func<string, string> EnumFilterTranslationFunc { get; set; }
+
+        /// <summary>
         /// The grouped and paged View
         /// </summary>
         IEnumerable<GroupResult> _groupedPagedView;

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -79,7 +79,7 @@
                                 else if (PropertyAccess.IsNullableEnum(Column.FilterPropertyType) || PropertyAccess.IsEnum(Column.FilterPropertyType))
                                 {
                                     <RadzenDropDown AllowClear="false" AllowFiltering="false" TValue="@object"
-                                                    Value=@Column.GetFilterValue() Multiple="false" Placeholder="@Grid.EnumFilterSelectText" TextProperty="Text" ValueProperty="Value" Data=@EnumExtensions.EnumAsKeyValuePair(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType)
+                                                    Value=@Column.GetFilterValue() Multiple="false" Placeholder="@Grid.EnumFilterSelectText" TextProperty="Text" ValueProperty="Value" Data=@EnumExtensions.EnumAsKeyValuePair(Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType, Grid.EnumFilterTranslationFunc)
                                                     Change="@(args => Column.SetFilterValue(args))"
                                                     InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", Column.Title + Grid.FilterValueArialLabel  + Column.GetFilterValue() }})" />
                                 }


### PR DESCRIPTION
In the RadzenDataGrid Enum filters there isn't the possibilty to intercept the render of the text in the options select menu. This causes that the texts in the DisplayAttribute Descriptions don't get translated if you use a different I18N stack than .NET's default. The aim of this feature is to offer the possibility to the developer to define a function that will be called for each text defined in a DisplayAttribute in addition to the Enum.ToString(). Radzen.Blazor is well I18N oriented, but in my opinion was lacking of this kind of translation posibility. 
This principle can be exported to other kinds of components with a similar problematic. 

The principle is simple: we define a property in the RadzenDataGrid component that brings the possibility to define a function `Func<string, string>`. In the RadzenDataGridHeaderCell component the function is passed to the `Extensions.EnumAsKeyValuePair()` function that passes it to the `Extensions.GetDisplayDescription()` that finally will call this function if it is not null. It lets the developer to define a custom function, in my case `_T(string text)` that returns a string containing the translation of the passed `text`.