### PR TITLE
Correction on how to get scrollTop and scrollLeft on openPopup

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -1066,13 +1066,8 @@ window.Radzen = {
 
     var parentRect = parent ? parent.getBoundingClientRect() : { top: y || 0, bottom: 0, left: x || 0, right: 0, width: 0, height: 0 };
 
-    if (/Edge/.test(navigator.userAgent)) {
-      var scrollLeft = document.body.scrollLeft;
-      var scrollTop = document.body.scrollTop;
-    } else {
-      var scrollLeft = document.documentElement.scrollLeft;
-      var scrollTop = document.documentElement.scrollTop;
-    }
+    var scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft;
+    var scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
 
     var top = y ? y : parentRect.bottom;
     var left = x ? x : parentRect.left;


### PR DESCRIPTION
The issue:
When the Dropdown is used after the scroll, (after 100vh), when oppening the dropdown popup, it would consider that the dropdown is at 100vh and would scroll the window up to render the popup above 100vh.

Got this issue on:
- Edge 121.0.2277.128
- OperaGX 113.0.5230.75

To resolve, instead of checking if it's edge to decide from where to get the scrollTop and scrollLeft, it just tries to get from one of them, regardless of the userAgent.