### PR TITLE
Add Reload method to RadzenTree

### DIFF
--- a/Radzen.Blazor/RadzenTree.razor.cs
+++ b/Radzen.Blazor/RadzenTree.razor.cs
@@ -326,6 +326,35 @@ namespace Radzen.Blazor
             SelectedItem?.Unselect();
             SelectedItem = null;
         }
+
+        /// <summary>
+        /// Forces the specified <paramref name="item"/> or, if
+        /// <paramref name="item"/> is <c>null</c>, all items in the tree to be
+        /// re-evaluated such that items lazily created via <see cref="Expand"/>
+        /// are realised if the underlying data model has been changed from
+        /// somewhere else.
+        /// </summary>
+        /// <param name="item">The item to be reloaded or <c>null</c> to refresh
+        /// the root nodes of the tree.</param>
+        /// <returns>A task to wait for the operation to complete.</returns>
+        public async Task Reload(RadzenTreeItem item = null) {
+            // Implementation node: I am absolute not sure whether "ExpandItem"
+            // is the "right" way to to this, but it does exactly what I need.
+            // The rationale behind the public "Reload" method is that (i) just
+            // making "ExpandItem" public would create an API that is not
+            // intuitively named and (ii) if "ExpandItem" gets changed in the
+            // future such that it cannot be used for this hack anymore, the
+            // implementation could be swapped with a different one without
+            // breaking the public API.
+            if (item == null) {
+                foreach (var i in this.items) {
+                    await this.ExpandItem(i);
+                }
+            } else {
+                await this.ExpandItem(item);
+            }
+        }
+
         internal async Task ExpandItem(RadzenTreeItem item)
         {
             var args = new TreeExpandEventArgs()

--- a/RadzenBlazorDemos/Pages/TreeDataBindingRefresh.razor
+++ b/RadzenBlazorDemos/Pages/TreeDataBindingRefresh.razor
@@ -4,7 +4,7 @@
 <RadzenRow class="rz-p-0 rz-p-lg-12">
     <RadzenColumn Size="12" SizeLG="6" OffsetLG="3">
         <RadzenCard>
-            <RadzenTree Data=@entries Expand=@LoadSubsidiaries ItemContextMenu="@this.GetContextMenuForNode" Style="width: 100%; height: 300px">
+            <RadzenTree @ref="this.tree" Data=@entries Expand=@LoadSubsidiaries ItemContextMenu="@this.GetContextMenuForNode" Style="width: 100%; height: 300px">
                 <RadzenTreeLevel Text="@this.GetTextForNode" />
             </RadzenTree>
         </RadzenCard>
@@ -22,6 +22,7 @@
 
     IEnumerable<string> entries;
     string subsidiary;
+    RadzenTree tree = new();
 
     protected override void OnInitialized() {
         entries = ["Volkswagen Group"];
@@ -41,11 +42,10 @@
     );
 
         if ((result is string s) && !string.IsNullOrWhiteSpace(s)) {
-            var subsidiaries = Data[parent];
-            if (subsidiaries == null) {
-                Data[parent] = [s];
-            } else {
+            if (Data.TryGetValue(parent, out var subsidiaries)) {
                 Data[parent] = subsidiaries.Append(s);
+            } else {
+                Data[parent] = [s];
             }
         }
     }
@@ -54,6 +54,7 @@
         this.ContextMenuService.Open(args, [new ContextMenuItem() { Text = "Add" }], async (e) => {
             this.subsidiary = null;
             await this.AddSubsidiary(args.Text);
+            await this.tree.Reload();
         });
     }
 

--- a/RadzenBlazorDemos/Pages/TreeDataBindingRefresh.razor
+++ b/RadzenBlazorDemos/Pages/TreeDataBindingRefresh.razor
@@ -54,6 +54,7 @@
         this.ContextMenuService.Open(args, [new ContextMenuItem() { Text = "Add" }], async (e) => {
             this.subsidiary = null;
             await this.AddSubsidiary(args.Text);
+            // Force the tree to re-evaluate LoadSubsidiaries to make the change visible.
             await this.tree.Reload();
         });
     }

