### PR TITLE
Feature: DatePicker, support for DateOnly/TimeOnly types

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -607,5 +607,35 @@ namespace Radzen.Blazor.Tests
             input.GetAttribute("value").MarkupMatches(enteredValue.ToString());
             Assert.Equal(enteredValue, component.Instance.Value);
         }
+
+        [Fact]
+        public void DatePicker_Supports_TimeOnly()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var timeOnly = new TimeOnly(23, 59, 59);
+            TimeOnly newValue;
+            var component = ctx.RenderComponent<RadzenDatePicker<TimeOnly>>(parameters =>
+            {
+                parameters.Add(p => p.Value, timeOnly);
+                parameters.Add(p => p.ValueChanged, args => { newValue = args; });
+            });
+            
+            Assert.True(component.Instance.TimeOnly);
+            Assert.True(component.Instance.ShowTime);
+            var input = component.Find("input");
+            input.GetAttribute("value").MarkupMatches(timeOnly.ToString());
+            
+            // update to new value
+            var inputElement = component.Find(".rz-inputtext");
+            var enteredValue = new TimeOnly(1, 4, 5);
+            ctx.JSInterop.Setup<string>("Radzen.getInputValue", invocation => true).SetResult(enteredValue.ToLongTimeString());
+            inputElement.Change(enteredValue);
+
+            input.GetAttribute("value").MarkupMatches(enteredValue.ToString());
+            Assert.Equal(enteredValue, component.Instance.Value);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -578,5 +578,34 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains(@$"rzi-time", component.Markup);
         }
+
+        [Fact]
+        public void DatePicker_Supports_DateOnly()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var dateOnly = new DateOnly(2024, 1, 31);
+            DateOnly newValue;
+            var component = ctx.RenderComponent<RadzenDatePicker<DateOnly>>(parameters =>
+            {
+                parameters.Add(p => p.Value, dateOnly);
+                parameters.Add(p => p.ValueChanged, args => { newValue = args; });
+            });
+            
+            Assert.False(component.Instance.ShowTime);
+            var input = component.Find("input");
+            input.GetAttribute("value").MarkupMatches(dateOnly.ToString());
+
+            // update to new value
+            var inputElement = component.Find(".rz-inputtext");
+            var enteredValue = new DateOnly(2024, 2, 28);
+            ctx.JSInterop.Setup<string>("Radzen.getInputValue", invocation => true).SetResult(enteredValue.ToShortDateString());
+            inputElement.Change(enteredValue);
+            
+            input.GetAttribute("value").MarkupMatches(enteredValue.ToString());
+            Assert.Equal(enteredValue, component.Instance.Value);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -255,6 +255,13 @@ namespace Radzen.Blazor
 
             UpdateYearsAndMonths(Min, Max);
 
+#if NET6_0_OR_GREATER
+            if (typeof(TValue) == typeof(TimeOnly))
+            {
+                TimeOnly = true;
+                ShowTime = true;
+            }
+#endif
         }
 
         void UpdateYearsAndMonths(DateTime? min, DateTime? max)
@@ -406,6 +413,10 @@ namespace Radzen.Blazor
                         {
                             DateTimeValue = dateOnly.ToDateTime(System.TimeOnly.MinValue, Kind);
                         }
