### PR TITLE
Added use of "fireChangeEvent" parameter in the "OnRemove" method in RadzenUpload.razor.cs

### DIFF
--- a/Radzen.Blazor/RadzenUpload.razor.cs
+++ b/Radzen.Blazor/RadzenUpload.razor.cs
@@ -310,7 +310,7 @@ namespace Radzen.Blazor
         {
             files.Remove(file);
             await JSRuntime.InvokeVoidAsync("Radzen.removeFileFromUpload", fileUpload, file.Name);
-            await Change.InvokeAsync(new UploadChangeEventArgs() { Files = files.Select(f => new FileInfo() { Name = f.Name, Size = f.Size }).ToList() });
+            if (fireChangeEvent) await Change.InvokeAsync(new UploadChangeEventArgs() { Files = files.Select(f => new FileInfo() { Name = f.Name, Size = f.Size }).ToList() });
         }
 
         /// <summary>


### PR DESCRIPTION
The "fireChangeEvent" parameter was present in the "OnRemove" method definition, but was never used - so when clearing all the files using the "ClearFiles" method, the Change event was additionally invoked for each of the files.