### PR TITLE
RadzenTree - Fixed inserting to CurrentItems

### DIFF
--- a/Radzen.Blazor/RadzenTreeItem.razor.cs
+++ b/Radzen.Blazor/RadzenTreeItem.razor.cs
@@ -261,7 +261,7 @@ namespace Radzen.Blazor
             {
                 ParentItem.AddItem(this);
 
-                var currentItems = ParentItem.ParentItem != null ? ParentItem.ParentItem.items : Tree.items;
+                var currentItems = Tree.items;
 
                 Tree.InsertInCurrentItems(currentItems.IndexOf(ParentItem) + (ParentItem != null ? ParentItem.items.Count : 0), this);
             }


### PR DESCRIPTION
**Issue**: 
Impared keyboard navigation around RadzenTree
**Description**: 
Description and code sample to reproduce bug provided in [forum topic](https://forum.radzen.com/t/radzentree-keyboard-navigation-issue/17760)
**Problem**: 
Children of expanded items where added with index relative to their parents, so when there where more ancestors, children where added with lower index than they should.
**Solution**: 
Always assign index of newly added items relative to main tree.