### PR TITLE
feat: DataGridSettings with CustomFilterExpression

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -373,7 +373,7 @@ namespace Radzen
         /// <summary>
         /// Columns.
         /// </summary>
-        public IEnumerable<DataGridColumnSettings> Columns { get; set; }
+        public IEnumerable<DataGridColumnSettings> Columns { get; set; } = Enumerable.Empty<DataGridColumnSettings>();
         /// <summary>
         /// Groups.
         /// </summary>
@@ -443,6 +443,11 @@ namespace Radzen
         /// LogicalFilterOperator.
         /// </summary>
         public LogicalFilterOperator LogicalFilterOperator { get; set; }
+
+        /// <summary>
+        /// CustomFilterExpression.
+        /// </summary>
+        public string CustomFilterExpression { get; set; }
     }
 #if NET7_0_OR_GREATER
 #else

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3400,7 +3400,9 @@ namespace Radzen.Blazor
                     shouldUpdateState = true;
                 }
 
-                if (gridColumn.GetCustomFilterExpression() != column.CustomFilterExpression)
+                if (gridColumn.GetCustomFilterExpression() != column.CustomFilterExpression &&
+                    !string.IsNullOrEmpty(column.CustomFilterExpression) &&
+                    gridColumn.FilterOperator == FilterOperator.Custom)
                 {
                     gridColumn.SetCustomFilterExpression(column.CustomFilterExpression);
                     shouldUpdateState = true;


### PR DESCRIPTION
CustomFilterExpression wasn't included in DataGridSettings. Added in this PR,

PR seems to be big but there are almost no changes.
DataGridSettings,Columns have default value Enumerable.Empty<>() which can save us checking if columns == null (not expected anyway).


```
var gridColumn = ColumnsCollection.Where(c => !string.IsNullOrEmpty(column.Property) && c.Property == column.Property).FirstOrDefault() ??
                                ColumnsCollection.Where(c => !string.IsNullOrEmpty(column.UniqueID) && c.UniqueID == column.UniqueID).FirstOrDefault();
```

was extracted to method 

```
        private RadzenDataGridColumn<TItem> GetColumnByPropertyAndUniqueIdOrDefault(DataGridColumnSettings dataGridColumnSettings)
        {
            return ColumnsCollection
                .Where(c => !string.IsNullOrEmpty(dataGridColumnSettings.Property) && c.Property == dataGridColumnSettings.Property)
                .FirstOrDefault() ?? ColumnsCollection
                    .Where(c => !string.IsNullOrEmpty(dataGridColumnSettings.UniqueID) && c.UniqueID == dataGridColumnSettings.UniqueID)
                    .FirstOrDefault();
        }
```

and used
`var gridColumn = GetColumnByPropertyAndUniqueIdOrDefault(column);`
because there was the same code duplicated.

```
if (SettingsChanged.HasDelegate)
{
    // content of the method
}
```
 changed to 

```
if (SettingsChanged.HasDelegate == false)
{
   return;
}

// content of the method
```

to make code more readable

the same with
```
if (gridColumn == null)
{
    continue;
}
```
which is reason why the PR looks so big

Only signicificant change is adding this:
```
if (gridColumn.GetCustomFilterExpression() != column.CustomFilterExpression &&
    !string.IsNullOrEmpty(column.CustomFilterExpression) &&
    gridColumn.FilterOperator == FilterOperator.Custom)
{
    gridColumn.SetCustomFilterExpression(column.CustomFilterExpression);
    shouldUpdateState = true;
}
```

