### PR TITLE
[DataGrid] Enhanced DataGridColumn EditMode control

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -556,7 +556,7 @@
                         <span class="rz-cell-data" @attributes="@spanAttributes">
                             @if (Item != null)
                             {
-                                @if (this.IsRowInEditMode(Item) && column.EditTemplate != null)
+                                @if ((column.IsInEditMode(column.Property, Item) || this.IsRowInEditMode(Item)) && column.EditTemplate is not null)
                                 {
                                     @column.EditTemplate(Item)
                                 }

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Dynamic.Core;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace Radzen.Blazor
@@ -158,7 +159,7 @@ namespace Radzen.Blazor
                 }
             }
         }
-
+        
         int? orderIndex;
 
         /// <summary>
@@ -473,6 +474,12 @@ namespace Radzen.Blazor
         /// <value>The edit template.</value>
         [Parameter]
         public RenderFragment<TItem> EditTemplate { get; set; }
+
+        /// <summary>
+        /// Allows the column to override whether or not this column's the <see cref="EditTemplate" /> is visible at runtime.
+        /// </summary>
+        [Parameter]
+        public Func<string, TItem, bool> IsInEditMode { get; set; } = (property, item) => false;
 
         /// <summary>
         /// Gets or sets the header template.

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Dynamic.Core;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace Radzen.Blazor

--- a/RadzenBlazorDemos/Pages/DataGridInCellEdit.razor
+++ b/RadzenBlazorDemos/Pages/DataGridInCellEdit.razor
@@ -2,7 +2,6 @@
 @using RadzenBlazorDemos.Models.Northwind
 @using Microsoft.EntityFrameworkCore
 @using Microsoft.JSInterop
-@using System.Linq
 
 @inject IJSRuntime JSRuntime
 @inherits DbContextPage

--- a/RadzenBlazorDemos/Pages/DataGridInCellEdit.razor
+++ b/RadzenBlazorDemos/Pages/DataGridInCellEdit.razor
@@ -2,74 +2,102 @@
 @using RadzenBlazorDemos.Models.Northwind
 @using Microsoft.EntityFrameworkCore
 @using Microsoft.JSInterop
+@using System.Linq
+
 @inject IJSRuntime JSRuntime
 @inherits DbContextPage
 
-<RadzenDataGrid AllowAlternatingRows="false" AllowFiltering="true" AllowPaging="true" PageSize="5" AllowSorting="true"
-                Data="@orders" TItem="Order" RowUpdate="@OnUpdateRow" Sort="@(args => Reset())" Page="@(args => Reset())" Filter="@(args => Reset())" 
+@*
+    Pay attention to the following event handlers below: Sort, Page, and Filter. They are required to help maintain state on the Item and Property being edited.
+    The 'CellClick' event handler is used to trigger the column edit mode.
+*@
+
+<RadzenDataGrid TItem="Order" AllowAlternatingRows="false" AllowFiltering="true" AllowPaging="true" PageSize="5" AllowSorting="true"
+                Data="@orders" RowUpdate="@OnUpdateRow" Sort="@(args => Reset())" Page="@(args => Reset())" Filter="@(args => Reset())" 
                 ColumnWidth="200px" CellClick="@OnCellClick">
     <Columns>
         <RadzenDataGridColumn Property="OrderID" Title="Order ID" Width="120px" Frozen="true" />
-        <RadzenDataGridColumn Property="Customer.CompanyName" Title="Customer" Width="280px">
+
+        <RadzenDataGridColumn TItem="Order" Property="Customer.CompanyName" Title="Customer" Width="280px" IsInEditMode="@IsEditing">
             <Template Context="order">
-                <RadzenText Text="@(order.Customer?.CompanyName)" Visible="@(!Edited("Customer.CompanyName", order))" />
-                <RadzenDropDown Visible="@(Edited("Customer.CompanyName", order))" @bind-Value="order.CustomerID" Data="@customers" TextProperty="CompanyName" ValueProperty="CustomerID" Style="width:100%; display: block;"
-                                InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Select customer" }})" />
+                <RadzenText Text="@(order.Customer?.CompanyName)" />
             </Template>
+            <EditTemplate Context="order">
+                <RadzenDropDown @bind-Value="order.CustomerID" Data="@customers" TextProperty="CompanyName" ValueProperty="CustomerID" Style="width:100%; display: block;"
+                                InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Select customer" }})" />
+            </EditTemplate>
         </RadzenDataGridColumn>
