### PR TITLE
#1338 Reset pagination to first page, when column sorting occurs, retaining default behavior.

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2483,7 +2483,7 @@ namespace Radzen.Blazor
         /// Gets or sets the ability to automatically goto the first page when sorting is changed.
         /// </summary>
         [Parameter]
-        public bool FirstPageOnSort { get; set; } = false;
+        public bool GotoFirstPageOnSort { get; set; } = false;
 
         internal string getCompositeCellCSSClass(RadzenDataGridColumn<TItem> column)
         {
@@ -3077,7 +3077,7 @@ namespace Radzen.Blazor
             if (column != null)
             {
                 SetColumnSortOrder(column);
-                if (FirstPageOnSort)
+                if (GotoFirstPageOnSort)
                 {
                     topPager?.FirstPage();
                     bottomPager?.FirstPage();

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3073,6 +3073,8 @@ namespace Radzen.Blazor
                 SetColumnSortOrder(column);
                 Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
                 SaveSettings();
+                topPager?.FirstPage().GetAwaiter().GetResult();
+                bottomPager?.FirstPage().GetAwaiter().GetResult();
             }
 
             if (LoadData.HasDelegate && IsVirtualizationAllowed())

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3071,10 +3071,11 @@ namespace Radzen.Blazor
             if (column != null)
             {
                 SetColumnSortOrder(column);
+                topPager?.FirstPage();
+                bottomPager?.FirstPage();
+                CurrentPage = 0;
                 Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
                 SaveSettings();
-                topPager?.FirstPage().GetAwaiter().GetResult();
-                bottomPager?.FirstPage().GetAwaiter().GetResult();
             }
 
             if (LoadData.HasDelegate && IsVirtualizationAllowed())

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -837,6 +837,13 @@ namespace Radzen.Blazor
         {
             if (AllowSorting && column.Sortable)
             {
+                if (GotoFirstPageOnSort)
+                {
+                    topPager?.FirstPage();
+                    bottomPager?.FirstPage();
+                    CurrentPage = 0;
+                }
+
                 var property = column.GetSortProperty();
                 if (!string.IsNullOrEmpty(property))
                 {
@@ -3077,12 +3084,6 @@ namespace Radzen.Blazor
             if (column != null)
             {
                 SetColumnSortOrder(column);
-                if (GotoFirstPageOnSort)
-                {
-                    topPager?.FirstPage();
-                    bottomPager?.FirstPage();
-                    CurrentPage = 0;
-                }
                 Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
                 SaveSettings();
             }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2479,6 +2479,12 @@ namespace Radzen.Blazor
             return column.Columns != null || column.Parent != null;
         }
 
+        /// <summary>
+        /// Gets or sets the ability to automatically goto the first page when sorting is changed.
+        /// </summary>
+        [Parameter]
+        public bool FirstPageOnSort { get; set; } = false;
+
         internal string getCompositeCellCSSClass(RadzenDataGridColumn<TItem> column)
         {
             return column.Columns != null || column.Parent != null ? "rz-composite-cell" : "";
@@ -3071,9 +3077,12 @@ namespace Radzen.Blazor
             if (column != null)
             {
                 SetColumnSortOrder(column);
-                topPager?.FirstPage();
-                bottomPager?.FirstPage();
-                CurrentPage = 0;
+                if (FirstPageOnSort)
+                {
+                    topPager?.FirstPage();
+                    bottomPager?.FirstPage();
+                    CurrentPage = 0;
+                }
                 Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
                 SaveSettings();
             }


### PR DESCRIPTION
Reset pagination to first page, when column sorting occurs.

Based on feedback to prior commit, I have added a `GotoFirstPageOnSort` property to conditionally enable this behavior and retain the current behavior by default.
 
This avoids having to add code to every usage of RadzenDataGrid.
 