### PR TITLE
Introduce ItemComparer parameter to DropDownBase, for IEqualityComparer support

### DIFF
--- a/Radzen.Blazor.Tests/DropDownTests.cs
+++ b/Radzen.Blazor.Tests/DropDownTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using Bunit;
@@ -112,6 +113,34 @@ namespace Radzen.Blazor.Tests
             items = component.FindAll(".rz-dropdown-item");
 
             Assert.Contains("rz-state-highlight", items[0].ClassList);
+        }
+
+        [Fact]
+        public void DropDown_Respects_ItemEqualityComparer()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            List<DataItem> boundCollection = [new() { Text = "Item 2" }];
+
+            var component = DropDown<string>(ctx, parameters => {
+                parameters.Add(p => p.ItemComparer, new DataItemComparer());
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.Value, boundCollection);
+            });
+
+            var selectedItems = component.FindAll(".rz-state-highlight");
+            Assert.Equal(1, selectedItems.Count);
+            Assert.Equal("Item 2", selectedItems[0].TextContent.Trim());
+
+            // select Item 1 in list
+            var items = component.FindAll(".rz-multiselect-item");
+            items[0].Click();
+            component.Render();
+
+            selectedItems = component.FindAll(".rz-state-highlight");
+            Assert.Equal(2, selectedItems.Count);
+            Assert.Equal("Item 1", selectedItems[0].TextContent.Trim());
         }
 
         [Fact]
@@ -244,6 +273,35 @@ namespace Radzen.Blazor.Tests
             var selectedItems = component.FindAll(".rz-chip-text");
 
             Assert.Collection(selectedItems, item => Assert.Contains("value: Item 1", item.Text()), item => Assert.Contains("value: Item 2", item.Text()));
+        }
+
+
+        class DataItemComparer : IEqualityComparer<DataItem>, IEqualityComparer<object>
+        {
+            public bool Equals(DataItem x, DataItem y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (x is null) return false;
+                if (y is null) return false;
+                if (x.GetType() != y.GetType()) return false;
+                return x.Text == y.Text;
+            }
+
+            public int GetHashCode(DataItem obj)
+            {
+                return obj.Text.GetHashCode();
+            }
+
+            public bool Equals(object x, object y)
+            {
+                return Equals((DataItem)x, (DataItem)y);
+            }
+
+            public int GetHashCode(object obj)
+            {
+                return GetHashCode((DataItem)obj);
+
+            }
         }
     }
 }

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -272,7 +272,7 @@ namespace Radzen
         /// <summary>
         /// The selected items
         /// </summary>
-        protected IList<object> selectedItems = new List<object>();
+        protected ISet<object> selectedItems = new HashSet<object>();
         /// <summary>
         /// The selected item
         /// </summary>
@@ -288,10 +288,10 @@ namespace Radzen
                 return;
             }
 
-            if (selectedItems.Count != View.Cast<object>().ToList().Where(i => disabledPropertyGetter != null ? disabledPropertyGetter(i) as bool? != true : true).Count())
+            if (selectedItems.Count != View.Cast<object>().ToList().Where(i => disabledPropertyGetter == null || disabledPropertyGetter(i) as bool? != true).Count())
             {
                 selectedItems.Clear();
-                selectedItems = View.Cast<object>().ToList().Where(i => disabledPropertyGetter != null ? disabledPropertyGetter(i) as bool? != true : true).ToList();
+                selectedItems = View.Cast<object>().ToList().Where(i => disabledPropertyGetter == null || disabledPropertyGetter(i) as bool? != true).ToHashSet(ItemComparer);
             }
             else
             {
@@ -453,6 +453,8 @@ namespace Radzen
                 {
                     disabledPropertyGetter = GetGetter(DisabledProperty, type);
                 }
+
+                selectedItems = new HashSet<object>(ItemComparer);
             }
         }
 
@@ -678,7 +680,7 @@ namespace Radzen
                     var itemToSelect = items.ElementAtOrDefault(selectedIndex);
 
                     await JSRuntime.InvokeAsync<string>("Radzen.setInputValue", search, $"{searchText}".Trim());
-                    
+
                     if (itemToSelect != null)
                     {
                         await OnSelectItem(itemToSelect, true);
@@ -990,7 +992,7 @@ namespace Radzen
             {
                 if (Multiple)
                 {
-                    return selectedItems.IndexOf(item) != -1;
+                    return selectedItems.Contains(item);
                 }
                 else
                 {
@@ -1216,18 +1218,14 @@ namespace Radzen
                 }
                 else
                 {
-                    selectedItems = selectedItems.AsQueryable().Where(DynamicLinqCustomTypeProvider.ParsingConfig, $@"!object.Equals(it.{ValueProperty},@0)", value).ToList();
+                    selectedItems = selectedItems.AsQueryable().Where(DynamicLinqCustomTypeProvider.ParsingConfig, $@"!object.Equals(it.{ValueProperty},@0)", value).ToHashSet(ItemComparer);
                 }
             }
             else
             {
-                if (!selectedItems.Any(i => object.Equals(i, item)))
+                if (!selectedItems.Add(item))
                 {
-                    selectedItems.Add(item);
-                }
-                else
-                {
-                    selectedItems = selectedItems.Where(i => !object.Equals(i, item)).ToList();
+                    selectedItems.Remove(item);
                 }
             }
         }
