### PR TITLE
Fix null exception when expanding tree node

### DIFF
--- a/Radzen.Blazor/RadzenTree.razor.cs
+++ b/Radzen.Blazor/RadzenTree.razor.cs
@@ -322,13 +322,16 @@ namespace Radzen.Blazor
 
                 if (AllowCheckBoxes && AllowCheckChildren && args.Children.Data != null)
                 {
-                    if (CheckedValues != null && CheckedValues.Contains(item.Value))
+                    if (CheckedValues != null)
                     {
-                        await SetCheckedValues(CheckedValues.Union(args.Children.Data.Cast<object>().Except(UncheckedValues)));
-                    }
-                    else
-                    {
-                        await SetCheckedValues(CheckedValues.Except(args.Children.Data.Cast<object>()));
+                        if (CheckedValues.Contains(item.Value))
+                        {
+                            await SetCheckedValues(CheckedValues.Union(args.Children.Data.Cast<object>().Except(UncheckedValues)));
+                        }
+                        else
+                        {
+                            await SetCheckedValues(CheckedValues.Except(args.Children.Data.Cast<object>()));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If:
- Checkboxes enabled
- CheckedValues is null

Fix works for me, but I'm not 100% sure it works for all cases supported by RadzenTree, so don't be shy on improving my fix :) .