### PR TITLE
Add base type to filter array

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -197,10 +197,12 @@ namespace Radzen
                         var enumerableValue = ((IEnumerable)(v != null ? v : Enumerable.Empty<object>())).AsQueryable();
                         var enumerableSecondValue = ((IEnumerable)(sv != null ? sv : Enumerable.Empty<object>())).AsQueryable();
 
-                        var enumerableValueAsString = "new []{" + String.Join(",",
+                        string baseType = column.FilterPropertyType.GetGenericArguments().Count() == 1 ? column.FilterPropertyType.GetGenericArguments()[0].Name : "";
+
+                        var enumerableValueAsString = "new " + baseType + "[]{" + String.Join(",",
                                 (enumerableValue.ElementType == typeof(string) ? enumerableValue.Cast<string>().Select(i => $@"""{i}""").Cast<object>() : enumerableValue.Cast<object>())) + "}";
 
-                        var enumerableSecondValueAsString = "new []{" + String.Join(",",
+                        var enumerableSecondValueAsString = "new " + baseType + "[]{" + String.Join(",",
                                 (enumerableSecondValue.ElementType == typeof(string) ? enumerableSecondValue.Cast<string>().Select(i => $@"""{i}""").Cast<object>() : enumerableSecondValue.Cast<object>())) + "}";
 
                         if (enumerableValue?.Any() == true)


### PR DESCRIPTION
After successfully creating a custom filter on DataGridColumn that was a reference to a related table, I then attempted to Export to CSV. Received this error -

`InvalidOperationException: No generic method 'Contains' on type 'System.Linq.Enumerable' is compatible with the supplied type arguments and arguments. No type arguments should be provided if the method is non-generic.
`

This is the filter - `SupplierRef = 18 and (new []{37}).Contains(CategoryRef)`

After debugging, it turned out that my column `(long [Int64])` was being declared as an array in the filter without a type, and it appeared that linq was inferring from the data, an `int` datatype. There is no `Contains` method for an integer datatype.

So I've created a baseType string variable that gets the type of the IEnumerable that has been passed to `column.FilterPropertyType`. I then include that in the filter array declaration.

Definitely needs a keen eye to look over this. I haven't tested it with any other data type than `Int64`.
My initial thoughts are that it's only the `int / long` confusion that causes this.

Paul
