### PR TITLE
add new options in auto complete type. custom value.

### DIFF
--- a/Radzen.Blazor.Tests/MaskTests.cs
+++ b/Radzen.Blazor.Tests/MaskTests.cs
@@ -157,6 +157,23 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Mask_Renders_CustomAutoCompleteParameter()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenNumeric<double>>(parameters => parameters
+                .Add(p => p.AutoComplete, true)
+                .Add(p => p.AutoCompleteType, AutoCompleteType.CustomValue)
+                .Add(p => p.AutoCompleteCustomValue, "Not-A-defaultValue"));
+
+            Assert.Contains(@$"autocomplete=""Not-A-defaultValue""", component.Markup);
+
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, false));
+
+            Assert.Contains(@$"autocomplete=""off""", component.Markup);
+        }
+
+        [Fact]
         public void Mask_Renders_MaxLengthParameter()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -254,6 +254,25 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Numeric_Renders_CustomAutoCompleteParameter()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenNumeric<double>>();
+
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.AutoComplete, true));
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.AutoCompleteType, AutoCompleteType.CustomValue));
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.AutoCompleteCustomValue, "Not-A-defaultValue"));
+
+            Assert.Contains(@$"autocomplete=""Not-A-defaultValue""", component.Markup);
+
+
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.AutoComplete, false));
+
+            Assert.Contains(@$"autocomplete=""off""", component.Markup);
+        }
+
+        [Fact]
         public void Numeric_Raises_ChangedEvent()
         {
             using var ctx = new TestContext();
@@ -410,14 +429,14 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains($" value=\"{valueToTest.ToString(format)}\"", component.Markup);
         }
-        
+
         public static TheoryData<decimal, decimal> NumericFormatterPreservesLeadingZerosData =>
             new()
             {
                 { 10.000m, 100.000m },
                 { 100.000m, 10.000m }
             };
-        
+
         [Theory]
         [MemberData(nameof(NumericFormatterPreservesLeadingZerosData))]
         public void Numeric_Formatter_PreservesLeadingZeros(decimal oldValue, decimal newValue)
@@ -434,11 +453,11 @@ namespace Radzen.Blazor.Tests
             );
 
             component.Render();
-            
+
             Assert.Contains($" value=\"{oldValue.ToString(format)}\"", component.Markup);
 
             component.Find("input").Change(newValue);
-            
+
             Assert.Contains($" value=\"{newValue.ToString(format)}\"", component.Markup);
         }
 
@@ -457,7 +476,7 @@ namespace Radzen.Blazor.Tests
             );
 
             component.Render();
-            
+
             Assert.Contains($" value=\"{value.ToString()}\"", component.Markup);
 
             var newValue = new Dollars(13.53m);
@@ -503,7 +522,7 @@ namespace Radzen.Blazor.Tests
                     parameters.Add(p => p.Max, maxValue);
                 });
             });
-            
+
             component.Find("input").Change("13.53");
 
             var maxDollars = new Dollars(2);

--- a/Radzen.Blazor.Tests/TextBoxTests.cs
+++ b/Radzen.Blazor.Tests/TextBoxTests.cs
@@ -181,7 +181,7 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains(@$"autofocus", component.Markup);
         }
