### PR TITLE
Add FilterSortOrder to RadzenDataFilterProperty

### DIFF
--- a/Radzen.Blazor/RadzenDataFilter.razor.cs
+++ b/Radzen.Blazor/RadzenDataFilter.razor.cs
@@ -294,15 +294,16 @@ namespace Radzen.Blazor
         /// Gets the properties collection.
         /// </summary>
         /// <value>The properties collection.</value>
-        public IList<RadzenDataFilterProperty<TItem>> PropertiesCollection
+        public List<RadzenDataFilterProperty<TItem>> PropertiesCollection
         {
             get
             {
-                return properties;
+                return properties.OrderBy(r => r.FilterSortOrder).ToList();
             }
         }
         
         internal List<RadzenDataFilterProperty<TItem>> properties = new List<RadzenDataFilterProperty<TItem>>();
+        
         internal void AddProperty(RadzenDataFilterProperty<TItem> property)
         {
             if (!properties.Contains(property))

--- a/Radzen.Blazor/RadzenDataFilterItem.razor
+++ b/Radzen.Blazor/RadzenDataFilterItem.razor
@@ -27,7 +27,7 @@
 }
 else
 {
-    <RadzenDropDown @bind-Value="@Filter.Property" Data="@(DataFilter?.properties)" TextProperty="Title" ValueProperty="Property" TValue="string"
+    <RadzenDropDown @bind-Value="@Filter.Property" Data="@(DataFilter?.PropertiesCollection)" TextProperty="Title" ValueProperty="Property" TValue="string"
                     DisabledProperty="@(DataFilter?.UniqueFilters == true ? nameof(property.IsSelected) : null)"
                     Change="@OnPropertyChange" AllowFiltering="@(DataFilter?.AllowColumnFiltering ?? false)" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive" class="rz-datafilter-property">
         <Template>

--- a/Radzen.Blazor/RadzenDataFilterProperty.cs
+++ b/Radzen.Blazor/RadzenDataFilterProperty.cs
@@ -153,6 +153,14 @@ namespace Radzen.Blazor
         [Parameter]
         public Type Type { get; set; }
 
+        /// <summary>
+        /// Gets or sets the FilterSortOrder.
+        /// Determines the sorting order of the filters.
+        /// </summary>
+        /// <value>The FilterSortOrder. Default value is 100.</value>
+        [Parameter]
+        public int FilterSortOrder { get; set; } = 100;
+
         Func<TItem, object> propertyValueGetter;
 
         internal object GetHeader()

--- a/RadzenBlazorDemos/Pages/DataFilterIQueryable.razor
+++ b/RadzenBlazorDemos/Pages/DataFilterIQueryable.razor
@@ -13,13 +13,15 @@
 
     <RadzenDataFilter @ref="dataFilter" Auto=auto Data="@orders" TItem="Order" ViewChanged=@ViewChanged FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive">
         <Properties>
-            <RadzenDataFilterProperty Property="@nameof(Order.OrderID)" Title="Order ID" FilterValue="@finalSelectedIds" 
-                Type="typeof(IEnumerable<int>)" FilterOperator="FilterOperator.Contains">
+            <RadzenDataFilterProperty Property="@nameof(Order.OrderID)" Title="Order ID" FilterValue="@finalSelectedIds"
+                                      Type="typeof(IEnumerable<int>)" FilterOperator="FilterOperator.Contains"
+                                      FilterSortOrder="1">
                 <FilterTemplate>
-                        <RadzenDropDown @bind-Value=@selectedIds Style="width:100%;"
-                        Change=@OnSelectedIdsChange Data="@(orderIds)" AllowClear="true" Multiple="true" />
+                    <RadzenDropDown @bind-Value=@selectedIds Style="width:100%;"
+                                    Change=@OnSelectedIdsChange Data="@(orderIds)" AllowClear="true" Multiple="true"/>
                 </FilterTemplate>
             </RadzenDataFilterProperty>
+            
             <RadzenDataFilterProperty Property="@nameof(Order.ProductIds)" Title="ProductIds" FilterValue="@finalSelectedProductIds"
                                       Type="typeof(IEnumerable<int>)" FilterOperator="FilterOperator.In">
                 <FilterTemplate>
@@ -30,7 +32,7 @@
             <RadzenDataFilterProperty Property="OrderDetails" FilterProperty="Product.ProductName" Title="Products"
                                       Type="typeof(IEnumerable<OrderDetail>)" FilterOperator="FilterOperator.Contains"/>
             <RadzenDataFilterProperty Property="Employee.LastName" Title="Employee Last Name" />
-            <MyCustomDataFilterProperty Property="@nameof(Order.OrderDate)" Title="Order Date">
+            <MyCustomDataFilterProperty Property="@nameof(Order.OrderDate)" Title="Order Date" FilterSortOrder="200">
                 <FilterTemplate>
                     <RadzenDatePicker @bind-Value="@context.FilterValue" Style="width:100%" ShowTime=false DateFormat="d"
                                       Change="@ApplyOrderDateFilter" />


### PR DESCRIPTION
Introduced a FilterSortOrder parameter to control the sorting order of filters in RadzenDataFilterProperty. Updated relevant components to utilize and display the correct property sort order. This change ensures that filters are organized as specified by their sort order values.

FilterSortOrder start at 100 to allow adding priority by just adding a small value to some filters and not enforce to set the order on all