### PR TITLE
Created RadzenDropdown LoadDataOnOpen Parameter

### DIFF
--- a/Radzen.WebAssembly.sln
+++ b/Radzen.WebAssembly.sln
@@ -23,18 +23,10 @@ Global
 		{DF9EC444-791A-415A-A3EB-C4B008E5FCB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF9EC444-791A-415A-A3EB-C4B008E5FCB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF9EC444-791A-415A-A3EB-C4B008E5FCB5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BC20637F-A979-425A-9C3F-D72633FE555C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BC20637F-A979-425A-9C3F-D72633FE555C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BC20637F-A979-425A-9C3F-D72633FE555C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BC20637F-A979-425A-9C3F-D72633FE555C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{18702B3F-791E-45F3-BCFD-1792A1300AAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{18702B3F-791E-45F3-BCFD-1792A1300AAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{18702B3F-791E-45F3-BCFD-1792A1300AAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{18702B3F-791E-45F3-BCFD-1792A1300AAB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EC869401-304A-45BC-93CA-C1CDFAAA7F7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EC869401-304A-45BC-93CA-C1CDFAAA7F7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC869401-304A-45BC-93CA-C1CDFAAA7F7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EC869401-304A-45BC-93CA-C1CDFAAA7F7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RadzenBlazorDemos/Pages/DropdownLoadDataOnOpen.razor
+++ b/RadzenBlazorDemos/Pages/DropdownLoadDataOnOpen.razor
@@ -1,0 +1,33 @@
+﻿@page "/dropdown-load-data-on-open"
+
+<RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.Center" Gap="0.5rem" class="rz-p-sm-12">
+    <RadzenLabel Text="Select Value" Component="DropDownLoadOnOpen" />
+    <RadzenDropDown Data="@Data"
+                    @bind-Value=@Values
+                    AllowClear
+                    AllowFiltering
+                    FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                    Style="width: 100%; max-width: 400px;"
+                    Name="DropDownLoadOnOpen"
+                    Multiple
+                    LoadData="@LoadData"
+                    LoadDataOnOpen>
+    </RadzenDropDown>
+</RadzenStack>
+<EventConsole @ref="console" />
+
+@code {
+    private List<string> Data { get; set; } = [];
+    private List<string> Values { get; set; } = [];
+
+    private EventConsole console { get; set; }
+
+    private void LoadData(LoadDataArgs args)
+    {
+        console.Log("loaded");
+
+        Data = ["Value 1", "Value 2", "Value 3", "Value 4", "Value 5"];
+
+        StateHasChanged();
+    }
+}


### PR DESCRIPTION
The issue:
On an app I have a dropdown component that uses RadzenDropdown and searchs on database for the options based on the Value type.
On a specific page of mass creation I have about 100 dropdowns that search on the dabase in generic ways, so it triggers about 100 SQL's in a very short time, what causes the database license to return an error for too many users.

The solution:
In order to not have to handle it manually every time I have this kind of scenario, I added a LoadDataOnOpen parameter to RadzenDropdown that basically does not trigger the LoadData on the dropdown initialization and runs it on the first time that the popup is oppened.

Also created a Demo for test on "/dropdown-load-data-on-open"