### PR TITLE
Fix null ref exception when column is null on GroupsCollectionChanged

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3030,14 +3030,14 @@ namespace Radzen.Blazor
             if (args.Action == NotifyCollectionChangedAction.Add)
             {
                 RadzenDataGridColumn<TItem> column;
-                column = columns.Where(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems[0]).Property).FirstOrDefault();
+                column = columns.FirstOrDefault(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems[0]).Property);
 
                 if(column == null)
                 {
-                   column = allColumns.Where(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems[0]).Property).FirstOrDefault();
+                   column = allColumns.FirstOrDefault(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems[0]).Property);
                 }
 
-                if (HideGroupedColumn)
+                if (column != null && HideGroupedColumn)
                 {
                     column.SetVisible(false);
                     if (!groupedColumns.Contains(column))
@@ -3049,14 +3049,14 @@ namespace Radzen.Blazor
             else if (args.Action == NotifyCollectionChangedAction.Remove)
             {
                 RadzenDataGridColumn<TItem> column;
-                column = columns.Where(c => c.GetGroupProperty() == ((GroupDescriptor)args.OldItems[0]).Property).FirstOrDefault();
+                column = columns.FirstOrDefault(c => c.GetGroupProperty() == ((GroupDescriptor)args.OldItems[0]).Property);
 
                 if (column == null)
                 {
-                    column = allColumns.Where(c => c.GetGroupProperty() == ((GroupDescriptor)args.OldItems[0]).Property).FirstOrDefault();
+                    column = allColumns.FirstOrDefault(c => c.GetGroupProperty() == ((GroupDescriptor)args.OldItems[0]).Property);
                 }
 
-                if (HideGroupedColumn)
+                if (column != null && HideGroupedColumn)
                 {
                     column.SetVisible(true);
                     if (groupedColumns.Contains(column))


### PR DESCRIPTION
Fixes a null reference exception issue when you add a GroupDescriptor with a property that is not currently part of the Columns.