### PR TITLE
Update to RadzenTree and RadzenTreeItem

### DIFF
--- a/Radzen.Blazor/RadzenTree.razor.cs
+++ b/Radzen.Blazor/RadzenTree.razor.cs
@@ -233,7 +233,7 @@ namespace Radzen.Blazor
         public EventCallback<IEnumerable<object>> CheckedValuesChanged { get; set; }
 
         void RenderTreeItem(RenderTreeBuilder builder, object data, RenderFragment<RadzenTreeItem> template, Func<object, string> text,
-            Func<object, bool> hasChildren, Func<object, bool> expanded, Func<object, bool> selected, IEnumerable children = null)
+            Func<object, bool> hasChildren, Func<object, bool> expanded, Func<object, bool> selected, IEnumerable children = null, string childrenProperty = null)
         {
             builder.OpenComponent<RadzenTreeItem>(0);
             builder.AddAttribute(1, nameof(RadzenTreeItem.Text), text(data));
@@ -242,6 +242,7 @@ namespace Radzen.Blazor
             builder.AddAttribute(4, nameof(RadzenTreeItem.Template), template);
             builder.AddAttribute(5, nameof(RadzenTreeItem.Expanded), expanded(data));
             builder.AddAttribute(6, nameof(RadzenTreeItem.Selected), Value == data || selected(data));
+            builder.AddAttribute(7, nameof(RadzenTreeItem.ChildrenProperty), childrenProperty);
             builder.SetKey(data);
         }
 
@@ -260,7 +261,7 @@ namespace Radzen.Blazor
                         text = level.Text ?? Getter<string>(data, level.TextProperty);
                     }
 
-                    RenderTreeItem(builder, data, level.Template, text, level.HasChildren, level.Expanded, level.Selected);
+                    RenderTreeItem(builder, data, level.Template, text, level.HasChildren, level.Expanded, level.Selected, null, level.ChildrenProperty);
 
                     var hasChildren = level.HasChildren(data);
 
@@ -270,12 +271,12 @@ namespace Radzen.Blazor
 
                         if (grandChildren != null && hasChildren)
                         {
-                            builder.AddAttribute(7, "ChildContent", RenderChildren(grandChildren, depth + 1));
-                            builder.AddAttribute(8, nameof(RadzenTreeItem.Data), grandChildren);
+                            builder.AddAttribute(8, "ChildContent", RenderChildren(grandChildren, depth + 1));
+                            builder.AddAttribute(9, nameof(RadzenTreeItem.Data), grandChildren);
                         }
                         else
                         {
-                            builder.AddAttribute(7, "ChildContent", (RenderFragment)null);
+                            builder.AddAttribute(8, "ChildContent", (RenderFragment)null);
                         }
                     }
 

--- a/Radzen.Blazor/RadzenTreeItem.razor.cs
+++ b/Radzen.Blazor/RadzenTreeItem.razor.cs
@@ -92,6 +92,9 @@ namespace Radzen.Blazor
         [Parameter]
         public IEnumerable Data { get; set; }
 
+        [Parameter]
+        public string ChildrenProperty { get; set; }
+        
         internal List<RadzenTreeItem> items = new List<RadzenTreeItem>();
 
         internal void AddItem(RadzenTreeItem item)
@@ -364,7 +367,16 @@ namespace Radzen.Blazor
 
         internal IEnumerable<object> GetAllChildValues(Func<object, bool> predicate = null)
         {
-            var children = items.Concat(items.SelectManyRecursive(i => i.items)).Select(i => i.Value);
+            IEnumerable<object> children = [];
+            if (string.IsNullOrEmpty(ChildrenProperty))
+            {
+                children = items.Concat(items.SelectManyRecursive(i => i.items)).Select(i => i.Value);
+            }
+            else
+            {
+                children = (PropertyAccess.GetValue(Value, ChildrenProperty) as IEnumerable<object>)
+                    .SelectManyRecursive(x => PropertyAccess.GetValue(x, ChildrenProperty) as IEnumerable<object>);
+            }
 
             return predicate != null ? children.Where(predicate) : children;
         }


### PR DESCRIPTION
Updated GetAllChildValues in RadzenTreeITem to get all children from it's value rather than the items list if a ChilrenProperty has been assigned to it