### PR TITLE
Correct scheduler year view for using rz-other-month class

### DIFF
--- a/Radzen.Blazor/Rendering/YearView.razor
+++ b/Radzen.Blazor/Rendering/YearView.razor
@@ -56,7 +56,7 @@
                                 var day = date.AddDays((row * 7) + col);
                                 var appointments = AppointmentsInSlot(day, day.AddDays(1));
                                 var excessCount = appointments.Count();
-                                string classname = $"rz-slot-title {(day.Month != month ? "rz-other-month" : "")} {(excessCount > 0 ? "rz-has-appointments" : "")} {(day == CurrentDate && month == CurrentMonth ? " rz-state-focused" : "")}".Trim();
+                                string classname = $"rz-slot-title {(day.Month != offSetMonth ? "rz-other-month" : "")} {(excessCount > 0 ? "rz-has-appointments" : "")} {(day == CurrentDate && month == CurrentMonth ? " rz-state-focused" : "")}".Trim();
 
                                     <div @onclick=@(args => OnListClick(day, appointments)) @attributes=@Attributes(day, "rz-slot")>
                                         <div class="@classname">


### PR DESCRIPTION
Fix issue in scheduler year view introduced in commit 347942668d9003788403ec4e315ae2bfcec68263 with correctly setting class rz-other-month for the days