### PR TITLE
RadzenDataGrid column resize sticking on after click

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -1539,6 +1539,11 @@ namespace Radzen.Blazor
             await JSRuntime.InvokeVoidAsync("Radzen.startColumnResize", getColumnUniqueId(columnIndex), Reference, columnIndex, args.ClientX);
         }
 
+        internal async Task StopColumnResize(MouseEventArgs args, int columnIndex)
+        {
+            await JSRuntime.InvokeVoidAsync("Radzen.stopColumnResize", getColumnUniqueId(columnIndex), Reference, columnIndex);
+        }
+
         int? indexOfColumnToReoder;
 
         internal async Task StartColumnReorder(MouseEventArgs args, int columnIndex)

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -51,7 +51,8 @@
             <div id="@(Grid.getColumnUniqueId(ColumnIndex) + "-resizer")" style="cursor:col-resize;float:right;"
                     @onclick:preventDefault="true" @onclick:stopPropagation="true" class="rz-column-resizer"
                     @onmousedown:preventDefault="true"
-                    @onmousedown=@StartColumnResize>&nbsp;</div>
+                    @onmousedown=@StartColumnResize
+                    @onmouseup=@StopColumnResize>&nbsp;</div>
         }
         @if (Grid.AllowFiltering && Column.Filterable && Grid.FilterMode == FilterMode.Advanced)
         {
@@ -282,6 +283,14 @@ else
         if(args.Button == 0) 
         { 
             await Grid.StartColumnResize(args, ColumnIndex);
+        }
+    }
+
+    async Task StopColumnResize(MouseEventArgs args)
+    {
+        if (args.Button == 0)
+        {
+            await Grid.StopColumnResize(args, ColumnIndex);
         }
     }
 

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -1873,7 +1873,24 @@ window.Radzen = {
       document.addEventListener('touchmove', Radzen[el].touchMoveHandler, { passive: true })
       document.addEventListener('touchend', Radzen[el].mouseUpHandler, { passive: true });
   },
-      startSplitterResize: function(id,
+  stopColumnResize: function (id, grid, columnIndex) {
+        var el = document.getElementById(id + '-resizer');
+        var cell = el.parentNode.parentNode;
+        if (Radzen[el]) {
+            grid.invokeMethodAsync(
+                'RadzenGrid.OnColumnResized',
+                columnIndex,
+                cell.getBoundingClientRect().width
+            );
+            el.style.width = null;
+            document.removeEventListener('mousemove', Radzen[el].mouseMoveHandler);
+            document.removeEventListener('mouseup', Radzen[el].mouseUpHandler);
+            document.removeEventListener('touchmove', Radzen[el].touchMoveHandler)
+            document.removeEventListener('touchend', Radzen[el].mouseUpHandler);
+            Radzen[el] = null;
+        }
+  },
+  startSplitterResize: function(id,
         splitter,
         paneId,
         paneNextId,


### PR DESCRIPTION
On tables with a large column count (>20), if a user clicks or double clicks the resize control in the column header, that column can get "stuck" in a resizing state.

This is because the `mouseup` handler for the element has not been registered in JS (`startColumnResize`) before the user has released the mouse button.

There needs to be an `onmouseup` handler registered on the resize control that is also hooked up to stop resizing to catch this scenario.