### PR TITLE
DataGrid Column Custom Command Filter

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -1669,15 +1669,15 @@ namespace Radzen
         /// </summary>
         DoesNotContain,
         /// <summary>
-        /// Satisfied if the current value is null.
+        /// Satisfied if the current value is in the specified value.
         /// </summary>
         In,
         /// <summary>
-        /// Satisfied if the current value is in the specified value.
+        /// Satisfied if the current value is not in the specified value.
         /// </summary>
         NotIn,
         /// <summary>
-        /// Satisfied if the current value is not in the specified value.
+        /// Satisfied if the current value is null.
         /// </summary>
         IsNull,
         /// <summary>

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -153,7 +153,8 @@ namespace Radzen
             Func<RadzenDataGridColumn<T>, bool> canFilter = (c) => c.Filterable && c.FilterPropertyType != null &&
                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) || c.GetFilterOperator() == FilterOperator.IsNotNull
                    || c.GetFilterOperator() == FilterOperator.IsNull || c.GetFilterOperator() == FilterOperator.IsEmpty
-                   || c.GetFilterOperator() == FilterOperator.IsNotEmpty)
+                   || c.GetFilterOperator() == FilterOperator.IsNotEmpty
+                   || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterCommand() != null))
                && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
@@ -170,7 +171,15 @@ namespace Radzen
                     var v = column.GetFilterValue();
                     var sv = column.GetSecondFilterValue();
 
-                    if (PropertyAccess.IsDate(column.FilterPropertyType))
+                    if (column.GetFilterOperator() == FilterOperator.Custom)
+                    {
+                        var customFilterCommand = column.GetCustomFilterCommand();
+                        if (!string.IsNullOrEmpty(customFilterCommand))
+                        {
+                            whereList.Add(customFilterCommand);
+                        }
+                    }
+                    else if (PropertyAccess.IsDate(column.FilterPropertyType))
                     {
                         if (v != null)
                         {
@@ -817,7 +826,8 @@ namespace Radzen
             Func<RadzenDataGridColumn<T>, bool> canFilter = (c) => c.Filterable && c.FilterPropertyType != null &&
                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty)
                 || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
-                || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty)
+                || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty
+                || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterCommand() != null))
                && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
@@ -833,7 +843,15 @@ namespace Radzen
                     var value = column.GetFilterValue();
                     var secondValue = column.GetSecondFilterValue();
 
-                    if (value != null || column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull
+                    if (column.GetFilterOperator() == FilterOperator.Custom)
+                    {
+                        var customFilterCommand = column.GetCustomFilterCommand();
+                        if (!string.IsNullOrEmpty(customFilterCommand))
+                        {
+                            whereList.Add(customFilterCommand);
+                        }
+                    }
+                    else if (value != null || column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull
                         || column.GetFilterOperator() == FilterOperator.IsEmpty || column.GetFilterOperator() == FilterOperator.IsNotEmpty)
                     {
                         var linqOperator = ODataFilterOperators[column.GetFilterOperator()];
@@ -964,7 +982,8 @@ namespace Radzen
             Func<RadzenDataGridColumn<T>, bool> canFilter = (c) => c.Filterable && c.FilterPropertyType != null &&
                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty)
                 || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
-                || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty)
+                || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty
+                || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterCommand() != null))
                && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
