### PR TITLE
Add FilterOperator null check so SetParametersAsync doesn't override initial values

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -152,7 +152,7 @@ namespace Radzen.Blazor
                     propertyValueGetter = PropertyAccess.Getter<TItem, object>(Property);
                 }
 
-                if (_filterPropertyType == typeof(string) && filterOperator != FilterOperator.Custom)
+                if (_filterPropertyType == typeof(string) && filterOperator != FilterOperator.Custom && filterOperator == null)
                 {
                     SetFilterOperator(FilterOperator.Contains);
                 }


### PR DESCRIPTION
FilterOperator initial values set in markup are being overridden since this [commit](https://github.com/radzenhq/radzen-blazor/releases/tag/v4.30.0) from 4.30.0 (6fe6b68).

See this thread for more details
https://forum.radzen.com/t/filteroperator-startswith-not-being-set-on-initial-load/17397/3