### PR TITLE
Fix DaySlotEvents rendering

### DIFF
--- a/Radzen.Blazor/Rendering/DaySlotEvents.razor
+++ b/Radzen.Blazor/Rendering/DaySlotEvents.razor
@@ -2,9 +2,9 @@
 
 <div class="rz-events">
 @{
-    // -------------------
-    // Rendering Algorithm
-    // -------------------
+    // ----------------------------------
+    // Rendering Algorithm - See Layout()
+    // ----------------------------------
     // Note - Column, a property of the AppointmentDataExtended class, and colunCount are values that are set depending on todays overlapping appointments.
     // i.e., if there are no overlapping appointments, all appointments will be assigned a Column value of 1
     // *** definition "Can fit in Column" - if an appointments "Start" is equal to or later than the last chronological appointments "End" in a column, this appointment can "fit in column" ***
@@ -27,45 +27,10 @@
 
     // Once the algorithm is complete, we then actually render the appointments
 
-    int columnCount = 1;
-    double columnWidth;
-    appointments = AppointmentsInSlot(StartDate, EndDate);
-
-    if (appointments.Length > 0)
+    foreach (var appointment in Layout())
     {
-        // Part 1 - Assign column
-        foreach (var appointment in appointments)
-        {
-            var assignedAppointments = appointments.Where(app => app.Column > 0);
-            var firstAvailableColumn = assignedAppointments.GroupBy(g => g.Column).Select(s => s.OrderByDescending(o => o.EventEnd).FirstOrDefault()).Where(w => w.End <= appointment.Start).FirstOrDefault();
-
-            appointment.Column = firstAvailableColumn != null ? firstAvailableColumn.Column : assignedAppointments.Count() > 0 ? assignedAppointments.Max(m => m.Column) + 1 : 1;
-            appointment.EventStart = appointment.Start < StartDate ? StartDate : appointment.Start;
-            appointment.EventEnd = appointment.End > EndDate ? EndDate : appointment.End;
-            appointment.Top = 1.5 * (appointment.EventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot);
-            appointment.Height = Math.Max(1.5, 1.5 * appointment.EventEnd.Subtract(appointment.EventStart).TotalMinutes / MinutesPerSlot);
-
-            columnCount = Math.Max(columnCount, appointment.Column);
-        }
-
-        columnWidth = 90.0 / columnCount;
-
-        // Part 2 - Assign Left and Width values
-        foreach (var appointment in appointments)
-        {
-            appointment.Left = ((appointment.Column - 1)) * columnWidth;
-        
-            var adjacentAppointment = OverlappingAppointments(appointment.EventStart, appointment.EventEnd).Where(o => o.Column > appointment.Column).OrderBy(o => o.Column).FirstOrDefault();
-            var adjacentColumn = adjacentAppointment == null ? columnCount + 1 : adjacentAppointment.Column;
-            appointment.Width = (adjacentColumn - (appointment.Column)) * columnWidth;
-        }
-    }
-
-    // Render the appointments
-    foreach (var appointment in appointments)
-    {
-    <Appointment Data=@((AppointmentData)appointment) Top=@appointment.Top Left=@appointment.Left Width=@appointment.Width Height=@appointment.Height Click=@OnAppointmentSelect
-                CssClass="@(CurrentDate.Date >= appointment.Start.Date && CurrentDate.Date <= appointment.End.Date && object.Equals(appointments.Where(i => i.Start.Date == CurrentDate.Date).OrderBy(i => i.Start).ThenByDescending(i => i.End).ElementAtOrDefault(CurrentAppointment),appointment) ? " rz-state-focused" : "" )"
+        <Appointment Data=@(appointment.Appointment) Top=@appointment.Top Left=@appointment.Left Width=@appointment.Width Height=@appointment.Height Click=@OnAppointmentSelect
+                CssClass="@(CurrentDate.Date >= appointment.Start.Date && CurrentDate.Date <= appointment.End.Date && object.Equals(Appointments.Where(i => i.Start.Date == CurrentDate.Date).OrderBy(i => i.Start).ThenByDescending(i => i.End).ElementAtOrDefault(CurrentAppointment),appointment.Appointment) ? " rz-state-focused" : "" )"
                 DragStart=@OnAppointmentDragStart />
     }
 }