-        
+
         [Fact]
         public void TextBox_Raises_ChangedEvent()
         {
@@ -218,6 +218,44 @@ namespace Radzen.Blazor.Tests
 
             Assert.True(raised);
             Assert.True(object.Equals(value, newValue));
+        }
+
+        [Theory]
+        [InlineData(false, AutoCompleteType.On, "", "off")]
+        [InlineData(true, AutoCompleteType.On, "", "on")]
+        [InlineData(true, AutoCompleteType.Organization, "", "organization")]
+        [InlineData(true, AutoCompleteType.CustomValue, "CustomValue", "CustomValue")]
+        [InlineData(false, AutoCompleteType.CustomValue, "CustomValue", "off")]
+        public void TextBox_Renders_AutoComplete_AttributeCorrectlySet(bool autoComplete, AutoCompleteType autoCompleteType, string customText, string expectedAutoCompleteValue)
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenTextBox>(parameters => parameters
+                .Add(p => p.AutoComplete, autoComplete)
+                .Add(p => p.AutoCompleteType, autoCompleteType)
+                .Add(p => p.AutoCompleteCustomValue, customText));
+
+            Assert.Contains(@$"autocomplete=""{expectedAutoCompleteValue}""", component.Markup);
+
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void TextBox_Renders_AriaAutoCompleteCorrectly(bool autoComplete, bool expectAriaAutoComplete)
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenTextBox>(parameters => parameters.Add(p => p.AutoComplete, autoComplete));
+
+            if(expectAriaAutoComplete)
+            {
+                Assert.Contains(@$"aria-autocomplete=""none""", component.Markup);
+            }
+            else
+            {
+                Assert.DoesNotContain(@$"aria-autocomplete", component.Markup);
+            }
         }
     }
 }

--- a/Radzen.Blazor/AutoCompleteType.cs
+++ b/Radzen.Blazor/AutoCompleteType.cs
@@ -134,5 +134,7 @@
         MiddleName,
         /// <summary>Last name.</summary>
         LastName,
+        /// <summary>Ability to set a custom name in the auto complete attribute.</summary>
+        CustomValue,
     }
 }

--- a/Radzen.Blazor/RadzenMask.razor.cs
+++ b/Radzen.Blazor/RadzenMask.razor.cs
@@ -97,6 +97,13 @@ namespace Radzen.Blazor
         }
 
         /// <summary>
+        /// Allows to input a custom value for the autocomplete attribute.
+        /// Only used when AutoComplete is set to <c>true</c>. and AutoCompleteType is set to <see cref="AutoCompleteType.CustomValue" />.
+        /// </summary>
+        [Parameter]
+        public string AutoCompleteCustomValue { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets the autocomplete attribute's string value.
         /// </summary>
         /// <value>
@@ -105,8 +112,8 @@ namespace Radzen.Blazor
         /// parameter is true, the value is <c>on</c> or, if set, the value of
         /// AutoCompleteType.</value>
         public string AutoCompleteAttribute
-        {
-            get => !AutoComplete ? "off" : AutoCompleteType.GetAutoCompleteValue();
-        }
+                => !AutoComplete ? "off" :
+                    AutoCompleteType == AutoCompleteType.CustomValue ? AutoCompleteCustomValue :
+                    AutoCompleteType.GetAutoCompleteValue();
     }
 }

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -228,6 +228,13 @@ namespace Radzen.Blazor
         public AutoCompleteType AutoCompleteType { get; set; } = AutoCompleteType.On;
 
         /// <summary>
+        /// Allows to input a custom value for the autocomplete attribute.
+        /// Only used when AutoComplete is set to <c>true</c>. and AutoCompleteType is set to <see cref="AutoCompleteType.CustomValue" />.
+        /// </summary>
+        [Parameter]
+        public string AutoCompleteCustomValue { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets the autocomplete attribute's string value.
         /// </summary>
         /// <value>
@@ -236,9 +243,9 @@ namespace Radzen.Blazor
         /// parameter is true, the value is <c>on</c> or, if set, the value of
         /// AutoCompleteType.</value>
         public string AutoCompleteAttribute
-        {
-            get => !AutoComplete ? "off" : AutoCompleteType.GetAutoCompleteValue();
-        }
+                => !AutoComplete ? "off" :
+                    AutoCompleteType == AutoCompleteType.CustomValue ? AutoCompleteCustomValue :
+                    AutoCompleteType.GetAutoCompleteValue();
 
         /// <summary>
         /// Gets or sets a value indicating whether up down buttons are shown.
@@ -274,7 +281,7 @@ namespace Radzen.Blazor
             if (!string.IsNullOrEmpty(Format))
             {
                 string formattedStringWithoutPlaceholder = Format.Replace("#", "").Trim();
-                
+
                 if (valueStr.Contains(Format))
                 {
                     string currencyDecimalSeparator = Culture.NumberFormat.CurrencyDecimalSeparator;
@@ -284,7 +291,7 @@ namespace Radzen.Blazor
                     int lengthDifference = splitValueString[0].Length - splitFormatString[0].Length;
                     formattedStringWithoutPlaceholder = formattedStringWithoutPlaceholder.PadLeft(formattedStringWithoutPlaceholder.Length + lengthDifference, '0');
                 }
-                
+
                 valueStr = valueStr.Replace(formattedStringWithoutPlaceholder, "");
             }
 
@@ -338,7 +345,7 @@ namespace Radzen.Blazor
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
             await Change.InvokeAsync(Value);
         }
