### PR TITLE
DatePicker add specific css selectors for week number

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -49,7 +49,8 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>();
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add<bool>(p => p.ShowTime, true);
                 parameters.Add<bool>(p => p.ShowSeconds, true);
             });
@@ -69,7 +70,8 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>();
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add<bool>(p => p.ShowTime, true);
                 parameters.Add<bool>(p => p.ShowTimeOkButton, true);
             });
@@ -91,7 +93,8 @@ namespace Radzen.Blazor.Tests
 
             var format = "d";
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.DateFormat, format);
                 parameters.Add<object>(p => p.Value, DateTime.Now);
             });
@@ -108,7 +111,8 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>();
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add<bool>(p => p.ShowTime, true);
                 parameters.Add(p => p.HourFormat, "12");
             });
@@ -127,7 +131,8 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>();
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add<bool>(p => p.ShowTime, true);
                 parameters.Add<bool>(p => p.TimeOnly, true);
             });
@@ -144,7 +149,8 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>();
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add<object>(p => p.Value, DateTime.Now);
                 parameters.Add<bool>(p => p.AllowClear, true);
             });
@@ -241,7 +247,8 @@ namespace Radzen.Blazor.Tests
             var raised = false;
             object newValue = null;
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.Change, args => { raised = true; newValue = args; });
             });
 
@@ -262,7 +269,8 @@ namespace Radzen.Blazor.Tests
             var raised = false;
             object newValue = null;
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.ValueChanged, args => { raised = true; newValue = args; });
             });
 
@@ -283,7 +291,8 @@ namespace Radzen.Blazor.Tests
             var raised = false;
             object newValue = null;
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.Change, args => { raised = true; newValue = args; });
             });
 
@@ -304,7 +313,8 @@ namespace Radzen.Blazor.Tests
             var raised = false;
             object newValue = null;
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.ValueChanged, args => { raised = true; newValue = args; });
             });
 
@@ -327,7 +337,8 @@ namespace Radzen.Blazor.Tests
             var raised = false;
             object newValue = null;
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.ValueChanged, args => { raised = true; newValue = args; })
                           .Add(p => p.DateRender, args => { args.Disabled = dates.Contains(args.Date); });
             });
@@ -360,7 +371,8 @@ namespace Radzen.Blazor.Tests
             var raised = false;
             object newValue = null;
 
-            component.SetParametersAndRender(parameters => {
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add(p => p.ValueChanged, args => { raised = true; newValue = args; })
                           .Add(p => p.DateRender, args => { args.Disabled = dates.Contains(args.Date); });
             });
@@ -415,7 +427,8 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenDatePicker<DateTime?>>();
 
-            Func<string, DateTime?> customParseInput = (input) => {
+            Func<string, DateTime?> customParseInput = (input) =>
+            {
                 if (DateTime.TryParseExact(input, "ddMM", null, DateTimeStyles.None, out var result))
                 {
                     return result;
@@ -593,7 +606,7 @@ namespace Radzen.Blazor.Tests
                 parameters.Add(p => p.Value, dateOnly);
                 parameters.Add(p => p.ValueChanged, args => { valueChangedValue = args; });
             });
-            
+
             Assert.False(component.Instance.ShowTime);
             var input = component.Find("input");
             input.GetAttribute("value").MarkupMatches(dateOnly.ToString());
@@ -603,7 +616,7 @@ namespace Radzen.Blazor.Tests
             DateOnly? enteredValue = new DateOnly(2024, 2, 28);
             ctx.JSInterop.Setup<string>("Radzen.getInputValue", invocation => true).SetResult(enteredValue.Value.ToShortDateString());
             inputElement.Change(enteredValue);
-            
+
             input.GetAttribute("value").MarkupMatches(enteredValue.ToString());
             Assert.Equal(enteredValue, component.Instance.Value);
             Assert.Equal(enteredValue, valueChangedValue);
@@ -623,12 +636,12 @@ namespace Radzen.Blazor.Tests
                 parameters.Add(p => p.Value, timeOnly);
                 parameters.Add(p => p.ValueChanged, args => { valueChangedValue = args; });
             });
-            
+
             Assert.True(component.Instance.TimeOnly);
             Assert.True(component.Instance.ShowTime);
             var input = component.Find("input");
             input.GetAttribute("value").MarkupMatches(timeOnly.ToString());
-            
+
             // update to new value
             var inputElement = component.Find(".rz-inputtext");
             TimeOnly? enteredValue = new TimeOnly(1, 4, 5);
@@ -638,6 +651,55 @@ namespace Radzen.Blazor.Tests
             input.GetAttribute("value").MarkupMatches(enteredValue.ToString());
             Assert.Equal(enteredValue, component.Instance.Value);
             Assert.Equal(enteredValue, valueChangedValue);
