### PR TITLE
#1335 Separate colour for odd striped row background

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_grid.scss
+++ b/Radzen.Blazor/themes/components/blazor/_grid.scss
@@ -14,8 +14,6 @@ $grid-hover-color: var(--rz-on-secondary-lighter) !default;
 $grid-selected-background-color: var(--rz-secondary-dark) !default;
 $grid-selected-color: var(--rz-on-secondary-dark) !default;
 
-$grid-stripe-background-color: var(--rz-base-100) !default;
-
 $grid-toolbar-background-color: var(--rz-base-background-color) !default;
 $grid-header-cell-border: $grid-cell-border !default;
 $grid-header-cell-border-bottom: none !default;
@@ -72,6 +70,9 @@ $grid-sort-icon-color: var(--rz-text-disabled-color) !default;
 $grid-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.01) !default;
 $grid-background-color: var(--rz-base-background-color) !default;
 
+$grid-stripe-background-color: var(--rz-base-100) !default;
+$grid-stripe-background-color-odd: var(--rz-base-background-color) !default;
+
 $grid-column-resizer-width: 0.5rem !default;
 $grid-column-resizer-helper-width: 0.25rem !default;
 $grid-column-resizer-helper-background-color: var(--rz-secondary) !default;
@@ -125,6 +126,7 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
   --rz-grid-selected-color: #{$grid-selected-color};
 
   --rz-grid-stripe-background-color: #{$grid-stripe-background-color};
+  --rz-grid-stripe-background-color-odd: #{$grid-stripe-background-color-odd};
 
   --rz-grid-toolbar-background-color: #{$grid-toolbar-background-color};
   --rz-grid-header-cell-border: #{$grid-header-cell-border};
@@ -510,21 +512,21 @@ $column-draggable-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.1) !default;
 }
 
 .rz-grid-table-striped {
-  tbody {
-    > tr:not(.rz-expanded-row-content)  {
-      &:nth-child(even) {
-        > td {
-          background-color: var(--rz-grid-stripe-background-color);
-        }
-      }
+    tbody {
+        > tr:not(.rz-expanded-row-content) {
+            &:nth-child(even) {
+                > td {
+                    background-color: var(--rz-grid-stripe-background-color);
+                }
+            }
 
-      &:nth-child(odd) {
-        > td {
-          background-color: var(--rz-grid-background-color);
+            &:nth-child(odd) {
+                > td {
+                    background-color: var(--rz-grid-stripe-background-color-odd);
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .rz-grid-table-composite {


### PR DESCRIPTION
We propose introducing a second color variable for the odd rows, e.g. --rz-grid-stripe-background-color-odd, or similar, whose value defaults to var(--rz-grid-background-color), to retain the current behavior, but can then be overridden to allow alternate striping patterns.

I moved the stripe colour definitions to under the background definition in case they need to be interconnected.

Note: I was unable to build the paid themes in order to check that it occurs in all themes. I checked this override in software-base 

    :root {
        --rz-grid-stripe-background-color-odd: red;
    }

and got this:
![image](https://github.com/radzenhq/radzen-blazor/assets/151647113/fe2219ef-a4f4-4591-adaa-873f7c6b5bfe)
