### PR TITLE
#1362 - RadzenDataFilter operator not being set using AddFilter

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -2020,7 +2020,7 @@ namespace Radzen
         /// Gets or sets the operator which will compare the property value with <see cref="FilterValue" />.
         /// </summary>
         /// <value>The filter operator.</value>
-        public FilterOperator FilterOperator { get; set; }
+        public FilterOperator? FilterOperator { get; set; }
 
         /// <summary>
         /// Gets or sets the logic used to combine the outcome of filtering by <see cref="FilterValue" />.

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -1174,7 +1174,7 @@ namespace Radzen
             }
             else
             {
-                if (filter.Property == null || (filter.FilterValue == null &&
+                if (filter.Property == null || filter.FilterOperator == null || (filter.FilterValue == null &&
                     filter.FilterOperator != FilterOperator.IsNull && filter.FilterOperator != FilterOperator.IsNotNull))
                 {
                     return;
@@ -1203,7 +1203,7 @@ namespace Radzen
                        && dataFilter.FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? ".ToLower()" : "";
 
 
-                var comparison = LinqFilterOperators[filter.FilterOperator];
+                var comparison = LinqFilterOperators[filter.FilterOperator.Value];
 
                 if (comparison == "StartsWith" || comparison == "EndsWith" || comparison == "Contains")
                 {
@@ -1319,7 +1319,7 @@ namespace Radzen
             }
             else
             {
-                if (filter.Property == null || (filter.FilterValue == null &&
+                if (filter.Property == null || filter.FilterOperator == null || (filter.FilterValue == null &&
                     filter.FilterOperator != FilterOperator.IsNull && filter.FilterOperator != FilterOperator.IsNotNull))
                 {
                     return;
@@ -1359,8 +1359,8 @@ namespace Radzen
                     else
                     {
                         var expression = dataFilter.FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ?
-                            $"{ODataFilterOperators[filter.FilterOperator]}({property}, tolower('{filter.FilterValue}'))" :
-                            $"{ODataFilterOperators[filter.FilterOperator]}({property}, '{filter.FilterValue}')";
+                            $"{ODataFilterOperators[filter.FilterOperator.Value]}({property}, tolower('{filter.FilterValue}'))" :
+                            $"{ODataFilterOperators[filter.FilterOperator.Value]}({property}, '{filter.FilterValue}')";
 
                         if (filter.FilterOperator == FilterOperator.DoesNotContain)
                         {
@@ -1407,7 +1407,7 @@ namespace Radzen
                         value = $"{value?.ToLower()}";
                     }
 
-                    filterExpressions.Add($@"{property} {ODataFilterOperators[filter.FilterOperator]} {value}");
+                    filterExpressions.Add($@"{property} {ODataFilterOperators[filter.FilterOperator.Value]} {value}");
                 }
             }
         }

--- a/Radzen.Blazor/RadzenDataFilterItem.razor
+++ b/Radzen.Blazor/RadzenDataFilterItem.razor
@@ -40,7 +40,7 @@ else
     if (property != null)
     {
         <RadzenDropDown @onclick:preventDefault="true" Data="@(property.GetFilterOperators().Select(t => new { Value = property.GetFilterOperatorText(t), Key = t }))" 
-                TextProperty="Value" ValueProperty="Key" TValue="FilterOperator" @bind-Value="@Filter.FilterOperator" Change="@OnOperatorChange" class="rz-datafilter-operator" />
+                TextProperty="Value" ValueProperty="Key" TValue="FilterOperator?" @bind-Value="@Filter.FilterOperator" Change="@OnOperatorChange" class="rz-datafilter-operator" />
         @if (property.FilterTemplate != null)
         {
             <div class="rz-datafilter-editor" style="display:flex">
@@ -120,14 +120,14 @@ else
                     
 	                Filter.Property = property.Property;
 
-                    if (!property.GetFilterOperators().Contains(Filter.FilterOperator))
-                    {
-                        Filter.FilterOperator = property.GetFilterOperators().FirstOrDefault();
-                    }
-
-                    if(Filter.FilterOperator != property.GetFilterOperator())
+                    if (Filter.FilterOperator == null)
                     {
                         Filter.FilterOperator = property.GetFilterOperator();
+                    }
+                    
+                    else if (!property.GetFilterOperators().Contains(Filter.FilterOperator.Value))
+                    {
+                        Filter.FilterOperator = property.GetFilterOperators().FirstOrDefault();
                     }
 
                     var v = property.GetFilterValue();


### PR DESCRIPTION
Removed lines that were setting the Filter.FilterOperator to the operator of the corresponding property. Made the FilterOperator property nullable. If a user does not specify a filter operator in the composite filter descriptor when using the AddFilter method, the filter operator will default to the operator of the corresponding property. If Filter.FilterOperator is not null, the original check to see if it exists in the property's filter operators is still ran. Also, added null checks to QueryableExtension.cs

There is a known issue. When not providing an initial filter operator via AddFilter, the corresponding property's filter will be displayed in the filter operator dropdown, but will not be applied to the view/results. Invoking the Filter method after the initial render will display the correct results. 