### PR TITLE
RadzenCompareValidator fails when validated RadzenDatePicker value cleared

### DIFF
--- a/Radzen.Blazor/RadzenCompareValidator.cs
+++ b/Radzen.Blazor/RadzenCompareValidator.cs
@@ -105,18 +105,18 @@ namespace Radzen.Blazor
 
             await base.SetParametersAsync(parameters);
 
-            if (ValidateOnComponentValueChange && valueChanged && !firstRender)
+            if (ValidateOnComponentValueChange && valueChanged && !firstRender && Visible)
             {
                 var component = Form.FindComponent(Component);
                 if (component != null && component.FieldIdentifier.FieldName != null)
                 {
                     IsValid = Validate(component);
 
-                    messages.Clear(component.FieldIdentifier);
+                    messages?.Clear(component.FieldIdentifier);
 
                     if (!IsValid)
                     {
-                        messages.Add(component.FieldIdentifier, Text);
+                        messages?.Add(component.FieldIdentifier, Text);
                     }
 
                     EditContext?.NotifyValidationStateChanged();


### PR DESCRIPTION
RadzenCompareValidator fails when validated RadzenDatePicker value cleared.

Steps to reproduce:
Create a new Blazor Web App or Blazor Server App in Visual Studio.
Install latest Radzen.Blazor NuGet (currently 4.34.1).

Add a new class with 2 nullable DateTime properties:
```
public class SearchPageViewModel
{
    public DateTime? DateFrom { get; set; }
    public DateTime? DateTo { get; set; }
}
```

Create a new page or use any existing one (e.g., Index.razor in Blazor Server App or Home.razor in Blazor Web App) to add the below code:
```
@page "/"
@rendermode InteractiveServer

@using RadzenBlazorWebApp.Data

<RadzenTemplateForm TItem="SearchPageViewModel" Data="@Model">
    <RadzenDatePicker AllowClear="true" AllowInput="true" @bind-Value="@Model.DateFrom" DateFormat="d" Max="new DateTime(2050, 1, 1)" Min="new DateTime(1900, 1, 1)" Name="SearchCriteria_DateFrom" TValue="DateTime?" />
    <RadzenCompareValidator Component="SearchCriteria_DateFrom" Operator="CompareOperator.LessThanEqual" Popup="false" Style="display: block" Text="Date From Must Be Same Or Earlier Than Date To" Value="@Model.DateTo" Visible="@(!string.IsNullOrEmpty(Model.DateTo.ToString()))" />
    <RadzenCompareValidator Component="SearchCriteria_DateFrom" Operator="CompareOperator.LessThanEqual" Popup="false" Style="display: block" Text="Future Dates Are Not Allowed" Value="@DateTime.Now" />
    <RadzenDatePicker AllowClear="true" AllowInput="true" @bind-Value="@Model.DateTo" DateFormat="d" Max="new DateTime(2050, 1, 1)" Min="new DateTime(1900, 1, 1)" Name="SearchCriteria_DateTo" TValue="DateTime?" />
    <RadzenCompareValidator Component="SearchCriteria_DateTo" Operator="CompareOperator.GreaterThanEqual" Popup="false" Style="display: block" Text="Date To Must Be Same Or Later Than Date From" Value="@Model.DateFrom" Visible="@(!string.IsNullOrEmpty(Model.DateFrom.ToString()))" />
    <RadzenCompareValidator Component="SearchCriteria_DateTo" Operator="CompareOperator.LessThanEqual" Popup="false" Style="display: block" Text="Future Dates Are Not Allowed" Value="@DateTime.Now" />
</RadzenTemplateForm>

@code {
    protected SearchPageViewModel Model = new();
}
```

Run the app.
Select the date in any of date-pickers and then clean the selected value.
It will fail with the error:
> Error: System.NullReferenceException: Object reference not set to an instance of an object.
   at Radzen.Blazor.RadzenCompareValidator.SetParametersAsync(ParameterView parameters)

This happens because when the value in date-picker is "cleared" it sets the Visible property of the RadzenCompareValidator to false.
That in turn causes the SetParametersAsync of ValidatorBase to call RemoveFromEditContext and set "messages" field to null,
but in SetParametersAsync method of the RadzenCompareValidator it's trying to call messages.Clear which fails with the above mentioned error.

The Visible property of the RadzenCompareValidator must be used, otherwise, in case Visible property is not set it shows validation error when the second date is not selected.
