### PR TITLE
fixed Crash in Validate RadzenDropDown

### DIFF
--- a/RadzenBlazorDemos/Pages/RequiredValidatorDropDown.razor
+++ b/RadzenBlazorDemos/Pages/RequiredValidatorDropDown.razor
@@ -47,6 +47,8 @@
         await base.OnInitializedAsync();
 
         categories = dbContext.Categories.ToList();
+        
+        products = new List<Product>();
     }
 
     void CategoryChange()


### PR DESCRIPTION
This pull request introduces a workaround for a bug that causes the demo to crash when clicking on the highlighted checkbox without selecting a category.

![image](https://github.com/radzenhq/radzen-blazor/assets/76875338/c72dcd44-37a2-42a0-bd5a-4326214d1219)