@@ -96,31 +61,65 @@
     [Parameter]
     public IList<AppointmentData> Appointments { get; set; }
 
-    private AppointmentDataExtended[] appointments { get; set; }
+    private RenderedAppointment[] Layout()
+    {
+        RenderedAppointment[] appointments = [];
+
+        int columnCount = 1;
+        double columnWidth;
+
+        if (Appointments == null)
+        {
+            return Array.Empty<RenderedAppointment>();
+        }
+        else
+        {
+            appointments = Appointments.Where(item => Scheduler.IsAppointmentInRange(item, StartDate, EndDate)).OrderBy(item => item.Start).ThenByDescending(item => item.End).Select(n => new RenderedAppointment(n)).ToArray();
+
+            // Part 1 - Assign column
+            foreach (var appointment in appointments)
+            {
+                var assignedAppointments = appointments.Where(app => app.Column > 0);
+                var firstAvailableColumn = assignedAppointments.GroupBy(g => g.Column).Select(s => s.OrderByDescending(o => o.End).FirstOrDefault()).Where(w => w.Appointment.End <= appointment.Appointment.Start).FirstOrDefault();
+
+                appointment.Column = firstAvailableColumn != null ? firstAvailableColumn.Column : assignedAppointments.Count() > 0 ? assignedAppointments.Max(m => m.Column) + 1 : 1;
+                appointment.Start = appointment.Appointment.Start < StartDate ? StartDate : appointment.Appointment.Start;
+                appointment.End = appointment.Appointment.End > EndDate ? EndDate : appointment.Appointment.End;
+                appointment.Top = 1.5 * (appointment.Start.Subtract(StartDate).TotalMinutes / MinutesPerSlot);
+                appointment.Height = Math.Max(1.5, 1.5 * appointment.End.Subtract(appointment.Start).TotalMinutes / MinutesPerSlot);
+
+                columnCount = Math.Max(columnCount, appointment.Column);
+            }
+
+            columnWidth = 90.0 / columnCount;
+
+            // Part 2 - Assign Left and Width values
+            foreach (var appointment in appointments)
+            {
+                appointment.Left = ((appointment.Column - 1)) * columnWidth;
+
+                var adjacentAppointment = OverlappingAppointments(appointments, appointment.Start, appointment.End).Where(o => o.Column > appointment.Column).OrderBy(o => o.Column).FirstOrDefault();
+                var adjacentColumn = adjacentAppointment == null ? columnCount + 1 : adjacentAppointment.Column;
+                appointment.Width = (adjacentColumn - (appointment.Column)) * columnWidth;
+            }
+
+            return appointments;
+        }
+    }
 
     async Task OnAppointmentSelect(AppointmentData data)
     {
         await Scheduler.SelectAppointment(data);
     }
 
-    private AppointmentDataExtended[] AppointmentsInSlot(DateTime start, DateTime end)
-    {
-        if (Appointments == null)
-        {
-            return Array.Empty<AppointmentDataExtended>();
-        }
-
-        return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).Select(n=>new AppointmentDataExtended(n)).ToArray();
-    }
-
-    private AppointmentDataExtended[] OverlappingAppointments(DateTime start, DateTime end)
+    private RenderedAppointment[] OverlappingAppointments(RenderedAppointment[] appointments, DateTime start, DateTime end)
     {
         if (appointments == null)
         {
-            return Array.Empty<AppointmentDataExtended>();
+            return Array.Empty<RenderedAppointment>();
         }
 
-        return appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
+        return appointments.Where(item => Scheduler.IsAppointmentInRange(item.Appointment, start, end)).OrderBy(item => item.Appointment.Start).ThenByDescending(item => item.Appointment.End).ToArray();
     }
 
     public async Task OnAppointmentDragStart(AppointmentData Data)
@@ -128,21 +127,18 @@
         await AppointmentDragStart.InvokeAsync(Data);
     }
 
