### PR TITLE
DatePicker: support for Nullable DateOnly / TimeOnly

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -586,12 +586,12 @@ namespace Radzen.Blazor.Tests
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 
-            var dateOnly = new DateOnly(2024, 1, 31);
-            DateOnly newValue;
-            var component = ctx.RenderComponent<RadzenDatePicker<DateOnly>>(parameters =>
+            DateOnly? dateOnly = new DateOnly(2024, 1, 31);
+            DateOnly? valueChangedValue = null!;
+            var component = ctx.RenderComponent<RadzenDatePicker<DateOnly?>>(parameters =>
             {
                 parameters.Add(p => p.Value, dateOnly);
-                parameters.Add(p => p.ValueChanged, args => { newValue = args; });
+                parameters.Add(p => p.ValueChanged, args => { valueChangedValue = args; });
             });
             
             Assert.False(component.Instance.ShowTime);
@@ -600,12 +600,13 @@ namespace Radzen.Blazor.Tests
 
             // update to new value
             var inputElement = component.Find(".rz-inputtext");
-            var enteredValue = new DateOnly(2024, 2, 28);
-            ctx.JSInterop.Setup<string>("Radzen.getInputValue", invocation => true).SetResult(enteredValue.ToShortDateString());
+            DateOnly? enteredValue = new DateOnly(2024, 2, 28);
+            ctx.JSInterop.Setup<string>("Radzen.getInputValue", invocation => true).SetResult(enteredValue.Value.ToShortDateString());
             inputElement.Change(enteredValue);
             
             input.GetAttribute("value").MarkupMatches(enteredValue.ToString());
             Assert.Equal(enteredValue, component.Instance.Value);
+            Assert.Equal(enteredValue, valueChangedValue);
         }
 
         [Fact]
@@ -615,12 +616,12 @@ namespace Radzen.Blazor.Tests
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 
-            var timeOnly = new TimeOnly(23, 59, 59);
-            TimeOnly newValue;
+            TimeOnly? timeOnly = new TimeOnly(23, 59, 59);
+            TimeOnly? valueChangedValue = null!;
             var component = ctx.RenderComponent<RadzenDatePicker<TimeOnly>>(parameters =>
             {
                 parameters.Add(p => p.Value, timeOnly);
-                parameters.Add(p => p.ValueChanged, args => { newValue = args; });
+                parameters.Add(p => p.ValueChanged, args => { valueChangedValue = args; });
             });
             
             Assert.True(component.Instance.TimeOnly);
@@ -630,12 +631,13 @@ namespace Radzen.Blazor.Tests
             
             // update to new value
             var inputElement = component.Find(".rz-inputtext");
-            var enteredValue = new TimeOnly(1, 4, 5);
-            ctx.JSInterop.Setup<string>("Radzen.getInputValue", invocation => true).SetResult(enteredValue.ToLongTimeString());
+            TimeOnly? enteredValue = new TimeOnly(1, 4, 5);
+            ctx.JSInterop.Setup<string>("Radzen.getInputValue", invocation => true).SetResult(enteredValue.Value.ToLongTimeString());
             inputElement.Change(enteredValue);
 
             input.GetAttribute("value").MarkupMatches(enteredValue.ToString());
             Assert.Equal(enteredValue, component.Instance.Value);
+            Assert.Equal(enteredValue, valueChangedValue);
         }
     }
 }

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -256,7 +256,7 @@ namespace Radzen.Blazor
             UpdateYearsAndMonths(Min, Max);
 
 #if NET6_0_OR_GREATER
-            if (typeof(TValue) == typeof(TimeOnly))
+            if (typeof(TValue) == typeof(TimeOnly) || typeof(TValue) == typeof(TimeOnly?))
             {
                 TimeOnly = true;
                 ShowTime = true;
@@ -430,14 +430,15 @@ namespace Radzen.Blazor
         private static object ConvertToTValue(object value)
         {
 #if NET6_0_OR_GREATER
+            var typeofTValue = typeof(TValue);
             if (value is DateTime dt)
             {
-                if (typeof(TValue) == typeof(DateOnly))
+                if (typeofTValue == typeof(DateOnly) || typeofTValue == typeof(DateOnly?))
                 {
                     value = DateOnly.FromDateTime(dt);
                     return (TValue)value;
                 }
-                if (typeof(TValue) == typeof(TimeOnly))
+                if (typeofTValue == typeof(TimeOnly) || typeofTValue == typeof(TimeOnly?))
                 {
                     value = System.TimeOnly.FromDateTime(dt);
                     return (TValue)value;


### PR DESCRIPTION
In my previous PR, I posted support for DateOnly/TimeOnly types, but neglected to test the nullable variation.  When using these today, an exception is thrown in `ParseDate`.
This PR updates the conversion type checks to also handle a TValue of `DateOnly?`/`TimeOnly?`.