### PR TITLE
Add empty string support, culture based cast

### DIFF
--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -463,10 +463,11 @@ namespace Radzen.Blazor.Tests
             ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
 
             var value = new Dollars(11m);
-            Dollars? ConvertFunc(string s) => decimal.TryParse(s, out var val) ? new Dollars(val) : null;
+            Dollars? ConvertFunc(string s) => decimal.TryParse(s, System.Globalization.CultureInfo.InvariantCulture, out var val) ? new Dollars(val) : null;
             var component = ctx.RenderComponent<RadzenNumeric<Dollars?>>(
                 ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars?>.ConvertValue), (Func<string, Dollars?>)ConvertFunc),
-                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars?>.Value), value)
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars?>.Value), value),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Culture), System.Globalization.CultureInfo.InvariantCulture)
             );
 
             component.Render();
@@ -489,12 +490,51 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenNumeric<Dollars>>(
                 ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Format), format),
-                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Value), valueToTest)
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Value), valueToTest),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Culture), System.Globalization.CultureInfo.InvariantCulture)
             );
 
             component.Render();
 
             Assert.Contains($" value=\"{valueToTest.ToString(format)}\"", component.Markup);
+        }
+
+        [Fact]
+        public void Numeric_Supports_EmptyString()
+        {
+            using var ctx = new TestContext();
+
+            var valueToTest = "";
+            string format = "0.00";
+
+            var component = ctx.RenderComponent<RadzenNumeric<string>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Value), valueToTest),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Culture), System.Globalization.CultureInfo.InvariantCulture)
+            );
+
+            component.Render();
+
+            Assert.Contains($" value=\"0.00\"", component.Markup);
+        }
+
+        [Fact]
+        public void Numeric_Supports_ValueString()
+        {
+            using var ctx = new TestContext();
+
+            var valueToTest = "12.50";
+            string format = "0.00";
+
+            var component = ctx.RenderComponent<RadzenNumeric<string>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Value), valueToTest),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Culture), System.Globalization.CultureInfo.InvariantCulture)
+            );
+
+            component.Render();
+
+            Assert.Contains($" value=\"{valueToTest}\"", component.Markup);
         }
 
         [Fact]

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -490,13 +490,30 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenNumeric<Dollars>>(
                 ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Value), valueToTest)
+            );
+
+            component.Render();
+
+            Assert.Contains($" value=\"{valueToTest.ToString(format, System.Globalization.CultureInfo.CurrentCulture)}\"", component.Markup);
+        }
+        [Fact]
+        public void Numeric_Supports_TypeConverterWithCulture()
+        {
+            using var ctx = new TestContext();
+
+            var valueToTest = new Dollars(100.234m);
+            string format = "0.00";
+
+            var component = ctx.RenderComponent<RadzenNumeric<Dollars>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Format), format),
                 ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Value), valueToTest),
                 ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Culture), System.Globalization.CultureInfo.InvariantCulture)
             );
 
             component.Render();
 
-            Assert.Contains($" value=\"{valueToTest.ToString(format)}\"", component.Markup);
+            Assert.Contains($" value=\"{valueToTest.ToString(format, System.Globalization.CultureInfo.InvariantCulture)}\"", component.Markup);
         }
 
         [Fact]

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -538,6 +538,44 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Numeric_Supports_ValueStringEsCLCulture()
+        {
+            using var ctx = new TestContext();
+
+            var valueToTest = "12,50";
+            string format = "0.00";
+
+            var component = ctx.RenderComponent<RadzenNumeric<string>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Value), valueToTest),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Culture), System.Globalization.CultureInfo.GetCultureInfo("es-CL"))
+            );
+
+            component.Render();
+
+            Assert.Contains($" value=\"{valueToTest}\"", component.Markup);
+        }
+
+        [Fact]
+        public void Numeric_Supports_ValueStringEnUSCulture()
+        {
+            using var ctx = new TestContext();
+
+            var valueToTest = "12.50";
+            string format = "0.00";
+
+            var component = ctx.RenderComponent<RadzenNumeric<string>>(
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Format), format),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<string>.Value), valueToTest),
+                ComponentParameter.CreateParameter(nameof(RadzenNumeric<Dollars>.Culture), System.Globalization.CultureInfo.GetCultureInfo("en-US"))
+            );
+
+            component.Render();
+
+            Assert.Contains($" value=\"{valueToTest}\"", component.Markup);
+        }
+
+        [Fact]
         public void Numeric_Supports_IComparable()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -7,6 +7,7 @@ using Radzen.Blazor.Rendering;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Dynamic.Core;
 using System.Linq.Dynamic.Core.Parser;