-    internal class AppointmentDataExtended : AppointmentData
+    internal class RenderedAppointment
     {
-        public AppointmentDataExtended(AppointmentData appointment)
+        public RenderedAppointment(AppointmentData appointment)
         {
-            this.Start = appointment.Start;
-            this.End = appointment.End;
-            this.Data = appointment.Data;
-            this.Text = appointment.Text;
-            this.Column = 0;
+            this.Appointment = appointment;
         }
 
+        public AppointmentData Appointment { get; set; }
         // This will be the same as the appointment Start. Otherwise, if the appointment started before today, it will be equal to the parameter StartDate
-        public DateTime EventStart { get; set; }
+        public DateTime Start { get; set; }
         // This will be the same as the appointment End. Otherwise, if the appointment finishes after today, it will be equal to the parameter EndDate
-        public DateTime EventEnd { get; set; }
+        public DateTime End { get; set; }
         public double Top { get; set; }
         public double Height { get; set; }        
         public double Left { get; set; }

--- a/Radzen.Blazor/Rendering/DaySlotEvents.razor
+++ b/Radzen.Blazor/Rendering/DaySlotEvents.razor
@@ -2,47 +2,18 @@
 
 <div class="rz-events">
 @{
-    var eventGroups = AppointmentGroups(); 
-    var lefts = new Dictionary<AppointmentData, double>();
-}
-@for (var date = StartDate; date < EndDate; date = date.AddMinutes(MinutesPerSlot))
-{
-    var start = date;
-    var end = start.AddMinutes(MinutesPerSlot);
-
-    var appointments = AppointmentsInSlot(start, end);
-    var existingLefts = ExistingLefts(lefts, appointments);
-
-    @foreach (var item in appointments)
+    if(InitializeView())
     {
-        var width = 90.0 / appointments.Max(data => eventGroups[Appointments.IndexOf(data)]);
-
-        if (!lefts.TryGetValue(item, out var left))
-        {
-            left = DetermineLeft(existingLefts, width);
-            lefts.Add(item, left);
-            existingLefts.Add(left);
-        }
-
-        var eventStart = item.Start < StartDate ? StartDate : item.Start;
-        var eventEnd = item.End > EndDate ? EndDate : item.End;
-        var length = eventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot;
-        var top = 1.5 * length;
-        var height = Math.Max(1.5, 1.5 * eventEnd.Subtract(eventStart).TotalHours * (60 / MinutesPerSlot));
-
-        @if (item.Start >= start && item.Start <= end)
-        {
-            <Appointment Data=@item Top=@top Left=@left Width=@width Height=@height Click=@OnAppointmentSelect
-                CssClass="@(CurrentDate.Date == date.Date && object.Equals(Appointments.Where(i => i.Start.Date == CurrentDate.Date).OrderBy(i => i.Start).ThenByDescending(i => i.End).ElementAtOrDefault(CurrentAppointment),item) ? "rz-state-focused" : "")" 
-                DragStart=@OnAppointmentDragStart />
-        } 
-        else if (date == StartDate)
-        {
-            <Appointment Data=@item Top=@top Left=@left Width=@width Height=@height Click=@OnAppointmentSelect
-                CssClass="@(CurrentDate == date && CurrentAppointment != - 1 && object.Equals(appointments.ElementAtOrDefault(CurrentAppointment),item) ? "rz-state-focused" : "")" 
-                DragStart=@OnAppointmentDragStart />
-        }
+        AssignColumns();
+        AssignLeftAndWidth();
     }
+}
+
+@foreach (var appointment in dayAppointments)
+{
+        <Appointment Data=@((AppointmentData)appointment) Top=@appointment.Top Left=@appointment.Left Width=@appointment.Width Height=@appointment.Height Click=@OnAppointmentSelect
+                    CssClass="@(CurrentDate.Date >= appointment.Start.Date && CurrentDate.Date <= appointment.End.Date && object.Equals(dayAppointments.Where(i => i.Start.Date == CurrentDate.Date).OrderBy(i => i.Start).ThenByDescending(i => i.End).ElementAtOrDefault(CurrentAppointment),appointment) ? " rz-state-focused" : "" )"
+                    DragStart=@OnAppointmentDragStart />
 }
 </div>
 
@@ -71,6 +42,67 @@
     [Parameter]
     public IList<AppointmentData> Appointments { get; set; }
 
+    public AppointmentDataRender[] dayAppointments { get; set; }
+
+    public int maxColumnCount { get; set; }
+    public double columnWidth { get; set; }
+
+    private bool InitializeView()
+    {
+        var appointments = AppointmentsInSlot(StartDate, EndDate);
+        maxColumnCount = 0;
+        dayAppointments = appointments.Select(e => new AppointmentDataRender(e)).ToArray();
+        if (dayAppointments.Length > 0)
+        {
+            dayAppointments[0].Column = 1;
+            dayAppointments[0].EventStart = dayAppointments[0].Start < StartDate ? StartDate : dayAppointments[0].Start;
+            dayAppointments[0].EventEnd = dayAppointments[0].End > EndDate ? EndDate : dayAppointments[0].End;
+            dayAppointments[0].Length = dayAppointments[0].EventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot; ;
+            dayAppointments[0].Top = 1.5 * dayAppointments[0].Length;
+            dayAppointments[0].Height = Math.Max(1.5, 1.5 * dayAppointments[0].EventEnd.Subtract(dayAppointments[0].EventStart).TotalMinutes / MinutesPerSlot);
+            dayAppointments[0].Left = 0;
+            dayAppointments[0].Width = 0;
+
+            maxColumnCount = 1;
+        }
+
+        return dayAppointments.Length > 0;
+    }
+
+    private void AssignColumns()
+    {
+        @foreach (var appointment in dayAppointments.Where(app => app.Column == 0))
+        {
+            var assignedAppointments = dayAppointments.Where(app => app.Column > 0);
+            var available = assignedAppointments.GroupBy(g => g.Column).Select(s => s.OrderByDescending(o => o.EventEnd).FirstOrDefault()).Where(w => w.End <= appointment.Start);
+            var available2 = available.Count() > 0 ? available.First() : null;
+
+            appointment.Column = available2 != null ? available2.Column : assignedAppointments.Max(m => m.Column) + 1;
+            appointment.EventStart = appointment.Start < StartDate ? StartDate : appointment.Start;
+            appointment.EventEnd = appointment.End > EndDate ? EndDate : appointment.End;
+            appointment.Length = appointment.EventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot; ;
+            appointment.Top = 1.5 * appointment.Length;
+            appointment.Height = Math.Max(1.5, 1.5 * appointment.EventEnd.Subtract(appointment.EventStart).TotalMinutes / MinutesPerSlot);
+            appointment.Left = 0;
+            appointment.Width = 0;
+
+            maxColumnCount = Math.Max(maxColumnCount, appointment.Column);
+        }
+        
+        columnWidth = 90.0 / maxColumnCount;
+    }
+
+    private void AssignLeftAndWidth()
+    {
+        @foreach (var appointment in dayAppointments)
+        {
+            var nextAdjacentAppointment = OverlappingAppointments(appointment.EventStart, appointment.EventEnd).Where(o => o.Column > appointment.Column).OrderBy(o => o.Column).FirstOrDefault();
+            var nextColumn = nextAdjacentAppointment == null ? maxColumnCount + 1 : nextAdjacentAppointment.Column;
+            appointment.Width = (nextColumn - appointment.Column) * columnWidth;
+            appointment.Left = (appointment.Column - 1) * columnWidth;
+        }
+    }
+
     async Task OnAppointmentSelect(AppointmentData data)
     {
         await Scheduler.SelectAppointment(data);
@@ -86,64 +118,38 @@
         return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
     }
 
-    double DetermineLeft(HashSet<double> existingLefts, double width)
+    private AppointmentDataRender[] OverlappingAppointments(DateTime start, DateTime end)
     {
-        double left = 0;
-
-        while (existingLefts.Contains(left))
+        if (dayAppointments == null)
         {
-            left += width;
+            return Array.Empty<AppointmentDataRender>();
         }
 
-        return left;
-    }
-
-    HashSet<double> ExistingLefts(IDictionary<AppointmentData, double> lefts, IEnumerable<AppointmentData> appointments)
-    {
-        var existingLefts = new HashSet<double>();
-
-        foreach (var appointment in appointments)
-        {
-            if (lefts.TryGetValue(appointment, out var existingLeft))
-            {
-                existingLefts.Add(existingLeft);
-            }
-        }
-
-        return existingLefts;
-    }
-    private IDictionary<int, int> AppointmentGroups()
-    {
-        var groups = new Dictionary<int, int>();
-
-        for (var index = 0; index < Appointments.Count(); index++)
-        {
-            groups[index] = 0;
-        }
-
-        for (var date = StartDate; date < EndDate; date = date.AddMinutes(MinutesPerSlot))
-        {
-            var start = date;
-            var end = start.AddMinutes(MinutesPerSlot);
-
-            var appointments = AppointmentsInSlot(start, end);
-
-            foreach (var item in appointments)
-            {
-                var index = Appointments.IndexOf(item);
-
-                var count = groups[index];
-
-                groups[index] = Math.Max(appointments.Length, count);
-            }
-        }
-
-        return groups;
+        return dayAppointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
     }
 
     public async Task OnAppointmentDragStart(AppointmentData Data)
     {
         await AppointmentDragStart.InvokeAsync(Data);
     }
-    
+
+    public class AppointmentDataRender : AppointmentData
+    {
+        public AppointmentDataRender(AppointmentData appointment)
+        {
+            this.Start = appointment.Start;
+            this.End = appointment.End;
+            this.Data = appointment.Data;
+            this.Text = appointment.Text;
+        }
+
+        public DateTime EventStart { get; set; }
+        public DateTime EventEnd { get; set; }
+        public double Length { get; set; }
+        public double Top { get; set; }
+        public double Height { get; set; }
+        public double Left { get; set; }
+        public double Width { get; set; }
+        public int Column { get; set; }
+    }
 }