@@ -976,7 +995,17 @@ namespace Radzen
                 var whereList = new Dictionary<string, IEnumerable<object>>();
                 foreach (var column in columns.Where(canFilter))
                 {
-                    var property = PropertyAccess.GetProperty(column.GetFilterProperty());
+                    if (column.GetFilterOperator() == FilterOperator.Custom)
+                    {
+                        var customFilterCommand = column.GetCustomFilterCommand();
+                        if (!string.IsNullOrEmpty(customFilterCommand))
+                        {
+                            whereList.Add(customFilterCommand, Enumerable.Empty<object>());
+                        }
+                    }
+                    else
+                    {
+                        var property = PropertyAccess.GetProperty(column.GetFilterProperty());
 
                     if (property.IndexOf(".") != -1)
                     {
@@ -1082,6 +1111,7 @@ namespace Radzen
                             whereList.Add($@"({firstFilter} {booleanOperator} {secondFilter})", new object[] { column.GetFilterValue(), column.GetSecondFilterValue() });
                         }
                     }
+                }
                 }
 
                 return whereList.Keys.Any() ?

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -154,7 +154,7 @@ namespace Radzen
                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty) || c.GetFilterOperator() == FilterOperator.IsNotNull
                    || c.GetFilterOperator() == FilterOperator.IsNull || c.GetFilterOperator() == FilterOperator.IsEmpty
                    || c.GetFilterOperator() == FilterOperator.IsNotEmpty
-                   || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterCommand() != null))
+                   || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterExpression() != null))
                && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
@@ -173,10 +173,10 @@ namespace Radzen
 
                     if (column.GetFilterOperator() == FilterOperator.Custom)
                     {
-                        var customFilterCommand = column.GetCustomFilterCommand();
-                        if (!string.IsNullOrEmpty(customFilterCommand))
+                        var customFilterExpression = column.GetCustomFilterExpression();
+                        if (!string.IsNullOrEmpty(customFilterExpression))
                         {
-                            whereList.Add(customFilterCommand);
+                            whereList.Add(customFilterExpression);
                         }
                     }
                     else if (PropertyAccess.IsDate(column.FilterPropertyType))
@@ -827,7 +827,7 @@ namespace Radzen
                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty)
                 || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
                 || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty
-                || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterCommand() != null))
+                || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterExpression() != null))
                && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
@@ -845,10 +845,10 @@ namespace Radzen
 
                     if (column.GetFilterOperator() == FilterOperator.Custom)
                     {
-                        var customFilterCommand = column.GetCustomFilterCommand();
-                        if (!string.IsNullOrEmpty(customFilterCommand))
+                        var customFilterExpression = column.GetCustomFilterExpression();
+                        if (!string.IsNullOrEmpty(customFilterExpression))
                         {
-                            whereList.Add(customFilterCommand);
+                            whereList.Add(customFilterExpression);
                         }
                     }
                     else if (value != null || column.GetFilterOperator() == FilterOperator.IsNotNull || column.GetFilterOperator() == FilterOperator.IsNull
@@ -983,7 +983,7 @@ namespace Radzen
                (!(c.GetFilterValue() == null || c.GetFilterValue() as string == string.Empty)
                 || c.GetFilterOperator() == FilterOperator.IsNotNull || c.GetFilterOperator() == FilterOperator.IsNull
                 || c.GetFilterOperator() == FilterOperator.IsEmpty || c.GetFilterOperator() == FilterOperator.IsNotEmpty
-                || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterCommand() != null))
+                || (c.GetFilterOperator() == FilterOperator.Custom && c.GetCustomFilterExpression() != null))
                && c.GetFilterProperty() != null;
 
             if (columns.Where(canFilter).Any())
@@ -997,10 +997,10 @@ namespace Radzen
                 {
                     if (column.GetFilterOperator() == FilterOperator.Custom)
                     {
-                        var customFilterCommand = column.GetCustomFilterCommand();
-                        if (!string.IsNullOrEmpty(customFilterCommand))
+                        var customFilterExpression = column.GetCustomFilterExpression();
+                        if (!string.IsNullOrEmpty(customFilterExpression))
                         {
-                            whereList.Add(customFilterCommand, Enumerable.Empty<object>());
+                            whereList.Add(customFilterExpression, Enumerable.Empty<object>());
                         }
                     }
                     else

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -308,7 +308,14 @@ namespace Radzen.Blazor
         /// <value>The filter placeholder value.</value>
         [Parameter]
         public string FilterPlaceholder { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the custom filter dynamic Linq dictionary.
+        /// </summary>
+        /// <value>The custom filter dynamic Linq dictionary.</value>
+        [Parameter]
+        public string CustomFilterCommand { get; set; }
+
         /// <summary>
         /// Gets the filter placeholder.
         /// </summary>
@@ -762,6 +769,7 @@ namespace Radzen.Blazor
         object secondFilterValue;
         FilterOperator? secondFilterOperator;
         LogicalFilterOperator? logicalFilterOperator;
+        string customFilterCommand;
 
         /// <summary>
         /// Set parameters as an asynchronous operation.
@@ -875,6 +883,32 @@ namespace Radzen.Blazor
                 }
             }
 
