### PR TITLE
MonthSelect event on all Year Views

### DIFF
--- a/Radzen.Blazor/IScheduler.cs
+++ b/Radzen.Blazor/IScheduler.cs
@@ -66,10 +66,15 @@ namespace Radzen.Blazor
         /// <summary>
         /// Selects the specified slot.
         /// </summary>
-        /// <param name="start">The start.</param>
+        /// <param name="monthStart">The start of the month.</param>
         /// <param name="end">The end.</param>
         /// <param name="appointments">The appointments for this range.</param>
         Task<bool> SelectSlot(DateTime start, DateTime end, IEnumerable<AppointmentData> appointments);
+        /// <summary>
+        /// Selects the specified month.
+        /// </summary>
+        /// <param name="monthStart">The start of the month.</param>
+        Task SelectMonth(DateTime monthStart, IEnumerable<AppointmentData> appointments);
         /// <summary>
         /// Selects the specified more link.
         /// </summary>

--- a/Radzen.Blazor/IScheduler.cs
+++ b/Radzen.Blazor/IScheduler.cs
@@ -66,7 +66,7 @@ namespace Radzen.Blazor
         /// <summary>
         /// Selects the specified slot.
         /// </summary>
-        /// <param name="start">The start of the month.</param>
+        /// <param name="start">The start.</param>
         /// <param name="end">The end.</param>
         /// <param name="appointments">The appointments for this range.</param>
         Task<bool> SelectSlot(DateTime start, DateTime end, IEnumerable<AppointmentData> appointments);

--- a/Radzen.Blazor/IScheduler.cs
+++ b/Radzen.Blazor/IScheduler.cs
@@ -66,7 +66,7 @@ namespace Radzen.Blazor
         /// <summary>
         /// Selects the specified slot.
         /// </summary>
-        /// <param name="monthStart">The start of the month.</param>
+        /// <param name="start">The start of the month.</param>
         /// <param name="end">The end.</param>
         /// <param name="appointments">The appointments for this range.</param>
         Task<bool> SelectSlot(DateTime start, DateTime end, IEnumerable<AppointmentData> appointments);
@@ -74,6 +74,7 @@ namespace Radzen.Blazor
         /// Selects the specified month.
         /// </summary>
         /// <param name="monthStart">The start of the month.</param>
+        /// <param name="appointments">The appointments for this range.</param>
         Task SelectMonth(DateTime monthStart, IEnumerable<AppointmentData> appointments);
         /// <summary>
         /// Selects the specified more link.

--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -171,6 +171,24 @@ namespace Radzen.Blazor
         public EventCallback<SchedulerTodaySelectEventArgs> TodaySelect { get; set; }
 
         /// <summary>
+        /// A callback that will be invoked when the user clicks a month header button.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// &lt;RadzenScheduler Data=@appointments MonthSelect=@OnMonthSelect&gt;
+        /// &lt;/RadzenScheduler&gt;
+        /// @code {
+        /// void OnMonthSelect(SchedulerTodaySelectEventArgs args)
+        /// {
+        ///     args.Month = DateTime.Month.AddMonth(1);
+        /// }
+        /// }
+        /// </code>
+        /// </example>
+        [Parameter]
+        public EventCallback<SchedulerMonthSelectEventArgs> MonthSelect { get; set; }
+
+        /// <summary>
         /// A callback that will be invoked when the user clicks an appointment in the current view. Commonly used to edit existing appointments.
         /// </summary>
         /// <example>
@@ -351,6 +369,12 @@ namespace Radzen.Blazor
             await SlotSelect.InvokeAsync(args);
 
             return args.IsDefaultPrevented;
+        }
+
+        /// <inheritdoc />
+        public async Task SelectMonth(DateTime monthStart, IEnumerable<AppointmentData> appointments)
+        {
+            await MonthSelect.InvokeAsync(new SchedulerMonthSelectEventArgs { MonthStart = monthStart, Appointments = appointments, View = SelectedView });
         }
 
         /// <inheritdoc />

--- a/Radzen.Blazor/Rendering/YearPlannerView.razor
+++ b/Radzen.Blazor/Rendering/YearPlannerView.razor
@@ -35,13 +35,14 @@
         realstart = new DateTime(curYear, offSetMonth, 1);
         daysinmonth = DateTime.DaysInMonth(curYear, offSetMonth);
         date = realstart.StartOfMonth().StartOfWeek();