--- a/Radzen.Blazor/Rendering/DaySlotEvents.razor
+++ b/Radzen.Blazor/Rendering/DaySlotEvents.razor
@@ -5,10 +5,10 @@
     var eventGroups = AppointmentGroups(); 
     var lefts = new Dictionary<AppointmentData, double>();
 }
-@for (var date = StartDate; date < EndDate; date = date.AddMinutes(MinutesPerSlot))
+@for (var date = StartDate; date < EndDate; date = date.AddMinutes(1))
 {
     var start = date;
-    var end = start.AddMinutes(MinutesPerSlot);
+    var end = start.AddMinutes(1);
 
     var appointments = AppointmentsInSlot(start, end);
     var existingLefts = ExistingLefts(lefts, appointments);
@@ -28,7 +28,7 @@
         var eventEnd = item.End > EndDate ? EndDate : item.End;
         var length = eventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot;
         var top = 1.5 * length;
-        var height = Math.Max(1.5, 1.5 * eventEnd.Subtract(eventStart).TotalHours * (60 / MinutesPerSlot));
+        var height = Math.Max(1.5, 1.5 * eventEnd.Subtract(eventStart).TotalMinutes / MinutesPerSlot);
 
         @if (item.Start >= start && item.Start <= end)
         {
@@ -121,10 +121,10 @@
             groups[index] = 0;
         }
 
-        for (var date = StartDate; date < EndDate; date = date.AddMinutes(MinutesPerSlot))
+        for (var date = StartDate; date < EndDate; date = date.AddMinutes(1))
         {
             var start = date;
-            var end = start.AddMinutes(MinutesPerSlot);
+            var end = start.AddMinutes(1);
 
             var appointments = AppointmentsInSlot(start, end);
 

--- a/Radzen.Blazor/Rendering/DaySlotEvents.razor
+++ b/Radzen.Blazor/Rendering/DaySlotEvents.razor
@@ -2,18 +2,72 @@
 
 <div class="rz-events">
 @{
-    if(InitializeView())
-    {
-        AssignColumns();
-        AssignLeftAndWidth();
-    }
-}
+    // -------------------
+    // Rendering Algorithm
+    // -------------------
+    // Note - Column, a property of the AppointmentDataExtended class, and colunCount are values that are set depending on todays overlapping appointments.
+    // i.e., if there are no overlapping appointments, all appointments will be assigned a Column value of 1
+    // *** definition "Can fit in Column" - if an appointments "Start" is equal to or later than the last chronological appointments "End" in a column, this appointment can "fit in column" ***
+    
+    // The algorithm is split into two parts.
+    // Part 1 - Assign columns to the appointments
+    // Part 2 - Set the Left and Width properties to the appointments
 
-@foreach (var appointment in dayAppointments)
-{
-        <Appointment Data=@((AppointmentData)appointment) Top=@appointment.Top Left=@appointment.Left Width=@appointment.Width Height=@appointment.Height Click=@OnAppointmentSelect
-                    CssClass="@(CurrentDate.Date >= appointment.Start.Date && CurrentDate.Date <= appointment.End.Date && object.Equals(dayAppointments.Where(i => i.Start.Date == CurrentDate.Date).OrderBy(i => i.Start).ThenByDescending(i => i.End).ElementAtOrDefault(CurrentAppointment),appointment) ? " rz-state-focused" : "" )"
-                    DragStart=@OnAppointmentDragStart />
+    // 1. Loop through all the appointments and assign which column they will be assigned (either existing or new)
+    //  1.1 If the appointment can fit in a column, it will be assigned that column value, otherwise a new column must be created to accomodate it
+    //  1.2 As the loop matures, there could be multiple columns that an appointment can fit in. It will select the one with the latest End time. This helps the view render more asthetically.
+
+    // Once we know how many columns are required, we can set the width of each column (columnWidth = 90.0 / columnCount).
+
+    // 2. Loop through the appointments and assign a Left and Width property value
+    //  2.1 Left is assigned directly from the column it sits in.
+    //  2.2 The Width of an appointment will be set to extend from it's Left to either -
+    //      2.2.1 The extreme right of the view if there are no "OverlappingAppointments()" or
+    //      2.2.2 The adjacent appointments column for the first in "OverlappingAppointments()"
+
+    // Once the algorithm is complete, we then actually render the appointments
+
+    int columnCount = 1;
+    double columnWidth;
+    appointments = AppointmentsInSlot(StartDate, EndDate);
+
+    if (appointments.Length > 0)
+    {
+        // Part 1 - Assign column
+        foreach (var appointment in appointments)
+        {
+            var assignedAppointments = appointments.Where(app => app.Column > 0);
+            var firstAvailableColumn = assignedAppointments.GroupBy(g => g.Column).Select(s => s.OrderByDescending(o => o.EventEnd).FirstOrDefault()).Where(w => w.End <= appointment.Start).FirstOrDefault();
+
+            appointment.Column = firstAvailableColumn != null ? firstAvailableColumn.Column : assignedAppointments.Count() > 0 ? assignedAppointments.Max(m => m.Column) + 1 : 1;
+            appointment.EventStart = appointment.Start < StartDate ? StartDate : appointment.Start;
+            appointment.EventEnd = appointment.End > EndDate ? EndDate : appointment.End;
+            appointment.Top = 1.5 * (appointment.EventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot);
+            appointment.Height = Math.Max(1.5, 1.5 * appointment.EventEnd.Subtract(appointment.EventStart).TotalMinutes / MinutesPerSlot);
+
+            columnCount = Math.Max(columnCount, appointment.Column);
+        }
+
+        columnWidth = 90.0 / columnCount;
+
+        // Part 2 - Assign Left and Width values
+        foreach (var appointment in appointments)
+        {
+            appointment.Left = ((appointment.Column - 1)) * columnWidth;
+        
+            var adjacentAppointment = OverlappingAppointments(appointment.EventStart, appointment.EventEnd).Where(o => o.Column > appointment.Column).OrderBy(o => o.Column).FirstOrDefault();
+            var adjacentColumn = adjacentAppointment == null ? columnCount + 1 : adjacentAppointment.Column;
+            appointment.Width = (adjacentColumn - (appointment.Column)) * columnWidth;
+        }
+    }
+
+    // Render the appointments
+    foreach (var appointment in appointments)
+    {
+    <Appointment Data=@((AppointmentData)appointment) Top=@appointment.Top Left=@appointment.Left Width=@appointment.Width Height=@appointment.Height Click=@OnAppointmentSelect
+                CssClass="@(CurrentDate.Date >= appointment.Start.Date && CurrentDate.Date <= appointment.End.Date && object.Equals(appointments.Where(i => i.Start.Date == CurrentDate.Date).OrderBy(i => i.Start).ThenByDescending(i => i.End).ElementAtOrDefault(CurrentAppointment),appointment) ? " rz-state-focused" : "" )"
+                DragStart=@OnAppointmentDragStart />
+    }
 }
 </div>
 
@@ -42,90 +96,31 @@
     [Parameter]
     public IList<AppointmentData> Appointments { get; set; }
 
-    public AppointmentDataRender[] dayAppointments { get; set; }
-
-    public int maxColumnCount { get; set; }
-    public double columnWidth { get; set; }
-
-    private bool InitializeView()
-    {
-        var appointments = AppointmentsInSlot(StartDate, EndDate);
-        maxColumnCount = 0;
-        dayAppointments = appointments.Select(e => new AppointmentDataRender(e)).ToArray();
-        if (dayAppointments.Length > 0)
-        {
-            dayAppointments[0].Column = 1;
-            dayAppointments[0].EventStart = dayAppointments[0].Start < StartDate ? StartDate : dayAppointments[0].Start;
-            dayAppointments[0].EventEnd = dayAppointments[0].End > EndDate ? EndDate : dayAppointments[0].End;
-            dayAppointments[0].Length = dayAppointments[0].EventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot; ;
-            dayAppointments[0].Top = 1.5 * dayAppointments[0].Length;
-            dayAppointments[0].Height = Math.Max(1.5, 1.5 * dayAppointments[0].EventEnd.Subtract(dayAppointments[0].EventStart).TotalMinutes / MinutesPerSlot);
-            dayAppointments[0].Left = 0;
-            dayAppointments[0].Width = 0;
-
-            maxColumnCount = 1;
-        }
-
-        return dayAppointments.Length > 0;
-    }
-
-    private void AssignColumns()
-    {
-        @foreach (var appointment in dayAppointments.Where(app => app.Column == 0))
-        {
-            var assignedAppointments = dayAppointments.Where(app => app.Column > 0);
-            var available = assignedAppointments.GroupBy(g => g.Column).Select(s => s.OrderByDescending(o => o.EventEnd).FirstOrDefault()).Where(w => w.End <= appointment.Start);
-            var available2 = available.Count() > 0 ? available.First() : null;
-
-            appointment.Column = available2 != null ? available2.Column : assignedAppointments.Max(m => m.Column) + 1;
-            appointment.EventStart = appointment.Start < StartDate ? StartDate : appointment.Start;
-            appointment.EventEnd = appointment.End > EndDate ? EndDate : appointment.End;
-            appointment.Length = appointment.EventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot; ;
-            appointment.Top = 1.5 * appointment.Length;
-            appointment.Height = Math.Max(1.5, 1.5 * appointment.EventEnd.Subtract(appointment.EventStart).TotalMinutes / MinutesPerSlot);
-            appointment.Left = 0;
-            appointment.Width = 0;
-
-            maxColumnCount = Math.Max(maxColumnCount, appointment.Column);
-        }
-        
-        columnWidth = 90.0 / maxColumnCount;
-    }
-
-    private void AssignLeftAndWidth()
-    {
-        @foreach (var appointment in dayAppointments)
-        {
-            var nextAdjacentAppointment = OverlappingAppointments(appointment.EventStart, appointment.EventEnd).Where(o => o.Column > appointment.Column).OrderBy(o => o.Column).FirstOrDefault();
-            var nextColumn = nextAdjacentAppointment == null ? maxColumnCount + 1 : nextAdjacentAppointment.Column;
-            appointment.Width = (nextColumn - appointment.Column) * columnWidth;
-            appointment.Left = (appointment.Column - 1) * columnWidth;
-        }
-    }
+    private AppointmentDataExtended[] appointments { get; set; }
 
     async Task OnAppointmentSelect(AppointmentData data)
     {
         await Scheduler.SelectAppointment(data);
     }
 
-    private AppointmentData[] AppointmentsInSlot(DateTime start, DateTime end)
+    private AppointmentDataExtended[] AppointmentsInSlot(DateTime start, DateTime end)
     {
         if (Appointments == null)
         {
-            return Array.Empty<AppointmentData>();
+            return Array.Empty<AppointmentDataExtended>();
         }
 
-        return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
+        return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).Select(n=>new AppointmentDataExtended(n)).ToArray();
     }
 
-    private AppointmentDataRender[] OverlappingAppointments(DateTime start, DateTime end)
+    private AppointmentDataExtended[] OverlappingAppointments(DateTime start, DateTime end)
     {
-        if (dayAppointments == null)
+        if (appointments == null)
         {
-            return Array.Empty<AppointmentDataRender>();
+            return Array.Empty<AppointmentDataExtended>();
         }
 
-        return dayAppointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
+        return appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
     }
 
     public async Task OnAppointmentDragStart(AppointmentData Data)
@@ -133,23 +128,28 @@
         await AppointmentDragStart.InvokeAsync(Data);
     }
 
