### PR TITLE
 implement missing dateonly check for parsing value of DateOnly

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -801,7 +801,12 @@ namespace Radzen
                 }
                 else
                 {
-                    return $"{property} {odataFilterOperator} {(column.FilterPropertyType == typeof(DateOnly?) ? value : DateTime.Parse(value, CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind).ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture))}";
+
+                    if (column.FilterPropertyType == typeof(DateOnly?) || column.FilterPropertyType == typeof(DateOnly))
+                    {
+                        return $"{property} {odataFilterOperator} {value}";
+                    }
+                    return $"{property} {odataFilterOperator} {DateTime.Parse(value, CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind).ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture)}";
                 }
             }
             else if (column.FilterPropertyType == typeof(Guid) || column.FilterPropertyType == typeof(Guid?))


### PR DESCRIPTION
In the filter string concatenation for OData  was the DateOnly type missing. For the nullable DateOnly it worked properly.