+        var startMonth = realstart;
 
         <div class="rz-month @(month == CurrentMonth ? "rz-state-focused" : "")">
             <div class="rz-events">
                 @for (var start = date; start < date.AddDays(NUMBER_DAYS_COLUMNS); start = start.AddDays(1))
                 {
                     var end = start.AddDays(1);
-                    var appointments = AppointmentsInSlot(start, end);
+                    var appointments = AppointmentsInRange(start, end);
                     var excessCount = appointments.Count() - MaxAppointmentsInSlot;
                     var existingTops = ExistingTops(points, appointments.Take(MaxAppointmentsInSlot));
                     if (start.Month == offSetMonth)
@@ -94,7 +95,7 @@
             </div>
             <div class="rz-slots">
                 <div @attributes=@Attributes(realstart, "rz-slot", false)>
-                    <div class="rz-slot-header">
+                    <div class="rz-slot-header" style="cursor: pointer;" @onclick=@(args => OnMonthClick(startMonth))>
                         @realstart.ToString("MMM", Scheduler.Culture)
                     </div>
                 </div>
@@ -125,7 +126,7 @@
                     }
                 }
                 <div @attributes=@Attributes(realstart, "rz-slot", false)>
-                    <div class="rz-slot-header">
+                    <div class="rz-slot-header" style="cursor: pointer;" @onclick=@(args => OnMonthClick(startMonth))>
                         @realstart.ToString("MMM", Scheduler.Culture)
                     </div>
                 </div>
@@ -173,7 +174,7 @@
 
     async Task OnSlotClick(DateTime date)
     {
-        await Scheduler.SelectSlot(date, date.AddDays(1), AppointmentsInSlot(date, date.AddDays(1)));
+        await Scheduler.SelectSlot(date, date.AddDays(1), AppointmentsInRange(date, date.AddDays(1)));
     }
 
     double DetermineTop(HashSet<double> existingTops)
@@ -208,7 +209,7 @@
         await Scheduler.SelectAppointment(data);
     }
 
-    private AppointmentData[] AppointmentsInSlot(DateTime start, DateTime end)
+    private AppointmentData[] AppointmentsInRange(DateTime start, DateTime end)
     {
         if (Appointments == null)
         {
@@ -216,6 +217,11 @@
         }
 
         return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
+    }
+
+    async Task OnMonthClick(DateTime monthStart)
+    {
+        await Scheduler.SelectMonth(monthStart, AppointmentsInRange(monthStart, monthStart.EndOfMonth()));
     }
 
     async Task OnListClick(DateTime date, IEnumerable<AppointmentData> appointments)
