### PR TITLE
refactor(demos): simplify DataGridColumnPicking example

### DIFF
--- a/Radzen.Blazor/ContextMenuService.cs
+++ b/Radzen.Blazor/ContextMenuService.cs
@@ -66,10 +66,7 @@ namespace Radzen
         /// <param name="e">The <see cref="Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs"/> instance containing the event data.</param>
         private void UriHelper_OnLocationChanged(object sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
         {
-            if (this.OnNavigate != null)
-            {
-                this.OnNavigate();
-            }
+            this.OnNavigate?.Invoke();
         }
 
         /// <summary>

--- a/RadzenBlazorDemos/Pages/DataGridColumnPicking.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnPicking.razor
@@ -4,50 +4,48 @@
 
 @inherits DbContextPage
 
-@inject ContextMenuService ContextMenuService
-
-<RadzenCard Variant="Variant.Outlined" class="rz-my-4">
-    <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center" Wrap="FlexWrap.Wrap">
-        <div>Column picker type:</div>
-        <RadzenSelectBar @bind-Value="@columnPickerType" TextProperty="Text" ValueProperty="Value"
-                         Data="@(Enum.GetValues(typeof(ColumnPickerType)).Cast<ColumnPickerType>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
-    </RadzenStack>
-</RadzenCard>
-
-<RadzenStack ContextMenu=@(args => { if(columnPickerType == ColumnPickerType.ContextMenu) ShowColumnPicker(args); })>
-    <RadzenButton Text="Toggle EmployeeID column visibility" Click=@(() => EmployeeIDVisible = !EmployeeIDVisible) class="rz-my-4" style="width:fit-content"/>
-    <RadzenDataGrid @ref=grid Data="@employees" TItem="Employee" AllowFiltering=true ColumnWidth="300px" AllowColumnPicking="@(columnPickerType == ColumnPickerType.Default)" PickedColumnsChanged="@PickedColumnsChanged">
-        <Columns>
-            <RadzenDataGridColumn Visible="@EmployeeIDVisible" Property="@nameof(Employee.EmployeeID)" Title="ID" Width="80px" TextAlign="TextAlign.Center" Frozen="true" />
-            <RadzenDataGridColumn Title="Photo" Sortable="false" Width="200px" Pickable="false">
-                <Template Context="data">
-                    <RadzenImage Path="@data.Photo" class="rz-gravatar" AlternateText="@(data.FirstName + " " + data.LastName)" />
-                </Template>
-            </RadzenDataGridColumn>
-            <RadzenDataGridColumn Property="@nameof(Employee.FirstName)" Title="First Name" />
-            <RadzenDataGridColumn Property="@nameof(Employee.LastName)" Title="Last Name" Width="150px"/>
-            <RadzenDataGridColumn Property="@nameof(Employee.Title)" Title="Title" />
-            <RadzenDataGridColumn Property="@nameof(Employee.TitleOfCourtesy)" Title="Title Of Courtesy" />
-            <RadzenDataGridColumn Property="@nameof(Employee.BirthDate)" Title="Birth Date" FormatString="{0:d}" />
-            <RadzenDataGridColumn Property="@nameof(Employee.HireDate)" Title="Hire Date" FormatString="{0:d}" />
-            <RadzenDataGridColumn Property="@nameof(Employee.Address)" Title="Address" />
-            <RadzenDataGridColumn Property="@nameof(Employee.City)" Title="City" />
-            <RadzenDataGridColumn Property="@nameof(Employee.Region)" Title="Region" />
-            <RadzenDataGridColumn Property="@nameof(Employee.PostalCode)" Title="Postal Code" />
-            <RadzenDataGridColumn Property="@nameof(Employee.Country)" Title="Country" />
-            <RadzenDataGridColumn Property="@nameof(Employee.HomePhone)" Title="Home Phone" />
-            <RadzenDataGridColumn Property="@nameof(Employee.Extension)" Title="Extension" />
-            <RadzenDataGridColumn Property="@nameof(Employee.Notes)" Title="Notes" />
-        </Columns>
-    </RadzenDataGrid>
-</RadzenStack>
+<RadzenDataGrid
+    Data="@employees"
+    TItem="Employee"
+    AllowFiltering=true
+    ColumnWidth="300px"
+    AllowColumnPicking="true"
+    PickedColumnsChanged="@PickedColumnsChanged"
+    ColumnsPickerAllowFiltering="true"
+>
+    <Columns>
+        <RadzenDataGridColumn
+            Property=@nameof(Employee.EmployeeID)
+            Title="ID"
+            Width="80px"
+            TextAlign="TextAlign.Center"
+            Frozen="true" />
+        <RadzenDataGridColumn Title="Photo" Sortable="false" Width="200px" Pickable="false">
+            <Template Context="data">
+                <RadzenImage Path="@data.Photo" class="rz-gravatar" AlternateText="@(data.FirstName + " " + data.LastName)" />
+            </Template>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn Property=@nameof(Employee.FirstName) Title="First Name" />
+        <RadzenDataGridColumn Property=@nameof(Employee.LastName) Title="Last Name" Width="150px"/>
+        <RadzenDataGridColumn Property=@nameof(Employee.Title) Title="Title" />
+        <RadzenDataGridColumn Property=@nameof(Employee.TitleOfCourtesy) Title="Title Of Courtesy" />
+        <RadzenDataGridColumn Property=@nameof(Employee.BirthDate) Title="Birth Date" FormatString="{0:d}" />
+        <RadzenDataGridColumn Property=@nameof(Employee.HireDate) Title="Hire Date" FormatString="{0:d}" />
+        <RadzenDataGridColumn Property=@nameof(Employee.Address) Title="Address" />
+        <RadzenDataGridColumn Property=@nameof(Employee.City) Title="City" />
+        <RadzenDataGridColumn Property=@nameof(Employee.Region) Title="Region" />
+        <RadzenDataGridColumn Property=@nameof(Employee.PostalCode) Title="Postal Code" />
+        <RadzenDataGridColumn Property=@nameof(Employee.Country) Title="Country" />
+        <RadzenDataGridColumn Property=@nameof(Employee.HomePhone) Title="Home Phone" />
+        <RadzenDataGridColumn Property=@nameof(Employee.Extension) Title="Extension" ColumnPickerTitle="Phone Number Extension" />
+        <RadzenDataGridColumn Property=@nameof(Employee.Notes) Title="Notes" />
+    </Columns>
+</RadzenDataGrid>
 <EventConsole @ref=@console />
 
 @code {
-    bool EmployeeIDVisible = false;
     IEnumerable<Employee> employees;
     EventConsole console;
-    RadzenDataGrid<Employee> grid;
 
     protected override async Task OnInitializedAsync()
     {
@@ -56,34 +54,11 @@
         employees = dbContext.Employees;
     }
 
+    /// <summary>
+    /// Only used to print the changes to the console.
+    /// </summary>
     void PickedColumnsChanged(DataGridPickedColumnsChangedEventArgs<Employee> args)
     {
-        EmployeeIDVisible = args.Columns.Select(c => c.Property).Contains(nameof(Employee.EmployeeID));
         console.Log($"Picked columns: {string.Join(", ", args.Columns.Select(c => c.Title))}");
-    }
-
-    void ShowColumnPicker(MouseEventArgs args) => ContextMenuService.Open(args, ds =>
-        @<RadzenListBox TValue="object" Style="height:200px;background-color:#fff"
-                            SelectAllText="@grid.AllColumnsText" AllowSelectAll="@grid.AllowPickAllColumns"
-                            MaxSelectedLabels="@grid.ColumnsPickerMaxSelectedLabels" 
-                            SelectedItemsText="@grid.ColumnsShowingText" FilterCaseSensitivity=FilterCaseSensitivity.CaseInsensitive
-                            Multiple="true" AllowFiltering="@grid.ColumnsPickerAllowFiltering"
-                            Placeholder="@grid.AllColumnsText"
-                            Data="@grid.ColumnsCollection"
-                            TextProperty="ColumnPickerTitle"
-                            Value="@(grid.ColumnsCollection.Where(c => c.GetVisible()))"
-                            Change=@(args => { 
-                                var checkedColumns = ((IEnumerable<object>)args).Cast<RadzenDataGridColumn<Employee>>();
-                                grid.ColumnsCollection.ToList().ForEach(c => c.Visible = checkedColumns.Contains(c)); 
-                                EmployeeIDVisible = checkedColumns.Select(c => c.Property).Contains(nameof(Employee.EmployeeID));
-                            })
-                            />
-    );
-
-    ColumnPickerType columnPickerType;
-    public enum ColumnPickerType
-    {
-        Default,
-        ContextMenu
     }
 }

--- a/RadzenBlazorDemos/Pages/DataGridColumnPickingContextMenu.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnPickingContextMenu.razor
@@ -1,0 +1,118 @@
+﻿@using RadzenBlazorDemos.Data
+@using RadzenBlazorDemos.Models.Northwind
+@using Microsoft.EntityFrameworkCore
+
+@inherits DbContextPage
+
+@inject ContextMenuService ContextMenuService
+
+<RadzenStack ContextMenu=@ShowContextMenuColumnPicker>
+    <RadzenDataGrid
+        @ref=grid
+        Data="@employees"
+        TItem="Employee"
+        ColumnWidth="300px"
+        AllowColumnPicking="false"
+    >
+        <Columns>
+            <RadzenDataGridColumn
+                @attributes=@GetAttributes(nameof(Employee.EmployeeID))
+                Title="ID"
+                Width="80px"
+                TextAlign="TextAlign.Center"
+                Frozen="true"
+            />
+            <RadzenDataGridColumn Title="Photo" Sortable="false" Width="200px" Pickable="false">
+                <Template Context="data">
+                    <RadzenImage Path="@data.Photo" class="rz-gravatar" AlternateText="@(data.FirstName + " " + data.LastName)" />
+                </Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.FirstName)) Title="First Name" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.LastName)) Title="Last Name" Width="150px"/>
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.Title)) Title="Title" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.TitleOfCourtesy)) Title="Title Of Courtesy" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.BirthDate)) Title="Birth Date" FormatString="{0:d}" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.HireDate)) Title="Hire Date" FormatString="{0:d}" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.Address)) Title="Address" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.City)) Title="City" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.Region)) Title="Region" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.PostalCode)) Title="Postal Code" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.Country)) Title="Country" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.HomePhone)) Title="Home Phone" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.Extension)) Title="Extension" />
+            <RadzenDataGridColumn @attributes=@GetAttributes(nameof(Employee.Notes)) Title="Notes" />
+        </Columns>
+    </RadzenDataGrid>
+</RadzenStack>
+<EventConsole @ref=@console />
+
+@code {
+    IEnumerable<Employee> employees;
+    EventConsole console;
+    RadzenDataGrid<Employee> grid;
+
+    /// <summary>
+    /// Stores the set of selected column property names.
+    /// When null - all columns are selected.
+    /// </summary>
+    private HashSet<string> selectedColumns;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        employees = dbContext.Employees;
+    }
+
+    /// <summary>
+    /// Returns a set of key-value pairs to splat as column attributes.
+    /// </summary>
+    IEnumerable<KeyValuePair<string, object>> GetAttributes(string columnName)
+    {
+        var isSelected = selectedColumns?.Contains(columnName) ?? true;
+        return new KeyValuePair<string, object>[] {
+            new ("Property", columnName),
+            new ("Visible", isSelected),
+        };
+    }
+
+    /// <summary>
+    /// Displays the column picker in a context menu.
+    /// </summary>
+    void ShowContextMenuColumnPicker(MouseEventArgs args)
+    {
+        ContextMenuService.Open(args, ds =>
+            @<RadzenListBox
+                TValue="object"
+                Style="height:200px;background-color:#fff"
+                SelectAllText="All"
+                AllowSelectAll="true"
+                AllowFiltering="true"
+                FilterCaseSensitivity=FilterCaseSensitivity.CaseInsensitive
+                Multiple="true"
+                Placeholder="All"
+                Data="@grid.ColumnsCollection.Where(c => c.Pickable)"
+                TextProperty="Title"
+                Value="@(grid.ColumnsCollection.Where(c => c.Pickable && c.GetVisible()))"
+                Change=@RadzenListBoxSelectionChange
+            />
+        );
+    }
+
+    /// <summary>
+    /// Reacts to the changes of selected columns in the context menu.
+    /// </summary>
+    void RadzenListBoxSelectionChange(object args)
+    {
+        var selectedColumnNames = ((IEnumerable<object>)args)
+            .Cast<RadzenDataGridColumn<Employee>>()
+            .Select(c => c.Title);
+
+        console.Log($"Picked columns: {string.Join(", ", selectedColumnNames)}");
+
+        this.selectedColumns = ((IEnumerable<object>)args)
+            .Cast<RadzenDataGridColumn<Employee>>()
+            .Select(c => c.Property)
+            .ToHashSet();
+    }
+}

