### PR TITLE
Handle nullable date type in queryable extension.

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -434,6 +434,11 @@ namespace Radzen
             }
             else if (PropertyAccess.IsDate(columnType))
             {
+                if (columnType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    property = $"{property}.Value";
+                }
+                
                 var v = column.FilterValue;
                 if (v != null)
                 {


### PR DESCRIPTION
Added a check to handle properties of nullable date types by accessing their `Value` property when filtering. This ensures that the filtering logic works correctly with nullable dates.

This PR correct an incorrect request built by the component if the filter need to be applied on a Nullable or Nullable in database