### PR TITLE
Changes aria-live regions for better screen reader

### DIFF
--- a/Radzen.Blazor/RadzenAlert.razor
+++ b/Radzen.Blazor/RadzenAlert.razor
@@ -2,7 +2,7 @@
 <div aria-live="polite">
 @if (visible)
 {
-    <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()>
+    <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
         <div class="rz-alert-item">
             @if (ShowIcon)
             {

--- a/Radzen.Blazor/RadzenAlert.razor
+++ b/Radzen.Blazor/RadzenAlert.razor
@@ -1,8 +1,7 @@
 ﻿@inherits RadzenComponentWithChildren
-<div aria-live="polite">
 @if (visible)
 {
-    <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
+    <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()" aria-live="polite">
         <div class="rz-alert-item">
             @if (ShowIcon)
             {
@@ -31,4 +30,3 @@
         }
     </div>
 }
-</div>

--- a/Radzen.Blazor/RadzenAlert.razor
+++ b/Radzen.Blazor/RadzenAlert.razor
@@ -1,7 +1,8 @@
 ﻿@inherits RadzenComponentWithChildren
+<div aria-live="polite">
 @if (visible)
 {
-    <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()" aria-live="polite">
+    <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()>
         <div class="rz-alert-item">
             @if (ShowIcon)
             {
@@ -30,3 +31,4 @@
         }
     </div>
 }
+</div>

--- a/Radzen.Blazor/RadzenNotification.razor
+++ b/Radzen.Blazor/RadzenNotification.razor
@@ -1,7 +1,7 @@
 ﻿@implements IDisposable
 @using System.Collections.Specialized
 
-<div class="rz-notification" style="position:fixed;z-index:1002;top:100px;float:right;right:10px;@Style">
+<div aria-live="polite" class="rz-notification" style="position:fixed;z-index:1002;top:100px;float:right;right:10px;@Style">
 @for (var i = 0; i < Service.Messages.Count; i++)
 {
     <div @key="Service.Messages[i]">

--- a/Radzen.Blazor/RadzenNotificationMessage.razor
+++ b/Radzen.Blazor/RadzenNotificationMessage.razor
@@ -5,7 +5,7 @@
     var classes = GetMessageCssClasses();
 
    <div class="rz-notification-message rz-growl " style="width: 250px;z-index: 1002;position:static;@(Message.Click != null || Message.CloseOnClick ? "cursor: pointer;" : "") @Style">
-        <div aria-live="polite" class="rz-growl-item-container rz-state-highlight @classes.Item1">
+        <div class="rz-growl-item-container rz-state-highlight @classes.Item1">
             <div class="rz-growl-item">
                 <div class="rz-growl-icon-close rzi rzi-times" @onclick="@Close" style="cursor:pointer"></div>
                 <span class="rz-growl-image rzi @classes.Item2" @onclick="NotificationClicked"></span>

--- a/RadzenBlazorDemos/Shared/EventConsole.razor
+++ b/RadzenBlazorDemos/Shared/EventConsole.razor
@@ -6,7 +6,7 @@
         <RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" Class="rz-m-0">Console log</RadzenText>
         <RadzenButton Click=@OnClearClick Text="Clear console" ButtonStyle="ButtonStyle.Light" Variant="Variant.Flat" Size="ButtonSize.Small" />
     </RadzenStack>
-    <RadzenStack Orientation="Orientation.Vertical" Gap="0" ID="event-console" Class="rz-pt-1" Style="border-top: var(--rz-grid-cell-border); min-height: 2rem; max-height: 12rem; overflow: auto;">
+    <RadzenStack Orientation="Orientation.Vertical" Gap="0" ID="event-console" Class="rz-pt-1" Style="border-top: var(--rz-grid-cell-border); min-height: 2rem; max-height: 12rem; overflow: auto;" role="log">
         @foreach (var message in messages)
         {
             <RadzenAlert ShowIcon="false" Variant="Variant.Flat" AlertStyle="message.AlertStyle" Size="AlertSize.ExtraSmall" Shade="Shade.Lighter" AllowClose="false" Style="font-size: 0.75rem">


### PR DESCRIPTION
According to the documentation of the [mdn ](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) live regions are only prompted if they are present **before** the content changes / is added. 

The live region of the RadzenAlert was moved outside of the `if(visible)`. If notifications are added, they will be announced.

For the same reason the aria-live was moved from the NotificationMessage to the Notification. 

Also the `role=log` was added to the example console so changes were announced there.

Those changes were tested with NVDA. 

