### PR TITLE
Update RadzenAccordion.razor

### DIFF
--- a/Radzen.Blazor/RadzenAccordion.razor
+++ b/Radzen.Blazor/RadzenAccordion.razor
@@ -18,7 +18,7 @@
             continue;
 
         <div @ref="@item.Element" id="@item.GetItemId()" @attributes="item.Attributes" class="@item.GetItemCssClass()" style="@item.Style">
-            <a @onkeypress="@((args) => OnKeyPress(args, item))" @onkeypress:preventDefault=preventKeyPress @onclick="@((args) => SelectItem(item))" aria-label="@ItemAriaLabel(i, item)" title="@ItemTitle(i, item)" @onclick:preventDefault="true" role="tab" tabindex="0"
+            <a href="javascript:void(0)" @onkeypress="@((args) => OnKeyPress(args, item))" @onkeypress:preventDefault=preventKeyPress @onclick="@((args) => SelectItem(item))" aria-label="@ItemAriaLabel(i, item)" title="@ItemTitle(i, item)" @onclick:preventDefault="true" role="tab" tabindex="0"
                id="@($"rz-accordiontab-{items.IndexOf(item)}")" aria-controls="@($"rz-accordiontab-{items.IndexOf(item)}-content")" aria-expanded="true">
                 @if (IsSelected(i, item))
                 {


### PR DESCRIPTION
Adding an href allows the browser to use it's default behavior such as mouse cursor on hover. This helps with Accessibility and indicates to users it is a clickable/interactive item. 

Setting it to javascript:void(0) disables the default navigation behavior.