### PR TITLE
enforce columnSize min width

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -1699,14 +1699,14 @@ window.Radzen = {
           },
           mouseMoveHandler: function (e) {
               if (Radzen[el]) {
-                  var widhtFloat = (Radzen[el].width - (Radzen[el].clientX - e.clientX));
+                  var widthFloat = (Radzen[el].width - (Radzen[el].clientX - e.clientX));
                   var minWidth = parseFloat(cell.style.minWidth || 0)
 
-                  if (widhtFloat < minWidth) {
-                      widhtFloat = minWidth;
+                  if (widthFloat < minWidth) {
+                      widthFloat = minWidth;
                   }
 
-                  var width = widhtFloat + 'px';
+                  var width = widthFloat + 'px';
 
                   if (cell) {
                       cell.style.width = width;

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -1699,7 +1699,15 @@ window.Radzen = {
           },
           mouseMoveHandler: function (e) {
               if (Radzen[el]) {
-                  var width = (Radzen[el].width - (Radzen[el].clientX - e.clientX)) + 'px';
+                  var widhtFloat = (Radzen[el].width - (Radzen[el].clientX - e.clientX));
+                  var minWidth = parseFloat(cell.style.minWidth || 0)
+
+                  if (widhtFloat < minWidth) {
+                      widhtFloat = minWidth;
+                  }
+
+                  var width = widhtFloat + 'px';
+
                   if (cell) {
                       cell.style.width = width;
                   }

--- a/RadzenBlazorDemos/Pages/DataGridColumnResizing.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnResizing.razor
@@ -7,7 +7,7 @@
 <RadzenDataGrid GridLines="Radzen.DataGridGridLines.Vertical" Data="@employees" TItem="Employee" ColumnWidth="300px" AllowColumnResize="true" ColumnResized=@OnColumnResized>
     <Columns>
         <RadzenDataGridColumn TItem="Employee" Property="EmployeeID" Title="ID" Width="50px" TextAlign="TextAlign.Center" />
-        <RadzenDataGridColumn TItem="Employee" Title="Photo" Sortable="false" Width="200px" >
+        <RadzenDataGridColumn TItem="Employee" Title="Photo" Sortable="false" Width="200px" MinWidth="100px">
             <Template Context="data">
                 <RadzenImage Path="@data.Photo" class="rz-gravatar" AlternateText="@(data.FirstName + " " + data.LastName)" />
             </Template>


### PR DESCRIPTION
changed startColumnResize to enforce the min width property of a column in JavaScript

th min-width is working in chromium based browsers, but not in Firefox and safari (possibly other browsers as wel)
this change will enforce the min width (if set) in the JavaScript resize method. to make min width working. 