### PR TITLE
Appointment Resize

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -739,6 +739,27 @@ namespace Radzen
     }
 
     /// <summary>
+    /// Supplies information about a <see cref="DropableViewBase.AppointmentMove" /> event that is being raised.
+    /// </summary>
+    public class SchedulerAppointmentResizeEventArgs
+    {
+        /// <summary>
+        /// Gets or sets the appointment data.
+        /// </summary>
+        public AppointmentData Appointment { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start DateTime.
+        /// </summary>
+        public DateTime Start { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end DateTime.
+        /// </summary>
+        public DateTime End { get; set; }
+    }
+
+    /// <summary>
     /// Supplies information about a <see cref="RadzenMenu.Click" /> event that is being raised.
     /// </summary>
     public class MenuItemEventArgs : MouseEventArgs

--- a/Radzen.Blazor/IScheduler.cs
+++ b/Radzen.Blazor/IScheduler.cs
@@ -17,6 +17,11 @@ namespace Radzen.Blazor
         /// <value>The appointment move event callback.</value>
         EventCallback<SchedulerAppointmentMoveEventArgs> AppointmentMove { get; set; }
         /// <summary>
+        /// Gets or sets the appointment resize event callback.
+        /// </summary>
+        /// <value>The appointment resize event callback.</value>
+        EventCallback<SchedulerAppointmentResizeEventArgs> AppointmentResize { get; set; }
+        /// <summary>
         /// Gets the appointments in the specified range.
         /// </summary>
         /// <param name="start">The start of the range.</param>
@@ -121,12 +126,24 @@ namespace Radzen.Blazor
         bool HasAppointmentMoveDelegate();
 
         /// <summary>
+        /// Returns true if the scheduler has an AppointmentResize listener.
+        /// </summary>
+        bool HasAppointmentResizeDelegate();
+
+        /// <summary>
         /// Notifies the scheduler that the user has moved the mouse out of the specified appointment.
         /// </summary>
         /// <param name="reference"></param>
         /// <param name="data"></param>
         /// <returns></returns>
         Task MouseLeaveAppointment(ElementReference reference, AppointmentData data);
+
+        /// <summary>
+        /// Notifies the scheduler that the user has resized an appointment.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        Task ResizeAppointment(SchedulerAppointmentResizeEventArgs args);
         /// <summary>
         /// Reloads this instance.
         /// </summary>

--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -328,6 +328,32 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback<SchedulerAppointmentMoveEventArgs> AppointmentMove { get; set; }
 
+        /// <summary>
+        /// A callback that will be invoked when an appointment is being resized to change it's date / time.
+        /// Commonly used to change the appointments length.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// &lt;RadzenScheduler Data=@appointments AppointmentResize=@OnAppointmentResize&gt;
+        /// &lt;/RadzenScheduler&gt;
+        /// @code {
+        ///   async Task OnAppointmentResize(SchedulerAppointmentResizeEventArgs resized)
+        ///   {
+        ///     var draggedAppointment = appointments.SingleOrDefault(x => x == (Appointment)resized.Appointment.Data);
+        ///     if (draggedAppointment != null)
+        ///     {
+        ///         draggedAppointment.Start = resized.Start;
+        ///         draggedAppointment.End = resized.End;
+        ///         await scheduler.Reload();
+        ///     }
+        ///   }
+        /// }
+        /// </code>
+        /// </example>
+        /// <value></value>
+        [Parameter]
+        public EventCallback<SchedulerAppointmentResizeEventArgs> AppointmentResize { get; set; }
+
         IList<ISchedulerView> Views { get; set; } = new List<ISchedulerView>();
 
         /// <summary>
@@ -709,6 +735,11 @@ namespace Radzen.Blazor
             await AppointmentMouseLeave.InvokeAsync(new SchedulerAppointmentMouseEventArgs<TItem> { Element = reference, Data = (TItem)data.Data });
         }
 
+        async Task IScheduler.ResizeAppointment(SchedulerAppointmentResizeEventArgs args)
+        {
+            await AppointmentResize.InvokeAsync(args);
+        }
+
         bool IScheduler.HasMouseEnterAppointmentDelegate()
         {
             return AppointmentMouseEnter.HasDelegate;
@@ -717,6 +748,11 @@ namespace Radzen.Blazor
         bool IScheduler.HasAppointmentMoveDelegate()
         {
             return AppointmentMove.HasDelegate;
+        }
+
+        bool IScheduler.HasAppointmentResizeDelegate()
+        {
+            return AppointmentResize.HasDelegate;
         }
     }
 }

