### PR TITLE
Add FilterOperator null check so SetParametersAsync doesn't override initial values

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -136,7 +136,7 @@ namespace Radzen.Blazor
                     propertyValueGetter = PropertyAccess.Getter<TItem, object>(Property);
                 }
 
-                if (_filterPropertyType == typeof(string))
+                if (_filterPropertyType == typeof(string) && filterOperator == null)
                 {
                     FilterOperator = FilterOperator.Contains;
                 }


### PR DESCRIPTION
FilterOperator initial values set in markup are being overridden since this [commit] from 4.30.0 (https://github.com/radzenhq/radzen-blazor/commit/6fe6b681acbdcd5409735b90aadcdce62187516f).

See this thread for more details
https://forum.radzen.com/t/filteroperator-startswith-not-being-set-on-initial-load/17397/3