### PR TITLE
Added DropDownTemplate / DropDownTextProperty to specify a different template / property name in the drop down list

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -228,11 +228,25 @@ namespace Radzen
         public RenderFragment<dynamic> Template { get; set; }
 
         /// <summary>
+        /// Gets or sets the template in drop down.
+        /// </summary>
+        /// <value>The template in drop down.</value>
+        [Parameter]
+        public RenderFragment<dynamic> DropDownTemplate { get; set; }
+
+        /// <summary>
         /// Gets or sets the value property.
         /// </summary>
         /// <value>The value property.</value>
         [Parameter]
         public string ValueProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value property.
+        /// </summary>
+        /// <value>The value property.</value>
+        [Parameter]
+        public string DropDownTextProperty { get; set; }
 
         /// <summary>
         /// Gets or sets the disabled property.
@@ -449,6 +463,11 @@ namespace Radzen
                     textPropertyGetter = GetGetter(TextProperty, type);
                 }
 
+                if (!string.IsNullOrEmpty(DropDownTextProperty))
+                {
+                    dropDownTextPropertyGetter = GetGetter(DropDownTextProperty, type);
+                }
+
                 if (!string.IsNullOrEmpty(DisabledProperty))
                 {
                     disabledPropertyGetter = GetGetter(DisabledProperty, type);
@@ -471,6 +490,7 @@ namespace Radzen
 
         internal Func<object, object> valuePropertyGetter;
         internal Func<object, object> textPropertyGetter;
+        internal Func<object, object> dropDownTextPropertyGetter;
         internal Func<object, object> disabledPropertyGetter;
 
         /// <summary>
@@ -492,6 +512,10 @@ namespace Radzen
                 if (property == TextProperty)
                 {
                     return textPropertyGetter != null ? textPropertyGetter(item) : PropertyAccess.GetItemOrValueFromProperty(item, property);
+                }
+                else if (property == DropDownTextProperty)
+                {
+                    return dropDownTextPropertyGetter != null ? dropDownTextPropertyGetter(item) : PropertyAccess.GetItemOrValueFromProperty(item, property);
                 }
                 else if (property == ValueProperty)
                 {
@@ -678,7 +702,7 @@ namespace Radzen
                     var itemToSelect = items.ElementAtOrDefault(selectedIndex);
 
                     await JSRuntime.InvokeAsync<string>("Radzen.setInputValue", search, $"{searchText}".Trim());
-                    
+
                     if (itemToSelect != null)
                     {
                         await OnSelectItem(itemToSelect, true);

--- a/Radzen.Blazor/RadzenDropDownItem.razor
+++ b/Radzen.Blazor/RadzenDropDownItem.razor
@@ -5,49 +5,65 @@
 @{var itemArgs = DropDown?.ItemAttributes(this); }
 @if (itemArgs.Visible)
 {
-Disabled = itemArgs.Disabled;
-@if (DropDown.Multiple)
-{
-    <li class="@GetComponentCssClass("rz-multiselect")"
-        aria-label="@DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)"
+    Disabled = itemArgs.Disabled;
+    @if (DropDown.Multiple)
+    {
+        <li class="@GetComponentCssClass("rz-multiselect")"
+            aria-label="@DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)"
         @onmousedown:preventDefault @onmousedown="args=>SelectItem(args,false)"
-        @onclick:preventDefault @onclick="args=>SelectItem(args,true)" 
-        @attributes="@(itemArgs.Attributes.Any() ? itemArgs.Attributes : Attributes)">
-        <div class="rz-chkbox ">
-            <div class="@(DropDown.IsSelected(Item) ? "notranslate rz-chkbox-box rz-state-active" : "notranslate rz-chkbox-box") @(Disabled ? " rz-state-disabled  " : "")">
-                <span class="@(DropDown.IsSelected(Item) ? "notranslate rz-chkbox-icon rzi rzi-check" : "notranslate rz-chkbox-icon")"></span>
+        @onclick:preventDefault @onclick="args=>SelectItem(args,true)"
+            @attributes="@(itemArgs.Attributes.Any() ? itemArgs.Attributes : Attributes)">
+            <div class="rz-chkbox ">
+                <div class="@(DropDown.IsSelected(Item) ? "notranslate rz-chkbox-box rz-state-active" : "notranslate rz-chkbox-box") @(Disabled ? " rz-state-disabled  " : "")">
+                    <span class="@(DropDown.IsSelected(Item) ? "notranslate rz-chkbox-icon rzi rzi-check" : "notranslate rz-chkbox-icon")"></span>
+                </div>
             </div>
-        </div>
-        <span class="rz-multiselect-item-content">
-            @if (DropDown.Template != null)
-            {
-                @DropDown.Template(Item)
-            }
-            else
-            {
-                @DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)
-            }
-        </span>
-    </li>
-}
-else
-{
-    <li role="option" class="@GetComponentCssClass("rz-dropdown")" aria-label="@DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)"
-    @onmousedown:preventDefault @onmousedown="args=>SelectItem(args,false)"
-    @onclick:preventDefault @onclick="args=>SelectItem(args,true)"
-    @attributes="@(itemArgs.Attributes.Any() ? itemArgs.Attributes : Attributes)">
-        <span>
-            @if (DropDown.Template != null)
-            {
-                @DropDown.Template(Item)
-            }
-            else
-            {
-                @DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)
-            }
-       </span>
-    </li>
-}
+            <span class="rz-multiselect-item-content">
+                @if (DropDown.DropDownTemplate != null)
+                {
+                    @DropDown.DropDownTemplate(Item)
+                }
+                else if (DropDown.Template != null)
+                {
+                    @DropDown.Template(Item)
+                }
+                else if (!string.IsNullOrEmpty(DropDown.DropDownTextProperty))
+                {
+                    @DropDown.GetItemOrValueFromProperty(Item, DropDown.DropDownTextProperty)
+                }
+                else
+                {
+                    @DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)
+                }
+            </span>
+        </li>
+    }
+    else
+    {
+        <li role="option" class="@GetComponentCssClass("rz-dropdown")" aria-label="@DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)"
+        @onmousedown:preventDefault @onmousedown="args=>SelectItem(args,false)"
+        @onclick:preventDefault @onclick="args=>SelectItem(args,true)"
+            @attributes="@(itemArgs.Attributes.Any() ? itemArgs.Attributes : Attributes)">
+            <span>
+                @if (DropDown.DropDownTemplate != null)
+                {
+                    @DropDown.DropDownTemplate(Item)
+                }
+                else if (DropDown.Template != null)
+                {
+                    @DropDown.Template(Item)
+                }
+                else if (!string.IsNullOrEmpty(DropDown.DropDownTextProperty))
+                {
+                    @DropDown.GetItemOrValueFromProperty(Item, DropDown.DropDownTextProperty)
+                }
+                else
+                {
+                    @DropDown.GetItemOrValueFromProperty(Item, DropDown.TextProperty)
+                }
+            </span>
+        </li>
+    }
 }
 @code {
     [Parameter(CaptureUnmatchedValues = true)]


### PR DESCRIPTION
Added DropDownTemplate to specify a different template in the drop down list vs control
Added DropDownTextProperty to specify a different text property in the drop down list vs control
Uses the normal template / property name if undefined so no breaking changes.

![RadzenDropDown_DropDownTemplate_DropDownTextProperty](https://github.com/user-attachments/assets/d0920739-75be-4fa0-b2ae-ebff58695bb4)