### PR TITLE
Fix exception if TreeLevel has no Text nor TextProperty

### DIFF
--- a/Radzen.Blazor/RadzenTree.razor.cs
+++ b/Radzen.Blazor/RadzenTree.razor.cs
@@ -257,7 +257,9 @@ namespace Radzen.Blazor
                 {
                     if (text == null)
                     {
-                        text = level.Text ?? Getter<string>(data, level.TextProperty);
+                        text = level.Text ?? 
+                            (!string.IsNullOrEmpty(level.TextProperty) ? Getter<string>(data, level.TextProperty) : null) ??
+                            (o => "");
                     }
 
                     RenderTreeItem(builder, data, level.Template, text, level.HasChildren, level.Expanded, level.Selected);


### PR DESCRIPTION
This can happen when using template.