### PR TITLE
Allow the icon in the ProfileMenu to be enabled/disabled

### DIFF
--- a/Radzen.Blazor/RadzenProfileMenu.razor
+++ b/Radzen.Blazor/RadzenProfileMenu.razor
@@ -13,7 +13,10 @@
                             @Template
                         }
                     </div>
-                    <i class="rzi rz-navigation-item-icon-children" style="@iconStyle">keyboard_arrow_down</i>
+                    @if (ShowIcon)
+                    {
+                        <i class="rzi rz-navigation-item-icon-children" style="@iconStyle">keyboard_arrow_down</i>
+                    }
                 </div>
             </div>
             <ul class="rz-navigation-menu" style="@contentStyle">

--- a/Radzen.Blazor/RadzenProfileMenu.razor.cs
+++ b/Radzen.Blazor/RadzenProfileMenu.razor.cs
@@ -42,6 +42,13 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback<RadzenProfileMenuItem> Click { get; set; }
 
+        /// <summary>
+        /// Enable/Disable the "arrow down" icon
+        /// </summary>
+        /// <value>Show the "arrow down" icon.</value>
+        [Parameter]
+        public bool ShowIcon { get; set; } = true;
+
         string contentStyle = "display:none;position:absolute;z-index:1;";
         string iconStyle = "transform: rotate(0deg);";
 

--- a/Radzen.Blazor/RadzenProfileMenu.razor.cs
+++ b/Radzen.Blazor/RadzenProfileMenu.razor.cs
@@ -43,7 +43,7 @@ namespace Radzen.Blazor
         public EventCallback<RadzenProfileMenuItem> Click { get; set; }
 
         /// <summary>
-        /// Enable/Disable the "arrow down" icon
+        /// Show/Hide the "arrow down" icon
         /// </summary>
         /// <value>Show the "arrow down" icon.</value>
         [Parameter]


### PR DESCRIPTION
Currently the ProfileMenu component always renders an arrow down icon.  This may not be preferred in certain instances, so I've added the ability to disable it. This will be enabled by default though! 

I haven't noticed any tests pertaining to this component, so I didn't update/extend any. 