### PR TITLE
Strong type Value on DataBoundFormComponent<T>

### DIFF
--- a/Radzen.Blazor.Tests/DropDownTests.cs
+++ b/Radzen.Blazor.Tests/DropDownTests.cs
@@ -123,7 +123,7 @@ namespace Radzen.Blazor.Tests
 
             List<DataItem> boundCollection = [new() { Text = "Item 2" }];
 
-            var component = DropDown<string>(ctx, parameters => {
+            var component = DropDown<List<DataItem>>(ctx, parameters => {
                 parameters.Add(p => p.ItemComparer, new DataItemComparer());
                 parameters.Add(p => p.Multiple, true);
                 parameters.Add(p => p.Value, boundCollection);

--- a/Radzen.Blazor/DataBoundFormComponent.cs
+++ b/Radzen.Blazor/DataBoundFormComponent.cs
@@ -106,13 +106,13 @@ namespace Radzen
         /// <summary>
         /// The value
         /// </summary>
-        object _value;
+        T _value;
         /// <summary>
         /// Gets or sets the value.
         /// </summary>
         /// <value>The value.</value>
         [Parameter]
-        public object Value
+        public T Value
         {
             get
             {
@@ -120,9 +120,9 @@ namespace Radzen
             }
             set
             {
-                if (_value != value)
+                if (!Equals(_value, value))
                 {
-                    _value = object.Equals(value, "null") ? null : value;
+                    _value = object.Equals(value, "null") ? default : value;
                 }
             }
         }
@@ -188,7 +188,7 @@ namespace Radzen
                 if (_data != value)
                 {
                     _view = null;
-                    _value = null;
+                    _value = default;
                     _data = value;
                     StateHasChanged();
                 }

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -256,7 +256,7 @@ namespace Radzen.Blazor
         /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
         protected async System.Threading.Tasks.Task OnChange(ChangeEventArgs args)
         {
-            Value = args.Value;
+            Value = (string)args.Value;
 
             await ValueChanged.InvokeAsync($"{Value}");
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
@@ -269,11 +269,11 @@ namespace Radzen.Blazor
         {
             if (!string.IsNullOrEmpty(TextProperty))
             {
-                Value = PropertyAccess.GetItemOrValueFromProperty(item, TextProperty);
+                Value = (string)PropertyAccess.GetItemOrValueFromProperty(item, TextProperty);
             }
             else
             {
-                Value = item;
+                Value = (string)item;
             }
 
             await ValueChanged.InvokeAsync($"{Value}");
@@ -344,7 +344,7 @@ namespace Radzen.Blazor
             {
                 var item = parameters.GetValueOrDefault<object>(nameof(SelectedItem));
                 if (item != null)
-                { 
+                {
                     await SelectItem(item);
                 }
             }
@@ -353,7 +353,7 @@ namespace Radzen.Blazor
 
             if (parameters.DidParameterChange(nameof(Value), Value))
             {
-                Value = parameters.GetValueOrDefault<object>(nameof(Value));
+                Value = parameters.GetValueOrDefault<string>(nameof(Value));
             }
 
             if (shouldClose && !firstRender)

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -156,8 +156,8 @@
                                     {
                                     <RadzenProgressBarCircular Style="position:absolute;width:100%;" Visible="@isLoading" Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
                                     <RadzenListBox AllowVirtualization="@Column.AllowCheckBoxListVirtualization" AllowClear="true" Multiple="true" Style="height: 300px"
-                                                   TValue="IEnumerable<object>" Value=@Column.GetFilterValue() Change="@ListBoxChange" 
-                                                   Data=@filterValues Count=@filterValuesCount LoadData="@LoadFilterValues" 
+                                                   TValue="IEnumerable<object>" Value=@((IEnumerable<object>)Column.GetFilterValue()) Change="@ListBoxChange"
+                                                   Data=@filterValues Count=@filterValuesCount LoadData="@LoadFilterValues"
                                                    AllowFiltering="@(!string.IsNullOrEmpty(Column.GetFilterProperty()) && PropertyAccess.GetPropertyType(typeof(TItem), Column.GetFilterProperty()) == typeof(string))"
                                                    Disabled="@(!Column.CanSetFilterValue())" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                                                    InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", Column.Title + Grid.FilterValueAriaLabel  + Column.GetFilterValue() }})">


### PR DESCRIPTION
This updates the Value property of `DataBoundFormComponent<T>` to be of type `T`, for more canonical use, consistency, and ease of extension.
We have several custom controls that benefit from inheriting from this component, to better fit in the Radzen ecosystem.  Needing to cast T when binding in these scenarios causes various difficulties, and is unnecessary as much as I can tell.

This should not result in any breaking changes, as users who are already casting this value to T will simply no longer need to.

Please let me know if I'm missing something as to the need for `Value` to be `object` vs `T`.