-        
+
         private TValue ApplyMinMax(TValue newValue)
         {
             if (Max == null && Min == null || newValue == null)
@@ -385,7 +392,7 @@ namespace Radzen.Blazor
             var converter = TypeDescriptor.GetConverter(typeof(TValue));
             if (converter.CanConvertTo(typeof(decimal)))
                 return (decimal)converter.ConvertTo(null, Culture, input, typeof(decimal));
-            
+
             return (decimal)ConvertType.ChangeType(input, typeof(decimal));
         }
 
@@ -399,7 +406,7 @@ namespace Radzen.Blazor
             {
                 return (TValue)converter.ConvertFrom(null, Culture, input);
             }
-            
+
             return (TValue)ConvertType.ChangeType(input, typeof(TValue));
         }
 

--- a/Radzen.Blazor/RadzenTextBox.razor.cs
+++ b/Radzen.Blazor/RadzenTextBox.razor.cs
@@ -28,6 +28,13 @@ namespace Radzen.Blazor
         public bool AutoComplete { get; set; } = true;
 
         /// <summary>
+        /// Allows to input a custom value for the autocomplete attribute.
+        /// Only used when AutoComplete is set to <c>true</c>. and AutoCompleteType is set to <see cref="AutoCompleteType.CustomValue" />.
+        /// </summary>
+        [Parameter]
+        public string AutoCompleteCustomValue { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets a value indicating the type of built-in autocomplete
         /// the browser should use.
         /// <see cref="Blazor.AutoCompleteType" />
@@ -88,7 +95,9 @@ namespace Radzen.Blazor
         /// AutoCompleteType parameter is "off". When the AutoComplete
         /// parameter is true, the value is <c>on</c> or, if set, the value of
         /// AutoCompleteType.</value>
-        public string AutoCompleteAttribute { get => !AutoComplete ? "off" :
-                AutoCompleteType.GetAutoCompleteValue(); }
+        public string AutoCompleteAttribute
+                => !AutoComplete ? "off" :
+                    AutoCompleteType == AutoCompleteType.CustomValue ? AutoCompleteCustomValue :
+                    AutoCompleteType.GetAutoCompleteValue();
     }
 }


### PR DESCRIPTION
add new options in auto complete type custom value. to allow a custom value in the auto complete attribute.
IN some cases it is not enough to set autocomplete="off" to really disable the autocomplete (e.g. in chrome)

The only whey to really disable the auto complete is to add a custom value in the autocomplete HTML attribute:
[https://stackoverflow.com/questions/15738259/disabling-chrome-autofill](https://stackoverflow.com/questions/15738259/disabling-chrome-autofill )

[https://gist.github.com/niksumeiko/360164708c3b326bd1c8#file-disable-html-form-input-autocomplete-autofill-md](https://gist.github.com/niksumeiko/360164708c3b326bd1c8#file-disable-html-form-input-autocomplete-autofill-md)

This pull request add the possibility to set a custom value and use it as the autocomplete value in the input element. 
added unit test to test the added properties. 

This pull request is created to beter fix the issues described here: https://github.com/radzenhq/radzen-blazor/issues/1422 