### PR TITLE
Update Scheduler Title when StartMonth changes in Year Views

### DIFF
--- a/Radzen.Blazor/RadzenYearPlannerView.razor
+++ b/Radzen.Blazor/RadzenYearPlannerView.razor
@@ -1,7 +1,7 @@
 @using Radzen.Blazor
 @using Radzen.Blazor.Rendering
 
-@inherits SchedulerViewBase
+@inherits SchedulerYearViewBase
 
 @code {
     public override RenderFragment Render()

--- a/Radzen.Blazor/RadzenYearPlannerView.razor.cs
+++ b/Radzen.Blazor/RadzenYearPlannerView.razor.cs
@@ -16,7 +16,7 @@ namespace Radzen.Blazor
     /// &lt;/RadzenScheduler&gt;
     /// </code>
     /// </example>
-    public partial class RadzenYearPlannerView : SchedulerViewBase
+    public partial class RadzenYearPlannerView : SchedulerYearViewBase
     {
         /// <inheritdoc />
         public override string Icon => "view_list";
@@ -91,7 +91,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The start month.</value>
         [Parameter]
-        public Month StartMonth { get; set; } = Month.January;
+        public override Month StartMonth { get; set; } = Month.January;
 
         /// <inheritdoc />
         public override DateTime Next()

--- a/Radzen.Blazor/RadzenYearTimelineView.razor
+++ b/Radzen.Blazor/RadzenYearTimelineView.razor
@@ -1,7 +1,7 @@
 @using Radzen.Blazor
 @using Radzen.Blazor.Rendering
 
-@inherits SchedulerViewBase
+@inherits SchedulerYearViewBase
 
 @code {
     public override RenderFragment Render()

--- a/Radzen.Blazor/RadzenYearTimelineView.razor.cs
+++ b/Radzen.Blazor/RadzenYearTimelineView.razor.cs
@@ -16,7 +16,7 @@ namespace Radzen.Blazor
     /// &lt;/RadzenScheduler&gt;
     /// </code>
     /// </example>
-    public partial class RadzenYearTimelineView : SchedulerViewBase
+    public partial class RadzenYearTimelineView : SchedulerYearViewBase
     {
         /// <inheritdoc />
         public override string Icon => "view_timeline";
@@ -91,7 +91,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The start month.</value>
         [Parameter]
-        public Month StartMonth { get; set; } = Month.January;
+        public override Month StartMonth { get; set; } = Month.January;
 
         /// <inheritdoc />
         public override DateTime Next()

--- a/Radzen.Blazor/RadzenYearView.razor
+++ b/Radzen.Blazor/RadzenYearView.razor
@@ -1,7 +1,7 @@
 @using Radzen.Blazor
 @using Radzen.Blazor.Rendering
 
-@inherits SchedulerViewBase
+@inherits SchedulerYearViewBase
 
 @code {
     public override RenderFragment Render()

--- a/Radzen.Blazor/RadzenYearView.razor.cs
+++ b/Radzen.Blazor/RadzenYearView.razor.cs
@@ -15,7 +15,7 @@ namespace Radzen.Blazor
     /// &lt;/RadzenScheduler&gt;
     /// </code>
     /// </example>
-    public partial class RadzenYearView : SchedulerViewBase
+    public partial class RadzenYearView : SchedulerYearViewBase
     {
         /// <inheritdoc />
         public override string Icon => "calendar_month";
@@ -89,7 +89,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The start month.</value>
         [Parameter]
-        public Month StartMonth { get; set; } = Month.January;
+        public override Month StartMonth { get; set; } = Month.January;
 
         /// <inheritdoc />
         public override DateTime Next()

--- a/Radzen.Blazor/SchedulerYearViewBase.cs
+++ b/Radzen.Blazor/SchedulerYearViewBase.cs
@@ -11,7 +11,7 @@ namespace Radzen.Blazor
     public abstract class SchedulerYearViewBase : SchedulerViewBase
     {
         /// <summary>
-        /// Gets the StartMonth of the view. It is used in rendering Year Views.
+        /// Gets the StartMonth of the view.
         /// </summary>
         /// <value>The start month.</value>
         public abstract Month StartMonth { get; set; }

--- a/Radzen.Blazor/SchedulerYearViewBase.cs
+++ b/Radzen.Blazor/SchedulerYearViewBase.cs
@@ -1,0 +1,36 @@
+using System;
+using Radzen;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor
+{
+    /// <summary>
+    /// A base class for <see cref="RadzenScheduler{TItem}" /> views.
+    /// </summary>
+    public abstract class SchedulerYearViewBase : SchedulerViewBase
+    {
+        /// <summary>
+        /// Gets the StartMonth of the view. It is used in rendering Year Views.
+        /// </summary>
+        /// <value>The start month.</value>
+        public abstract Month StartMonth { get; set; }
+
+        /// <summary>
+        /// Called by the Blazor runtime when parameters are set.
+        /// </summary>
+        /// <param name="parameters">The parameters.</param>
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            if (parameters.DidParameterChange(nameof(StartMonth), StartMonth))
+            {
+                if (Scheduler != null)
+                {
+                    await Scheduler.Reload();
+                }
+            }
+
+            await base.SetParametersAsync(parameters);
+        }
+    }
+}

--- a/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
+++ b/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
@@ -2,8 +2,7 @@
 
 <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem" class="rz-p-4 rz-mb-6 rz-border-radius-1" Style="border: var(--rz-grid-cell-border);">
     <RadzenLabel Text="Schedule Start Month:" />
-    <RadzenSelectBar @bind-Value="@startMonth" TextProperty="Text" ValueProperty="Value" Data="@(Enum.GetValues(typeof(Month)).Cast<Month>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" class="rz-display-none rz-display-xl-flex" />
-    <RadzenDropDown @bind-Value="@startMonth" Change="StartMonthChange" TextProperty="Text" ValueProperty="Value" Data="@(Enum.GetValues(typeof(Month)).Cast<Month>().Select(t => new { Text = $"{t}", Value = t }))" class="rz-display-inline-flex rz-display-xl-none" />
+    <RadzenSelectBar @bind-Value="@startMonth" TextProperty="Text" ValueProperty="Value" Data="@(Enum.GetValues(typeof(Month)).Cast<Month>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" class="rz-display-xl-flex" />
 </RadzenStack>
 
 <RadzenScheduler @ref=@scheduler SlotRender=@OnSlotRender style="height: 768px;" TItem="Appointment" Data=@appointments StartProperty="Start" EndProperty="End"
@@ -33,11 +32,6 @@
         new Appointment { Start = DateTime.Today.AddHours(14), End = DateTime.Today.AddHours(14).AddMinutes(30), Text = "Dentist appointment" },
         new Appointment { Start = DateTime.Today.AddDays(1), End = DateTime.Today.AddDays(12), Text = "Vacation" },
     };
-
-    async Task StartMonthChange()
-    {
-        await scheduler.Reload();
-    }
 
     void OnSlotRender(SchedulerSlotRenderEventArgs args)
     {


### PR DESCRIPTION
@akorchev

This is in response to our conversation earlier in the week where the `Change` event was behaving differently in a couple of controls.

Because the `StartMonth` property is only applicable to 'Year Views' and is not in the Parent `Scheduler` component, the `Title` doesn't automatically update.

So I've implemented it in the same way that forces the `Reload` of the `Scheduler` in the `SchedulerViewBase` when the `Title` changes. But I've put it in a derived `SchedulerYearViewBase` that will react to a change in `StartMonth`.

Regards
Paul

