### PR TITLE
Index calculation when adding panels dynamically

### DIFF
--- a/Radzen.Blazor/RadzenSplitterPane.razor.cs
+++ b/Radzen.Blazor/RadzenSplitterPane.razor.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿#nullable enable
+using System;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using Radzen.Blazor.Rendering;
@@ -159,6 +161,12 @@ namespace Radzen.Blazor
         /// <value>The visibility of the splitter bar.</value>
         [Parameter]
         public bool BarVisible { get; set; } = true;
+        
+        /// <summary>
+        /// Delegate for getting index of current pane (set UseGetIndex=true in RadzenSplitter)
+        /// </summary>
+        [Parameter]
+        public Func<int>? GetIndex { get; set; }
 
         /// <summary>
         /// Gets or sets the splitter.


### PR DESCRIPTION
This fixes an issue when dynamically inserting panels into the middle of a collection.

```
    <RadzenSplitter>

        @if (FirstItems is { Count: > 0 })
        {
            @foreach (var c in FirstItems)
            {
                <RadzenSplitterPane>
                    <SomeComponent1>
                    </SomeComponent1>
                </RadzenSplitterPane>
            }
        }

        @if (LastItem is not null)
        {
            <RadzenSplitterPane>
                <SomeComponent2>
                </SomeComponent2>
            </RadzenSplitterPane>
        }

    </RadzenSplitter>
```

If you first add LastItem, and then FirstItems, the index of the latter will not be calculated correctly.

But it will work like this:
```
    <RadzenSplitter UseGetIndex="true">

        @if (FirstItems is { Count: > 0 })
        {
            @foreach (var c in FirstItems)
            {
                <RadzenSplitterPane GetIndex="() => Array.IndexOf(FirstItems.ToArray(), c)">
                    <SomeComponent1>
                    </SomeComponent1>
                </RadzenSplitterPane>
            }
        }

        @if (LastItem is not null)
        {
            <RadzenSplitterPane GetIndex="() => FirstItems.Count">
                <SomeComponent2>
                </SomeComponent2>
            </RadzenSplitterPane>
        }

    </RadzenSplitter>
```