### PR TITLE
Radzensteps onafterchange

### DIFF
--- a/Radzen.Blazor/RadzenSteps.razor
+++ b/Radzen.Blazor/RadzenSteps.razor
@@ -60,11 +60,11 @@
     {
     <div class="rz-steps-buttons">
         <a id="@(GetId() + "prev")" title="@PreviousTitle" arial-label="@PreviousAriaLabel" tabindex="@(IsFirstVisibleStep() ? -1 : 0)"
-           class='@($"rz-steps-prev {(IsPreviousDisabled() ?  "rz-state-disabled" : "")}")' style="@(PreviousButtonStyle)"
+           class='@($"rz-steps-prev {(IsPreviousDisabled() ?  "rz-state-disabled" : "")}")'
                    @onkeypress="@(args => OnKeyPress(args, PrevStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@PrevStep" @onclick:preventDefault="true"><span class="rzi"></span>@PreviousText</a>
         <a id="@(GetId() + "next")" title="@NextTitle" arial-label="@NextAriaLabel" tabindex="@(IsLastVisibleStep() ? -1 : 0)"
-           class='@($"rz-steps-next {(IsNextDisabled() ?  "rz-state-disabled" : "")}")' style="@(NextButtonStyle)"
+           class='@($"rz-steps-next {(IsNextDisabled() ?  "rz-state-disabled" : "")}")'
                    @onkeypress="@(args => OnKeyPress(args, NextStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@NextStep" @onclick:preventDefault="true">@NextText<span class="rzi"></span></a>
     </div>

--- a/Radzen.Blazor/RadzenSteps.razor
+++ b/Radzen.Blazor/RadzenSteps.razor
@@ -60,11 +60,11 @@
     {
     <div class="rz-steps-buttons">
         <a id="@(GetId() + "prev")" title="@PreviousTitle" arial-label="@PreviousAriaLabel" tabindex="@(IsFirstVisibleStep() ? -1 : 0)"
-           class='@($"rz-steps-prev {(IsPreviousDisabled() ?  "rz-state-disabled" : "")}")' style="@(IsPreviousDisabled() ? "pointer-events: none; cursor: default" : "")"
+           class='@($"rz-steps-prev {(IsPreviousDisabled() ?  "rz-state-disabled" : "")}")' style="@(PreviousButtonStyle)"
                    @onkeypress="@(args => OnKeyPress(args, PrevStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@PrevStep" @onclick:preventDefault="true"><span class="rzi"></span>@PreviousText</a>
         <a id="@(GetId() + "next")" title="@NextTitle" arial-label="@NextAriaLabel" tabindex="@(IsLastVisibleStep() ? -1 : 0)"
-           class='@($"rz-steps-next {(IsNextDisabled() ?  "rz-state-disabled" : "")}")' style="@(IsNextDisabled() ? "pointer-events: none; cursor: default" : "")"
+           class='@($"rz-steps-next {(IsNextDisabled() ?  "rz-state-disabled" : "")}")' style="@(NextButtonStyle)"
                    @onkeypress="@(args => OnKeyPress(args, NextStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@NextStep" @onclick:preventDefault="true">@NextText<span class="rzi"></span></a>
     </div>

--- a/Radzen.Blazor/RadzenSteps.razor
+++ b/Radzen.Blazor/RadzenSteps.razor
@@ -60,11 +60,11 @@
     {
     <div class="rz-steps-buttons">
         <a id="@(GetId() + "prev")" title="@PreviousTitle" arial-label="@PreviousAriaLabel" tabindex="@(IsFirstVisibleStep() ? -1 : 0)"
-           class='@($"rz-steps-prev {(IsFirstVisibleStep() ?  "rz-state-disabled" : "")}")'
+           class='@($"rz-steps-prev {(IsPreviousDisabled() ?  "rz-state-disabled" : "")}")' style="@(IsPreviousDisabled() ? "pointer-events: none; cursor: default" : "")"
                    @onkeypress="@(args => OnKeyPress(args, PrevStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@PrevStep" @onclick:preventDefault="true"><span class="rzi"></span>@PreviousText</a>
         <a id="@(GetId() + "next")" title="@NextTitle" arial-label="@NextAriaLabel" tabindex="@(IsLastVisibleStep() ? -1 : 0)"
-           class='@($"rz-steps-next {(IsLastVisibleStep() ?  "rz-state-disabled" : "")}")' 
+           class='@($"rz-steps-next {(IsNextDisabled() ?  "rz-state-disabled" : "")}")' style="@(IsNextDisabled() ? "pointer-events: none; cursor: default" : "")"
                    @onkeypress="@(args => OnKeyPress(args, NextStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@NextStep" @onclick:preventDefault="true">@NextText<span class="rzi"></span></a>
     </div>

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -181,6 +181,43 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback<StepsCanChangeEventArgs> CanChange { get; set; }
 
+
+        /// <summary>
+        /// A boolean that sets the disabled or enabled state of the next button.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// &lt;RadzenSteps @ref="steps"&gt;
+        /// &lt;/RadzenSteps&gt;
+        /// @code {
+        ///  void OnActionTakenByUser()
+        ///  {
+        ///     // Condition not met to move forward
+        ///     steps.AllowNext = false;
+        ///  }
+        /// }
+        /// </code>
+        /// </example>
+        public bool AllowNext { get; set; }
+
+        /// <summary>
+        /// A boolean that sets the disabled or enabled state of the previous button.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// &lt;RadzenSteps @ref="steps"&gt;
+        /// &lt;/RadzenSteps&gt;
+        /// @code {
+        ///  void OnActionTakenByUser()
+        ///  {
+        ///     // Condition not met to movebackwards 
+        ///     steps.AllowPrevious = false;
+        ///  }
+        /// }
+        /// </code>
+        /// </example>
+        public bool AllowPrevious { get; set; }
+
         private string _nextStep = "Next";
         /// <summary>
         /// Gets or sets the next button text.
@@ -429,6 +466,16 @@ namespace Radzen.Blazor
             {
                 preventKeyPress = false;
             }
+        }
+
+        private bool IsPreviousDisabled()
+        {
+            return IsFirstVisibleStep() || !AllowPrevious;
+        }
+
+        private bool IsNextDisabled()
+        {
+            return IsLastVisibleStep() || !AllowNext;
         }
     }
 }

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -468,11 +468,15 @@ namespace Radzen.Blazor
             }
         }
 
