### PR TITLE
Fixed a bug where it was possible to apply a filter on an empty string

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -1000,11 +1000,11 @@ namespace Radzen.Blazor
 
             if (isFirst)
             {
-                filterValue = CanSetFilterValue() ? value : null;
+                filterValue = CanSetCurrentValue(value) ? value : null;
             }
             else
             {
-                secondFilterValue = CanSetFilterValue() ? value : null;
+                secondFilterValue = CanSetCurrentValue(value, false) ? value : null;
             }
         }
 
@@ -1027,6 +1027,11 @@ namespace Radzen.Blazor
                     && fo != FilterOperator.IsNotNull
                     && fo != FilterOperator.IsEmpty
                     && fo != FilterOperator.IsNotEmpty;
+        }
+
+        internal bool CanSetCurrentValue(object value, bool isFirst = true)
+        {
+            return CanSetFilterValue(isFirst) ? !string.IsNullOrEmpty(value?.ToString()) : false;
         }
 
         internal bool HasCustomFilter()


### PR DESCRIPTION
Thank you for your attention to my problem in the last merge request, but you missed one bug when the filter could still be applied to an empty string, I offer my own version of the fix