### PR TITLE
Fix a spelling error in StepsCanChange.razor

### DIFF
--- a/RadzenBlazorDemos/Pages/StepsCanChange.razor
+++ b/RadzenBlazorDemos/Pages/StepsCanChange.razor
@@ -80,7 +80,7 @@
         }
 
         var response = await DialogService.Confirm(
-            "Are you sure you want to contine without saving?",
+            "Are you sure you want to continue without saving?",
             "Confirm",
             new ConfirmOptions()
             {


### PR DESCRIPTION
I was looking at the documentation on https://blazor.radzen.com/steps and noticed a minor spelling mistake.