-    public class AppointmentDataRender : AppointmentData
+    internal class AppointmentDataExtended : AppointmentData
     {
-        public AppointmentDataRender(AppointmentData appointment)
+        public AppointmentDataExtended(AppointmentData appointment)
         {
             this.Start = appointment.Start;
             this.End = appointment.End;
             this.Data = appointment.Data;
             this.Text = appointment.Text;
+            this.Column = 0;
         }
 
+        // This will be the same as the appointment Start. Otherwise, if the appointment started before today, it will be equal to the parameter StartDate
         public DateTime EventStart { get; set; }
+        // This will be the same as the appointment End. Otherwise, if the appointment finishes after today, it will be equal to the parameter EndDate
         public DateTime EventEnd { get; set; }
-        public double Length { get; set; }
         public double Top { get; set; }
-        public double Height { get; set; }
+        public double Height { get; set; }        
         public double Left { get; set; }
         public double Width { get; set; }
+        // This is used for both querying a collection of AppointmentExtended and for rendering the display
+        // A value of zero (the initial value) indicates that this appointment has not been assigned a column
+        // A value greater than zero is the actual column that this appointment has been assigned
         public int Column { get; set; }
     }
 }

--- a/Radzen.Blazor/Rendering/DaySlotEvents.razor
+++ b/Radzen.Blazor/Rendering/DaySlotEvents.razor
@@ -5,10 +5,10 @@
     var eventGroups = AppointmentGroups(); 
     var lefts = new Dictionary<AppointmentData, double>();
 }