@@ -288,7 +294,7 @@
         }
         else if (key == "Enter")
         {
-            await OnListClick(CurrentDate, AppointmentsInSlot(CurrentDate, CurrentDate.AddDays(1)));
+            await OnListClick(CurrentDate, AppointmentsInRange(CurrentDate, CurrentDate.AddDays(1)));
 #if NET5_0_OR_GREATER
             await view.FocusAsync();
 #endif
@@ -296,7 +302,7 @@
         }
         else if (key == "Space")
         {
-            var appointment = AppointmentsInSlot(CurrentDate, CurrentDate.AddDays(1)).FirstOrDefault();
+            var appointment = AppointmentsInRange(CurrentDate, CurrentDate.AddDays(1)).FirstOrDefault();
             if (appointment != null)
             {
                 await Scheduler.SelectAppointment(appointment);

--- a/Radzen.Blazor/Rendering/YearTimelineView.razor
+++ b/Radzen.Blazor/Rendering/YearTimelineView.razor
@@ -36,13 +36,14 @@
         realstart = new DateTime(curYear, offSetMonth, 1);
         daysinmonth = DateTime.DaysInMonth(curYear, offSetMonth);
         date = realstart.StartOfMonth().StartOfWeek();
+        var startMonth = realstart;
 
         <div class="rz-month @(month == CurrentMonth ? "rz-state-focused" : "")">
             <div class="rz-events">
                 @for (var start = date; start < date.AddDays(NUMBER_DAYS_COLUMNS); start = start.AddDays(1))
                 {
                     var end = start.AddDays(1);
-                    var appointments = AppointmentsInSlot(start, end);
+                    var appointments = AppointmentsInRange(start, end);
                     var excessCount = appointments.Count() - MaxAppointmentsInSlot;
                     var existingTops = ExistingTops(points, appointments.Take(MaxAppointmentsInSlot));
                     if (start.Month == offSetMonth)
@@ -95,7 +96,7 @@
             </div>
             <div class="rz-slots">
                 <div @attributes=@Attributes(realstart, "rz-slot", false)>
-                    <div class="rz-slot-header">
+                    <div class="rz-slot-header" style="cursor: pointer;" @onclick=@(args => OnMonthClick(startMonth))>
                         @realstart.ToString("MMMM", Scheduler.Culture)
                     </div>
                 </div>
@@ -165,7 +166,7 @@
 
     async Task OnSlotClick(DateTime date)
     {
-        await Scheduler.SelectSlot(date, date.AddDays(1), AppointmentsInSlot(date, date.AddDays(1)));
+        await Scheduler.SelectSlot(date, date.AddDays(1), AppointmentsInRange(date, date.AddDays(1)));
     }
 
     double DetermineTop(HashSet<double> existingTops)
@@ -200,7 +201,7 @@
         await Scheduler.SelectAppointment(data);
     }
 
-    private AppointmentData[] AppointmentsInSlot(DateTime start, DateTime end)
+    private AppointmentData[] AppointmentsInRange(DateTime start, DateTime end)
     {
         if (Appointments == null)
         {
@@ -208,6 +209,11 @@
         }
 
         return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
+    }
+
+    async Task OnMonthClick(DateTime monthStart)
+    {
+        await Scheduler.SelectMonth(monthStart, AppointmentsInRange(monthStart, monthStart.EndOfMonth()));
     }
 
     async Task OnListClick(DateTime date, IEnumerable<AppointmentData> appointments)
@@ -285,7 +291,7 @@
         }
         else if (key == "Enter")
         {
-            await OnListClick(CurrentDate, AppointmentsInSlot(CurrentDate, CurrentDate.AddDays(1)));
+            await OnListClick(CurrentDate, AppointmentsInRange(CurrentDate, CurrentDate.AddDays(1)));
 #if NET5_0_OR_GREATER
             await view.FocusAsync();
 #endif
@@ -293,7 +299,7 @@
         }
         else if (key == "Space")
         {
-            var appointment = AppointmentsInSlot(CurrentDate, CurrentDate.AddDays(1)).FirstOrDefault();
+            var appointment = AppointmentsInRange(CurrentDate, CurrentDate.AddDays(1)).FirstOrDefault();
             if (appointment != null)
             {
                 await Scheduler.SelectAppointment(appointment);

--- a/Radzen.Blazor/Rendering/YearView.razor
+++ b/Radzen.Blazor/Rendering/YearView.razor
@@ -26,12 +26,13 @@
         date = realstart.StartOfMonth().StartOfWeek();
         var currentDate = date;
         var currentMonth = month;
+        var startMonth = realstart;
 
         <div class="rz-year-month rz-display-flex rz-flex-column rz-col-12 rz-col-sm-6 rz-col-md-4 rz-col-lg-3"
                  tabindex="0" @onkeydown="@(args => OnKeyPress(args))" @onkeydown:preventDefault="@preventKeyPress" @onkeydown:stopPropagation
                  @onfocus=@(args => {CurrentDate = currentDate; CurrentMonth = currentMonth; })>
 
-            <div class="rz-slot-header rz-pb-2">
+            <div class="rz-slot-header rz-pb-2" style="cursor: pointer;" @onclick=@(args => OnMonthClick(startMonth))>
                 <span class="rz-text-subtitle1">
                     @realstart.ToString("MMMM yyyy", Scheduler.Culture)
                 </span>
@@ -54,7 +55,7 @@
                             @for (var col = 0; col < 7; col++)
                             {
                                 var day = date.AddDays((row * 7) + col);
-                                var appointments = AppointmentsInSlot(day, day.AddDays(1));
+                                var appointments = AppointmentsInRange(day, day.AddDays(1));
                                 var excessCount = appointments.Count();
                                 string classname = $"rz-slot-title {(day.Month != offSetMonth ? "rz-other-month" : "")} {(excessCount > 0 ? "rz-has-appointments" : "")} {(day == CurrentDate && month == CurrentMonth ? " rz-state-focused" : "")}".Trim();
 
@@ -117,7 +118,7 @@
         await Scheduler.SelectAppointment(data);
     }
 
-    private AppointmentData[] AppointmentsInSlot(DateTime start, DateTime end)
+    private AppointmentData[] AppointmentsInRange(DateTime start, DateTime end)
     {
         if (Appointments == null)
         {
@@ -125,6 +126,11 @@
         }
 
         return Appointments.Where(item => Scheduler.IsAppointmentInRange(item, start, end)).OrderBy(item => item.Start).ThenByDescending(item => item.End).ToArray();
+    }
+
+    async Task OnMonthClick(DateTime monthStart)
+    {
+        await Scheduler.SelectMonth(monthStart, AppointmentsInRange(monthStart, monthStart.EndOfMonth()));
     }
 
     async Task OnListClick(DateTime date, IEnumerable<AppointmentData> appointments)
@@ -183,7 +189,7 @@
         }
         else if (key == "Enter")
         {
-            await OnListClick(CurrentDate, AppointmentsInSlot(CurrentDate, CurrentDate.AddDays(1)));
+            await OnListClick(CurrentDate, AppointmentsInRange(CurrentDate, CurrentDate.AddDays(1)));
 
             preventKeyPress = true;
         }

--- a/Radzen.Blazor/SchedulerMonthSelectEventArgs.cs
+++ b/Radzen.Blazor/SchedulerMonthSelectEventArgs.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Radzen.Blazor;
+
+namespace Radzen
+{
+    /// <summary>
+    /// Supplies information about a <see cref="RadzenScheduler{TItem}.MonthSelect" /> event that is being raised.
+    /// </summary>
+    public class SchedulerMonthSelectEventArgs
+    {
+        /// <summary>
+        /// Monthg start date. You can change this value to navigate to a different date.
+        /// </summary>
+        public DateTime MonthStart { get; set; }
+        /// <summary>
+        /// List of appointments.
+        /// </summary>
+        public IEnumerable<AppointmentData> Appointments { get; set; }
+        /// <summary>
+        /// Current View.
+        /// </summary>
+        public ISchedulerView View { get; set; }
+    }
+}

--- a/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
+++ b/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
@@ -8,7 +8,7 @@
 
 <RadzenScheduler @ref=@scheduler SlotRender=@OnSlotRender style="height: 768px;" TItem="Appointment" Data=@appointments StartProperty="Start" EndProperty="End"
     TextProperty="Text" SelectedIndex="1"
-    SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender>
+    SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender MonthSelect=@OnMonthSelect>
     <RadzenMonthView />
     <RadzenYearPlannerView StartMonth="@startMonth" />
     <RadzenYearTimelineView StartMonth="@startMonth" />
@@ -70,6 +70,11 @@
                 await scheduler.Reload();
             }
         }
+    }
+
+    async Task OnMonthSelect(SchedulerMonthSelectEventArgs args)
+    {
+        console.Log($"MonthSelect: MonthStart={args.MonthStart} AppointmentCount={args.Appointments.Count()}");
     }
 
     async Task OnAppointmentSelect(SchedulerAppointmentSelectEventArgs<Appointment> args)


### PR DESCRIPTION
Instigated from [this forum issue](https://forum.radzen.com/t/scheduler-change-month-from-year-view/16651)

Although the request was to open a month detail view from the Year View, this would not be generic enough for the scheduler component. But the request to react to a month click was valid. So this PR adds a `MonthSelect` event that reacts to -

- Year - The Month title of each month segment
- Timeline - The Month titles down the left hand side of the view
- Planner - The Month titles down either side of the view

Whilst creating this PR, I needed to return all appointments for the month selected. It became apparent that the method `AppointmentsInSlot` would return the appointments for the month with the required Start and End dates. With this in mind, it appears that `AppointmentsInRange` would be a more appropriate name.

What do you think? If that name change seems acceptable, let me know, and I'll make the change to the other views for consistency.

Regards

Paul
