### PR TITLE
IRadzenFormComponent: Add Disabled, from RadzenFormComponent<T>

### DIFF
--- a/Radzen.Blazor.Tests/NumericRangeValidatorTests.cs
+++ b/Radzen.Blazor.Tests/NumericRangeValidatorTests.cs
@@ -28,6 +28,8 @@ namespace Radzen.Blazor.Tests
                 throw new NotImplementedException();
             }
 
+            public bool Disabled { get; set; }
+
             public object Value { get; set; }
         }
 

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -3405,6 +3405,11 @@ namespace Radzen
         /// Sets the focus.
         /// </summary>
         ValueTask FocusAsync();
+
+        /// <summary>
+        /// Sets the Disabled state of the component
+        /// </summary>
+        bool Disabled { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
Include Disabled on the `IRadzenFormComponent` interface, for better integration with cross-cutting form behavior.  For example, we have a component that leverages this interface to apply FluentValidations in a transparent manner, leveraging the `IRadzenFormComponent.FieldIdentifier` retrieved from the cascading `IRadzenForm`.  This allows the setting of the Disabled state in a cross-cutting manner.