-        <RadzenDataGridColumn Property="Employee.LastName" Title="Employee" Width="220px">
+
+        <RadzenDataGridColumn TItem="Order" Property="Employee.LastName" Title="Employee" Width="220px" IsInEditMode="@IsEditing">
             <Template Context="order">
-                <RadzenStack Orientation="Orientation.Horizontal" Visible="@(!Edited("Employee.LastName", order))">
+                <RadzenStack Orientation="Orientation.Horizontal">
                     <RadzenImage Path="@order.Employee?.Photo" style="width: 32px; height: 32px; border-radius: 16px; margin-right: 6px;" AlternateText="@(order.Employee?.FirstName + " " + order.Employee?.LastName)" />
                     @order.Employee?.FirstName @order.Employee?.LastName
                 </RadzenStack>
-                <RadzenDropDown Visible="@(Edited("Employee.LastName", order))" @bind-Value="order.EmployeeID" Data="@employees" ValueProperty="EmployeeID" Style="width:100%; display: block;"
+            </Template>
+            <EditTemplate Context="order">
+                <RadzenDropDown @bind-Value="order.EmployeeID" Data="@employees" ValueProperty="EmployeeID" Style="width:100%; display: block;"
                                 InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Select employee" }})">
                     <Template>
                         <RadzenImage Path="@context.Photo" style="width: 20px; height: 20px; border-radius: 16px; margin-right: 6px;" />
                         @context.FirstName @context.LastName
                     </Template>
                 </RadzenDropDown>
-            </Template>
+            </EditTemplate>
         </RadzenDataGridColumn>
-        <RadzenDataGridColumn Property="OrderDate" Title="Order Date" Width="200px">
+
+        <RadzenDataGridColumn TItem="Order" Property="OrderDate" Title="Order Date" Width="200px" IsInEditMode="@IsEditing">
             <Template Context="order">
-                <RadzenText Text="@(String.Format("{0:d}", order.OrderDate))" Visible="@(!Edited("OrderDate", order))" />
-                <RadzenDatePicker @bind-Value="order.OrderDate" Visible="@(Edited("OrderDate", order))" Style="width:100%" InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Select order date" }})" />
+                <RadzenText Text="@(String.Format("{0:d}", order.OrderDate))" />
             </Template>
+            <EditTemplate Context="order">
+                <RadzenDatePicker @bind-Value="order.OrderDate" Style="width:100%" InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Select order date" }})" />
+            </EditTemplate>
         </RadzenDataGridColumn>
-        <RadzenDataGridColumn Property="Freight" Title="Freight">
+
+        <RadzenDataGridColumn TItem="Order" Property="Freight" Title="Freight" IsInEditMode="@IsEditing">
             <Template Context="order">
-                <RadzenText Text="@(String.Format(new System.Globalization.CultureInfo("en-US"), "{0:C}", order.Freight))" Visible="@(!Edited("Freight", order))" />
-                <RadzenNumeric @bind-Value="order.Freight" Visible="@(Edited("Freight", order))" Style="width:100%" InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Select freight" }})" />
+                <RadzenText Text="@(String.Format(new System.Globalization.CultureInfo("en-US"), "{0:C}", order.Freight))" />
             </Template>
+            <EditTemplate Context="order">
+                <RadzenNumeric @bind-Value="order.Freight" Style="width:100%" InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Select freight" }})" />
+            </EditTemplate>
         </RadzenDataGridColumn>
-        <RadzenDataGridColumn Property="ShipName" Title="Ship Name">
+
+        <RadzenDataGridColumn TItem="Order" Property="ShipName" Title="Ship Name" IsInEditMode="@IsEditing">
             <Template Context="order">
-                <RadzenText Text="@(order.ShipName)" Visible="@(!Edited("ShipName", order))" />
-                <RadzenTextBox @bind-Value="order.ShipName" Visible="@(Edited("ShipName", order))" Style="width:200px; display: block" Name="ShipName" aria-label="Enter ship name" />
-                <RadzenRequiredValidator Text="ShipName is required" Visible="@(Edited("ShipName", order))" Component="ShipName" Popup="true" />
+                <RadzenText Text="@(order.ShipName)" />
             </Template>
+            <EditTemplate Context="order">
+                <RadzenTextBox @bind-Value="order.ShipName" Style="width:200px; display: block" Name="ShipName" aria-label="Enter ship name" />
+                <RadzenRequiredValidator Text="ShipName is required" Component="ShipName" Popup="true" />
+            </EditTemplate>
         </RadzenDataGridColumn>
