### PR TITLE
Ranking: restore filled stars

### DIFF
--- a/Radzen.Blazor/RadzenSelectBar.razor
+++ b/Radzen.Blazor/RadzenSelectBar.razor
@@ -15,7 +15,27 @@
 {
     <div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
         @foreach (var item in allItems.Where(i => i.Visible))
-        {<div @ref="@item.Element" id="@item.GetItemId()" @onclick="@(args => SelectItem(item))" @onkeypress="@(args => OnKeyPress(args, SelectItem(item)))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation @attributes="item.Attributes" style="@item.Style"
-              class=@ButtonClassList(item) aria-label="@item.Text" tabindex="@(Disabled || item.Disabled ? "-1" : $"{TabIndex}")">@if(item.Template != null){ @item.Template(item)}else{@if (!string.IsNullOrEmpty(item.Icon)){<i class="notranslate rzi rz-navigation-item-icon" style="margin-right:2px;@(!string.IsNullOrEmpty(item.IconColor) ? $"color:{item.IconColor}" : "")">@((MarkupString)item.Icon)</i>}@if (!string.IsNullOrEmpty(item.Image)){<img class="rz-navigation-item-icon" src="@item.Image" style="@item.ImageStyle" alt=@item.ImageAlternateText/>}<span class="rz-button-text">@item.Text</span>}</div>}
+        {
+            <div @ref="@item.Element" id="@item.GetItemId()"
+                @onclick="@(args => SelectItem(item))" @onkeypress="@(args => OnKeyPress(args, SelectItem(item)))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
+                @attributes="item.Attributes" style="@item.Style" class=@ButtonClassList(item) aria-label="@item.Text" tabindex="@(Disabled || item.Disabled ? "-1" : $"{TabIndex}")">
+                @if (item.Template != null)
+                {
+                    @item.Template(item)
+                }
+                else
+                {
+                    @if (!string.IsNullOrEmpty(item.Icon))
+                    {
+                        <i class="notranslate rzi rz-navigation-item-icon" style="margin-right:2px;@(!string.IsNullOrEmpty(item.IconColor) ? $"color:{item.IconColor}" : "")">@((MarkupString)item.Icon)</i>
+                    }
+                    @if (!string.IsNullOrEmpty(item.Image))
+                    {
+                        <img class="rz-navigation-item-icon" src="@item.Image" style="@item.ImageStyle" alt=@item.ImageAlternateText/>
+                    }
+                    <span class="rz-button-text">@item.Text</span>
+                }
+            </div>
+        }
     </div>
 }

--- a/Radzen.Blazor/RadzenSelectBar.razor.cs
+++ b/Radzen.Blazor/RadzenSelectBar.razor.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.JSInterop;
 using Radzen.Blazor.Rendering;
 using System;
 using System.Collections;
@@ -34,16 +33,24 @@ namespace Radzen.Blazor
         }
 
         /// <summary>
-        /// Gets or sets the size.
+        /// Gets or sets the size. Set to <c>ButtonSize.Medium</c> by default.
         /// </summary>
         /// <value>The size.</value>
         [Parameter]
         public ButtonSize Size { get; set; } = ButtonSize.Medium;
 
+        /// <summary>
+        /// Gets or sets the orientation. Set to <c>Orientation.Horizontal</c> by default.
+        /// </summary>
+        /// <value>The orientation.</value>
+        [Parameter]
+        public Orientation Orientation { get; set; } = Orientation.Horizontal;
 
-        ClassList ButtonClassList(RadzenSelectBarItem item) => ClassList.Create($"rz-button rz-button-{getButtonSize()} rz-button-text-only")
-                            .Add("rz-state-active", IsSelected(item))
-                            .AddDisabled(Disabled || item.Disabled);
+
+        ClassList ButtonClassList(RadzenSelectBarItem item)
+            => ClassList.Create($"rz-button rz-button-{getButtonSize()} rz-button-text-only")
+                        .Add("rz-state-active", IsSelected(item))
+                        .AddDisabled(Disabled || item.Disabled);
 
         /// <summary>
         /// Gets or sets the value property.
@@ -98,9 +105,10 @@ namespace Radzen.Blazor
 
         /// <inheritdoc />
         protected override string GetComponentCssClass()
