### PR TITLE
Standard dark theme base flag fix

### DIFF
--- a/Radzen.Blazor/themes/standard-dark-base.scss
+++ b/Radzen.Blazor/themes/standard-dark-base.scss
@@ -1,5 +1,6 @@
 @import 'variables';
 @import 'mixins';
+$base: true;
 $dark: true;
 $standard: true;
 $theme-name: standard-dark;

--- a/Radzen.Blazor/themes/standard-dark.scss
+++ b/Radzen.Blazor/themes/standard-dark.scss
@@ -1,6 +1,5 @@
 @import 'variables';
 @import 'mixins';
-$base: true;
 $dark: true;
 $standard: true;
 $theme-name: standard-dark;


### PR DESCRIPTION
The incorrect assignment caused inconsistencies between the dark and light modes of the standard theme, such as differently formatted headings.