### PR TITLE
Add DaySelect event to Day, Week and Month Views

### DIFF
--- a/Radzen.Blazor/IScheduler.cs
+++ b/Radzen.Blazor/IScheduler.cs
@@ -77,6 +77,12 @@ namespace Radzen.Blazor
         /// <param name="appointments">The appointments for this range.</param>
         Task SelectMonth(DateTime monthStart, IEnumerable<AppointmentData> appointments);
         /// <summary>
+        /// Selects the specified day.
+        /// </summary>
+        /// <param name="day">The selected day.</param>
+        /// <param name="appointments">The appointments for this range.</param>
+        Task SelectDay(DateTime day, IEnumerable<AppointmentData> appointments);
+        /// <summary>
         /// Selects the specified more link.
         /// </summary>
         /// <param name="start">The start.</param>

--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -206,6 +206,24 @@ namespace Radzen.Blazor
         public EventCallback<SchedulerMonthSelectEventArgs> MonthSelect { get; set; }
 
         /// <summary>
+        /// A callback that will be invoked when the user clicks a month header button.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// &lt;RadzenScheduler Data=@appointments MonthSelect=@OnMonthSelect&gt;
+        /// &lt;/RadzenScheduler&gt;
+        /// @code {
+        /// void OnMonthSelect(SchedulerTodaySelectEventArgs args)
+        /// {
+        ///     args.Month = DateTime.Month.AddMonth(1);
+        /// }
+        /// }
+        /// </code>
+        /// </example>
+        [Parameter]
+        public EventCallback<SchedulerDaySelectEventArgs> DaySelect { get; set; }
+
+        /// <summary>
         /// A callback that will be invoked when the user clicks an appointment in the current view. Commonly used to edit existing appointments.
         /// </summary>
         /// <example>
@@ -392,6 +410,12 @@ namespace Radzen.Blazor
         public async Task SelectMonth(DateTime monthStart, IEnumerable<AppointmentData> appointments)
         {
             await MonthSelect.InvokeAsync(new SchedulerMonthSelectEventArgs { MonthStart = monthStart, Appointments = appointments, View = SelectedView });
+        }
+
+        /// <inheritdoc />
+        public async Task SelectDay(DateTime day, IEnumerable<AppointmentData> appointments)
+        {
+            await DaySelect.InvokeAsync(new SchedulerDaySelectEventArgs { Day = day, Appointments = appointments, View = SelectedView });
         }
 
         /// <inheritdoc />

--- a/Radzen.Blazor/Rendering/DateTimeExtensions.cs
+++ b/Radzen.Blazor/Rendering/DateTimeExtensions.cs
@@ -54,5 +54,25 @@ namespace Radzen.Blazor.Rendering
         {
             return date.StartOfWeek().AddDays(6);
         }
+
+        /// <summary>
+        /// Start of the day.
+        /// </summary>
+        /// <param name="date">The date.</param>
+        /// <returns>DateTime.</returns>
+        public static DateTime StartOfDay(this DateTime date)
+        {
+            return date.Date;
+        }
+
+        /// <summary>
+        /// End of the day.
+        /// </summary>
+        /// <param name="date">The date.</param>
+        /// <returns>DateTime.</returns>
+        public static DateTime EndOfDay(this DateTime date)
+        {
+            return date.AddHours(23).AddMinutes(59).AddSeconds(59);
+        }
     }
 }

--- a/Radzen.Blazor/Rendering/DayView.razor
+++ b/Radzen.Blazor/Rendering/DayView.razor
@@ -2,7 +2,7 @@
 @inherits DropableViewBase
 
 <div class="rz-view rz-day-view">
-    <div class="rz-view-header">
+    <div class="rz-view-header" style="cursor: pointer;" @onclick=@(args => OnDayClick(@StartDate))>
         <div class="rz-slot-hour-header"></div>
         <div class="rz-slot-header">
             @StartDate.ToString("ddd", Scheduler.Culture)
@@ -64,6 +64,11 @@
         await Scheduler.SelectSlot(date, date.AddMinutes(MinutesPerSlot), AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
     }
 
+    async Task OnDayClick(DateTime day)
+    {
+        await Scheduler.SelectDay(day, AppointmentsInSlot(day.StartOfDay(), day.EndOfDay()));
+    }
+
     IDictionary<string, object> Attributes(DateTime date)
     {
         var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot));
@@ -84,7 +89,7 @@
         var updown = key == "ArrowUp" || key == "ArrowDown";
         var leftright = key == "ArrowLeft" || key == "ArrowRight";
 
