### PR TITLE
Change RadzenDataGrid OnSort to async

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -834,7 +834,7 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback<DataGridColumnSortEventArgs<TItem>> Sort { get; set; }
 
-        internal void OnSort(EventArgs args, RadzenDataGridColumn<TItem> column)
+        internal async Task OnSort(EventArgs args, RadzenDataGridColumn<TItem> column)
         {
             if (AllowSorting && column.Sortable)
             {
@@ -846,26 +846,24 @@ namespace Radzen.Blazor
                 }
 
                 var property = column.GetSortProperty();
-                if (!string.IsNullOrEmpty(property))
-                {
-                    OrderBy(property);
-                }
-                else
-                {
-                    SetColumnSortOrder(column);
 
-                    Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
-                    SaveSettings();
+                SetColumnSortOrder(column);
+                await Sort.InvokeAsync(new DataGridColumnSortEventArgs<TItem>() { Column = column, SortOrder = column.GetSortOrder() });
+                SaveSettings();
 
-                    if (LoadData.HasDelegate && IsVirtualizationAllowed())
-                    {
-                        Data = null;
+                if (LoadData.HasDelegate && IsVirtualizationAllowed())
+                {
+                    Data = null;
 #if NET5_0_OR_GREATER
-                        ResetLoadData();
+                    ResetLoadData();
 #endif
-                    }
+                }
 
-                    InvokeAsync(ReloadInternal);
+                await InvokeAsync(ReloadInternal);
+
+                if (IsVirtualizationAllowed())
+                {
+                    StateHasChanged();
                 }
             }
         }

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -246,13 +246,14 @@ else
         return $"rzi rz-grid-filter-icon {additionalStyle}";
     }
 
-    private void OnSortKeyPressed(KeyboardEventArgs args)
+    private Task OnSortKeyPressed(KeyboardEventArgs args)
     {
         var key = args.Code ?? args.Key;
         if (key == "Enter")
         {
-            Grid.OnSort(args, Column);
+            return Grid.OnSort(args, Column);
         }
+        return Task.CompletedTask;
     }
 
     string getColumnPopupID()


### PR DESCRIPTION
Fix for RadzenDataGrid displays incorrectly ordered data when using async LoadData #1345
OnSort function has been changed to an async function similar to OnFilter