### PR TITLE
RadzenTree AllowCheckOnLabelClick parameter

### DIFF
--- a/Radzen.Blazor/RadzenTree.razor.cs
+++ b/Radzen.Blazor/RadzenTree.razor.cs
@@ -183,6 +183,12 @@ namespace Radzen.Blazor
         /// </summary>
         [Parameter]
         public bool AllowCheckParents { get; set; } = true;
+        
+        /// <summary>
+        /// Specifies whether clicking on a item's label will check its checkbox. Set to <c>true</c> by default.
+        /// </summary>
+        [Parameter]
+        public bool AllowCheckOnLabelClick { get; set; } = true;
 
         /// <summary>
         /// Specifies whether siblings items are collapsed. Set to <c>false</c> by default.

--- a/Radzen.Blazor/RadzenTreeItem.razor
+++ b/Radzen.Blazor/RadzenTreeItem.razor
@@ -18,7 +18,14 @@
             <div class="rz-treenode-label" @onkeydown:stopPropagation>@Template(this)</div>
         } else
         {
-            <span for="@(GetHashCode())" class="rz-treenode-label">@Text</span>
+            if (Tree.AllowCheckOnLabelClick)
+            {
+                <label for="@(GetHashCode())" class="rz-treenode-label">@Text</label>
+            }
+            else
+            {
+                <span class="rz-treenode-label">@Text</span>
+            }
         }
     </div>
     @if (ChildContent != null && expanded)

--- a/Radzen.Blazor/themes/components/blazor/_tree.scss
+++ b/Radzen.Blazor/themes/components/blazor/_tree.scss
@@ -87,6 +87,7 @@ $tree-transition: var(--rz-transition-all), width 0, height 0 !default;
   .rz-treenode-label {
     display: flex;
     align-items: center;
+    cursor: inherit;
     padding-block: var(--rz-tree-node-padding-block);
     padding-inline: var(--rz-tree-node-padding-inline);
 


### PR DESCRIPTION
This PR add a new parameter to RadzenTree to allow users to click on the label of an item to check its checkbox.

When the parameter is true, the `span` is replaced with a `label` tag. I moved the `for` attribute to this new `label`, as a `span` cannot use it.

I also added a `cursor: inherit;` style to the `.rz-treenode-label` class to overwrite the `cursor: default;` style set by browsers on the `label` tag.