-        currentAppointments = AppointmentsInSlot(CurrentDate, CurrentDate.AddDays(1));
+        currentAppointments = AppointmentsInSlot(CurrentDate.StartOfDay(), CurrentDate.EndOfDay());
 
         if (arrow && currentAppointments.Any())
         {

--- a/Radzen.Blazor/Rendering/MonthView.razor
+++ b/Radzen.Blazor/Rendering/MonthView.razor
@@ -82,7 +82,7 @@
             {
                 var dayOfWeek = StartDate.AddDays(days++);
                 <div @onclick="@(args => OnSlotClick(dayOfWeek))" ondragover="event.preventDefault();" @ondrop=@(args => @OnDrop(dayOfWeek)) @attributes=@Attributes(dayOfWeek)>
-                    <div class="rz-slot-title @(dayOfWeek == CurrentDate ? " rz-state-focused" : "")">
+                    <div class="rz-slot-title @(dayOfWeek == CurrentDate ? " rz-state-focused" : "")" style="cursor: pointer;" @onclick=@(args => OnDayClick(dayOfWeek)) @onclick:stopPropagation>
                         @dayOfWeek.Day
                     </div>
                 </div>
@@ -123,6 +123,11 @@
     async Task OnSlotClick(DateTime date)
     {
         await Scheduler.SelectSlot(date, date.AddDays(1), AppointmentsInSlot(date, date.AddDays(1)));
+    }
+
+    async Task OnDayClick(DateTime day)
+    {
+        await Scheduler.SelectDay(day, AppointmentsInSlot(day.StartOfDay(), day.EndOfDay()));
     }
 
     double DetermineTop(HashSet<double> existingTops)

--- a/Radzen.Blazor/Rendering/WeekView.razor
+++ b/Radzen.Blazor/Rendering/WeekView.razor
@@ -8,7 +8,8 @@
         <div class="rz-slot-hour-header"></div>
     @for (var day = StartDate; day < EndDate; day = day.AddDays(1))
     {
-        <div class="rz-slot-header">
+        var loopDay = day;
+        <div class="rz-slot-header" style="cursor: pointer;" @onclick=@(args => OnDayClick(@loopDay))>
             @day.ToString(HeaderFormat, Scheduler.Culture)
         </div>
     }
@@ -76,6 +77,11 @@
     async Task OnSlotClick(DateTime date)
     {
         await Scheduler.SelectSlot(date, date.AddMinutes(MinutesPerSlot), AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
+    }
+
+    async Task OnDayClick(DateTime day)
+    {
+        await Scheduler.SelectDay(day, AppointmentsInSlot(day.StartOfDay(), day.EndOfDay()));
     }
 
     IDictionary<string, object> Attributes(DateTime date)

--- a/Radzen.Blazor/SchedulerDaySelectEventArgs.cs
+++ b/Radzen.Blazor/SchedulerDaySelectEventArgs.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Radzen.Blazor;
+
+namespace Radzen
+{
+    /// <summary>
+    /// Supplies information about a <see cref="RadzenScheduler{TItem}.MonthSelect" /> event that is being raised.
+    /// </summary>
+    public class SchedulerDaySelectEventArgs
+    {
+        /// <summary>
+        /// Monthg start date. You can change this value to navigate to a different date.
+        /// </summary>
+        public DateTime Day { get; set; }
+        /// <summary>
+        /// List of appointments.
+        /// </summary>
+        public IEnumerable<AppointmentData> Appointments { get; set; }
+        /// <summary>
+        /// Current View.
+        /// </summary>
+        public ISchedulerView View { get; set; }
+    }
+}

--- a/RadzenBlazorDemos/Pages/SchedulerConfig.razor
+++ b/RadzenBlazorDemos/Pages/SchedulerConfig.razor
@@ -7,7 +7,7 @@
 
 <RadzenScheduler @ref=@scheduler SlotRender=@OnSlotRender style="height: 768px;" TItem="Appointment" Data=@appointments StartProperty="Start" EndProperty="End" ShowHeader=@showHeader
                  TextProperty="Text" SelectedIndex="2"
-    SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender
+    SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender DaySelect="@OnDaySelect"
     AppointmentMove=@OnAppointmentMove >
     <RadzenDayView />
     <RadzenWeekView />
@@ -33,6 +33,12 @@
         new Appointment { Start = DateTime.Today.AddHours(14), End = DateTime.Today.AddHours(14).AddMinutes(30), Text = "Dentist appointment" },
         new Appointment { Start = DateTime.Today.AddDays(1), End = DateTime.Today.AddDays(12), Text = "Vacation" },
     };
+
+    async Task OnDaySelect(SchedulerDaySelectEventArgs args)
+    {
+        console.Log($"DaySelect: Day={args.Day} AppointmentCount={args.Appointments.Count()}");
+        await Task.CompletedTask;
+    }
 
     void OnSlotRender(SchedulerSlotRenderEventArgs args)
     {


### PR DESCRIPTION
Similar to the `MonthSelect` on the various Year Views, this will raise a `SelectDay` event on a click of the Day Header (Day and Week View) or the Day Number (Month View).

Additional

Also in this PR, I had to change a line in the `OnKeyPress` event in `DayView.razor`. 

    `currentAppointments = AppointmentsInSlot(CurrentDate, CurrentDate.AddDays(1));`

This was taking the `CurrentDate`, which includes the `StartTime` and setting the range to `CurrentDate.AddDays(1)`. This resulted in (using default `StartTime` value) from 08:00 one day to to 08:00 the next day. All other range calculations are based on actual start of day to end of day.

