### PR TITLE
Implement OpenPopup and ClosePopup Events for Radzen Dropdown

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -1048,10 +1048,10 @@ namespace Radzen
         {
             var isOpen = await JSRuntime.InvokeAsync<bool>("Radzen.popupOpened", PopupID);
 
-            if (isOpen && !oldStateIsOpen)
-                OpenPopupCallback?.Invoke();
-            else if (isOpen is false && oldStateIsOpen)
-                ClosePopupCallback?.Invoke();
+            if (isOpen && !oldStateIsOpen && OpenPopupCallback.HasDelegate)
+                await OpenPopupCallback.InvokeAsync(null);
+            else if (isOpen is false && oldStateIsOpen && ClosePopupCallback.HasDelegate)
+                await ClosePopupCallback.InvokeAsync(null);
         }
 
 

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -976,13 +976,13 @@ namespace Radzen
         /// Method that is triggered when the popup opens.
         /// </summary>
         [Parameter]
-        public Action OnOpenPopup { get; set; }
+        public EventCallback OpenPopupCallback { get; set; }
 
         /// <summary>
         /// Method that is triggered when the popup closes.
         /// </summary>
         [Parameter]
-        public Action OnClosePopup { get; set; }
+        public EventCallback ClosePopupCallback { get; set; }
 
 
         /// <summary>
@@ -1039,8 +1039,8 @@ namespace Radzen
 
         /// <summary>
         /// Checks the current state of the popup by invoking a JavaScript function and triggers the appropriate action.
-        /// If the popup is currently open and was previously closed, it invokes the OnOpenPopup action.
-        /// If the popup is currently closed and was previously open, it invokes the OnClosePopup action.
+        /// If the popup is currently open and was previously closed, it invokes the OpenPopup action.
+        /// If the popup is currently closed and was previously open, it invokes the ClosePopup action.
         /// </summary>
         /// <param name="oldStateIsOpen">A boolean value indicating whether the popup was previously open.</param>
         [JSInvokable]
@@ -1049,9 +1049,9 @@ namespace Radzen
             var isOpen = await JSRuntime.InvokeAsync<bool>("Radzen.popupOpened", PopupID);
 
             if (isOpen && !oldStateIsOpen)
-                OnOpenPopup?.Invoke();
+                OpenPopupCallback?.Invoke();
             else if (isOpen is false && oldStateIsOpen)
-                OnClosePopup?.Invoke();
+                ClosePopupCallback?.Invoke();
         }
 
 

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -972,6 +972,18 @@ namespace Radzen
         }
 
         /// <summary>
+        /// Método que se dispara al abrir el popup
+        /// </summary>
+        [Parameter]
+        public Action OnOpenPopup { get; set; }
+
+        /// <summary>
+        /// Método que se dispara al cerrar el popup
+        /// </summary>
+        [Parameter]
+        public Action OnClosePopup { get; set; }
+
+        /// <summary>
         /// Determines whether the specified item is selected.
         /// </summary>
         /// <param name="item">The item.</param>

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -581,12 +581,12 @@ namespace Radzen
         protected int selectedIndex = -1;
 
         /// <summary>
-        /// Opens the popup.
+        /// Open or close instace popup 
         /// </summary>
         /// <param name="key">The key.</param>
         /// <param name="isFilter">if set to <c>true</c> [is filter].</param>
         /// <param name="isFromClick">if set to <c>true</c> [is from click].</param>
