### PR TITLE
implemented: user decimal separator on 'NumpadDecimal'

### DIFF
--- a/Radzen.Blazor/RadzenNumeric.razor
+++ b/Radzen.Blazor/RadzenNumeric.razor
@@ -1,6 +1,7 @@
 ﻿@using Radzen
 @using Microsoft.JSInterop
 @using Microsoft.AspNetCore.Components.Forms
+@using System.Globalization
 @typeparam TValue
 @inherits FormComponent<TValue>
 
@@ -10,7 +11,7 @@
         <input @ref="@input" @attributes="InputAttributes" type="text" inputmode="decimal" name="@Name" disabled="@Disabled" readonly="@ReadOnly"
                class="@GetInputCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@Name"
                placeholder="@CurrentPlaceholder" autocomplete="@AutoCompleteAttribute" value="@FormattedValue" @onchange="@OnChange"
-               onkeypress="Radzen.numericKeyPress(event, @IsInteger().ToString().ToLower())"
+               onkeypress="Radzen.numericKeyPress(event, @IsInteger().ToString().ToLower(), '@CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator')"
            onblur="@getOnInput()" onpaste="@getOnPaste()" />
         @if (ShowUpDown)
         {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -526,7 +526,7 @@ window.Radzen = {
       if (!table.rows[table.nextSelectedIndex].classList.contains('rz-state-highlight')) {
         table.rows[table.nextSelectedIndex].classList.add('rz-state-highlight');
       }
-     
+
       table.parentNode.parentNode.scrollTop = table.rows[table.nextSelectedIndex].offsetTop - table.rows[table.nextSelectedIndex].offsetHeight;
     }
 
@@ -713,7 +713,7 @@ window.Radzen = {
         }
       }
   },
-  numericKeyPress: function (e, isInteger) {
+  numericKeyPress: function (e, isInteger, decimalSeparator) {
     if (
       e.metaKey ||
       e.ctrlKey ||
@@ -721,6 +721,12 @@ window.Radzen = {
       e.keyCode == 8 ||
       e.keyCode == 13
     ) {
+      return;
+      }
+
+    if (e.code === 'NumpadDecimal') {
+      e.target.value += decimalSeparator;
+      e.preventDefault();
       return;
     }
 


### PR DESCRIPTION
When a culture other then English's is used. e.g. Dutch( Nederlands) the decimal separator is a , instead of an . 
this Commit allows users to use the numpad with the numpad decimal. which will than insert CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator in the value instead of always a . (period)

this allows users with other cultures to easy use the numpad without the need to specifically use a , as the decimal separator. 