@@ -1289,7 +1287,7 @@ namespace Radzen
                         }
                         else
                         {
-                            selectedItems = ((IEnumerable)values).Cast<object>().ToList();
+                            selectedItems = values.Cast<object>().ToHashSet(ItemComparer);
                         }
 
                     }
@@ -1300,6 +1298,8 @@ namespace Radzen
                 selectedItem = null;
             }
         }
+
+        [Parameter] public IEqualityComparer<object> ItemComparer { get; set; }
 
         internal bool IsItemSelectedByValue(object v)
         {

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -1299,6 +1299,9 @@ namespace Radzen
             }
         }
 
+        /// <summary>
+        /// For lists of objects, an IEqualityComparer to control how selected items are determined
+        /// </summary>
         [Parameter] public IEqualityComparer<object> ItemComparer { get; set; }
 
         internal bool IsItemSelectedByValue(object v)

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -37,7 +37,7 @@
         }
         else if ((selectedItems.Count > 0 || SelectedValue is IEnumerable && !(SelectedValue is string)) && Multiple)
         {
-            var itemsToUse = SelectedValue is IEnumerable && !(SelectedValue is string) ? ((IEnumerable)SelectedValue).Cast<object>().ToList() : selectedItems;
+            var itemsToUse = SelectedValue is IEnumerable && !(SelectedValue is string) ? ((IEnumerable)SelectedValue).Cast<object>().ToHashSet() : selectedItems;
             @if (itemsToUse.Count < MaxSelectedLabels && Chips)
             {
                 <div class="rz-dropdown-chips-wrapper">

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -628,10 +628,7 @@ namespace Radzen.Blazor
                         {
                             foreach (object v in valueList)
                             {
-                                if (selectedItems.IndexOf(v) == -1)
-                                {
-                                    selectedItems.Add(v);
-                                }
+                                selectedItems.Add(v);
                             }
                         }
 

--- a/RadzenBlazorDemos/Models/Northwind/Product.cs
+++ b/RadzenBlazorDemos/Models/Northwind/Product.cs
@@ -16,6 +16,34 @@ namespace RadzenBlazorDemos.Models.Northwind
       set;
     }
 
+    public static ProductComparer Comparer { get; } = new();
+    public class ProductComparer : IEqualityComparer<Product>, IEqualityComparer<object>
+    {
+      public bool Equals(Product x, Product y)
+      {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+        if (x.GetType() != y.GetType()) return false;
+        return x.ProductName == y.ProductName;
+      }
+
+      public int GetHashCode(Product obj)
+      {
+        return (obj.ProductName != null ? obj.ProductName.GetHashCode() : 0);
+      }
+
+      public bool Equals(object x, object y)
+      {
+        return Equals((Product)x, (Product)y);
+      }
+
+      public int GetHashCode(object obj)
+      {
+        return GetHashCode((Product)obj);
+      }
+    }
+
 
     [InverseProperty("Product")]
     public ICollection<OrderDetail> OrderDetails { get; set; }

--- a/RadzenBlazorDemos/Pages/DropDownMultipleItemComparer.razor
+++ b/RadzenBlazorDemos/Pages/DropDownMultipleItemComparer.razor
@@ -1,0 +1,27 @@
+﻿@using RadzenBlazorDemos.Models.Northwind
+
+@inherits DbContextPage
+
+<RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.Center" Gap="0.5rem" class="rz-p-sm-12">
+    <RadzenLabel Text="Select Values" Component="DropDownMultiple" />
+    <RadzenDropDown @bind-Value=@values Data=@products TextProperty="@nameof(Product.ProductName)" Name="DropDownMultiple"
+                    Multiple=true AllowClear=true Placeholder="Select products" Style="width: 100%; max-width: 400px;"
+                    ItemComparer="@Product.Comparer"/>
+</RadzenStack>
+
+@code {
+    IEnumerable<Product> values = [];
+    IEnumerable<Product> products;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        products = dbContext.Products;
+        values =
+        [
+            new Product { ProductName = "Chai" },
+            new Product { ProductName = "Aniseed Syrup" }
+        ];
+    }
+}

--- a/RadzenBlazorDemos/Pages/DropDownMultiplePage.razor
+++ b/RadzenBlazorDemos/Pages/DropDownMultiplePage.razor
@@ -20,3 +20,10 @@
 <RadzenExample ComponentName="DropDown" Example="DropDownMultipleMaxLabels">
     <DropDownMultipleMaxLabels />
 </RadzenExample>
+
+<RadzenText Anchor="dropdown-multiple#item-comparer" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8 rz-mb-6">
+    Specify an Equality Comparer for item selection. Useful when binding directly to an object collection.
+</RadzenText>
+<RadzenExample ComponentName="DropDown" Example="DropDownMultipleItemComparer">
+    <DropDownMultipleItemComparer />
+</RadzenExample>


### PR DESCRIPTION
This adds the ability for a user to explicitly control how Selected items in a bound collection are compared.
See Feature #1853 

Additionally, performance for larger lists is improved by leveraging a HashSet instead of a List.