### PR TITLE
fix(adds missing non-nullable DateOnly typecheck)

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -788,6 +788,7 @@ namespace Radzen
                     column.FilterPropertyType == typeof(DateTime?) ||
                     column.FilterPropertyType == typeof(DateTimeOffset) ||
                     column.FilterPropertyType == typeof(DateTimeOffset?) ||
+                    column.FilterPropertyType == typeof(DateOnly) || 
                     column.FilterPropertyType == typeof(DateOnly?))
             {
                 if (columnFilterOperator == FilterOperator.IsNull || columnFilterOperator == FilterOperator.IsNotNull)


### PR DESCRIPTION
Adds the missing non-nullable DateOnly type to the typecheck for the OData filter string   