### PR TITLE
Improved FileInput Image Preview Rendering

### DIFF
--- a/Radzen.Blazor/RadzenFileInput.razor
+++ b/Radzen.Blazor/RadzenFileInput.razor
@@ -23,7 +23,7 @@
                         <div>
                             @if (IsImage)
                             {
-                                <img style="@ImageStyle" src="@Value" @onclick="@OnImageClick" alt="@ImageAlternateText" />
+                                <img style="@ImageStyle" src="@ImageValue" @onclick="@OnImageClick" alt="@ImageAlternateText" />
                             }
                         </div>
                         <div>

--- a/Radzen.Blazor/RadzenFileInput.razor.cs
+++ b/Radzen.Blazor/RadzenFileInput.razor.cs
@@ -100,6 +100,23 @@ namespace Radzen.Blazor
             }
         }
 
+        private string ImageValue
+        {
+            get
+            {
+                if (Value == null)
+                {
+                    return string.Empty;
+                }
+                else if (Value is byte[] bytes)
+                {
+                    return System.Text.Encoding.Default.GetString(bytes);
+                }
+
+                return Value.ToString();
+            }
+        }
+
         async Task OnChange()
         {
             string uploadValue;

--- a/RadzenBlazorDemos/Pages/FileInputByteArray.razor
+++ b/RadzenBlazorDemos/Pages/FileInputByteArray.razor
@@ -1,0 +1,26 @@
+﻿<RadzenStack AlignItems="AlignItems.Center">
+    <RadzenCard class="rz-m-0 rz-m-md-12" Style="width: 100%; max-width: 600px;">
+        <RadzenFileInput @bind-Value=@photo @bind-FileName=@fileName @bind-FileSize=@fileSize TValue="byte[]" Style="width: 100%" 
+            Change=@(args => OnChange(args, "FileInput")) Error=@(args => OnError(args, "FileInput")) InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "select file" }})"/>
+    </RadzenCard>
+</RadzenStack>
+
+<EventConsole @ref=@console />
+
+@code {
+    EventConsole console;
+    byte[] photo;
+
+    string fileName;
+    long? fileSize;
+
+    void OnChange(byte[] value, string name)
+    {
+        console.Log($"{name} value changed");
+    }
+
+    void OnError(UploadErrorEventArgs args, string name)
+    {
+        console.Log($"{args.Message}");
+    }
+}

--- a/RadzenBlazorDemos/Pages/FileInputPage.razor
+++ b/RadzenBlazorDemos/Pages/FileInputPage.razor
@@ -11,6 +11,16 @@
     <FileInputConfig />
 </RadzenExample>
 
+<RadzenText Anchor="fileinput#byte-array" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    Byte Array Support
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    The <strong>FileInput</strong> component also supports the use of the <strong>byte[]</strong> type.
+</RadzenText>
+<RadzenExample ComponentName="FileInput" Example="FileInputByteArray">
+    <FileInputByteArray />
+</RadzenExample>
+
 <RadzenText Anchor="fileinput#keyboard-navigation" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
     Keyboard Navigation
 </RadzenText>


### PR DESCRIPTION
The RadzenFileInput component has support for `byte[]` in addition to the default of `string`, however when using `byte[]` the image preview would not display correctly as it would just reference Value directly for the src attribute of the preview img. This would result in something like the following: 
![CleanShot 2024-09-07 at 09 39 53](https://github.com/user-attachments/assets/255da44a-6263-430b-a7b8-4eee19389b3e)

To address this I have added a new private get only property that will decode the Value if the TValue is of `byte[]`. This results in the image preview behaving normally eg: 
![CleanShot 2024-09-07 at 11 28 17](https://github.com/user-attachments/assets/f5f01bf6-a34c-43c4-9efd-c385034ed74a)

Additionally I have added a corresponding demo to the FileInput Demos to highlight this usage. 

Pleases let me know if additional changes are required. I tried to keep things aligned style wise where I could and as this is my first PR on this project any feedback would be appreciated 😄  