+        }
+
+        [Fact]
+        public void DatePicker_ShowCalendarWeek_WeekNumberAddedInAdditionalColumn()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameter =>
+            {
+                parameter.Add(p => p.ShowCalendarWeek, true);
+            });
+
+            Assert.Contains(@$"rz-datepicker-week-number", component.Markup);
+            Assert.Equal(8, component.FindAll(".rz-datepicker-calendar th").Count());
+        }
+
+        [Fact]
+        public void DatePicker_ShowCalendarWeekFalse_NoAdditionalColumn()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameter =>
+            {
+                parameter.Add(p => p.ShowCalendarWeek, false);
+            });
+
+            Assert.DoesNotContain(@$"rz-datepicker-week-number", component.Markup);
+            Assert.Equal(7, component.FindAll(".rz-datepicker-calendar th").Count());
+        }
+
+        [Fact]
+        public void DatePicker_ShowCalendarWeekWithCustomTitle_TitleCorrectlyRendered()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDatePicker<DateTime>>(parameter =>
+            {
+                parameter.Add(p => p.ShowCalendarWeek, true);
+                parameter.Add(p => p.CalendarWeekTitle, "Wk");
+            });
+
+            var weekNumberHeader = component.Find(".rz-datepicker-calendar th.rz-datepicker-week-number");
+            Assert.Contains("Wk", weekNumberHeader.InnerHtml);
         }
     }
 }

--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -667,6 +667,9 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains(@$"rz-datepicker-week-number", component.Markup);
             Assert.Equal(8, component.FindAll(".rz-datepicker-calendar th").Count());
+            // check header and week number column
+            Assert.Single(component.FindAll("th.rz-datepicker-week-number"));
+            Assert.Equal(6, component.FindAll("td.rz-datepicker-week-number").Count());
         }
 
         [Fact]

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -79,7 +79,7 @@
                                         <tr>
                                             @if (ShowCalendarWeek)
                                             {
-                                                <td class="rz-datepicker-week-number">@Culture.Calendar.GetWeekOfYear(new DateTime(CurrentDate.Year, CurrentDate.Month, 1).AddDays(i * 7), Culture.DateTimeFormat.CalendarWeekRule, Culture.DateTimeFormat.FirstDayOfWeek)</td>
+                                                <td class="rz-datepicker-other-month rz-datepicker-week-number">@Culture.Calendar.GetWeekOfYear(new DateTime(CurrentDate.Year, CurrentDate.Month, 1).AddDays(i * 7), Culture.DateTimeFormat.CalendarWeekRule, Culture.DateTimeFormat.FirstDayOfWeek)</td>
                                             }
                                             @for (int j = 0; j < 7; j++)
                                             {
@@ -87,7 +87,7 @@
                                                 {
                                                     break;
                                                 }
-                                                
+
                                                 DateTime date = StartDate.AddDays(dayNumber++);
                                                 var dateArgs = DateAttributes(date);
 
@@ -113,7 +113,7 @@
                 @if (ShowTime)
                 {
                 <div class="rz-timepicker" @onmousedown:stopPropagation>
-                        <RadzenNumeric InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "hour" }})" TValue="int" Disabled="@Disabled" Value="@(HourFormat == "12" ? ((CurrentDate.Hour + 11) % 12) + 1 : CurrentDate.Hour)" 
+                        <RadzenNumeric InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "hour" }})" TValue="int" Disabled="@Disabled" Value="@(HourFormat == "12" ? ((CurrentDate.Hour + 11) % 12) + 1 : CurrentDate.Hour)"
                            Min="@(HourFormat == "12" ? 1 : -1)" Max="@(HourFormat == "12" ? 12 : 24)" TValue="double" Step="@HoursStep"
                            Change="@UpdateHour" class="rz-hour-picker" @oninput=@OnUpdateHourInput Format="@(PadHours ? "00" : "")" Name="@($"{UniqueID}-h")" />
                         <div class="rz-separator">
@@ -152,6 +152,6 @@
                     </div>
                 }
         </Popup>
-        
+
     </div>
 }

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -58,7 +58,7 @@
                                     <tr>
                                         @if (ShowCalendarWeek)
                                         {
-                                            <th scope="col">
+                                            <th scope="col" class="rz-datepicker-week-number">
                                                 <span>@CalendarWeekTitle</span>
                                             </th>
                                         }
@@ -79,7 +79,7 @@
                                         <tr>
                                             @if (ShowCalendarWeek)
                                             {
-                                                <td class="rz-datepicker-other-month">@Culture.Calendar.GetWeekOfYear(new DateTime(CurrentDate.Year, CurrentDate.Month, 1).AddDays(i * 7), Culture.DateTimeFormat.CalendarWeekRule, Culture.DateTimeFormat.FirstDayOfWeek)</td>
+                                                <td class="rz-datepicker-week-number">@Culture.Calendar.GetWeekOfYear(new DateTime(CurrentDate.Year, CurrentDate.Month, 1).AddDays(i * 7), Culture.DateTimeFormat.CalendarWeekRule, Culture.DateTimeFormat.FirstDayOfWeek)</td>
                                             }
                                             @for (int j = 0; j < 7; j++)
                                             {

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -347,8 +347,12 @@ $timepicker-border: none !default;
   .rz-state-disabled {
     opacity: 0.5;
   }
-  
+
   .rz-datepicker-other-month {
+    opacity: 0.5;
+  }
+
+  .rz-datepicker-week-number {
     opacity: 0.5;
   }
 }


### PR DESCRIPTION
added specific scss selector for week number in the date picker
added unittest for the week number in date picker
unit teste file auto formated. 

Added these selector so it is easier to add specific styling to the week number column (italic for instance)
<img width="260" alt="image" src="https://github.com/radzenhq/radzen-blazor/assets/122032239/166a0173-719a-47b9-ab8b-a0ecb09f9f61">