+                        else if (value is TimeOnly timeOnly)
+                        {
+                            DateTimeValue = new DateTime(1,1,0001, timeOnly.Hour, timeOnly.Minute, timeOnly.Second, timeOnly.Millisecond, Kind);
+                        }
 #endif
                         else
                         {
@@ -419,10 +430,18 @@ namespace Radzen.Blazor
         private static object ConvertToTValue(object value)
         {
 #if NET6_0_OR_GREATER
-            if (typeof(TValue) == typeof(DateOnly) && value is DateTime dt)
+            if (value is DateTime dt)
             {
-                value = DateOnly.FromDateTime(dt);
-                return (TValue)value;
+                if (typeof(TValue) == typeof(DateOnly))
+                {
+                    value = DateOnly.FromDateTime(dt);
+                    return (TValue)value;
+                }
+                if (typeof(TValue) == typeof(TimeOnly))
+                {
+                    value = System.TimeOnly.FromDateTime(dt);
+                    return (TValue)value;
+                }
             }
 #endif
             return value;

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -375,7 +375,7 @@ namespace Radzen.Blazor
             {
                 if (_value != value)
                 {
-                    _value = value;
+                    _value = ConvertToTValue(value);
                     _currentDate = default(DateTime);
 
                     if (value is DateTimeOffset offset)
@@ -401,6 +401,12 @@ namespace Radzen.Blazor
                         {
                             DateTimeValue = DateTime.SpecifyKind(dateTime, Kind);
                         }
+#if NET6_0_OR_GREATER
+                        else if (value is DateOnly dateOnly)
+                        {
+                            DateTimeValue = dateOnly.ToDateTime(System.TimeOnly.MinValue, Kind);
+                        }
+#endif
                         else
                         {
                             DateTimeValue = null;
@@ -408,6 +414,18 @@ namespace Radzen.Blazor
                     }
                 }
             }
+        }
+
+        private static object ConvertToTValue(object value)
+        {
+#if NET6_0_OR_GREATER
+            if (typeof(TValue) == typeof(DateOnly) && value is DateTime dt)
+            {
+                value = DateOnly.FromDateTime(dt);
+                return (TValue)value;
+            }
+#endif
+            return value;
         }
 
         DateTime _currentDate;

--- a/RadzenBlazorDemos/Pages/DatePickerPage.razor
+++ b/RadzenBlazorDemos/Pages/DatePickerPage.razor
@@ -99,3 +99,13 @@
 <RadzenExample ComponentName="DatePicker" Example="DatePickerYearMonth">
     <DatePickerYearMonth />
 </RadzenExample>
+
+<RadzenText TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
+    DatePicker binds to types DateOnly or TimeOnly
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    <code>Value</code> property can be bound to values of type <code>DateOnly</code> or <code>TimeOnly</code>
+</RadzenText>
+<RadzenExample ComponentName="DatePicker" Example="DatePickerWithDateOnlyTimeOnly">
+    <DatePickerWithDateOnlyTimeOnly />
+</RadzenExample>

--- a/RadzenBlazorDemos/Pages/DatePickerWithDateOnlyTimeOnly.razor
+++ b/RadzenBlazorDemos/Pages/DatePickerWithDateOnlyTimeOnly.razor
@@ -1,0 +1,17 @@
+﻿<div class="rz-p-12 rz-text-align-center">
+    <RadzenStack Orientation="Orientation.Horizontal">
+        <RadzenStack>
+            <RadzenLabel Text="Select Date, bound to DateOnly" Component="DatePickerDateOnlyType" Style="margin-right: 8px; vertical-align: middle;"/>
+            <RadzenDatePicker @bind-Value="@value" DateFormat="MM/dd/yyyy" Name="DatePickerDateOnlyType"/>
+        </RadzenStack>
+        <RadzenStack>
+            <RadzenLabel Text="Select Time, bound to TimeOnly" Component="DatePickerTimeOnlyType" Style="margin-right: 8px; vertical-align: middle;" />
+            <RadzenDatePicker @bind-Value="@timeValue" ShowSeconds="true" DateFormat="HH:mm" Name="DatePickerTimeOnlyType" />
+        </RadzenStack>
+    </RadzenStack>
+</div>
+
+@code {
+    DateOnly value = DateOnly.FromDateTime(DateTime.Now);
+    TimeOnly timeValue = TimeOnly.FromDateTime(DateTime.Now);
+}


### PR DESCRIPTION
NET 6.0 added the `DateOnly` and `TimeOnly` data type primitives to the BCL.
`RadzenDatePicker` does not support these types, as it assumes you are binding to DateTime/Offset.
This PR adds support by:
- when assigning to `Value`, first check `TValue` and if DateOnly or TimeOnly, attempt to convert to that type
- when assigning a set value that is `DateOnly` or `TimeOnly` to `DateTimeValue`, convert it appropriately.
- if `TimeOnly` if `TValue`, then configure control for `TimeOnly` / `ShowTime`, as it is safe to assume the user is only dealing with time.