### PR TITLE
Custom filters on RadzenDataGridColumn not recognized

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -150,7 +150,7 @@ namespace Radzen.Blazor
                     propertyValueGetter = PropertyAccess.Getter<TItem, object>(Property);
                 }
 
-                if (_filterPropertyType == typeof(string))
+                if (_filterPropertyType == typeof(string) && filterOperator != FilterOperator.Custom)
                 {
                     SetFilterOperator(FilterOperator.Contains);
                 }


### PR DESCRIPTION
Couldn't get my system to recognize a Custom filtered column. Looks like this code

```
if (_filterPropertyType == typeof(string))
{
    SetFilterOperator(FilterOperator.Contains);
}
```

was setting the `filterOperator` to `FilterOperator.Contains`. This meant that `GetFilterOperator` would return `FilterOperator.Contains` instead of `FilterOperator.Custom`, thus resulting in `HasCustomFilter` returning `false`.

```
        internal bool HasCustomFilter()
        {
            return GetFilterOperator() == FilterOperator.Custom && GetCustomFilterExpression() != null;
        }

        public FilterOperator GetFilterOperator()
        {
            return filterOperator ?? FilterOperator;
        }

```

Regards

Paul

