### PR TITLE
Added ChipTemplate to DropDownDataGrid

### DIFF
--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -45,9 +45,9 @@
                     {
                         <div class="rz-chip">
                             <span class="rz-chip-text" @onkeydown:stopPropagation>
-                                @if (Template != null)
+                                @if (ChipTemplate != null)
                                 {
-                                    @Template(item)
+                                    @ChipTemplate(item)
                                 }
                                 else
                                 {

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -129,6 +129,13 @@ namespace Radzen.Blazor
         public RenderFragment<dynamic> ValueTemplate { get; set; }
 
         /// <summary>
+        /// Gets or sets the chip template.
+        /// </summary>
+        /// <value>The chip template.</value>
+        [Parameter]
+        public RenderFragment<dynamic> ChipTemplate { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating DataGrid density.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
Chips only had effect if no Template was present (line 41).  And the markup for when Chips was active was trying to use template (line 50).

Fixed the confusion by adding a new template to personalize the rendering of the chips...