### PR TITLE
Use ToString() on property to filter in DataGrid CheckBoxList to check for empty strings

### DIFF
--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -267,7 +267,7 @@ else
                 query = query.Take(loadDataArgs.Top.Value);
             }
 
-            filterValues = query.Select("it => it == string.Empty ? null : it");
+            filterValues = query.Select("it => it.ToString() == string.Empty ? null : it");
 
             if (!Column.AllowCheckBoxListVirtualization)
             {


### PR DESCRIPTION
The change in 35c9f55c413353a18bf96ae523a596f8d9cc00af broke filtering when the property to be filtered was not a string.

Using `ToString()` on the property before the check for `string.Empty` fixes this.