### PR TITLE
Bug fix present in RadzenDropDownDataGrid from version 5.7.0

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -454,7 +454,10 @@ namespace Radzen
                     disabledPropertyGetter = GetGetter(DisabledProperty, type);
                 }
 
-                selectedItems = new HashSet<object>(ItemComparer);
+                if (selectedItems.Count == 0)
+                {
+                    selectedItems = new HashSet<object>(ItemComparer);
+                }
             }
         }
 


### PR DESCRIPTION
When `RadzenDropDownDataGrid` is set to allow multi-selection and virtualization with LoadData, it doesn't keep all items selected as you scroll through the list. Optimized the initialization of selectedItems in **DropDownBase**, so that selectedItems is reinitialized only if empty, thus preserving existing items.