### PR TITLE
Added ReadOnly parameter for RadzenSwitch component

### DIFF
--- a/Radzen.Blazor.Tests/SwitchTests.cs
+++ b/Radzen.Blazor.Tests/SwitchTests.cs
@@ -134,5 +134,18 @@ namespace Radzen.Blazor.Tests
             Assert.True(raised);
             Assert.True(object.Equals(value, !(bool)newValue));
         }
+
+        [Fact]
+        public void Switch_Renders_ReadOnlyParameter()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenSwitch>();
+
+            component.SetParametersAndRender(parameters => parameters.Add<bool>(p => p.ReadOnly, true));
+
+            Assert.Contains(@$"rz-readonly", component.Markup);
+        }
+
     }
 }

--- a/Radzen.Blazor/RadzenSwitch.razor
+++ b/Radzen.Blazor/RadzenSwitch.razor
@@ -8,6 +8,6 @@
     <div class="rz-helper-hidden-accessible">
             <input type="checkbox" name="@Name" id="@Name" checked="@Value" value="@ValueAsString" tabindex="-1" aria-checked="@(Value.ToString().ToLowerInvariant())" @attributes=@InputAttributes>
     </div>
-    <span class="rz-switch-circle@(Disabled ? " rz-disabled" : "")"></span>
+        <span class="rz-switch-circle@(Disabled ? " rz-disabled" : ReadOnly ? " rz-readonly" : "")"></span>
 </div>
 }

--- a/Radzen.Blazor/RadzenSwitch.razor
+++ b/Radzen.Blazor/RadzenSwitch.razor
@@ -8,6 +8,6 @@
     <div class="rz-helper-hidden-accessible">
             <input type="checkbox" name="@Name" id="@Name" checked="@Value" value="@ValueAsString" tabindex="-1" aria-checked="@(Value.ToString().ToLowerInvariant())" @attributes=@InputAttributes>
     </div>
-        <span class="rz-switch-circle@(Disabled ? " rz-disabled" : ReadOnly ? " rz-readonly" : "")"></span>
+    <span class="rz-switch-circle@(Disabled ? " rz-disabled" : ReadOnly ? " rz-readonly" : "")"></span>
 </div>
 }

--- a/Radzen.Blazor/RadzenSwitch.razor.cs
+++ b/Radzen.Blazor/RadzenSwitch.razor.cs
@@ -15,6 +15,13 @@ namespace Radzen.Blazor
     /// </example>
     public partial class RadzenSwitch : FormComponent<bool>
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether is read only.
+        /// </summary>
+        /// <value><c>true</c> if is read only; otherwise, <c>false</c>.</value>
+        [Parameter]
+        public bool ReadOnly { get; set; }
+
         /// <inheritdoc />
         protected override string GetComponentCssClass()
         {
@@ -35,7 +42,7 @@ namespace Radzen.Blazor
         /// </summary>
         public async System.Threading.Tasks.Task Toggle()
         {
-            if (Disabled)
+            if (Disabled || ReadOnly)
             {
                 return;
             }

--- a/Radzen.Blazor/themes/components/blazor/_switch.scss
+++ b/Radzen.Blazor/themes/components/blazor/_switch.scss
@@ -44,6 +44,10 @@ $switch-focus-outline-offset: var(--rz-outline-offset) !default;
   cursor: initial;
 }
 
+.rz-switch-circle.rz-readonly {
+  cursor: initial;
+}
+
 .rz-switch .rz-switch-circle {
   background: var(--rz-switch-background-color);
   transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;


### PR DESCRIPTION
I have noticed that the RadzenSwitch component does not have a ReadOnly parameter. Currently the switch can only be set to Disabled, but this makes it visually different (grayed out) from other ReadOnly components and leads to a non-uniform UI.

This pull request contains all necessary changes (RadzenSwitch-Component, SCSS and UnitTest) for the ReadOnly parameter.

Best regards
Frank
