### PR TITLE
Rating: restore filled stars

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_rating.scss
+++ b/Radzen.Blazor/themes/components/blazor/_rating.scss
@@ -46,7 +46,8 @@ $rating-ban-icon-color: $rating-color !default;
     opacity: var(--rz-rating-opacity);
 
     &:before {
-      content: "star_border";
+      content: "star";
+      font-variation-settings: "FILL" 0;
     }
   }
 
@@ -55,34 +56,19 @@ $rating-ban-icon-color: $rating-color !default;
 
     &:before {
       content: "star";
+      font-variation-settings: "FILL" 1;
     }
   }
 
   &:not(.rz-state-disabled):not(.rz-state-readonly) {
 
-    a:hover {
+    a:hover, a:focus-visible {
       cursor: pointer;
 
       .rzi-star,
       .rzi-star-o,
       .rzi-ban {
-        color: var(--rz-rating-selected-color);
-      }
-
-      .rzi-star-o:before {
-        content: "star";
-      }
-    }
-
-    a:focus-visible {
-      .rzi-star,
-      .rzi-star-o,
-      .rzi-ban {
         color: var(--rz-rating-focus-color);
-      }
-
-      .rzi-star-o:before {
-        content: "star";
       }
     }
   }


### PR DESCRIPTION
Radzen 5 has introduced a new icon font that made rating stars no longer fill:
![image](https://github.com/user-attachments/assets/9170b38b-b543-4f8e-be4d-2c64fa6ba5fa)
The first two stars are selected.

These changes:
- make selected stars always filled,
- prevent hovered stars from looking like selected stars,
- make hovered stars use the same style as focused ones.

![ranking new](https://github.com/user-attachments/assets/b5a92d1d-98bb-4b5a-81cb-737a833c2bb2)
(for some reason this gif doesn't animate here – you need to open it in a new tab)

⚠️ The dark premium styles have a really dark, inaccessible focus color. Please check them.