-        {
-            return GetClassList("rz-selectbutton rz-buttonset").Add($"rz-buttonset-{items.Count}").ToString();
-        }
+            => GetClassList("rz-selectbutton rz-buttonset")
+                .Add($"rz-selectbutton-{(Orientation == Orientation.Vertical ? "vertical" : "horizontal")}")
+                .Add($"rz-buttonset-{items.Count}")
+                .ToString();
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="RadzenSelectBar{TValue}"/> is multiple.
@@ -180,7 +188,7 @@ namespace Radzen.Blazor
         /// Selects the item.
         /// </summary>
         /// <param name="item">The item.</param>
-        protected async System.Threading.Tasks.Task SelectItem(RadzenSelectBarItem item)
+        protected async Task SelectItem(RadzenSelectBarItem item)
         {
             if (Disabled || item.Disabled)
                 return;

--- a/Radzen.Blazor/themes/components/blazor/_rating.scss
+++ b/Radzen.Blazor/themes/components/blazor/_rating.scss
@@ -46,7 +46,8 @@ $rating-ban-icon-color: $rating-color !default;
     opacity: var(--rz-rating-opacity);
 
     &:before {
-      content: "star_border";
+      content: "star";
+      font-variation-settings: "FILL" 0;
     }
   }
 
@@ -55,34 +56,19 @@ $rating-ban-icon-color: $rating-color !default;
 
     &:before {
       content: "star";
+      font-variation-settings: "FILL" 1;
     }
   }
 
   &:not(.rz-state-disabled):not(.rz-state-readonly) {
 
-    a:hover {
+    a:hover, a:focus-visible {
       cursor: pointer;
 
       .rzi-star,
       .rzi-star-o,
       .rzi-ban {
-        color: var(--rz-rating-selected-color);
-      }
-
-      .rzi-star-o:before {
-        content: "star";
-      }
-    }
-
-    a:focus-visible {
-      .rzi-star,
-      .rzi-star-o,
-      .rzi-ban {
         color: var(--rz-rating-focus-color);
-      }
-
-      .rzi-star-o:before {
-        content: "star";
       }
     }
   }

--- a/Radzen.Blazor/themes/components/blazor/_selectbar.scss
+++ b/Radzen.Blazor/themes/components/blazor/_selectbar.scss
@@ -12,6 +12,14 @@ $selectbar-sizes: xs, sm, md, lg;
   box-sizing: border-box;
   display: inline-flex;
 
+  &.rz-selectbutton-horizontal {
+      flex-direction: row;
+  }
+
+  &.rz-selectbutton-vertical {
+      flex-direction: column;
+  }
+
   .rz-button {
     &:focus-visible {
       z-index: 1;
@@ -19,30 +27,58 @@ $selectbar-sizes: xs, sm, md, lg;
   }
 }
 
-@each $size in $selectbar-sizes {  //.rz-selectbutton .rz-button.rz-button-md
-  .rz-selectbutton .rz-button.rz-button-#{$size} {
-    margin-inline-start: -1px;
-    display: inline-block;
-    background-color: var(--rz-selectbar-background-color);
-    color: var(--rz-selectbar-color);
-    border: var(--rz-selectbar-border);
-    border-radius: 0;
-
-    &:first-child {
-      margin-inline-start: 0;
-      border-start-start-radius: var(--rz-selectbar-border-radius);
-      border-end-start-radius: var(--rz-selectbar-border-radius);
+@each $size in $selectbar-sizes {
+  .rz-selectbutton {
+    .rz-button.rz-button-#{$size} {
+      display: inline-block;
+      background-color: var(--rz-selectbar-background-color);
+      color: var(--rz-selectbar-color);
+      border: var(--rz-selectbar-border);
+      border-radius: 0;
+    
+      &.rz-state-active {
+        background-color: var(--rz-selectbar-selected-background-color);
+        color: var(--rz-selectbar-selected-color);
+        border: var(--rz-selectbar-selected-border);
+      }
     }
 
-    &:last-child {
-      border-start-end-radius: var(--rz-selectbar-border-radius);
-      border-end-end-radius: var(--rz-selectbar-border-radius);
+    &.rz-selectbutton-horizontal {
+      .rz-button.rz-button-#{$size} {
+        &:first-child {
+          border-start-start-radius: var(--rz-selectbar-border-radius);
+          border-end-start-radius: var(--rz-selectbar-border-radius);
+        }
+
+        &:not(:first-child) {
+          border-inline-start: none;
+        }
+      
+        &:last-child {
+          border-start-end-radius: var(--rz-selectbar-border-radius);
+          border-end-end-radius: var(--rz-selectbar-border-radius);
+        }
+      }
     }
 
-    &.rz-state-active {
-      background-color: var(--rz-selectbar-selected-background-color);
-      color: var(--rz-selectbar-selected-color);
-      border: var(--rz-selectbar-selected-border);
+    &.rz-selectbutton-vertical {
+      .rz-button.rz-button-#{$size} {
+        text-align: center;
+
+        &:first-child {
+          border-top-left-radius: var(--rz-selectbar-border-radius);
+          border-top-right-radius: var(--rz-selectbar-border-radius);
+        }
+
+        &:not(:first-child) {
+          border-top: none;
+        }
+      
+        &:last-child {
+          border-bottom-left-radius: var(--rz-selectbar-border-radius);
+          border-bottom-right-radius: var(--rz-selectbar-border-radius);
+        }
+      }
     }
   }
 }

--- a/RadzenBlazorDemos/Pages/SelectBarOrientation.razor
+++ b/RadzenBlazorDemos/Pages/SelectBarOrientation.razor
@@ -1,0 +1,18 @@
+﻿<RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.Center" Gap="1rem" Wrap="FlexWrap.Wrap" class="rz-p-12">
+    <RadzenSelectBar Orientation="Orientation.Horizontal" @bind-Value=@value TValue="bool">
+        <Items>
+            <RadzenSelectBarItem Text="On" Value="true" />
+            <RadzenSelectBarItem Text="Off" Value="false" />
+        </Items>
+    </RadzenSelectBar>
+    <RadzenSelectBar Orientation="Orientation.Vertical" @bind-Value=@value TValue="bool">
+        <Items>
+            <RadzenSelectBarItem Text="On" Value="true" />
+            <RadzenSelectBarItem Text="Off" Value="false" />
+        </Items>
+    </RadzenSelectBar>
+</RadzenStack>
+
+@code {
+    bool value;
+}

--- a/RadzenBlazorDemos/Pages/SelectBarPage.razor
+++ b/RadzenBlazorDemos/Pages/SelectBarPage.razor
@@ -84,6 +84,13 @@
     <SelectBarSize />
 </RadzenExample>
 
+<RadzenText Anchor="selectbar#orientation" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
+    SelectBar Orientation
+</RadzenText>
+<RadzenExample ComponentName="SelectBar" Example="SelectBarOrientation">
+    <SelectBarOrientation />
+</RadzenExample>
+
 <RadzenText Anchor="selectbar#keyboard-navigation" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
     Keyboard Navigation
 </RadzenText>

--- a/RadzenBlazorDemos/RadzenBlazorDemos.csproj
+++ b/RadzenBlazorDemos/RadzenBlazorDemos.csproj
@@ -18,5 +18,8 @@
     <Content Update="Pages\DataGridRowDragSchedulerPage.razor">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>
+    <Content Update="Pages\SelectBarOrientation.razor">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
   </ItemGroup>
 </Project>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -1474,6 +1474,7 @@ namespace RadzenBlazorDemos
                 {
                     Name = "SelectBar",
                     Path = "selectbar",
+                    Updated = true,
                     Description = "Demonstration and configuration of the Radzen Blazor SelectBar component.",
                     Icon = "&#xf8e8",
                     Tags = new [] { "form", "edit" }


### PR DESCRIPTION
Radzen 5 has introduced a new icon font that made ranking stars no longer fill:
![image](https://github.com/user-attachments/assets/9170b38b-b543-4f8e-be4d-2c64fa6ba5fa)
The first two stars are selected.

These changes:
- make selected stars always filled,
- prevent hovered stars from looking like selected stars,
- make hovered stars use the same style as focused ones.

![ranking new](https://github.com/user-attachments/assets/b5a92d1d-98bb-4b5a-81cb-737a833c2bb2)
(for some reason this gif doesn't animate here – you need to open it in a new tab)