--- a/RadzenBlazorDemos/Pages/TreeDataBindingRefresh.razor
+++ b/RadzenBlazorDemos/Pages/TreeDataBindingRefresh.razor
@@ -1,0 +1,71 @@
+@inject ContextMenuService ContextMenuService
+@inject DialogService DialogService
+
+<RadzenRow class="rz-p-0 rz-p-lg-12">
+    <RadzenColumn Size="12" SizeLG="6" OffsetLG="3">
+        <RadzenCard>
+            <RadzenTree Data=@entries Expand=@LoadSubsidiaries ItemContextMenu="@this.GetContextMenuForNode" Style="width: 100%; height: 300px">
+                <RadzenTreeLevel Text="@this.GetTextForNode" />
+            </RadzenTree>
+        </RadzenCard>
+    </RadzenColumn>
+</RadzenRow>
+
+@code {
+    private static readonly Dictionary<string, IEnumerable<string>> Data = new() {
+        { "Volkswagen Group", ["Audi AG", "Dr. Ing. h.c. F. Porsche Aktiengesellschaft", "Seat S.A.", "Škoda Auto a.s.", "Volkswagen"] },
+        { "Audi AG", ["Audi Sport GmbH", "Automobili Lamborghini S.p.A.", "Bentley Motors Ltd."] },
+        { "Seat S.A.", ["Seat Cupra S.A.U."] },
+        { "Volkswagen", ["Volkswagen Nutzfahrzeuge"] },
+        { "Automobili Lamborghini S.p.A.", ["Ducati Motor Holding S.p.A.", "Italdesign Giugiaro S.p.A."]}
+    };
+
+    IEnumerable<string> entries;
+    string subsidiary;
+
+    protected override void OnInitialized() {
+        entries = ["Volkswagen Group"];
+    }
+
+    private async Task AddSubsidiary(string parent) {
+        var result = await DialogService.OpenAsync("Add a subsidiary", d =>
+    @<RadzenStack Gap="1.5rem">
+        <RadzenTextBox @bind-Value="this.subsidiary" Placeholder="Name the subsidiary." />
+        <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween">
+            <RadzenStack Orientation="Orientation.Horizontal">
+                <RadzenButton Text="Ok" Click="() => d.Close(this.subsidiary)" Style="width: 80px;" />
+                <RadzenButton Text="Cancel" Click="() => d.Close(null)" ButtonStyle="ButtonStyle.Light" />
+            </RadzenStack>
+        </RadzenStack>
+    </RadzenStack>
+    );
+
+        if ((result is string s) && !string.IsNullOrWhiteSpace(s)) {
+            var subsidiaries = Data[parent];
+            if (subsidiaries == null) {
+                Data[parent] = [s];
+            } else {
+                Data[parent] = subsidiaries.Append(s);
+            }
+        }
+    }
+
+    private void GetContextMenuForNode(TreeItemContextMenuEventArgs args) {
+        this.ContextMenuService.Open(args, [new ContextMenuItem() { Text = "Add" }], async (e) => {
+            this.subsidiary = null;
+            await this.AddSubsidiary(args.Text);
+        });
+    }
+
+    private string GetTextForNode(object data) => (string)data;
+
+    private void LoadSubsidiaries(TreeExpandEventArgs args) {
+        var company = args.Value as string;
+
+        if (Data.TryGetValue(company, out var subsidiaries)) {
+            args.Children.Data = subsidiaries;
+            args.Children.HasChildren = c => Data.TryGetValue((string) c, out var _);
+            args.Children.Checkable = o => false;
+        }
+    }
+}

--- a/RadzenBlazorDemos/Pages/TreeDataBindingRefreshPage.razor
+++ b/RadzenBlazorDemos/Pages/TreeDataBindingRefreshPage.razor
@@ -1,0 +1,12 @@
+@page "/tree-data-binding-refresh"
+
+<RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
+    Refreshing tree data-binding
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    Lazily populate a RadzenTree and refresh it programmatically. Use the context menu of a node to open a dialog for adding new child items in the data model.
+</RadzenText>
+
+<RadzenExample ComponentName="Tree" Example="TreeDataBindingRefresh">
+    <TreeDataBindingRefresh />
+</RadzenExample>

--- a/RadzenBlazorDemos/RadzenBlazorDemos.csproj
+++ b/RadzenBlazorDemos/RadzenBlazorDemos.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
 	<PublishTrimmed>false</PublishTrimmed>
 	<WasmEnableWebcil>false</WasmEnableWebcil>
-	<UserSecretsId>c17b1963-c1e5-44b1-8a5f-f35b6fc0471e</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Radzen.Blazor" Version="*" Condition="'$(Configuration)' == 'Release'" />

--- a/RadzenBlazorDemos/RadzenBlazorDemos.csproj
+++ b/RadzenBlazorDemos/RadzenBlazorDemos.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
 	<PublishTrimmed>false</PublishTrimmed>
 	<WasmEnableWebcil>false</WasmEnableWebcil>
+	<UserSecretsId>c17b1963-c1e5-44b1-8a5f-f35b6fc0471e</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Radzen.Blazor" Version="*" Condition="'$(Configuration)' == 'Release'" />

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -900,6 +900,14 @@ namespace RadzenBlazorDemos
                             Description = "This example demonstrates context menu in RadzenTree.",
                             Path = "tree-contextmenu",
                             Tags = new [] { "tree", "treeview", "nodes", "context", "menu" },
+                        },
+                        new Example
+                        {
+                            Name = "Refreshing tree data-binding",
+                            Title = "Blazor Tree Component - Refreshing tree data-binding | Free UI Components by Radzen",
+                            Description = "This example demonstrates how to refresh a lazily loaded RadzenTree.",
+                            Path = "tree-data-binding-refresh",
+                            Tags = new [] { "tree", "treeview", "nodes" },
                         }
                     }
                 },


### PR DESCRIPTION
This PR follows up on the discussion at https://forum.radzen.com/t/programmatically-refresh-branch-of-radzentree-created-in-expand-callback/17892.

The problem to be solved are trees that are lazily created from a data source that is outside the control of the application like the file system tree example. If that example would be exteded to allow users adding files, the tree needs to be reloaded programmatically after the operation completed.

The internal `RadzenTree.ExpandItem` method would re-evaluate the `RadzenTree.Expand` callback, but it cannot be called outside. As I am unsure whether there are any unforeseen consequences of making this API public, I have instead added a new `RadzenTree.Reload` method that calls `ExpandItem` instead.

The `TreeDataBindingRefresh` example in the PR demonstrates how I would imagine the API being used. Note that it is a bit pointless to use an in-memory source, but creating an example that allows for writing on the server seemed unwise.