### PR TITLE
Fix: Prevent 'NumpadDecimal' Key When isInteger is True

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -978,7 +978,7 @@ window.Radzen = {
       return;
       }
 
-      if (e.code === 'NumpadDecimal') {
+      if (e.code === 'NumpadDecimal' && !isInteger) {
           var cursorPosition = e.target.selectionEnd;
           e.target.value = [e.target.value.slice(0, e.target.selectionStart), decimalSeparator, e.target.value.slice(e.target.selectionEnd)].join('');
           e.target.selectionStart = ++cursorPosition;


### PR DESCRIPTION
This pull request addresses a bug where the `numericKeyPress` function did not correctly handle the `'NumpadDecimal'` key when `isInteger` is `true`. The updated function now includes a condition to prevent the `'NumpadDecimal'` key from being allowed if `isInteger` is `true`.

**Changes Made**
- Added a condition to check if `isInteger` is `true` before handling the `'NumpadDecimal'` key.
- If `isInteger` is `true`, the function will not allow the `'NumpadDecimal'` key.