+            if (parameters.DidParameterChange(nameof(CustomFilterCommand), CustomFilterCommand))
+            {
+                customFilterCommand = parameters.GetValueOrDefault<string>(nameof(CustomFilterCommand));
+
+                if (CustomFilterCommand != null)
+                {
+                    CustomFilterCommand = customFilterCommand;
+                    Grid.SaveSettings();
+                    if (Grid.IsVirtualizationAllowed())
+                    {
+#if NET5_0_OR_GREATER
+                        if (Grid.virtualize != null)
+                        {
+                            await Grid.virtualize.RefreshDataAsync();
+                        }
+#endif
+                    }
+                    else
+                    {
+                        await Grid.Reload();
+                    }
+
+                    return;
+                }
+            }
+            
             if (parameters.DidParameterChange(nameof(FilterOperator), FilterOperator))
             {
                 filterOperator = parameters.GetValueOrDefault<FilterOperator>(nameof(FilterOperator));
@@ -985,6 +1019,33 @@ namespace Radzen.Blazor
                     || GetFilterOperator() == FilterOperator.IsNotNull
                     || GetFilterOperator() == FilterOperator.IsEmpty
                     || GetFilterOperator() == FilterOperator.IsNotEmpty;
+        }
+
+        /// <summary>
+        /// Get custom filter linq.
+        /// </summary>
+        public string GetCustomFilterCommand()
+        {
+            return customFilterCommand ?? CustomFilterCommand;
+        }
+
+        /// <summary>
+        /// Set column custom filter linq.
+        /// </summary>
+        public void SetCustomFilterCommand(string value)
+        {
+            customFilterCommand = value;
+        }
+
+        /// <summary>
+        /// Set column custom filter linq and reload grid.
+        /// </summary>
+        /// <param name="value">Filter value.</param>
+        public async Task SetCustomFilterCommandAsync(string value)
+        {
+            SetCustomFilterCommand(value);
+            Grid.SaveSettings();
+            await Grid.FirstPage(true);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -314,7 +314,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The custom filter dynamic Linq dictionary.</value>
         [Parameter]
-        public string CustomFilterCommand { get; set; }
+        public string CustomFilterExpression { get; set; }
 
         /// <summary>
         /// Gets the filter placeholder.
@@ -769,7 +769,7 @@ namespace Radzen.Blazor
         object secondFilterValue;
         FilterOperator? secondFilterOperator;
         LogicalFilterOperator? logicalFilterOperator;
-        string customFilterCommand;
+        string customFilterExpression;
 
         /// <summary>
         /// Set parameters as an asynchronous operation.
@@ -883,13 +883,13 @@ namespace Radzen.Blazor
                 }
             }
 
