### PR TITLE
Support for custom Numeric Types

### DIFF
--- a/Radzen.Blazor.Tests/Dollars.cs
+++ b/Radzen.Blazor.Tests/Dollars.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Radzen.Blazor.Tests;
+
+[TypeConverter(typeof(DollarsTypeConverter))]
+public readonly record struct Dollars(decimal Amount) : IComparable<decimal>
+{
+    public int CompareTo(decimal other)
+    {
+        return Amount.CompareTo(other);
+    }
+
+    public string ToString(string format, CultureInfo culture = null) => Amount.ToString(format, culture ?? CultureInfo.CreateSpecificCulture("en-US"));
+    public override string ToString() => Amount.ToString("F2", CultureInfo.CreateSpecificCulture("en-US"));
+}
+
+public class DollarsTypeConverter : TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    {
+        if (sourceType == typeof(decimal) ||
+            sourceType == typeof(string)) 
+        {
+            return true;
+        }
+
+        return base.CanConvertFrom(context, sourceType);
+    }
+
+    public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+    {
+        if (destinationType == typeof(decimal))
+            return true;
+        
+        return base.CanConvertTo(context, destinationType);
+    }
+
+    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+    {
+        if (value is decimal d)
+            return new Dollars(d);
+
+        if (value is string s)
+            return decimal.TryParse(s, out var val) ? new Dollars(val) : null;
+        
+        return base.ConvertFrom(context, culture, value);
+    }
+
+    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+    {
+        if (destinationType == typeof(decimal) && value is Dollars d)
+            return d.Amount;
+        
+        return base.ConvertTo(context, culture, value, destinationType);
+    }
+}

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -452,5 +452,32 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains($" value=\"{valueToTest.ToString(format)}\"", component.Markup);
         }
+
+        [Fact]
+        public void Numeric_Supports_IComparable()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenNumeric<Dollars>>();
+
+            var maxValue = 2;
+
+            component.SetParametersAndRender(parameters =>
+            {
+                component.SetParametersAndRender(parameters =>
+                {
+                    parameters.Add(p => p.Value, new Dollars(1m));
+                    parameters.Add(p => p.Max, maxValue);
+                });
+            });
+            
+            component.Find("input").Change("13.53");
+
+            var maxDollars = new Dollars(2);
+            Assert.Contains($" value=\"{maxDollars.ToString()}\"", component.Markup);
+            Assert.Equal(component.Instance.Value, maxDollars);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Bunit;
 using Xunit;
 
@@ -409,5 +410,34 @@ namespace Radzen.Blazor.Tests
             
             Assert.Contains($" value=\"{newValue.ToString(format)}\"", component.Markup);
         }
+
+        [Fact]
+        public void Numeric_Uses_ConvertValue()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var value = new Dollars(11m);
+            Dollars? ConvertFunc(string s) => decimal.TryParse(s, out var val) ? new Dollars(val) : null;
+            var component = ctx.RenderComponent<RadzenNumeric<Dollars?>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars?>.ConvertValue), (Func<string, Dollars?>)ConvertFunc),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars?>.Value), value)
+            );
+
+            component.Render();
+            
+            Assert.Contains($" value=\"{value.ToString()}\"", component.Markup);
+
+            var newValue = new Dollars(13.53m);
+            component.Find("input").Change("13.53");
+
+            Assert.Contains($" value=\"{newValue.ToString()}\"", component.Markup);
+        }
+    }
+    
+    public readonly record struct Dollars(decimal Amount)
+    {
+        public override string ToString() => Amount.ToString("F2", System.Globalization.CultureInfo.CreateSpecificCulture("en-US"));
     }
 }

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -435,9 +435,4 @@ namespace Radzen.Blazor.Tests
             Assert.Contains($" value=\"{newValue.ToString()}\"", component.Markup);
         }
     }
-    
-    public readonly record struct Dollars(decimal Amount)
-    {
-        public override string ToString() => Amount.ToString("F2", System.Globalization.CultureInfo.CreateSpecificCulture("en-US"));
-    }
 }

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -434,5 +434,23 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains($" value=\"{newValue.ToString()}\"", component.Markup);
         }
+
+        [Fact]
+        public void Numeric_Supports_TypeConverter()
+        {
+            using var ctx = new TestContext();
+
+            var valueToTest = new Dollars(100.234m);
+            string format = "0.00";
+
+            var component = ctx.RenderComponent<RadzenNumeric<Dollars>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Value), valueToTest)
+            );
+
+            component.Render();
+
+            Assert.Contains($" value=\"{valueToTest.ToString(format)}\"", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -317,10 +317,7 @@ namespace Radzen.Blazor
                 return;
             }
 
-            if (Max.HasValue || Min.HasValue)
-            {
-                newValue = CheckBounds(newValue);
-            }
+            newValue = CheckBounds(newValue);
 
             Value = newValue;
             if (!ValueChanged.HasDelegate)
@@ -335,6 +332,11 @@ namespace Radzen.Blazor
         
         private TValue CheckBounds(TValue newValue)
         {
+            if (Max == null && Min == null)
+            {
+                return newValue;
+            }
+
             if (newValue is IComparable<decimal> c)
             {
                 if (Max.HasValue && c.CompareTo(Max.Value) > 0)

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -2,6 +2,7 @@
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -334,6 +335,14 @@ namespace Radzen.Blazor
         
         private TValue CheckBounds(TValue newValue)
         {
+            if (newValue is IComparable<decimal> c)
+            {
+                if (Max.HasValue && c.CompareTo(Max.Value) > 0)
+                    return ConvertFromDecimal(Max.Value);
+                if (Min.HasValue && c.CompareTo(Min.Value) < 0)
+                    return ConvertFromDecimal(Min.Value);
+            }
+
             decimal? newValueAsDecimal;
             try
             {


### PR DESCRIPTION
In my project, we have various custom numeric types, like `Money`, `Point`, etc, that we would like to use with RadzenNumeric.
RadzenNumeric's support for these kind of types is problematic, as it uses `Convert.ChangeType` behind the scenes, such that it only works with primitive types.

This adds support for custom numeric types by:
1. Adding `TypeConverter` support to/from decimal for TValue
2. Adding support for `IComparable<decimal>`, in the case the type implements it
3. Update flow of `InternalValueChanged` to remove unnecessary ChangeValue conversion attempts.  This allows limited support for custom numeric types, even if they don't have a TypeConverter (as long as `ConvertValue` is set)

This would really be a great help!