### PR TITLE
Enum filtering using underlying types other than Int32 is now supported.

### DIFF
--- a/Radzen.Blazor/Extensions.cs
+++ b/Radzen.Blazor/Extensions.cs
@@ -35,7 +35,8 @@ namespace Radzen.Blazor
         /// </summary>
         public static IEnumerable<object> EnumAsKeyValuePair(Type enumType, Func<string, string> translationFunction = null)
         {
-            return Enum.GetValues(enumType).Cast<Enum>().Distinct().Select(val => new { Value = Convert.ToInt32(val), Text = val.GetDisplayDescription(translationFunction) });
+            Type underlyingType = Enum.GetUnderlyingType(enumType);
+            return Enum.GetValues(enumType).Cast<Enum>().Distinct().Select(val => new { Value = Convert.ChangeType(val, underlyingType), Text = val.GetDisplayDescription(translationFunction) });
         }
 
         /// <summary>

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -152,13 +152,14 @@ namespace Radzen
                     }
                     else if (PropertyAccess.IsEnum(column.FilterPropertyType) || PropertyAccess.IsNullableEnum(column.FilterPropertyType))
                     {
+                        Type enumType = Enum.GetUnderlyingType(column.FilterPropertyType);
                         if (v != null)
                         {
-                            value = ((int)v).ToString();
+                            value = Convert.ChangeType(v, enumType).ToString();
                         }
                         if (sv != null)
                         {
-                            secondValue = ((int)sv).ToString();
+                            secondValue = Convert.ChangeType(sv, enumType).ToString();
                         }
                     }
                     else if (IsEnumerable(column.FilterPropertyType) && column.FilterPropertyType != typeof(string))

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -1052,7 +1052,8 @@ namespace Radzen.Blazor
 
             if (PropertyAccess.IsEnum(FilterPropertyType) || (PropertyAccess.IsNullableEnum(FilterPropertyType)))
             {
-                value = value is not null ? (int)value : null;
+                Type enumType = Enum.GetUnderlyingType(FilterPropertyType);
+                value = value is not null ? Convert.ChangeType(value, enumType) : null;
             }
 
             if (isFirst)


### PR DESCRIPTION
Currently Enum filtering only supports underlying types of Int32.

Reproducible example using the datagrid-enum-filter example (https://blazor.radzen.com/datagrid-enum-filter). Change the GenderType enum from:

```
public enum GenderType
{
    Ms,
    Mr,
    Unknown,
}
```

to

```
public enum GenderType : long
{
    Ms=0x100000000,
    Mr=0x100000001,
    Unknown=0x100000010,
}
```

and click run. The application throws the following exception:
```
System.OverflowException: Value was either too large or too small for an Int32.
```

Cheers!