-            if (parameters.DidParameterChange(nameof(CustomFilterCommand), CustomFilterCommand))
+            if (parameters.DidParameterChange(nameof(CustomFilterExpression), CustomFilterExpression))
             {
-                customFilterCommand = parameters.GetValueOrDefault<string>(nameof(CustomFilterCommand));
+                customFilterExpression = parameters.GetValueOrDefault<string>(nameof(CustomFilterExpression));
 
-                if (CustomFilterCommand != null)
+                if (CustomFilterExpression != null)
                 {
-                    CustomFilterCommand = customFilterCommand;
+                    CustomFilterExpression = customFilterExpression;
                     Grid.SaveSettings();
                     if (Grid.IsVirtualizationAllowed())
                     {
@@ -1024,26 +1024,26 @@ namespace Radzen.Blazor
         /// <summary>
         /// Get custom filter linq.
         /// </summary>
-        public string GetCustomFilterCommand()
+        public string GetCustomFilterExpression()
         {
-            return customFilterCommand ?? CustomFilterCommand;
+            return customFilterExpression ?? CustomFilterExpression;
         }
 
         /// <summary>
         /// Set column custom filter linq.
         /// </summary>
-        public void SetCustomFilterCommand(string value)
+        public void SetCustomFilterExpression(string value)
         {
-            customFilterCommand = value;
+            customFilterExpression = value;
         }
 
         /// <summary>
         /// Set column custom filter linq and reload grid.
         /// </summary>
         /// <param name="value">Filter value.</param>
-        public async Task SetCustomFilterCommandAsync(string value)
+        public async Task SetCustomFilterExpressionAsync(string value)
         {
-            SetCustomFilterCommand(value);
+            SetCustomFilterExpression(value);
             Grid.SaveSettings();
             await Grid.FirstPage(true);
         }

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
@@ -140,7 +140,7 @@ else
             whereCommand = "";
         }
 
-        await column.SetCustomFilterCommandAsync(whereCommand);
+        await column.SetCustomFilterExpressionAsync(whereCommand);
     }
 
     void OnRender(DataGridRenderEventArgs<Employee> args)

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
@@ -128,7 +128,7 @@ else
         {
             foreach (var item in selectedWorkStatus)
             {
-                createWhereCommand.Add($"(WorkStatus == null ? \"\" : WorkStatus).Contains(\"{item}\")");
+                createWhereCommand.Add($"WorkStatus.Contains(\"{item}\")");
             }
             var booleanOperator = workStatusOperator == LogicalFilterOperator.And ? "and" : "or";
 

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
@@ -1,0 +1,154 @@
+﻿@using System.Linq.Dynamic.Core
+
+@if (employees == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <RadzenText TextStyle="TextStyle.H6" TagName="TagName.H2" class="my-4">Custom filtering template with Custom Command</RadzenText>
+    <RadzenDataGrid Render="@OnRender" Style="height:400px;" AllowVirtualization="true" @ref="grid" Data=@employees FilterMode="FilterMode.Advanced"
+                    AllowFiltering="true" AllowPaging="false" AllowSorting="true" TItem="Employee" ColumnWidth="200px">
+        <Columns>
+            <RadzenDataGridColumn TItem="Employee" Property="ID" Title="ID" FilterValue="@idValue">
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Employee" Title="Customer" Property="CompanyName">
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Employee" Title="Hire Date" Property="HireDate.Date" FormatString="{0:d}"
+                                  FilterValue="@hireDate?.Date">
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Employee" Title="Work Status" Property="WorkStatus" Type="typeof(IEnumerable<string>)" Sortable=true
+                                  FilterValue="@selectedWorkStatus" FilterOperator="FilterOperator.Custom" LogicalFilterOperator="@workStatusOperator">
+                <FilterTemplate Context="column">
+                    <div class="rz-grid-filter">
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Stretch" JustifyContent="JustifyContent.SpaceBetween">
+                            <span class="rz-grid-filter-label">Filter</span>
+                            <RadzenSelectBar Style="margin-top:-6px;" Change="@(()=>OnSelectedWorkStatusChange(column))" @bind-Value=@workStatusOperator TValue="LogicalFilterOperator">
+                                <Items>
+                                    <RadzenSelectBarItem Text="Any" Value="@(LogicalFilterOperator.Or)" />
+                                    <RadzenSelectBarItem Text="All" Value="@(LogicalFilterOperator.And)" />
+                                </Items>
+                            </RadzenSelectBar>
+                            @* <RadzenButton Variant="Variant.Text" Text="X" Click="@(() => CollectionFilterApply(column))" Style="margin-top:-12px;margin-right:-10px;" /> *@
+                        </RadzenStack>
+                        <RadzenListBox AllowClear="true" @bind-Value=@selectedWorkStatus Multiple="true" AllowSelectAll=true Style="width:100%; height:200px;"
+                                       Change="@(()=>OnSelectedWorkStatusChange(column))" Data=@workStatuses />
+                        <div class="rz-grid-filter-buttons">
+                            <RadzenButton ButtonStyle="ButtonStyle.Secondary" Text="Clear" Click="@(() => WorkStatusFilterClear(column))" />
+                            <RadzenButton ButtonStyle="ButtonStyle.Primary" Text="Close" Click="@(() => WorkStatusFilterClose(column))" />
+                        </div>
+                    </div>
+                </FilterTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Employee" Property="TitleOfCourtesy" Title="Title Of Courtesy" 
+                FilterValue="@currentTOC">
+                <FilterTemplate>
+                    <RadzenListBox @bind-Value="@currentTOC" TextProperty="Text" ValueProperty="Value" Style="width:100%;" InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "filter by title of courtesy" }})"
+                                    Change=@OnSelectedTOCChange
+                                    Data="@(Enum.GetValues(typeof(TitleOfCourtesy)).Cast<TitleOfCourtesy?>().Select(t => new { Text = $"{t}", Value = t == TitleOfCourtesy.All ? null : t }))" />
+                </FilterTemplate>
+            </RadzenDataGridColumn>
+        </Columns>
+    </RadzenDataGrid>
+}
+
+
+@code {
+    RadzenDataGrid<Employee> grid;
+    int? idValue;
+    DateTime? hireDate;
+    TitleOfCourtesy? currentTOC;
+    IEnumerable<string> selectedCompanyNames;
+    List<string> selectedWorkStatus;
+    string whereCommand;
+
+    public LogicalFilterOperator workStatusOperator { get; set; } = LogicalFilterOperator.Or;
+
+    List<string> companyNames = new List<string> {"Vins et alcools Chevalier", "Toms Spezialitäten", "Hanari Carnes", "Richter Supermarkt", "Wellington Importadora", "Centro comercial Moctezuma" };
+    List<string> workStatuses = new List<string> { "Office", "Remote", "Temporary", "Permanent" };
+    public enum TitleOfCourtesy
+    {
+        Ms,
+        Mr,
+        All = -1
+    }
+
+    public class Employee
+    {
+        public int ID { get; set; }
+        public string CompanyName { get; set; }
+        public DateTime HireDate { get; set; }
+        public TitleOfCourtesy TitleOfCourtesy { get; set; }
+        public string WorkStatus { get; set; }
+    }
+
+    void OnSelectedTOCChange(object value)
+    {
+        if (currentTOC == TitleOfCourtesy.All)
+        {
+            currentTOC = null;
+        }
+    }
+
+    IEnumerable<Employee> employees; 
+
+    protected override async Task OnInitializedAsync()
+    {
+        employees = await Task.FromResult(Enumerable.Range(0, 60).Select(i =>
+            new Employee
+            {
+                ID = i,
+                CompanyName = companyNames[i % 6],
+                HireDate = DateTime.Now.AddMonths(-i),
+                TitleOfCourtesy = i % 2 == 1 ? TitleOfCourtesy.Mr : TitleOfCourtesy.Ms,
+                    WorkStatus = $"{(i < 20 ? "Office" : i >= 20 && i < 40 ? "Remote" : "Office, Remote")} {(i < 12 ? ", Temporary" : i >= 12 && i < 30 ? ", Permanent" : i > 30 && i < 44 ? ", Temporary" : ", Permanent")}"
+            }).AsQueryable());
+    }
+
+    private async Task WorkStatusFilterClear(RadzenDataGridColumn<Employee> column)
+    {
+        if(selectedWorkStatus!=null)
+        {
+            selectedWorkStatus.Clear();
+            await OnSelectedWorkStatusChange(column);            
+        }
+        await column.CloseFilter();
+    }
+
+    private async Task WorkStatusFilterClose(RadzenDataGridColumn<Employee> column)
+    {
+        await column.CloseFilter();
+    }
+
+    async Task OnSelectedWorkStatusChange(RadzenDataGridColumn<Employee> column)
+    {
+        var createWhereCommand = new List<string>();
+
+        if (selectedWorkStatus != null && selectedWorkStatus.Count > 0)
+        {
+            foreach (var item in selectedWorkStatus)
+            {
+                createWhereCommand.Add($"(WorkStatus == null ? \"\" : WorkStatus).Contains(\"{item}\")");
+            }
+            var booleanOperator = workStatusOperator == LogicalFilterOperator.And ? "and" : "or";
+
+            whereCommand = string.Join($" {booleanOperator} ", createWhereCommand);
+            whereCommand = $"({whereCommand})";
+        }
+        else
+        {
+            whereCommand = "";
+        }
+
+        await column.SetCustomFilterCommandAsync(whereCommand);
+    }
+
+    void OnRender(DataGridRenderEventArgs<Employee> args)
+    {
+        if (args.FirstRender)
+        {
+            args.Grid.Sorts.Add(new SortDescriptor() { Property = "CompanyName", SortOrder = SortOrder.Ascending });
+            args.Grid.Sorts.Add(new SortDescriptor() { Property = "TitleOfCourtesy", SortOrder = SortOrder.Ascending });
+        }
+    }
+}

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterCustomCommand.razor
@@ -60,7 +60,7 @@ else
     TitleOfCourtesy? currentTOC;
     IEnumerable<string> selectedCompanyNames;
     List<string> selectedWorkStatus;
