### PR TITLE
Make MaxLength a parameter

### DIFF
--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -79,6 +79,7 @@ namespace Radzen.Blazor
         /// Gets or sets the underlying max length.
         /// </summary>
         /// <value>The max length value.</value>
+        [Parameter]
         public long? MaxLength { get; set; }
 
         /// <summary>


### PR DESCRIPTION
I don't understand why MaxLength isn't a parameter and how to use it if its not. 