@@ -2871,9 +2872,14 @@ namespace Radzen
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="type">The type.</param>
+        /// <param name="culture">The culture.</param>
         /// <returns>System.Object</returns>
-        public static object ChangeType(object value, Type type)
+        public static object ChangeType(object value, Type type, CultureInfo culture = null)
         {
+            if (culture == null)
+            {
+                culture = CultureInfo.CurrentCulture;
+            }
             if (value == null && Nullable.GetUnderlyingType(type) != null)
             {
                 return value;
@@ -2901,7 +2907,7 @@ namespace Radzen
 
             }
 
-            return value is IConvertible ? Convert.ChangeType(value, Nullable.GetUnderlyingType(type) ?? type) : value;
+            return value is IConvertible ? Convert.ChangeType(value, Nullable.GetUnderlyingType(type) ?? type, culture) : value;
         }
     }
 

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -317,8 +317,6 @@ namespace Radzen.Blazor
         [Parameter]
         public TextAlign TextAlign { get; set; } = TextAlign.Left;
 
-        TypeConverter validator = TypeDescriptor.GetConverter(typeof(decimal));
-
         /// <summary>
         /// Handles the <see cref="E:Change" /> event.
         /// </summary>
@@ -448,15 +446,16 @@ namespace Radzen.Blazor
                 return default;
 
             var converter = TypeDescriptor.GetConverter(typeof(TValue));
-            
-
             if (converter.CanConvertTo(typeof(decimal)))
-                if (!validator.IsValid(input))
-                    return 0;
-                else
-                    return (decimal)converter.ConvertTo(null, Culture, input, typeof(decimal));
-            
-            return (decimal)ConvertType.ChangeType(input, typeof(decimal));
+                return (decimal)converter.ConvertTo(null, Culture, input, typeof(decimal));
+            try
+            {
+                return (decimal)ConvertType.ChangeType(input, typeof(decimal), Culture);
+            }
+            catch
+            {
+                return decimal.Zero;
+            }
         }
 
         private TValue ConvertFromDecimal(decimal? input)
@@ -470,7 +469,7 @@ namespace Radzen.Blazor
                 return (TValue)converter.ConvertFrom(null, Culture, input);
             }
             
-            return (TValue)ConvertType.ChangeType(input, typeof(TValue));
+            return (TValue)ConvertType.ChangeType(input, typeof(TValue), Culture);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -317,6 +317,8 @@ namespace Radzen.Blazor
         [Parameter]
         public TextAlign TextAlign { get; set; } = TextAlign.Left;
 
+        TypeConverter validator = TypeDescriptor.GetConverter(typeof(decimal));
+
         /// <summary>
         /// Handles the <see cref="E:Change" /> event.
         /// </summary>
@@ -446,8 +448,13 @@ namespace Radzen.Blazor
                 return default;
 
             var converter = TypeDescriptor.GetConverter(typeof(TValue));
+            
+
             if (converter.CanConvertTo(typeof(decimal)))
-                return (decimal)converter.ConvertTo(null, Culture, input, typeof(decimal));
+                if (!validator.IsValid(input))
+                    return 0;
+                else
+                    return (decimal)converter.ConvertTo(null, Culture, input, typeof(decimal));
             
             return (decimal)ConvertType.ChangeType(input, typeof(decimal));
         }


### PR DESCRIPTION
Add empty string support and culture base type conversion, update test suite to use culture and validate string to number conversion and empty string to zero value conversion.

Use component culture parameter to cast value to decimal type.