### PR TITLE
NumericRangeValidator: AllowNull

### DIFF
--- a/Radzen.Blazor.Tests/NumericRangeValidatorTests.cs
+++ b/Radzen.Blazor.Tests/NumericRangeValidatorTests.cs
@@ -71,7 +71,7 @@ namespace Radzen.Blazor.Tests
                 component.SetParametersAndRender(parameters => parameters.Add(p => p.Min, 0).Add(p => p.Max, 10).Add(p => p.AllowNull, true));
             });
 
-            Assert.False(component.Instance.Validate(null));
+            Assert.True(component.Instance.Validate(null));
         }
 
         [Fact]

--- a/Radzen.Blazor.Tests/NumericRangeValidatorTests.cs
+++ b/Radzen.Blazor.Tests/NumericRangeValidatorTests.cs
@@ -60,6 +60,19 @@ namespace Radzen.Blazor.Tests
 
             Assert.False(component.Instance.Validate(null));
         }
+        [Fact]
+        public void Returns_True_If_Value_Is_Null_And_AllowNull_Is_True()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenNumericRangeValidatorTestDouble>();
+
+            component.SetParametersAndRender(parameters =>
+            {
+                component.SetParametersAndRender(parameters => parameters.Add(p => p.Min, 0).Add(p => p.Max, 10).Add(p => p.AllowNull, true));
+            });
+
+            Assert.False(component.Instance.Validate(null));
+        }
 
         [Fact]
         public void Returns_False_If_Value_Overflows()

--- a/Radzen.Blazor/RadzenNumericRangeValidator.cs
+++ b/Radzen.Blazor/RadzenNumericRangeValidator.cs
@@ -42,6 +42,12 @@ namespace Radzen.Blazor
         [Parameter]
         public IComparable Max { get; set; }
 
+        /// <summary>
+        /// Specifies if value can be null. If true, range validation will only be tested if component value is not null.
+        /// </summary>
+        [Parameter]
+        public bool AllowNull { get; set; } = false;
+
         /// <inheritdoc />
         protected override bool Validate(IRadzenFormComponent component)
         {
@@ -54,7 +60,7 @@ namespace Radzen.Blazor
 
             if (value == null)
             {
-                return false;
+                return AllowNull ? true : false;
             }
 
 

--- a/Radzen.Blazor/RadzenNumericRangeValidator.cs
+++ b/Radzen.Blazor/RadzenNumericRangeValidator.cs
@@ -43,7 +43,7 @@ namespace Radzen.Blazor
         public IComparable Max { get; set; }
 
         /// <summary>
-        /// Specifies if value can be null. If true, range validation will only be tested if component value is not null.
+        /// Specifies if value can be null. If true, a null component value will be accepted.
         /// </summary>
         [Parameter]
         public bool AllowNull { get; set; } = false;


### PR DESCRIPTION
Adds property `AllowNull` to `RadzenNumericRangeValidator`, with default value `false`; default behavior is hence unchanged.

If set to `true`, null component values are validated as OK.

Added a test for this case.