+        private string DissabledStyle => "pointer-events: none; opacity: 0.5; cursor:default";
+        
+        private string PrevioustButtonStyle => IsPreviousDisabled() ? DissabledStyle : "";
         private bool IsPreviousDisabled()
         {
             return IsFirstVisibleStep() || !AllowPrevious;
         }
-
+        
+        private string NextButtonStyle => IsNextDisabled() ? DissabledStyle : "";
         private bool IsNextDisabled()
         {
             return IsLastVisibleStep() || !AllowNext;

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -198,7 +198,7 @@ namespace Radzen.Blazor
         /// }
         /// </code>
         /// </example>
-        public bool AllowNext { get; set; }
+        public bool AllowNext { get; set; } = true;
 
         /// <summary>
         /// A boolean that sets the disabled or enabled state of the previous button.
@@ -216,7 +216,7 @@ namespace Radzen.Blazor
         /// }
         /// </code>
         /// </example>
-        public bool AllowPrevious { get; set; }
+        public bool AllowPrevious { get; set; } = true;
 
         private string _nextStep = "Next";
         /// <summary>

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -470,7 +470,7 @@ namespace Radzen.Blazor
 
         private string DissabledStyle => "pointer-events: none; opacity: 0.5; cursor:default";
         
-        private string PrevioustButtonStyle => IsPreviousDisabled() ? DissabledStyle : "";
+        private string PreviousButtonStyle => IsPreviousDisabled() ? DissabledStyle : "";
         private bool IsPreviousDisabled()
         {
             return IsFirstVisibleStep() || !AllowPrevious;

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -391,6 +391,16 @@ namespace Radzen.Blazor
         {
             var newIndex = steps.IndexOf(step);
 
+            if (newIndex > SelectedIndex && !AllowNext)
+            {
+                return;
+            }
+            
+            if (newIndex < SelectedIndex && !AllowPrevious)
+            {
+                return;
+            }
+            
             var canChangeArgs = new StepsCanChangeEventArgs { SelectedIndex = SelectedIndex, NewIndex = newIndex };
 
             await CanChange.InvokeAsync(canChangeArgs);
@@ -468,15 +478,11 @@ namespace Radzen.Blazor
             }
         }
 
-        private string DissabledStyle => "pointer-events: none; opacity: 0.5; cursor:default";
-        
-        private string PreviousButtonStyle => IsPreviousDisabled() ? DissabledStyle : "";
         private bool IsPreviousDisabled()
         {
             return IsFirstVisibleStep() || !AllowPrevious;
         }
         
-        private string NextButtonStyle => IsNextDisabled() ? DissabledStyle : "";
         private bool IsNextDisabled()
         {
             return IsLastVisibleStep() || !AllowNext;

--- a/RadzenBlazorDemos/Pages/StepsAllowPreviousNext.razor
+++ b/RadzenBlazorDemos/Pages/StepsAllowPreviousNext.razor
@@ -1,0 +1,43 @@
+@inject DialogService DialogService
+
+<RadzenSteps @ref="steps" Change="OnChange">
+    <Steps>
+        <RadzenStepsItem>
+            <div class="rz-p-12 rz-text-align-center">
+                <RadzenButton Text="Enable next" Click="@EnableNext"/>
+            </div>
+        </RadzenStepsItem>
+        <RadzenStepsItem>
+            <div class="rz-p-12 rz-text-align-center">
+                <RadzenButton Text="Enable previous" Click="@EnablePrevious" />
+                <RadzenButton Text="Enable next" Click="@EnableNext" />
+            </div>
+        </RadzenStepsItem>
+        <RadzenStepsItem>
+            <div class="rz-p-12 rz-text-align-center">
+                <RadzenButton Text="Enable previous" Click="@EnablePrevious" />
+            </div>  
+        </RadzenStepsItem>
+    </Steps>
+</RadzenSteps>
+
+@code {
+    
+    private RadzenSteps steps;
+    
+    private void OnChange()
+    {
+        steps.AllowPrevious = false;
+        steps.AllowNext = false;
+    }
+    
+    private void EnablePrevious()
+    {
+        steps.AllowPrevious = true;
+    }
+    
+    private void EnableNext()
+    {
+        steps.AllowNext = true;
+    }
+}

--- a/RadzenBlazorDemos/Pages/StepsPage.razor
+++ b/RadzenBlazorDemos/Pages/StepsPage.razor
@@ -20,3 +20,13 @@
 <RadzenExample ComponentName="StepsCanChange" Example="StepsCanChange">
     <StepsCanChange />
 </RadzenExample>
+
+<RadzenText Anchor="steps#allowpreviousnext-flag" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    AllowPrevious and AllowNext flags 
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    The <code>AlowPrevious</code> and <code>AllowNext</code> properties allow you to control the enablement of the previous and next buttons respectively.
+</RadzenText>
+<RadzenExample ComponentnAME="StepsAllowPreviousNext" Example="StepsAllowPreviousNext">
+    <StepsAllowPreviousNext />
+</RadzenExample>


### PR DESCRIPTION
The purpose of this PR is to enable the RadzenSteps component to provide more control over the flow of moving between steps. As well as making more clarity in the logic flow.

Things done:

- Renamed the CanChange event to BeforeChange: This is becase the CanChange event did not actually prevent the user clicking the change buttons, instead it allowed the button to be clicked and then the event handler had to do something to prevent that from happening.

- Added AllowPrevious and AllowNext boolean flags: Using these flags, the steps provide more control of when a user can go forward or backwards. This way, a user can be completelly prevented from triggering the previous/next button until they perform a required action in the wizard.