### PR TITLE
Added missing ContentCssClass set in DialogService

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -401,6 +401,7 @@ namespace Radzen
                 CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
                 CssClass = options != null ? $"rz-dialog-alert {options.CssClass}" : "rz-dialog-alert",
                 WrapperCssClass = options != null ? $"rz-dialog-wrapper {options.WrapperCssClass}" : "rz-dialog-wrapper",
+                ContentCssClass = options != null ? $"rz-dialog-content {options.ContentCssClass}" : "rz-dialog-content",
                 CloseTabIndex = options != null ? options.CloseTabIndex : 0,
             };
 
@@ -476,7 +477,12 @@ namespace Radzen
         /// Gets or sets the CSS classes added to the dialog's wrapper element.
         /// </summary>
         public string WrapperCssClass { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the CSS classes added to the dialog's content element.
+        /// </summary>
+        public string ContentCssClass { get; set; }
+
         /// <summary>
         /// Gets or sets a value the dialog escape tabindex. Set to <c>0</c> by default.
         /// </summary>

--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -279,6 +279,7 @@ namespace Radzen
                 CssClass = options != null ? options.CssClass : "",
                 WrapperCssClass = options != null ? options.WrapperCssClass : "",
                 CloseTabIndex = options != null ? options.CloseTabIndex : 0,
+                ContentCssClass = options != null ? options.ContentCssClass : ""
             });
         }
 

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -175,6 +175,15 @@
         }
     }
 
+    string ContentCssClass
+    {
+        get
+        {
+            var baseCss = "rz-dialog-content";
+            return string.IsNullOrEmpty(Dialog.Options.ContentCssClass) ? baseCss : $"{baseCss} {Dialog.Options.ContentCssClass}";
+        }
+    }
+
     string Style
     {
         get

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -31,7 +31,7 @@
             }
             else
             {
-                <div class="rz-dialog-titlebar">
+                <div class="@ContentCssClass">
                     <div class="rz-dialog-title" style="display: inline" id="rz-dialog-0-label">
                         @if (Dialog.Options.TitleContent != null)
                         {

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -31,7 +31,7 @@
             }
             else
             {
-                <div class="@ContentCssClass">
+                <div class="rz-dialog-titlebar">
                     <div class="rz-dialog-title" style="display: inline" id="rz-dialog-0-label">
                         @if (Dialog.Options.TitleContent != null)
                         {
@@ -51,7 +51,7 @@
                 </div>
             }
         }
-        <div class="rz-dialog-content">
+        <div class="@ContentCssClass">
             @if (Dialog.Options.ChildContent != null)
             {
                 @Dialog.Options.ChildContent(Service)


### PR DESCRIPTION
@enchev I missed the setting in DialogService.cs, now it's working properly

1. ContentCssClass parameter not set:
![image](https://github.com/radzenhq/radzen-blazor/assets/51879801/337a768d-1d5d-4aec-b88b-a31d249ceafe)

2. ContentCssClass parameter set to "custom-dialog-content-class"
![image](https://github.com/radzenhq/radzen-blazor/assets/51879801/dade3d2e-9ae4-464a-a8ff-aabac91ef367)