### PR TITLE
Added 2.5rem width to class rz-slot-hour-header with max-width: 576px…

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_scheduler.scss
+++ b/Radzen.Blazor/themes/components/blazor/_scheduler.scss
@@ -769,6 +769,12 @@ $scheduler-focus-outline-offset: calc(-1 * var(--rz-outline-width)) !default;
       width: auto;
     }
   }
+
+  .rz-view-header {
+    .rz-slot-hour-header {
+      width: 2.5rem;
+    }
+  }
 }
 
 @media (max-width: 1399px) {


### PR DESCRIPTION
Css fix for mobile resolution in Scheduler module to fix with issue #1445