-        protected virtual async System.Threading.Tasks.Task OpenPopup(string key = "ArrowDown", bool isFilter = false, bool isFromClick = false)
+        protected virtual async System.Threading.Tasks.Task TogglePopup(string key = "ArrowDown", bool isFilter = false, bool isFromClick = false)
         {
             if (Disabled)
                 return;
@@ -681,7 +681,7 @@ namespace Radzen
 
                 if (!popupOpened)
                 {
-                    await OpenPopup(key, isFilter);
+                    await TogglePopup(key, isFilter);
                 }
                 else
                 {
@@ -695,7 +695,7 @@ namespace Radzen
             {
                 preventKeydown = true;
 
-                await OpenPopup(key, isFilter);
+                await TogglePopup(key, isFilter);
             }
             else if (key == "Escape" || key == "Tab")
             {
@@ -976,13 +976,13 @@ namespace Radzen
         /// Method that is triggered when the popup opens.
         /// </summary>
         [Parameter]
-        public EventCallback OpenPopupCallback { get; set; }
+        public EventCallback OpenPopup { get; set; }
 
         /// <summary>
         /// Method that is triggered when the popup closes.
         /// </summary>
         [Parameter]
-        public EventCallback ClosePopupCallback { get; set; }
+        public EventCallback ClosePopup { get; set; }
 
 
         /// <summary>
@@ -1048,10 +1048,10 @@ namespace Radzen
         {
             var isOpen = await JSRuntime.InvokeAsync<bool>("Radzen.popupOpened", PopupID);
 
-            if (isOpen && !oldStateIsOpen && OpenPopupCallback.HasDelegate)
-                await OpenPopupCallback.InvokeAsync(null);
-            else if (isOpen is false && oldStateIsOpen && ClosePopupCallback.HasDelegate)
-                await ClosePopupCallback.InvokeAsync(null);
+            if (isOpen && !oldStateIsOpen && OpenPopup.HasDelegate)
+                await OpenPopup.InvokeAsync(null);
+            else if (isOpen is false && oldStateIsOpen && ClosePopup.HasDelegate)
+                await ClosePopup.InvokeAsync(null);
         }
 
 

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -9,7 +9,7 @@
 
 @if (Visible)
 {
-    <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" onmousedown="Radzen.activeElement = null" @onclick="@(args => OpenPopup("ArrowDown", false, true))" @onclick:preventDefault @onclick:stopPropagation style="@Style" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
+    <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" onmousedown="Radzen.activeElement = null" @onclick="@(args => TogglePopup("ArrowDown", false, true))" @onclick:preventDefault @onclick:stopPropagation style="@Style" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
          @onkeydown="@((args) => OnKeyPress(args))" id="@GetId()"  @onfocus="@((args) => OnFocus(args))">
         <div class="rz-helper-hidden-accessible">
             <input disabled="@Disabled" aria-haspopup="listbox" readonly="" type="text" tabindex="-1"

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -71,7 +71,7 @@ namespace Radzen.Blazor
         {
             if (OpenOnFocus)
             {
-                await OpenPopup("Enter", false);
+                await TogglePopup("Enter", false);
             }
         }
 
@@ -81,7 +81,7 @@ namespace Radzen.Blazor
         /// <param name="key">The key.</param>
         /// <param name="isFilter">if set to <c>true</c> [is filter].</param>
         /// <param name="isFromClick">if set to <c>true</c> [is from click].</param>
-        protected override async Task OpenPopup(string key = "ArrowDown", bool isFilter = false, bool isFromClick = false)
+        protected override async Task TogglePopup(string key = "ArrowDown", bool isFilter = false, bool isFromClick = false)
         {
             if (Disabled)
                 return;

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -86,6 +86,8 @@ namespace Radzen.Blazor
             if (Disabled)
                 return;
 
+            var popupLastState = await JSRuntime.InvokeAsync<bool>("Radzen.popupOpened", PopupID);
+
             await JSRuntime.InvokeVoidAsync(OpenOnFocus ? "Radzen.openPopup" : "Radzen.togglePopup", Element, PopupID, true);
             await JSRuntime.InvokeVoidAsync("Radzen.focusElement", isFilter ? UniqueID : SearchID);
 
@@ -93,6 +95,8 @@ namespace Radzen.Blazor
             {
                 await JSRuntime.InvokeVoidAsync("Radzen.selectListItem", search, list, selectedIndex);
             }
+
+            await CheckAndTriggerPopupStateChange(popupLastState);
         }
 
         internal override void RenderItem(RenderTreeBuilder builder, object item)

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -88,15 +88,13 @@ namespace Radzen.Blazor
 
             var popupLastState = await JSRuntime.InvokeAsync<bool>("Radzen.popupOpened", PopupID);
 
-            await JSRuntime.InvokeVoidAsync(OpenOnFocus ? "Radzen.openPopup" : "Radzen.togglePopup", Element, PopupID, true);
+            await JSRuntime.InvokeVoidAsync(OpenOnFocus ? "Radzen.openPopup" : "Radzen.togglePopup", Element, PopupID, true, DotNetObjectReference.Create<RadzenDropDown<TValue>>(this));
             await JSRuntime.InvokeVoidAsync("Radzen.focusElement", isFilter ? UniqueID : SearchID);
 
             if (list != null)
             {
                 await JSRuntime.InvokeVoidAsync("Radzen.selectListItem", search, list, selectedIndex);
             }
-
-            await CheckAndTriggerPopupStateChange(popupLastState);
         }
 
         internal override void RenderItem(RenderTreeBuilder builder, object item)

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -223,7 +223,7 @@ namespace Radzen.Blazor
             {
                 if (!Multiple && !isFromKey)
                 {
-                    await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID);
+                    await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID, DotNetObjectReference.Create<RadzenDropDown<TValue>>(this));
                 }
 
                 if (ClearSearchAfterSelection)
@@ -278,7 +278,7 @@ namespace Radzen.Blazor
 
         internal async Task ClosePopup()
         {
-            await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID);
+            await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID, DotNetObjectReference.Create<RadzenDropDown<TValue>>(this));
         }
     }
 }

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -10,7 +10,7 @@
 @if (Visible)
 {
     <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" @onfocus="@((args) => OnFocus(args))"
-         style="@Style" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()" @onclick="@(args => OpenPopup("ArrowDown", false, true))" @onclick:preventDefault @onclick:stopPropagation
+         style="@Style" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" id="@GetId()" @onclick="@(args => TogglePopup("ArrowDown", false, true))" @onclick:preventDefault @onclick:stopPropagation
          @onkeydown="@((args) => OnKeyPress(args))" @onkeydown:preventDefault="@preventKeydown">
         <div class="rz-helper-hidden-accessible">
             <input tabindex="-1" disabled="@Disabled" style="width:100%" aria-haspopup="listbox" readonly="" type="text" id="@Name"

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -88,7 +88,7 @@ namespace Radzen.Blazor
         {
             if (OpenOnFocus)
             {
-                await OpenPopup("Enter", false);
+                await TogglePopup("Enter", false);
             }
         }
 
@@ -98,7 +98,7 @@ namespace Radzen.Blazor
         /// <param name="key">The key.</param>
         /// <param name="isFilter">if set to <c>true</c> [is filter].</param>
         /// <param name="isFromClick">if set to <c>true</c> [is from click].</param>
-        protected override async System.Threading.Tasks.Task OpenPopup(string key = "ArrowDown", bool isFilter = false, bool isFromClick = false)
+        protected override async System.Threading.Tasks.Task TogglePopup(string key = "ArrowDown", bool isFilter = false, bool isFromClick = false)
         {
             if (Disabled)
                 return;
@@ -680,7 +680,7 @@ namespace Radzen.Blazor
 
                 if (!popupOpened)
                 {
-                    await OpenPopup(key, isFilter);
+                    await TogglePopup(key, isFilter);
                 }
                 else
                 {
@@ -702,7 +702,7 @@ namespace Radzen.Blazor
             {
                 preventKeydown = true;
 
-                await OpenPopup(key, isFilter);
+                await TogglePopup(key, isFilter);
             }
             else if (key == "Escape")
             {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -1013,6 +1013,8 @@ window.Radzen = {
     var popup = document.getElementById(id);
     if (!popup) return;
 
+    var oldPopupStateIsOpen = popup.style.display == "block";
+
     Radzen.activeElement = document.activeElement;
 
     var parentRect = parent ? parent.getBoundingClientRect() : { top: y || 0, bottom: 0, left: x || 0, right: 0, width: 0, height: 0 };
@@ -1178,7 +1180,11 @@ window.Radzen = {
                 firstFocusable.focus();
             }
         }, 500);
-    }
+      }
+
+      if (instance) {
+          instance.invokeMethodAsync("CheckAndTriggerPopupStateChange", oldPopupStateIsOpen)
+      }
   },
   closeAllPopups: function (e, id) {
     if (!Radzen.popups) return;
@@ -1198,7 +1204,10 @@ window.Radzen = {
   },
   closePopup: function (id, instance, callback, e) {
     var popup = document.getElementById(id);
-    if (!popup) return;
+    if (!popup) return; 
+
+    var oldPopupStateIsOpen = popup.style.display == "block";
+
     if (popup.style.display == 'none') {
         var popups = Radzen.findPopup(id);
         if (popups.length > 1) {
@@ -1230,8 +1239,8 @@ window.Radzen = {
     window.removeEventListener('resize', Radzen[id]);
     Radzen[id] = null;
 
-    if (instance) {
-      instance.invokeMethodAsync(callback);
+    if (instance && callback) {
+        instance.invokeMethodAsync(callback);
     }
     Radzen.popups = (Radzen.popups || []).filter(function (obj) {
         return obj.id !== id;
@@ -1250,7 +1259,11 @@ window.Radzen = {
             }
             Radzen.activeElement = null;
         }, 100);
-    }
+      } 
+
+      if (instance) {
+          instance.invokeMethodAsync("CheckAndTriggerPopupStateChange", oldPopupStateIsOpen)
+      }
   },
   popupOpened: function (id) { 
     var popup = document.getElementById(id);


### PR DESCRIPTION
## Introduction
This pull request introduces two new features to the Radzen Dropdown component: `OpenPopup` and `OnClosePopup` event handlers. These additions enhance the component's interactivity by allowing developers to hook into the dropdown's lifecycle and execute custom logic when the dropdown is either opened or closed. This functionality is crucial for use cases where additional actions are required upon opening or closing the dropdown, such as fetching data, adjusting the UI, or logging events.

## Key Changes
- **OpenPopup Event:** This event is triggered when the dropdown transitions from closed to open. It allows for the execution of custom logic at the moment the dropdown becomes visible to the user.
- **ClosePopup Event:** Similarly, this event is fired when the dropdown goes from open to closed. It provides a hook for executing custom logic right after the dropdown is hidden.

## Implementation Details
- Added two new `[Parameter]` properties to the Radzen Dropdown component: `OpenPopup` and `ClosePopup`, both of type `Action`. These properties allow for executing custom logic upon opening and closing the dropdown, respectively.
- Introduced a new function `CheckAndTriggerPopupStateChange` marked with the `[JSInvokable]` attribute. This function assesses the current state of the popup by invoking a JavaScript function and triggers the appropriate action:
    - If the popup is currently open and was previously closed, it invokes the `OpenPopup` action.
    - If the popup is currently closed and was previously open, it invokes the `ClosePopup` action.
- To properly invoke `CheckAndTriggerPopupStateChange` from JavaScript and allow for the callback to the Blazor instance, `DotNetObjectReference.Create` is used to pass a reference of the component into the JavaScript context. This is necessary so that the JavaScript functions `Radzen.openPopup` and `Radzen.closePopup` can perform the callback to the correct Blazor instance:
    - Example invocation from JavaScript to close the popup and perform the callback: `await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID, DotNetObjectReference.Create<DropDownBase<T>>(this));`
- This approach ensures that the custom logic specified in `OpenPopupCallback` and `ClosePopupCallback` is executed appropriately in response to dropdown state changes, providing seamless integration between the Blazor component behavior and client-side actions handled by JavaScript.

## How to Test
1. Integrate the updated Radzen Dropdown component into a Blazor project.
2. Assign delegate methods to `OpenPopup` and `ClosePopup` properties.
3. Observe that the assigned delegate methods are called appropriately when the dropdown is opened and closed.

This enhancement provides developers with greater control and flexibility over the Radzen Dropdown component, paving the way for more dynamic and interactive user interfaces.

https://github.com/radzenhq/radzen-blazor/assets/62311324/a2416ab1-6de8-4c73-9783-c199cbe81f59

