### PR TITLE
Stopped Radzen Dialog Service unwanted Render Cycles during dragging.

### DIFF
--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -6,50 +6,24 @@
     <div @ref="dialog" class="@CssClass" role="dialog" aria-labelledby="rz-dialog-0-label" style=@Style>
         @if (Dialog.Options.ShowTitle)
         {
-            @if (Dialog.Options.Draggable)
-            {
-                <Draggable Drag="@OnDrag" DragStart="@OnDragStart">
-                    <div class="rz-dialog-titlebar">
-                        <div class="rz-dialog-title" style="display: inline" id="rz-dialog-0-label">
-                            @if (Dialog.Options.TitleContent != null)
-                            {
-                                @Dialog.Options.TitleContent(Service)
-                            }
-                            else
-                            {
-                                @((MarkupString)Dialog.Title)
-                            }
-                        </div>
-                        @if (Dialog.Options.ShowClose)
-                        {
-                            <a @onclick:preventDefault="true" @onclick=@Close @onkeydown="@OnKeyPress" role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close" tabindex=@Dialog.Options.CloseTabIndex>
-                                <span class="rzi rzi-times"></span>
-                            </a>
-                        }
-                    </div>
-                </Draggable>
-            }
-            else
-            {
-                <div class="rz-dialog-titlebar">
-                    <div class="rz-dialog-title" style="display: inline" id="rz-dialog-0-label">
-                        @if (Dialog.Options.TitleContent != null)
-                        {
-                            @Dialog.Options.TitleContent(Service)
-                        }
-                        else
-                        {
-                            @((MarkupString)Dialog.Title)
-                        }
-                    </div>
-                    @if (Dialog.Options.ShowClose)
+            <div class="rz-dialog-titlebar">
+                <div class="rz-dialog-title" style="display: inline" id="rz-dialog-0-label">
+                    @if (Dialog.Options.TitleContent != null)
                     {
-                        <a @onclick:preventDefault="true" @onclick=@Close @onkeydown="@OnKeyPress" role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close" tabindex=@Dialog.Options.CloseTabIndex>
-                            <span class="rzi rzi-times"></span>
-                        </a>
+                        @Dialog.Options.TitleContent(Service)
+                    }
+                    else
+                    {
+                        @((MarkupString)Dialog.Title)
                     }
                 </div>
-            }
+                @if (Dialog.Options.ShowClose)
+                {
+                    <a @onclick:preventDefault="true" @onclick=@Close @onkeydown="@OnKeyPress" role="button" class="rz-dialog-titlebar-icon rz-dialog-titlebar-close" tabindex=@Dialog.Options.CloseTabIndex>
+                        <span class="rzi rzi-times"></span>
+                    </a>
+                }
+            </div>
         }
         <div class="@ContentCssClass">
             @if (Dialog.Options.ChildContent != null)
@@ -95,26 +69,6 @@
     string height;
     string width;
 
-    double clientX;
-    double clientY;
-
-    void OnDragStart(DraggableEventArgs args)
-    {
-        clientX = args.ClientX;
-        clientY = args.ClientY;
-    }
-
-    void OnDrag(DraggableEventArgs args)
-    {
-        shouldRender = false;
-
-        left = string.Format(System.Globalization.CultureInfo.InvariantCulture, "left: {0}px;", args.Rect.Left + (args.ClientX - clientX));
-        top = string.Format(System.Globalization.CultureInfo.InvariantCulture, "top: {0}px;", args.Rect.Top + (args.ClientY - clientY));
-
-        shouldRender = true;
-    }
-
-
     /// <summary>
     /// Called when resized.
     /// </summary>
@@ -127,6 +81,17 @@
 
         width = $"width: {w}px;";
         height = $"height: {h}px;";
+
+        shouldRender = true;
+    }
+
+    [JSInvokable("RadzenDialog.OnDrag")]
+    public void OnDrag(string t, string l)
+    {
+        shouldRender = false;
+
+        top = $"top: {t};";
+        left = $"left: {l};";
 
         shouldRender = true;
     }
@@ -210,7 +175,7 @@
         }
     }
 
-    [Inject] 
+    [Inject]
     DialogService Service { get; set; }
 
     protected override void OnInitialized()
@@ -222,7 +187,7 @@
     {
         var stateHasChanged = reference?.GetType().GetMethod("StateHasChanged", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        InvokeAsync(() => 
+        InvokeAsync(() =>
         {
             StateHasChanged();
             stateHasChanged?.Invoke(reference, null);
@@ -263,6 +228,7 @@
                 };
 
             await JSRuntime.InvokeAsync<string>("Radzen.openDialog", dialogOptions, Service.Reference, DotNetReference);
+            await JSRuntime.InvokeVoidAsync("Radzen.makeElementDraggable", Dialog.Options.Draggable.ToString(), Dialog.Options.ShowTitle.ToString(), DotNetReference);
         }
     }
 

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -175,7 +175,7 @@
         }
     }
 
-    [Inject]
+    [Inject] 
     DialogService Service { get; set; }
 
     protected override void OnInitialized()
@@ -187,7 +187,7 @@
     {
         var stateHasChanged = reference?.GetType().GetMethod("StateHasChanged", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        InvokeAsync(() =>
+        InvokeAsync(() => 
         {
             StateHasChanged();
             stateHasChanged?.Invoke(reference, null);

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -2290,5 +2290,53 @@ window.Radzen = {
         } else {
             start();
         }
+    },
+
+    makeElementDraggable: function (draggable, showTitle, dialogRef) {
+        if (draggable == "True" && showTitle == "True") {
+            var dialogs = document.querySelectorAll('.rz-dialog');
+            if (dialogs.length == 0) return;
+            var lastDialog = dialogs[dialogs.length - 1];
+
+            var initialPositionX = 0
+            var changeInX = 0
+            var initialPositionY = 0
+            var changeInY = 0
+
+            var dialogTitles = document.querySelectorAll('.rz-dialog-titlebar');
+            if (dialogTitles.length == 0) return;
+            dialogTitles[dialogTitles.length - 1].addEventListener('mousedown', initiateElementDrag);
+
+            function initiateElementDrag(e) {
+                e.preventDefault();
+                initialPositionX = e.clientX;
+                initialPositionY = e.clientY;
+                document.addEventListener("mouseup", endDrag)
+                document.addEventListener("mousemove", drag)
+            }
+
+            function endDrag(e) {
+                document.removeEventListener("mousemove", drag)
+                document.removeEventListener("mouseup", endDrag);
+
+                dialogRef.invokeMethodAsync(
+                    'RadzenDialog.OnDrag',
+                    lastDialog.style.top,
+                    lastDialog.style.left
+                );
+            }
+
+            function drag(e) {
+                e.preventDefault();
+
+                changeInX = initialPositionX - e.clientX;
+                changeInY = initialPositionY - e.clientY;
+                initialPositionX = e.clientX;
+                initialPositionY = e.clientY;
+
+                lastDialog.style.top = `${lastDialog.offsetTop - changeInY}px`;
+                lastDialog.style.left = `${lastDialog.offsetLeft - changeInX}px`;
+            }
+        }
     }
 };


### PR DESCRIPTION
- I stopped Radzen Dialog Service unwanted Render Cycles during dragging.
- I did this by removing the current method for making dialogs draggable, and replacing it with a JavaScript implementation.
- This stop the unwanted render cycles during dragging because JavaScript can modify the element properities without triggering a render cycle.
- Eliminating these unwanter render cycles means prevents any render logic from being executed, 
- The unwanted render cycles cause render logic to be executed, which can make a dialogs dragging be slow. Eliminating these render cycles fixes this issue.