### PR TITLE
New Property - RadzenMultiDayView->AdvanceDays

### DIFF
--- a/Radzen.Blazor/RadzenMultiDayView.razor.cs
+++ b/Radzen.Blazor/RadzenMultiDayView.razor.cs
@@ -15,7 +15,7 @@ namespace Radzen.Blazor
     public partial class RadzenMultiDayView : SchedulerViewBase
     {
         /// <inheritdoc />
-        public override string Icon => "calendar_view_week";
+        public override string Icon => "width_normal";
 
         /// <inheritdoc />
         [Parameter]
@@ -62,6 +62,13 @@ namespace Radzen.Blazor
         /// <value>The number of days.</value>
         [Parameter]
         public int NumberOfDays { get; set; } = 2;
+
+        /// <summary>
+        /// Gets or sets number of days to advance when using prev / next. Set to <c>1</c> by default.
+        /// </summary>
+        /// <value>The number of days to advance.</value>
+        [Parameter]
+        public int AdvanceDays { get; set; } = 1;
         /// <inheritdoc />
         public override DateTime StartDate
         {
@@ -85,7 +92,14 @@ namespace Radzen.Blazor
         {
             get
             {
-                return $"{StartDate.ToString(Scheduler.Culture.DateTimeFormat.ShortDatePattern)} - {EndDate.AddDays(-1).ToString(Scheduler.Culture.DateTimeFormat.ShortDatePattern)}";
+                if (StartDate == EndDate.AddDays(-1))
+                {
+                    return $"{StartDate.ToString(Scheduler.Culture.DateTimeFormat.ShortDatePattern)}";
+                }
+                else
+                {
+                    return $"{StartDate.ToString(Scheduler.Culture.DateTimeFormat.ShortDatePattern)} - {EndDate.AddDays(-1).ToString(Scheduler.Culture.DateTimeFormat.ShortDatePattern)}";
+                }
             }
         }
 
@@ -93,13 +107,13 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         public override DateTime Next()
         {
-            return Scheduler.CurrentDate.Date.AddDays(NumberOfDays);
+            return Scheduler.CurrentDate.Date.AddDays(AdvanceDays);
         }
 
         /// <inheritdoc />
         public override DateTime Prev()
         {
-            return Scheduler.CurrentDate.Date.AddDays(-NumberOfDays);
+            return Scheduler.CurrentDate.Date.AddDays(-AdvanceDays);
         }
     }
 }

--- a/Radzen.Blazor/Rendering/DaySlotEvents.razor
+++ b/Radzen.Blazor/Rendering/DaySlotEvents.razor
@@ -5,7 +5,7 @@
     // ----------------------------------
     // Rendering Algorithm - See Layout()
     // ----------------------------------
-    // Note - Column, a property of the AppointmentDataExtended class, and colunCount are values that are set depending on todays overlapping appointments.
+    // Note - Column, a property of the AppointmentDataExtended class, and columnCount are values that are set depending on todays overlapping appointments.
     // i.e., if there are no overlapping appointments, all appointments will be assigned a Column value of 1
     // *** definition "Can fit in Column" - if an appointments "Start" is equal to or later than the last chronological appointments "End" in a column, this appointment can "fit in column" ***
     
@@ -15,7 +15,7 @@
 
     // 1. Loop through all the appointments and assign which column they will be assigned (either existing or new)
     //  1.1 If the appointment can fit in a column, it will be assigned that column value, otherwise a new column must be created to accomodate it
-    //  1.2 As the loop matures, there could be multiple columns that an appointment can fit in. It will select the one with the latest End time. This helps the view render more asthetically.
+    //  1.2 As the loop matures, there could be multiple columns that an appointment can fit in. It will select the one with the earliest End time. This helps the view render more asthetically.
 
     // Once we know how many columns are required, we can set the width of each column (columnWidth = 90.0 / columnCount).
 

--- a/RadzenBlazorDemos/Pages/SchedulerMultiDay.razor
+++ b/RadzenBlazorDemos/Pages/SchedulerMultiDay.razor
@@ -8,6 +8,14 @@
     {
         <RadzenText TextStyle="TextStyle.Caption" Text="@($"(default)")" Style="margin-left:0.1rem;margin-top:0.5rem;" />
     }
+    <div class="rz-w-25" />
+    <RadzenLabel Text="Advance days:" />
+    <RadzenSlider @bind-Value=@sliderAdvanceDays TValue="int" Min="1" Max="14" Style="margin-left:1.5rem;margin-right:1.5rem;" />
+    <RadzenLabel Text="@($"{sliderAdvanceDays}")" />
+    @if (sliderAdvanceDays == 1)
+    {
+        <RadzenText TextStyle="TextStyle.Caption" Text="@($"(default)")" Style="margin-left:0.1rem;margin-top:0.5rem;" />
+    }
 </RadzenStack>
 
 <RadzenScheduler @ref=@scheduler SlotRender=@OnSlotRender style="height: 768px;" TItem="Appointment" Data=@appointments StartProperty="Start" EndProperty="End"
@@ -16,7 +24,7 @@ SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRende
 AppointmentMove=@OnAppointmentMove >
     <RadzenDayView />
     <RadzenWeekView />
-    <RadzenMultiDayView NumberOfDays="@sliderNumberOfDays" />
+    <RadzenMultiDayView NumberOfDays="@sliderNumberOfDays" AdvanceDays="@sliderAdvanceDays" />
     <RadzenMonthView />
 </RadzenScheduler>
 
@@ -28,6 +36,7 @@ AppointmentMove=@OnAppointmentMove >
     Dictionary<DateTime, string> events = new Dictionary<DateTime, string>();
 
     int sliderNumberOfDays { get; set; } = 2;
+    int sliderAdvanceDays { get; set; } = 1;
 
     IList<Appointment> appointments = new List<Appointment>
     {
@@ -42,7 +51,7 @@ AppointmentMove=@OnAppointmentMove >
 
     async Task NumberOfDaysChange()
     {
-        await scheduler.Reload();
+        StateHasChanged();
     }
 
     void OnSlotRender(SchedulerSlotRenderEventArgs args)


### PR DESCRIPTION
Rather than hardcoding how many days this view will Advance or Retract, currently set to equal the `NumberOfDays` displayed, this is a new property that allows you to set it explicitly.

Additional changes

- There were some errors I made in the comments for `DaySlotEvents`. Now rectified.
- When `NumberOfDays` slider is changed, it will call `StateHasChanged()` rather than reloading the Schedule (see notes below)




NOTES (let me know if you want me to raise issues for these)

Everything about the `RadzenScheduler` updates fine, with the exception of the title. This can be highlighted on the demo with the year views. Selecting a new `StartMonth` using the `RadzenSelectBar` updates all but the title. If January is selected, it should just show the current year. Any other month will show from and to. If you switch between, you will see that the title is one step behind, i.e. 

1. Select another month (this should now show a from and to. It doesn't)
2. Select January (this should now just show the current year. It doesn't)
3. Select another month (this should now show a from and to). It now shows just the current year)

Would address it but I've not been successful in my attempts. Been getting out of memory errors. Obviously, my attempts at inserting `StateHasChanged` in certain places has caused some sort of infinite loop!

For the `NumberOfDays` slider, I call `StateHasChanged` on the `Change` event to rectify this. Sure that this shouldn't be required and be part of the component.

Also, for the life in me, I couldn't get the `Change` event working on the `RadzenSelectBar`. May need looking into (the demo page has a section _"Get and Set the value of SelectBar using Value and Change event"_ that doesn't seem to demonstrate this).


Regards
Paul
