### PR TITLE
Added filter clearing when closing a window via the escape button and…

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -331,7 +331,7 @@ namespace Radzen.Blazor
         {
             return FilterPlaceholder ?? string.Empty;
         }
-        
+
         /// <summary>
         /// Gets or sets the second filter value.
         /// </summary>
@@ -915,7 +915,7 @@ namespace Radzen.Blazor
                     return;
                 }
             }
-            
+
             if (parameters.DidParameterChange(nameof(FilterOperator), FilterOperator))
             {
                 filterOperator = parameters.GetValueOrDefault<FilterOperator>(nameof(FilterOperator));
@@ -998,13 +998,31 @@ namespace Radzen.Blazor
                 value = offset;
             }
 
-            if (isFirst)
+            if ((filterOperator != FilterOperator.IsNull || filterOperator != FilterOperator.IsNotNull
+                || filterOperator != FilterOperator.IsEmpty || filterOperator != FilterOperator.IsNotEmpty) &&
+                string.IsNullOrEmpty(value?.ToString()))
             {
-                filterValue = value;
+                if (isFirst)
+                {
+                    filterValue = null;
+                }
+                else
+                {
+                    filterValue = null;
+                }
+
+                return;
             }
             else
             {
-                secondFilterValue = value;
+                if (isFirst)
+                {
+                    filterValue = value;
+                }
+                else
+                {
+                    secondFilterValue = value;
+                }
             }
         }
 
@@ -1198,7 +1216,7 @@ namespace Radzen.Blazor
                 var isStringOperator = o == FilterOperator.Contains || o == FilterOperator.DoesNotContain
                     || o == FilterOperator.StartsWith || o == FilterOperator.EndsWith || o == FilterOperator.IsEmpty || o == FilterOperator.IsNotEmpty;
 
-                if ((FilterPropertyType == typeof(string) || !QueryableExtension.IsEnumerable(FilterPropertyType)) && 
+                if ((FilterPropertyType == typeof(string) || !QueryableExtension.IsEnumerable(FilterPropertyType)) &&
                     (o == FilterOperator.In || o == FilterOperator.NotIn)) return false;
 
                 return FilterPropertyType == typeof(string) || QueryableExtension.IsEnumerable(FilterPropertyType) ? isStringOperator

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -311,6 +311,7 @@ else
         if (key == "Escape")
         {
             await CloseFilter();
+            await ClearFilter();
             await Grid.GetJSRuntime().InvokeVoidAsync("Radzen.focusElement", Grid.GridId());
         }
     }


### PR DESCRIPTION
I found two bugs. Here are the reproduction steps:

Bug 1
1. Open advanced filter window
2. Write something in any of two meanings
3. Press Tab
4. The filter icon changes to active
5. Press Escape

Result: The filter icon remains active, although the data has not been loaded, which is misleading

Because when you enter any value, the filter value changes and I cannot bypass this. As one of the options, I suggest clearing the column filter by pressing a button Escape

Bug 2

1. Open advanced filter window
2. Select any filter operator except IsNull/IsNotNull/IsEmpty/IsNotEmpty
3. Write something in any of two meanings
4. Erase everything you wrote and click Apply.

Result: The filter was applied when it shouldn't be
After all, to filter by “empty string” there are the above listed filters

I fixed these bugs in my merge request