### PR TITLE
RadzenDataFilter.DrawNumericFilter to use ValueChanged

### DIFF
--- a/Radzen.Blazor/RadzenDataFilterItem.razor
+++ b/Radzen.Blazor/RadzenDataFilterItem.razor
@@ -289,7 +289,7 @@ else
             var eventCallbackGenericCreate = typeof(NumericFilterEventCallback).GetMethod("Create").MakeGenericMethod(type);
             var eventCallbackGenericAction = typeof(NumericFilterEventCallback).GetMethod("Action").MakeGenericMethod(type);
 
-            builder.AddAttribute(4, "Change", eventCallbackGenericCreate.Invoke(this,
+            builder.AddAttribute(4, "ValueChanged", eventCallbackGenericCreate.Invoke(this,
                 new object[] { this, eventCallbackGenericAction.Invoke(this, new object[] { action }) }));
 
             builder.CloseComponent();


### PR DESCRIPTION
This fixes case when numeric input is sometimes not registered in RadzenDataFilter when there are 2+ numeric inputs rendered at the same time.