### PR TITLE
RadzenDataGridHeaderCell to handle nullable types in ApplyFilter

### DIFF
--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -339,15 +339,17 @@ else
     async Task ApplyFilter()
     {
         if (Grid.FilterMode == FilterMode.Advanced &&
-            PropertyAccess.IsNumeric(Column.FilterPropertyType) && 
-                !(PropertyAccess.IsEnum(Column.FilterPropertyType) || PropertyAccess.IsNullableEnum(Column.FilterPropertyType)))
+            PropertyAccess.IsNumeric(Column.FilterPropertyType) &&
+            !(PropertyAccess.IsEnum(Column.FilterPropertyType) || PropertyAccess.IsNullableEnum(Column.FilterPropertyType)))
         {
+
             if (Column.FilterValueTemplate == null)
             {
-                var firstInputValue = await Grid.GetJSRuntime().InvokeAsync<string>("Radzen.getNumericValue", Grid.getFilterInputId(Column)  + "f");
+                var firstInputValue = await Grid.GetJSRuntime().InvokeAsync<string>("Radzen.getNumericValue", Grid.getFilterInputId(Column) + "f");
                 if (!object.Equals($"{Column.GetFilterValue()}", $"{firstInputValue}"))
                 {
-                    Column.SetFilterValue(!string.IsNullOrEmpty(firstInputValue) ? Convert.ChangeType(firstInputValue, Column.FilterPropertyType) : null);
+                    var targetType = Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType;
+                    Column.SetFilterValue(!string.IsNullOrEmpty(firstInputValue) ? Convert.ChangeType(firstInputValue, targetType) : null);
                 }
             }
 
@@ -356,7 +358,8 @@ else
                 var secondInputValue = await Grid.GetJSRuntime().InvokeAsync<string>("Radzen.getNumericValue", Grid.getFilterInputId(Column) + "s");
                 if (!object.Equals($"{Column.GetSecondFilterValue()}", $"{secondInputValue}"))
                 {
-                    Column.SetFilterValue(!string.IsNullOrEmpty(secondInputValue) ? Convert.ChangeType(secondInputValue, Column.FilterPropertyType) : null, false);
+                    var targetType = Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType;
+                    Column.SetFilterValue(!string.IsNullOrEmpty(secondInputValue) ? Convert.ChangeType(secondInputValue, targetType) : null, false);
                 }
             }
         }
@@ -365,6 +368,7 @@ else
         {
             await popup.CloseAsync();
         }
+
         await Grid.ApplyFilter(Column, true);
     }
 

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -340,9 +340,8 @@ else
     {
         if (Grid.FilterMode == FilterMode.Advanced &&
             PropertyAccess.IsNumeric(Column.FilterPropertyType) &&
-            !(PropertyAccess.IsEnum(Column.FilterPropertyType) || PropertyAccess.IsNullableEnum(Column.FilterPropertyType)))
+                !(PropertyAccess.IsEnum(Column.FilterPropertyType) || PropertyAccess.IsNullableEnum(Column.FilterPropertyType)))
         {
-
             if (Column.FilterValueTemplate == null)
             {
                 var firstInputValue = await Grid.GetJSRuntime().InvokeAsync<string>("Radzen.getNumericValue", Grid.getFilterInputId(Column) + "f");
@@ -368,7 +367,6 @@ else
         {
             await popup.CloseAsync();
         }
-
         await Grid.ApplyFilter(Column, true);
     }
 

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -342,12 +342,13 @@ else
             PropertyAccess.IsNumeric(Column.FilterPropertyType) &&
                 !(PropertyAccess.IsEnum(Column.FilterPropertyType) || PropertyAccess.IsNullableEnum(Column.FilterPropertyType)))
         {
+            var targetType = Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType;
+
             if (Column.FilterValueTemplate == null)
             {
                 var firstInputValue = await Grid.GetJSRuntime().InvokeAsync<string>("Radzen.getNumericValue", Grid.getFilterInputId(Column) + "f");
                 if (!object.Equals($"{Column.GetFilterValue()}", $"{firstInputValue}"))
                 {
-                    var targetType = Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType;
                     Column.SetFilterValue(!string.IsNullOrEmpty(firstInputValue) ? Convert.ChangeType(firstInputValue, targetType) : null);
                 }
             }
@@ -357,7 +358,6 @@ else
                 var secondInputValue = await Grid.GetJSRuntime().InvokeAsync<string>("Radzen.getNumericValue", Grid.getFilterInputId(Column) + "s");
                 if (!object.Equals($"{Column.GetSecondFilterValue()}", $"{secondInputValue}"))
                 {
-                    var targetType = Nullable.GetUnderlyingType(Column.FilterPropertyType) ?? Column.FilterPropertyType;
                     Column.SetFilterValue(!string.IsNullOrEmpty(secondInputValue) ? Convert.ChangeType(secondInputValue, targetType) : null, false);
                 }
             }


### PR DESCRIPTION
Convert.ChangeType is designed to work with non-nullable value types and will return null when trying to convert an empty string or a null value to a nullable type, which leads to a InvalidCastException if not handled correctly.