### PR TITLE
RadzenMask: fix unexpected behavior when a character allowed by the pattern is in the mask

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -48,7 +48,7 @@ window.Radzen = {
               for (var i = 0; i < mask.length; i++) {
                   const c = mask[i];
                   if (chars && chars[count]) {
-                      if (/\*/.test(c)) {
+                      if (c === '*' || c == chars[count]) {
                           formatted += chars[count];
                           count++;
                       } else {


### PR DESCRIPTION
Consider a mask component with these attributes:
```
Mask="+48 *** *** ***"
CharacterPattern="[0-9]"
```
Currently, when you type numbers, the value gets duplicated to some extent. Even if you try to backspace characters, this will continue:
![Mask current](https://github.com/user-attachments/assets/91096b38-a4f1-4a0a-b179-b7e367772671)

My change makes the algorithm try to adjust the value not only to *s, but also to explicit characters in the mask:
![Mask new](https://github.com/user-attachments/assets/72d44133-bd16-4cfd-99c1-9859dcb78cb6)