--- a/RadzenBlazorDemos/Pages/DataGridColumnPickingPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridColumnPickingPage.razor
@@ -4,9 +4,29 @@
     DataGrid <strong>Column Picker</strong>
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
-    Enable default column picker by setting the AllowColumnPicking property to true or use the code example for context menu to create your own custom column picker.
+    Enable default column picker by setting the <strong>AllowColumnPicking</strong> grid property to true.
+    You can disable picking for specific columns by setting their <strong>Pickable</strong> property to false.
+    The example below also sets <strong>ColumnsPickerAllowFiltering</strong> on the grid to make picking columns easier.
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    Documentation:
+    <a href="https://blazor.radzen.com/docs/api/Radzen.Blazor.RadzenDataGrid-1.html">grid</a>,
+    <a href="https://blazor.radzen.com/docs/api/Radzen.Blazor.RadzenDataGridColumn-1.html">column</a>.
 </RadzenText>
 
 <RadzenExample ComponentName="DataGrid" Example="DataGridColumnPicking">
     <DataGridColumnPicking />
+</RadzenExample>
+
+<RadzenText TextStyle="TextStyle.H3" TagName="TagName.H2" class="rz-pt-8">
+    Picking columns with <strong>Context Menu</strong>
+</RadzenText>
+
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    You could also create your own custom column picker using the context menu.
+    In this case you will have to track column visibility yourself.
+</RadzenText>
+
+<RadzenExample ComponentName="DataGrid" Example="DataGridColumnPickingContextMenu">
+    <DataGridColumnPickingContextMenu />
 </RadzenExample>


### PR DESCRIPTION
- DataGridColumnPicking example was split in two. Each example using a separate mechanism for managing visible columns.
- Both examples are included on the `/datagrid-column-picker` page with some more comments.

Related to the issue #1874 
