### PR TITLE
#1338 reset to firstpage on sort change

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3073,6 +3073,8 @@ namespace Radzen.Blazor
                 SetColumnSortOrder(column);
                 Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
                 SaveSettings();
+                topPager?.FirstPage().GetAwaiter().GetResult();
+                bottomPager?.FirstPage().GetAwaiter().GetResult();
             }
 
             if (LoadData.HasDelegate && IsVirtualizationAllowed())

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3071,10 +3071,11 @@ namespace Radzen.Blazor
             if (column != null)
             {
                 SetColumnSortOrder(column);
+                topPager?.FirstPage();
+                bottomPager?.FirstPage();
+                CurrentPage = 0;
                 Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
                 SaveSettings();
-                topPager?.FirstPage().GetAwaiter().GetResult();
-                bottomPager?.FirstPage().GetAwaiter().GetResult();
             }
 
             if (LoadData.HasDelegate && IsVirtualizationAllowed())


### PR DESCRIPTION
Reset pagination to first page, when column sorting occurs.

Note: I attempted to implement this change, simply using conditional awaited calls to the 2 pagers async FirstPage() methods, and testing the change within the DataGrid demos, but it resulted in the pages not responding to paging, or sorting, or even the demo menus, after a few selections. Seemed like a deadlock, so instead I made the changes as shown in this PR (not await and reset the current page). 

I could use some advice on the correct way to implement such a change, but have posted this change for reference/testing.