### PR TITLE
Add support for proper OData filtering of numeric data grid columns with null or not null options

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -751,7 +751,14 @@ namespace Radzen
             }
             else if (PropertyAccess.IsNumeric(column.FilterPropertyType))
             {
-                return $"{property} {odataFilterOperator} {value}";
+                if (columnFilterOperator == FilterOperator.IsNull || columnFilterOperator == FilterOperator.IsNotNull)
+                {
+                    return $"{property} {odataFilterOperator} null";
+                }
+                else
+                {
+                    return $"{property} {odataFilterOperator} {value}";
+                }
             }
             else if (column.FilterPropertyType == typeof(bool) || column.FilterPropertyType == typeof(bool?))
             {


### PR DESCRIPTION
Choosing the "Is Null" or "Is Not Null" filter options on a column with a numeric property generates an invalid OData filter string.
 
<img width="280" alt="image" src="https://github.com/radzenhq/radzen-blazor/assets/36829918/85dcff00-0eda-4cc1-ac01-a346f384b873">
<img width="725" alt="image" src="https://github.com/radzenhq/radzen-blazor/assets/36829918/cc3f5b09-544b-4d0b-9821-e5fa2ccfb54b">

The very small addition in this pull request should fix the issue