### PR TITLE
#1320 Cascade RadzenDataGrid class to all descendants

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -5,11 +5,10 @@
 @typeparam TItem
 @inherits PagedDataBoundComponent<TItem>
 
+<CascadingValue Value=this>
 @if (Columns != null)
 {
-    <CascadingValue Value=this>
         @Columns
-    </CascadingValue>
 }
 
 @if (Visible)
@@ -433,6 +432,7 @@
         }
     </div>
 }
+</CascadingValue>
 @code {
     internal void SetAttribute(Dictionary<string, object> attributes, string attributeName, object attributeValue)
     {


### PR DESCRIPTION
Move the RadzenDataGrid cascading value to surround the entire component, allowing it to be picked up in customer header/footer etc. Splitting the existing CascadingValue to lines 8 (before all HTML) and approx line 435 just before the @code
