### PR TITLE
Allow disabling splitter resize client to server invocations

### DIFF
--- a/Radzen.Blazor/RadzenSplitter.razor.cs
+++ b/Radzen.Blazor/RadzenSplitter.razor.cs
@@ -30,6 +30,13 @@ namespace Radzen.Blazor
         [Parameter]
         public Orientation Orientation { get; set; } = Orientation.Horizontal;
 
+        /// <summary>
+        /// Gets or sets whether server side <see cref="JSInvokableAttribute">JSInvokable</see>s should be invoked by the client on pane resizing events or not. Set to <c>true</c> by default.
+        /// </summary>
+        /// <value><c>true</c> if should be invoked; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ClientToServerInvocationsOnPaneResize { get; set; } = true;
+
         internal List<RadzenSplitterPane> Panes = new List<RadzenSplitterPane>();
 
         /// <summary>
@@ -112,7 +119,8 @@ namespace Radzen.Blazor
                 pane.Min,
                 pane.Max,
                 paneNextResizable?.Min,
-                paneNextResizable?.Max).AsTask();
+                paneNextResizable?.Max,
+                ClientToServerInvocationsOnPaneResize).AsTask();
         }
 
         /// <summary>

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -2062,7 +2062,8 @@ window.Radzen = {
         minValue,
         maxValue,
         minNextValue,
-        maxNextValue) {
+        maxNextValue,
+        clientToServerInvocationsOnPaneResize) {
 
         var el = document.getElementById(id);
         var pane = document.getElementById(paneId);
@@ -2124,13 +2125,15 @@ window.Radzen = {
             paneNextLength: isFinite(paneNextLength) ? paneNextLength : 0,
             mouseUpHandler: function(e) {
                 if (Radzen[el]) {
-                    splitter.invokeMethodAsync(
-                        'RadzenSplitter.OnPaneResized',
-                        parseInt(pane.getAttribute('data-index')),
-                        parseFloat(pane.style.flexBasis),
-                        paneNext ? parseInt(paneNext.getAttribute('data-index')) : null,
-                        paneNext ? parseFloat(paneNext.style.flexBasis) : null
-                    );
+                    if (clientToServerInvocationsOnPaneResize) {
+                      splitter.invokeMethodAsync(
+                          'RadzenSplitter.OnPaneResized',
+                          parseInt(pane.getAttribute('data-index')),
+                          parseFloat(pane.style.flexBasis),
+                          paneNext ? parseInt(paneNext.getAttribute('data-index')) : null,
+                          paneNext ? parseFloat(paneNext.style.flexBasis) : null
+                      );
+                    }
 
                     document.removeEventListener('pointerup', Radzen[el].mouseUpHandler);
                     document.removeEventListener('pointermove', Radzen[el].mouseMoveHandler);
@@ -2141,9 +2144,11 @@ window.Radzen = {
             mouseMoveHandler: function(e) {
                 if (Radzen[el]) {
 
-                    splitter.invokeMethodAsync(
-                        'RadzenSplitter.OnPaneResizing'
-                    );
+                    if (clientToServerInvocationsOnPaneResize) {
+                        splitter.invokeMethodAsync(
+                            'RadzenSplitter.OnPaneResizing'
+                        );
+                    }
 
                     var spacePerc = Radzen[el].panePerc + Radzen[el].paneNextPerc;
                     var spaceLength = Radzen[el].paneLength + Radzen[el].paneNextLength;
@@ -2188,10 +2193,10 @@ window.Radzen = {
             }
           };
 
-        const preventDefaultAndStopPropagation = (ev) => {
-            ev.preventDefault();
-            ev.stopPropagation();
-        };
+          const preventDefaultAndStopPropagation = (ev) => {
+              ev.preventDefault();
+              ev.stopPropagation();
+          };
           document.addEventListener('pointerup', Radzen[el].mouseUpHandler);
           document.addEventListener('pointermove', Radzen[el].mouseMoveHandler);
           el.addEventListener('touchmove', preventDefaultAndStopPropagation, { passive: false });


### PR DESCRIPTION
Fixes #1506. By setting `ClientToServerInvocationsOnPaneResize = false`, both the freezing problem and infinite memory consumption are gone and splitters resize smoothly, even if the render mode is interactive, there's network lag and there's complex content on the panes.