### PR TITLE
Added a parameter called "Size" to the "RadzenGravatar" component. 

### DIFF
--- a/Radzen.Blazor/RadzenGravatar.razor.cs
+++ b/Radzen.Blazor/RadzenGravatar.razor.cs
@@ -29,12 +29,11 @@ namespace Radzen.Blazor
         public string AlternateText { get; set; } = "gravatar";
 
         /// <summary>
-        /// Gets or sets the size. Defaulted to 32 (pixels).
-        /// 
+        /// Gets or sets the size. Defaulted to 36 (pixels). 
         /// <value>The size.</value>
         /// </summary>
         [Parameter]
-        public int Size { get; set; } = 32;
+        public int Size { get; set; } = 36;
 
         /// <summary>
         /// Gets gravatar URL.
@@ -46,9 +45,8 @@ namespace Radzen.Blazor
                 var md5Email = MD5.Calculate(System.Text.Encoding.ASCII.GetBytes(Email != null ? Email : ""));
 
                 var style = "retro";
-                var width = Size;
 
-                return $"https://secure.gravatar.com/avatar/{md5Email}?d={style}&s={width}";
+                return $"https://secure.gravatar.com/avatar/{md5Email}?d={style}&s={Size}";
             }
         }
 

--- a/Radzen.Blazor/RadzenGravatar.razor.cs
+++ b/Radzen.Blazor/RadzenGravatar.razor.cs
@@ -29,6 +29,14 @@ namespace Radzen.Blazor
         public string AlternateText { get; set; } = "gravatar";
 
         /// <summary>
+        /// Gets or sets the size. Defaulted to 32 (pixels).
+        /// 
+        /// <value>The size.</value>
+        /// </summary>
+        [Parameter]
+        public int Size { get; set; } = 32;
+
+        /// <summary>
         /// Gets gravatar URL.
         /// </summary>
         protected string Url
@@ -38,7 +46,7 @@ namespace Radzen.Blazor
                 var md5Email = MD5.Calculate(System.Text.Encoding.ASCII.GetBytes(Email != null ? Email : ""));
 
                 var style = "retro";
-                var width = "36";
+                var width = Size;
 
                 return $"https://secure.gravatar.com/avatar/{md5Email}?d={style}&s={width}";
             }

--- a/Radzen.Blazor/RadzenGravatar.razor.cs
+++ b/Radzen.Blazor/RadzenGravatar.razor.cs
@@ -30,8 +30,8 @@ namespace Radzen.Blazor
 
         /// <summary>
         /// Gets or sets the size. Defaulted to 36 (pixels). 
-        /// <value>The size.</value>
-        /// </summary>
+        /// </summary> 
+        /// <value>The size of the image in pixels.</value>
         [Parameter]
         public int Size { get; set; } = 36;
 


### PR DESCRIPTION
This will allow for users to adjust the size of the gravatar image coming in, so that they are not stuck with just a 32px image.