### PR TITLE
Fix FilterString generation for the FilterOperator.In and FilterOperator.NotIn

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -166,20 +166,34 @@ namespace Radzen
                     {
                         var enumerableValue = ((IEnumerable)(v != null ? v : Enumerable.Empty<object>())).AsQueryable();
                         var enumerableSecondValue = ((IEnumerable)(sv != null ? sv : Enumerable.Empty<object>())).AsQueryable();
-                        
-                        var enumerableValueAsString = "(" + String.Join(",",
-                                (enumerableValue.ElementType == typeof(string) ? 
-                                        enumerableValue.Cast<string>().Select(i => $@"""{i}""").Cast<object>() 
-                                            : PropertyAccess.IsDate(enumerableValue.ElementType) ?
-                                                enumerableValue.Cast<object>().Select(i => $@"DateTime(""{i}"")").Cast<object>() 
-                                                    : enumerableValue.Cast<object>())) + ")";
 
-                        var enumerableSecondValueAsString = "(" + String.Join(",",
-                                (enumerableSecondValue.ElementType == typeof(string) ?
-                                        enumerableSecondValue.Cast<string>().Select(i => $@"""{i}""").Cast<object>()
-                                            : PropertyAccess.IsDate(enumerableSecondValue.ElementType) ?
-                                                enumerableSecondValue.Cast<object>().Select(i => $@"DateTime(""{i}"")").Cast<object>()
-                                                    : enumerableSecondValue.Cast<object>())) + ")";
+
+                        string baseType = column.FilterPropertyType.GetGenericArguments().Count() == 1
+                                              ? column.FilterPropertyType.GetGenericArguments()[0].Name
+                                              : "";
+                        var enumerableValueAsString = "new " + baseType + "[]{" + String.Join(",",
+                                                          (enumerableValue.ElementType == typeof(string)
+                                                               ? enumerableValue.Cast<string>().Select(i => $@"""{i}""")
+                                                                   .Cast<object>()
+                                                               : PropertyAccess.IsDate(enumerableValue.ElementType)
+                                                                   ? enumerableValue.Cast<object>()
+                                                                       .Select(i => $@"DateTime.Parse(""{i}"")")
+                                                                       .Cast<object>()
+                                                                   : enumerableValue.Cast<object>()
+                                                          )) + "}";
+
+
+                        var enumerableSecondValueAsString = "new " + baseType + "[]{" + String.Join(",",
+                                                                (enumerableSecondValue.ElementType == typeof(string)
+                                                                     ? enumerableSecondValue.Cast<string>()
+                                                                         .Select(i => $@"""{i}""").Cast<object>()
+                                                                     : PropertyAccess.IsDate(
+                                                                         enumerableSecondValue.ElementType)
+                                                                         ? enumerableSecondValue.Cast<object>()
+                                                                             .Select(i => $@"DateTime.Parse(""{i}"")")
+                                                                             .Cast<object>()
+                                                                         : enumerableSecondValue.Cast<object>()
+                                                                )) + "}";
 
                         if (enumerableValue?.Any() == true)
                         {


### PR DESCRIPTION
After the commit https://github.com/radzenhq/radzen-blazor/commit/0f7f7173300544493f4edd56682a5c59c8761e23?diff=split#diff-5e70b54e61695944357a6150dbcaf61f03f7c31d03f3e85fc1943de042d8f045R173, the filter in RadzenDataGrid broke.

An example for test can be found in the pull request: https://github.com/radzenhq/radzen-blazor/pull/1260

Current behavior:

https://github.com/user-attachments/assets/84cbb9d2-e418-42af-a748-814c4cb79144


**The FilterString generates an incorrect string: `"(Color).Intersect((Red)).Any()"`**


Fix:

https://github.com/user-attachments/assets/f8e62264-c386-43cd-87ea-e8e4f54e60f1



**The FilterString generates the correct string: `"(Color).Intersect(new ColorType[]{Red,AlmondGreen}).Any()"`**



Demo page:

```
@using System.Linq.Dynamic.Core
@using System.ComponentModel.DataAnnotations
@using Radzen.Blazor

@inject IJSRuntime JSRuntime

<RadzenDataGrid LoadData="LoadData" IsLoading=@isLoading Count="count" Data=@employees FilterMode="FilterMode.Simple"
				AllowFiltering="true" AllowPaging="true" AllowSorting="true" TItem="Employee" ColumnWidth="200px">
	<Columns>
		<RadzenDataGridColumn TItem="Employee" Property="ID" Title="ID" />
		<RadzenDataGridColumn TItem="Employee" Property="Gender" Title="Gender" />
		<RadzenDataGridColumn TItem="Employee" Property="Status" Title="Nullable Status" />
		<RadzenDataGridColumn TItem="Employee" Property="Color"
							  Title="Favorite Color (Display Attribute in Filter)"
							  Sortable="false" FilterOperator="FilterOperator.In" Type="typeof(IEnumerable<ColorType>)">
			<FilterTemplate>
				<RadzenDropDown TValue="IEnumerable<ColorType>" Value="context.GetFilterValue()"
								ValueChanged="v => context.SetFilterValueAsync(v)" Multiple="true" AllowClear="true"
								AllowSelectAll="false" Style="width:100%;"
								Data=_allColors TextProperty="Text" ValueProperty="Value" />
			</FilterTemplate>
			<Template Context="item">
				@(string.Join(", ", item.Color.ToList()))
			</Template>
		</RadzenDataGridColumn>
	</Columns>
</RadzenDataGrid>
<EventConsole @ref=@console />

@code {
	int count;
	IEnumerable<Employee> initialEmployees;
	IEnumerable<Employee> employees;
	bool isLoading = false;
	EventConsole console;

	public sealed record SelectListEnum<TEnum>(string Text, TEnum? Value);


	List<SelectListEnum<ColorType>> _allColors = Enum.GetValues(typeof(ColorType))
		.Cast<ColorType>()
		.Select(elem => new SelectListEnum<ColorType>
		(
			elem.GetDisplayDescription(),
			elem
		))
		.ToList();

	public class Employee
	{
		public int ID { get; set; }
		public GenderType Gender { get; set; }
		public StatusType? Status { get; set; }
		public IEnumerable<ColorType>? Color { get; set; }
	}

	public enum GenderType
	{
		Ms,
		Mr,
		Unknown,
	}

	public enum ColorType
	{
		Red,
		Green,
		Blue,
		[Display(Description = "Almond Green")]
		AlmondGreen,
		[Display(Description = "Amber Gray")]
		AmberGray,
		[Display(Description = "Apple Blue... ")]
		AppleBlueSeaGreen,
		[Display(Description = "Azure")]
		AzureBlue,

	}

	public enum StatusType
	{
		Inactive,
		Active,
	}

	protected override void OnInitialized()
	{
		initialEmployees = Enumerable.Range(0, 10).Select(i =>
			new Employee
				{
					ID = i,
					Gender = i < 3 ? GenderType.Mr : i < 6 ? GenderType.Ms : GenderType.Unknown,
					Status = i < 3 ? StatusType.Active : i < 6 ? StatusType.Inactive : null,
					Color = i < 3 ? [_allColors[0].Value, _allColors[2].Value]
						: i < 6 ? [_allColors[1].Value, _allColors[3].Value]
						: [_allColors[4].Value, _allColors[6].Value],
				});
	}

	void LoadData(LoadDataArgs args)
	{
		isLoading = true;
		console.Log($"LoadData. {DateTime.Now.ToLongTimeString()}");
		var query = initialEmployees.AsQueryable();

		if (!string.IsNullOrEmpty(args.Filter))
		{
			query = query.Where(args.Filter);
		}
		if (!string.IsNullOrEmpty(args.OrderBy))
		{
			query = query.OrderBy(args.OrderBy);
		}

		count = query.Count();

		employees = query.Skip(args.Skip.Value).Take(args.Top.Value).ToList();
		isLoading = false;

	}
}
```