--- a/Radzen.Blazor/Rendering/Appointment.razor
+++ b/Radzen.Blazor/Rendering/Appointment.razor
@@ -9,7 +9,7 @@
 @* These classes are to style the handles for the resize operation. Not sure how you guys do this now with all the theming and such. So I'll just park it here and I'll leave it with you :) *@
 
 <style type="text/css">
-    .resizer {
+    .rz-appointment-resize {
     width: 100%;
     height: 6px;
     left: 0;
@@ -18,11 +18,11 @@
     cursor: row-resize;
     }
 
-    .resizer-south {
+    .rz-appointment-resize-south {
     bottom: -1px;
     }
 
-    .resizer-north {
+    .rz-appointment-resize-north {
     top: -1px;
     }
 </style>
@@ -37,11 +37,11 @@
     {
         if (CanResizeNorth)
         {
-            <div class="resizer resizer-north" @onmousedown=@((args) => OnResizeMouseDown(args, "north")) />
+            <div class="rz-appointment-resize rz-appointment-resize-north" @onmousedown=@((args) => OnResizeMouseDown(args, "north")) />
         }
         if (CanResizeSouth)
         {
-            <div class="resizer resizer-south" @onmousedown=@((args) => OnResizeMouseDown(args, "south")) />
+            <div class="rz-appointment-resize rz-appointment-resize-south" @onmousedown=@((args) => OnResizeMouseDown(args, "south")) />
         }
     }
     <div class="rz-event-content" title=@Title @attributes=@Attributes>

--- a/Radzen.Blazor/Rendering/Appointment.razor
+++ b/Radzen.Blazor/Rendering/Appointment.razor
@@ -1,22 +1,68 @@
 @using Radzen.Blazor
 @using Radzen.Blazor.Rendering
+@using Microsoft.JSInterop
+@using System.Globalization
 
-    <div @ref=@element class="@($"{"rz-event"} {CssClass}".Trim())" draggable=@DraggableAttribute style=@Style @onclick=@OnClick @onmouseenter=@OnMouseEnter @onmouseleave=@OnMouseLeave @ondrag=@OnDragStart ondragstart=@OnDragStartAttribute>
-        <div class="rz-event-content" title=@Title @attributes=@Attributes>
-            @if (ShowAppointmentContent)
-            {
-                @Scheduler.RenderAppointment(Data)
-            }
-        </div>
+@inject IJSRuntime JSRuntime
+@inject TooltipService TooltipService
+
+@* These classes are to style the handles for the resize operation. Not sure how you guys do this now with all the theming and such. So I'll just park it here and I'll leave it with you :) *@
+
+<style type="text/css">
+    .resizer {
+    width: 100%;
+    height: 6px;
+    left: 0;
+    background-color: transparent;
+    position: absolute;
+    cursor: row-resize;
+    }
+
+    .resizer-south {
+    bottom: -1px;
+    }
+
+    .resizer-north {
+    top: -1px;
+    }
+</style>
+
+@* Added id in order to reference from JavaScript *@
+
+<div @ref=@element id="@UniqueId" class="@($"{"rz-event"} {CssClass}".Trim())" draggable=@DraggableAttribute style=@Style @onclick=@OnClick @onmouseenter=@OnMouseEnter @onmouseleave=@OnMouseLeave @ondrag=@OnDragStart ondragstart=@OnDragStartAttribute>
+    @* The CanResize properties are internal and used to indicate whether to show the resize elements. We don't want them (yet?) for the Month and Year views. Only Day View sets it to true 
+       and only if the Start (North) or End (South) are within the CurrentDate
+    *@
+    @if (Scheduler?.HasAppointmentResizeDelegate() ?? false)
+    {
+        if (CanResizeNorth)
+        {
+            <div class="resizer resizer-north" @onmousedown=@((args) => OnResizeMouseDown(args, "north")) />
+        }
+        if (CanResizeSouth)
+        {
+            <div class="resizer resizer-south" @onmousedown=@((args) => OnResizeMouseDown(args, "south")) />
+        }
+    }
+    <div class="rz-event-content" title=@Title @attributes=@Attributes>
+        @if (ShowAppointmentContent)
+        {
+            @Scheduler.RenderAppointment(Data)
+        }
     </div>
+</div>
 @code {
     private ElementReference element;
 
     private string Title => Scheduler.HasMouseEnterAppointmentDelegate() ? null : Data?.Text;
 
-    private string DraggableAttribute => Scheduler?.HasAppointmentMoveDelegate() == true ? "true" : null;
+    @* Changed this to a normal property that is set in OnParametersAsync and elsewhere. 
+    We need to disable dragging when a resize is in operation, so this is set along with new property AppointmentResizing to achieve this. *@
+    private string DraggableAttribute { get; set; }
 
     private string OnDragStartAttribute => Scheduler?.HasAppointmentMoveDelegate() == true ? "event.dataTransfer.setData('', event.target.id)" : null;
+
+    private bool AppointmentResizing { get; set; }
 
     [Parameter]
     public string CssClass { get; set; }
@@ -47,13 +93,27 @@
     [Parameter]
     public bool ShowAppointmentContent { get; set; } = true;
 
+    [Parameter]
+    public bool CanResizeNorth { get; set; } = false;
+
+    [Parameter]
+    public bool CanResizeSouth { get; set; } = false;
+
     [CascadingParameter]
     public IScheduler Scheduler { get; set; }
 
     string Style { get; set; }
 
+    @* UniqueId for JavaScript to identify <div> *@
+    private string UniqueId { get; set; }
+
+    protected override void OnInitialized()
+    {
+        UniqueId = Guid.NewGuid().ToString();
+    }
     protected override void OnParametersSet()
     {
+        DraggableAttribute = Scheduler?.HasAppointmentMoveDelegate() == true && !AppointmentResizing ? "true" : null;
         Attributes = Scheduler.GetAppointmentAttributes(Data);
 
         var style = new List<string>();
@@ -99,5 +159,53 @@
     public async Task OnDragStart(DragEventArgs args)
     {
         await DragStart.InvokeAsync(Data);
+    }
+
+    @* Initialtes the Resize operation *@
+    async Task OnResizeMouseDown(MouseEventArgs args, string direction)
+    {        
+        @* Disable dragging while we are resizing *@
+        AppointmentResizing = true;
+        DraggableAttribute = Scheduler?.HasAppointmentMoveDelegate() == true && !AppointmentResizing ? "true" : null;
+
+        @* Setup and call into JavaScript *@
+        var reference = DotNetObjectReference.Create(this);
+
+        await JSRuntime.InvokeAsync<string>("Radzen.startResizeAppointment", reference, UniqueId, direction);
+    }
+
+    @* This is the callback from JavaScript when the resize operation ends *@
+    [JSInvokable("EndResize")]
+    public async Task OnResize(string dateTime, string direction)
+    {
+        var dateTimeParsed = DateTime.Parse(dateTime);
+
+        @* Re-enable dragging *@
+        AppointmentResizing = false;
+        DraggableAttribute = Scheduler?.HasAppointmentMoveDelegate() == true && !AppointmentResizing ? "true" : null;
+
+        @* Initiate Resize EventCallback with parameters dependant on direction of resize *@
+        if (direction == "south")
+        {
+            await Scheduler.ResizeAppointment(new SchedulerAppointmentResizeEventArgs { Appointment = Data, Start = Data.Start, End = dateTimeParsed });
+        }
+        else
+        {
+            await Scheduler.ResizeAppointment(new SchedulerAppointmentResizeEventArgs { Appointment = Data, Start = dateTimeParsed, End = Data.End });
+        }
+
+        TooltipService.Close();
+    }
+
+    @* This is the callback from JavaScript when the resize changes slot *@
+    [JSInvokable("ResizeShowTooltip")]
+    public async Task ShowTooltip( string dateTime, string direction)
+    {
+        var dateTimeParsed = DateTime.Parse(dateTime);
+
+        string time = dateTimeParsed.ToString("hh:mm tt", CultureInfo.InvariantCulture);
+        string prefix = direction == "south" ? "End at" : "Start at";
+        var toolPos = direction == "south" ? TooltipPosition.Bottom : TooltipPosition.Top;
+        TooltipService.Open(element, $"{prefix} {time}", new TooltipOptions() { Position = toolPos });
     }
 }

--- a/Radzen.Blazor/Rendering/DaySlotEvents.razor
+++ b/Radzen.Blazor/Rendering/DaySlotEvents.razor
@@ -29,9 +29,15 @@
 
     foreach (var appointment in Layout())
     {
+        var canResizeNorth = StartDate <= appointment.Appointment.Start;
+        var canResizeSouth = EndDate >= appointment.Appointment.End;
+
+        @* Only Day, Multiday and Week views will allow resizing and only if Appointment Starts and Ends are within StartDate and EndDate *@
         <Appointment Data=@(appointment.Appointment) Top=@appointment.Top Left=@appointment.Left Width=@appointment.Width Height=@appointment.Height Click=@OnAppointmentSelect
                 CssClass="@(CurrentDate.Date >= appointment.Start.Date && CurrentDate.Date <= appointment.End.Date && object.Equals(Appointments.Where(i => i.Start.Date == CurrentDate.Date).OrderBy(i => i.Start).ThenByDescending(i => i.End).ElementAtOrDefault(CurrentAppointment),appointment.Appointment) ? " rz-state-focused" : "" )"
-                DragStart=@OnAppointmentDragStart />
+                DragStart=@OnAppointmentDragStart
+                CanResizeNorth="@(canResizeNorth)"
+                CanResizeSouth="@(canResizeSouth)" />
     }
 }
 </div>

--- a/Radzen.Blazor/Rendering/DayView.razor
+++ b/Radzen.Blazor/Rendering/DayView.razor
@@ -16,7 +16,10 @@
             @for (var date = StartDate; date < EndDate; date = date.AddMinutes(MinutesPerSlot))
             {
                 var slotDate = date;
-                    <div @onclick=@(args => OnSlotClick(slotDate)) ondragover="event.preventDefault();" @ondrop=@(args => @OnDrop(slotDate)) @attributes=@Attributes(date)></div>
+                @* The following is to cap off any drags to "today" 23:59 as this always overruns past midnight. Going into next day will require a manual edit of the appointment *@
+                var slotDateSouth = slotDate.AddMinutes(MinutesPerSlot).Date > date.Date ? slotDate.Date.AddHours(23).AddMinutes(59) : slotDate.AddMinutes(MinutesPerSlot);
+                @* Pass the slotDate as an attribute so JavaScript can grab it to send it back on completion of the resize *@
+                <div data-slotdate-north="@slotDate" data-slotdate-south="@slotDateSouth" @onclick=@(args => OnSlotClick(slotDate)) ondragover="event.preventDefault();" @ondrop=@(args => @OnDrop(slotDate)) @attributes=@Attributes(date)></div>
             }
         </div>
     </div>

--- a/Radzen.Blazor/Rendering/WeekView.razor
+++ b/Radzen.Blazor/Rendering/WeekView.razor
@@ -26,7 +26,10 @@
                 @for (var date = start; date < end; date = date.AddMinutes(MinutesPerSlot))
                 {
                     var slotDate = date;
-                    <div @onclick=@(args => OnSlotClick(slotDate)) ondragover="event.preventDefault();" @ondrop=@(args => @OnDrop(slotDate)) @attributes=@Attributes(date)></div>
+                    @* The following is to cap off any drags to "today" 23:59 as this always overruns past midnight. Going into next day will require a manual edit of the appointment *@
+                    var slotDateSouth = slotDate.AddMinutes(MinutesPerSlot).Date > date.Date ? slotDate.Date.AddHours(23).AddMinutes(59) : slotDate.AddMinutes(MinutesPerSlot);
+                    @* Pass the slotDates as attributes so JavaScript can grab it to send it back on completion of the resize *@
+                    <div data-slotdate-north="@slotDate" data-slotdate-south="@slotDateSouth" @onclick=@(args => OnSlotClick(slotDate)) ondragover="event.preventDefault();" @ondrop=@(args => @OnDrop(slotDate)) @attributes=@Attributes(date)></div>
                 }
             </div>
         }

--- a/RadzenBlazorDemos/Pages/SchedulerConfig.razor
+++ b/RadzenBlazorDemos/Pages/SchedulerConfig.razor
@@ -5,12 +5,14 @@
     <RadzenSwitch @bind-Value=@showHeader />
 </RadzenStack>
 
-<RadzenScheduler @ref=@scheduler SlotRender=@OnSlotRender style="height: 768px;" TItem="Appointment" Data=@appointments StartProperty="Start" EndProperty="End" ShowHeader=@showHeader
-                 TextProperty="Text" SelectedIndex="2"
-    SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender
-    AppointmentMove=@OnAppointmentMove >
-    <RadzenDayView />
-    <RadzenWeekView />
+<RadzenScheduler @ref=@scheduler SlotRender=@OnSlotRender style="height: 868px;" TItem="Appointment" Data=@appointments StartProperty="Start" EndProperty="End" ShowHeader=@showHeader
+                 TextProperty="Text" SelectedIndex="0"
+                 SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender
+                 AppointmentMove=@OnAppointmentMove
+                 AppointmentResize="@OnAppointmentResize">
+    <RadzenDayView TimeFormat="hh:mm tt" />
+    <RadzenMultiDayView NumberOfDays="4" AdvanceDays="1" TimeFormat="hh:mm tt" />
+    <RadzenWeekView TimeFormat="hh:mm tt" />
     <RadzenMonthView />
 </RadzenScheduler>
 
@@ -25,13 +27,13 @@
 
     IList<Appointment> appointments = new List<Appointment>
     {
-        new Appointment { Start = DateTime.Today.AddDays(-2), End = DateTime.Today.AddDays(-2), Text = "Birthday" },
-        new Appointment { Start = DateTime.Today.AddDays(-11), End = DateTime.Today.AddDays(-10), Text = "Day off" },
-        new Appointment { Start = DateTime.Today.AddDays(-10), End = DateTime.Today.AddDays(-8), Text = "Work from home" },
+        new Appointment { Start = DateTime.Today.AddDays(-3), End = DateTime.Today.AddDays(-3).AddHours(23).AddMinutes(59), Text = "Birthday" },
+        new Appointment { Start = DateTime.Today.AddDays(2), End = DateTime.Today.AddDays(2).AddHours(23).AddMinutes(59), Text = "Day off" },
+        new Appointment { Start = DateTime.Today.AddDays(-10).AddHours(8).AddMinutes(30), End = DateTime.Today.AddDays(-8).AddHours(17).AddMinutes(0), Text = "Work from home" },
         new Appointment { Start = DateTime.Today.AddHours(10), End = DateTime.Today.AddHours(12), Text = "Online meeting" },
         new Appointment { Start = DateTime.Today.AddHours(10), End = DateTime.Today.AddHours(13), Text = "Skype call" },
         new Appointment { Start = DateTime.Today.AddHours(14), End = DateTime.Today.AddHours(14).AddMinutes(30), Text = "Dentist appointment" },
-        new Appointment { Start = DateTime.Today.AddDays(1), End = DateTime.Today.AddDays(12), Text = "Vacation" },
+        new Appointment { Start = DateTime.Today.AddDays(-5).AddHours(8), End = DateTime.Today.AddDays(-2), Text = "Vacation" },
     };
 
     void OnSlotRender(SchedulerSlotRenderEventArgs args)
@@ -110,6 +112,20 @@
             draggedAppointment.Start = draggedAppointment.Start + args.TimeSpan;
 
             draggedAppointment.End = draggedAppointment.End + args.TimeSpan;
+
+            await scheduler.Reload();
+        }
+    }
+
+    async Task OnAppointmentResize(SchedulerAppointmentResizeEventArgs args)
+    {
+        var draggedAppointment = appointments.FirstOrDefault(x => x == args.Appointment.Data);
+
+        if (draggedAppointment != null)
+        {
+            draggedAppointment.Start = args.Start;
+
+            draggedAppointment.End = args.End;
 
             await scheduler.Reload();
         }


### PR DESCRIPTION
Hi Team

This is a PR that addresses resizing appointments in the Scheduler.

I've only implemented this for `DayView`, `MultidayView` and `WeekView`. The other views show partial appointments as occupying full slots. It's not really applicable as is stands.

I've tried to comment all aspects of the changes so you can follow the logic.

Apart from the standard summary / documentation, I've not added any comments to `Common.cs`, `IScheduler.cs` and `RadzenScheduler.razor.cs` as the changes are straightforward boilerplate to service Events and such.

The bulk of the changes lie in `Appointment.razor` and `Radzen.Blazor.js`, which I have heavily commented.

You will notice that I've included a `<style>` block within `Appointment.razor`. I couldn't find how to add this properly, so I must leave it with you to transfer to the appropriate place (or advise how I do that).

The first demo on the Scheduler page is the one that implements `AppointmentResize`.

Stay well and regards
Paul



