### PR TITLE
Fixed a typo in cookie name in ThemeServicePage.razor

### DIFF
--- a/RadzenBlazorDemos/Pages/ThemeServicePage.razor
+++ b/RadzenBlazorDemos/Pages/ThemeServicePage.razor
@@ -118,7 +118,7 @@ Register CookieThemeService in all <code>Program.cs</code> files of your applica
 <code>
 @@inject Radzen.ThemeService ThemeService
 @@{
-    var theme = HttpContext.Request.Cookies["MuApplicationTheme"];
+    var theme = HttpContext.Request.Cookies["MyApplicationTheme"];
 
     if (!string.IsNullOrEmpty(theme))
     {


### PR DESCRIPTION
When consulting the demos, I noticed the typo and decided to fix it.