-    string whereCommand;
+    string whereExpression;
 
     public LogicalFilterOperator workStatusOperator { get; set; } = LogicalFilterOperator.Or;
 
@@ -122,25 +122,24 @@ else
 
     async Task OnSelectedWorkStatusChange(RadzenDataGridColumn<Employee> column)
     {
-        var createWhereCommand = new List<string>();
+        var createWhereExpression = new List<string>();
 
         if (selectedWorkStatus != null && selectedWorkStatus.Count > 0)
         {
             foreach (var item in selectedWorkStatus)
             {
-                createWhereCommand.Add($"WorkStatus.Contains(\"{item}\")");
+                createWhereExpression.Add($"WorkStatus.Contains(\"{item}\")");
             }
             var booleanOperator = workStatusOperator == LogicalFilterOperator.And ? "and" : "or";
 
-            whereCommand = string.Join($" {booleanOperator} ", createWhereCommand);
-            whereCommand = $"({whereCommand})";
+            whereExpression = string.Join($" {booleanOperator} ", createWhereExpression);
         }
         else
         {
-            whereCommand = "";
+            whereExpression = "";
         }
 
-        await column.SetCustomFilterExpressionAsync(whereCommand);
+        await column.SetCustomFilterExpressionAsync(whereExpression);
     }
 
     void OnRender(DataGridRenderEventArgs<Employee> args)

--- a/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnFilterTemplatePage.razor
@@ -10,3 +10,11 @@
 <RadzenExample ComponentName="DataGrid" Example="DataGridColumnFilterTemplate">
     <DataGridColumnFilterTemplate />
 </RadzenExample>
+
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pt-8 rz-mb-6">
+    This page demonstrates how to use a Custom Command (FilterOperator.Custom) in a custom DataGrid column filter template.
+</RadzenText>
+
+<RadzenExample ComponentName="DataGrid" Example="DataGridColumnFilterCustomCommand">
+    <DataGridColumnFilterCustomCommand />
+</RadzenExample>


### PR DESCRIPTION
Rather than skipping over, the Custom Filter Operator type now takes it's value from a new property CustomFilterCommand and adds that value to whereList for processing.

This enables the developer to write whatever dynamic linq filter they require without predefined functions / restrictions.

The changes in Common.cs do not pertain to the Custom Command Filter. They were documentation errors discovered while writing this.

Because of changes when wrapping an `if () {...}` block in Queryable.cs, lines 1010 to 1114, I have not reformatted the code which should, by rights, be tabbed along, as it was showing all these lines as deleted and then added in my git file changes. They made need shifting over when code has been checked so it is formatted correctly.
