### PR TITLE
Fix missing element reference for RadzenSplitterPane

### DIFF
--- a/Radzen.Blazor/RadzenSplitterPane.razor
+++ b/Radzen.Blazor/RadzenSplitterPane.razor
@@ -4,7 +4,7 @@
 
 @if (Visible)
 {
-    <div id="@GetId()" @attributes="Attributes" class="@GetComponentCssClass()" style="flex-basis: @Size; @Style" data-index="@Index">
+    <div @ref=Element id="@GetId()" @attributes="Attributes" class="@GetComponentCssClass()" style="flex-basis: @Size; @Style" data-index="@Index">
         @ChildContent
         @if (Splitter.IsResizing)
         {


### PR DESCRIPTION
`RadzenSplitterPane` implements `RadzenComponent` which contains the Element property, but `RadzenSplitterPane` does not assign it.