-@for (var date = StartDate; date < EndDate; date = date.AddMinutes(1))
+@for (var date = StartDate; date < EndDate; date = date.AddMinutes(MinutesPerSlot))
 {
     var start = date;
-    var end = start.AddMinutes(1);
+    var end = start.AddMinutes(MinutesPerSlot);
 
     var appointments = AppointmentsInSlot(start, end);
     var existingLefts = ExistingLefts(lefts, appointments);
@@ -28,7 +28,7 @@
         var eventEnd = item.End > EndDate ? EndDate : item.End;
         var length = eventStart.Subtract(StartDate).TotalMinutes / MinutesPerSlot;
         var top = 1.5 * length;
-        var height = Math.Max(1.5, 1.5 * eventEnd.Subtract(eventStart).TotalMinutes / MinutesPerSlot);
+        var height = Math.Max(1.5, 1.5 * eventEnd.Subtract(eventStart).TotalHours * (60 / MinutesPerSlot));
 
         @if (item.Start >= start && item.Start <= end)
         {
@@ -121,10 +121,10 @@
             groups[index] = 0;
         }
 
-        for (var date = StartDate; date < EndDate; date = date.AddMinutes(1))
+        for (var date = StartDate; date < EndDate; date = date.AddMinutes(MinutesPerSlot))
         {
             var start = date;
-            var end = start.AddMinutes(1);
+            var end = start.AddMinutes(MinutesPerSlot);
 
             var appointments = AppointmentsInSlot(start, end);
 


### PR DESCRIPTION
A fix to address the following forum posts -

[Scheduler Weird behavior when adding 45 min appointments](https://forum.radzen.com/t/scheduler-weird-behavior-when-adding-45-min-appointments/14489)
[Scheduler Week View Time Slots Render Issue](https://forum.radzen.com/t/scheduler-week-view-time-slots-render-issue/17395)

Whilst testing the rendering as per multiple events per slot but no time overlap, I noticed that the height of the event wasn't correct.

Fixed that by changing to `var height = Math.Max(1.5, 1.5 * eventEnd.Subtract(eventStart).TotalMinutes / MinutesPerSlot);`
This is the same calculation as setting the top of the event, which was always correct. Not sure why these were different.

Admittedly, I haven't carried out extensive tests. Just that appointments don't render side-by-side in same slot when the actually times don't overlap.