-        <RadzenDataGridColumn Property="ShipCountry" Title="ShipCountry">
+
+        <RadzenDataGridColumn TItem="Order" Property="ShipCountry" Title="ShipCountry" IsInEditMode="@IsEditing">
             <Template Context="order">
-                <RadzenText Text="@(order.ShipCountry)" Visible="@(!Edited("ShipCountry", order))" />
-                <RadzenTextBox @bind-Value="order.ShipCountry" Visible="@(Edited("ShipCountry", order))" Style="width:200px; display: block" Name="ShipCountry" aria-label="Enter ship country" />
-                <RadzenRequiredValidator Text="ShipCountry is required" Visible="@(Edited("ShipCountry", order))" Component="ShipCountry" Popup="true" />
+                <RadzenText Text="@(order.ShipCountry)" />
             </Template>
+            <EditTemplate Context="order">
+                <RadzenTextBox @bind-Value="order.ShipCountry" Style="width:200px; display: block" Name="ShipCountry" aria-label="Enter ship country" />
+                <RadzenRequiredValidator Text="ShipCountry is required" Component="ShipCountry" Popup="true" />
+            </EditTemplate>
         </RadzenDataGridColumn>
-        <RadzenDataGridColumn Property="ShipCity" Title="ShipCity">
+
+        <RadzenDataGridColumn TItem="Order" Property="ShipCity" Title="ShipCity" IsInEditMode="@IsEditing">
             <Template Context="order">
-                <RadzenText Text="@(order.ShipCountry)" Visible="@(!Edited("ShipCity", order))" />
-                <RadzenTextBox @bind-Value="order.ShipCity" Visible="@(Edited("ShipCity", order))" Style="width:200px; display: block" Name="ShipCity" aria-label="Enter ship city" />
-                <RadzenRequiredValidator Text="ShipCity is required" Visible="@(Edited("ShipCity", order))" Component="ShipCity" Popup="true" />
+                <RadzenText Text="@(order.ShipCountry)" />
             </Template>
+            <EditTemplate Context="order">
+                <RadzenTextBox @bind-Value="order.ShipCity" Style="width:200px; display: block" Name="ShipCity" aria-label="Enter ship city" />
+                <RadzenRequiredValidator Text="ShipCity is required" Component="ShipCity" Popup="true" />
+            </EditTemplate>
         </RadzenDataGridColumn>
     </Columns>
 </RadzenDataGrid>
 
 @code {
-    string editedColumn;
+    string columnEditing;
 
     IEnumerable<Order> orders;
     IEnumerable<Customer> customers;
@@ -87,20 +115,30 @@
         orders = dbContext.Orders.Include("Customer").Include("Employee");
     }
 
-    bool Edited(string columnName, Order order)
+    /// <summary>
+    /// Determines if the specified column is in edit mode for the specified order.
+    /// </summary>
+    /// <param name="columnName">The RadzenDataGridColumn.Property currently being rendered by the RadzenDataGrid.</param>
+    /// <param name="order">The Order currently being rendered by the RadzenDataGrid.</param>
+    /// <returns>True if the column should render the EditTemplate for the specified Order, otherwise false.</returns>
+    bool IsEditing(string columnName, Order order)
     {
-        return editedColumn == columnName && ordersToUpdate.Contains(order);
+        // Comparing strings is quicker than checking the contents of a List, so let the property check fail first.
+        return columnEditing == columnName && ordersToUpdate.Contains(order);
     }
 
     void OnCellClick(DataGridCellMouseEventArgs<Order> args)
     {
-        editedColumn = args.Column.Property;
+        // This sets which column is currently being edited.
+        columnEditing = args.Column.Property;
 
+        // This triggers a save on the previous edit. This can be removed if you are going to batch edits through another method.
         if (ordersToUpdate.Any())
         {
             OnUpdateRow(ordersToUpdate.First());
         }
 
+        // This sets the Item to be edited.
         EditRow(args.Data);
     }
 


### PR DESCRIPTION
Creates a more elegant solution for #1543.

- [x] Adds an `IsInEditMode` Func on `RadzenDataGridColumn` that allows you to override when to show the `EditTemplate`, with a default Func that evaluates to `false` so the default behavior can proceed as expected.
- [x] Enhances the proper codepath in `RadzenDataGrid` to evaluate whether the `EditTemplate` should be rendered.
- [x] Enhances the `InCellEditMode` demo with a structure that would be more in line with customer expectations, including:
  - [x] comments on things to pay attention to when making changes
  - [x] comments on where to make changes for your own custom behaviors
  - [x] some minor variable name fixes
- [x] All unit tests pass