### PR TITLE
RadzenTreeItem now gets children from Value rather than Items list

### DIFF
--- a/Radzen.Blazor/RadzenTree.razor.cs
+++ b/Radzen.Blazor/RadzenTree.razor.cs
@@ -233,7 +233,7 @@ namespace Radzen.Blazor
         public EventCallback<IEnumerable<object>> CheckedValuesChanged { get; set; }
 
         void RenderTreeItem(RenderTreeBuilder builder, object data, RenderFragment<RadzenTreeItem> template, Func<object, string> text,
-            Func<object, bool> hasChildren, Func<object, bool> expanded, Func<object, bool> selected, IEnumerable children = null)
+            Func<object, bool> hasChildren, Func<object, bool> expanded, Func<object, bool> selected, IEnumerable children = null, string childrenProperty = null)
         {
             builder.OpenComponent<RadzenTreeItem>(0);
             builder.AddAttribute(1, nameof(RadzenTreeItem.Text), text(data));
@@ -242,6 +242,7 @@ namespace Radzen.Blazor
             builder.AddAttribute(4, nameof(RadzenTreeItem.Template), template);
             builder.AddAttribute(5, nameof(RadzenTreeItem.Expanded), expanded(data));
             builder.AddAttribute(6, nameof(RadzenTreeItem.Selected), Value == data || selected(data));
+            builder.AddAttribute(7, nameof(RadzenTreeItem.ChildrenProperty), childrenProperty);
             builder.SetKey(data);
         }
 
@@ -260,7 +261,7 @@ namespace Radzen.Blazor
                         text = level.Text ?? Getter<string>(data, level.TextProperty);
                     }
 
-                    RenderTreeItem(builder, data, level.Template, text, level.HasChildren, level.Expanded, level.Selected);
+                    RenderTreeItem(builder, data, level.Template, text, level.HasChildren, level.Expanded, level.Selected, null, level.ChildrenProperty);
 
                     var hasChildren = level.HasChildren(data);
 
@@ -270,12 +271,12 @@ namespace Radzen.Blazor
 
                         if (grandChildren != null && hasChildren)
                         {
-                            builder.AddAttribute(7, "ChildContent", RenderChildren(grandChildren, depth + 1));
-                            builder.AddAttribute(8, nameof(RadzenTreeItem.Data), grandChildren);
+                            builder.AddAttribute(8, "ChildContent", RenderChildren(grandChildren, depth + 1));
+                            builder.AddAttribute(9, nameof(RadzenTreeItem.Data), grandChildren);
                         }
                         else
                         {
-                            builder.AddAttribute(7, "ChildContent", (RenderFragment)null);
+                            builder.AddAttribute(8, "ChildContent", (RenderFragment)null);
                         }
                     }
 

--- a/Radzen.Blazor/RadzenTreeItem.razor.cs
+++ b/Radzen.Blazor/RadzenTreeItem.razor.cs
@@ -92,6 +92,9 @@ namespace Radzen.Blazor
         [Parameter]
         public IEnumerable Data { get; set; }
 
+        [Parameter]
+        public string ChildrenProperty { get; set; }
+        
         internal List<RadzenTreeItem> items = new List<RadzenTreeItem>();
 
         internal void AddItem(RadzenTreeItem item)
@@ -364,7 +367,16 @@ namespace Radzen.Blazor
 
         internal IEnumerable<object> GetAllChildValues(Func<object, bool> predicate = null)
         {
-            var children = items.Concat(items.SelectManyRecursive(i => i.items)).Select(i => i.Value);
+            IEnumerable<object> children = [];
+            if (string.IsNullOrEmpty(ChildrenProperty))
+            {
+                children = items.Concat(items.SelectManyRecursive(i => i.items)).Select(i => i.Value);
+            }
+            else
+            {
+                children = (PropertyAccess.GetValue(Value, ChildrenProperty) as IEnumerable<object>)
+                    .SelectManyRecursive(x => PropertyAccess.GetValue(x, ChildrenProperty) as IEnumerable<object>);
+            }
 
             return predicate != null ? children.Where(predicate) : children;
         }

--- a/Radzen.Blazor/RadzenTreeItem.razor.cs
+++ b/Radzen.Blazor/RadzenTreeItem.razor.cs
@@ -365,7 +365,7 @@ namespace Radzen.Blazor
             return Tree.CheckedValues != null ? Tree.CheckedValues : Enumerable.Empty<object>();
         }
 
-        internal IEnumerable<object> GetAllChildValues(Func<object, bool> predicate = null)
+        internal IEnumerable<object> GetAllChildValues(Func<object, bool> predicate = null) 
         {
             IEnumerable<object> children = [];
             if (string.IsNullOrEmpty(ChildrenProperty))
@@ -374,13 +374,32 @@ namespace Radzen.Blazor
             }
             else
             {
-                children = (PropertyAccess.GetValue(Value, ChildrenProperty) as IEnumerable<object>)
-                    .SelectManyRecursive(x => PropertyAccess.GetValue(x, ChildrenProperty) as IEnumerable<object>);
+                // children = (PropertyAccess.GetValue(Value, ChildrenProperty) as IEnumerable<object>)
+                //     .SelectManyRecursive(x => PropertyAccess.GetValue(x, ChildrenProperty) as IEnumerable<object>);
+                children = GetChildrenRecusvie(Value);
             }
 
             return predicate != null ? children.Where(predicate) : children;
         }
 
+        public IEnumerable<object> GetChildrenRecusvie(object value)
+        {
+            IEnumerable<object> children = PropertyAccess.GetValue(value, ChildrenProperty) as IEnumerable<object>;
+            if (children is not null && children.Any())
+            {
+                foreach (object child in children)
+                {
+                    IEnumerable<object> grandChildren = GetChildrenRecusvie(child);
+                    if (grandChildren is not null && grandChildren.Any())
+                    {
+                        children = children.Concat(grandChildren);
+                    }
+                }
+            }
+
+            return children;
+        }
+        
         IEnumerable<object> GetValueAndAllChildValues()
         {
             return new object[] { Value }.Concat(GetAllChildValues());


### PR DESCRIPTION
Updated the RadzenTree to provide the level's "ChildrenProperty" value to the RadzenTreeItems.  If that value exists in the tree item, then the tree item will get it's children from the Value property rather than the Items property.