### PR TITLE
Fix IsAllSelected InDropdownBase

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -341,15 +341,17 @@ namespace Radzen
 
         internal bool IsAllSelected()
         {
+            List<object> notDisabledItemsInList = View.Cast<object>().ToList()
+                .Where(i => disabledPropertyGetter == null || disabledPropertyGetter(i) as bool? != true)
+                .ToList();
+
             if (LoadData.HasDelegate && !string.IsNullOrEmpty(ValueProperty))
             {
-                return View != null && View.Cast<object>().ToList()
-                    .Where(i => disabledPropertyGetter != null ? disabledPropertyGetter(i) as bool? != true : true)
+                return View != null && notDisabledItemsInList.Count > 0 && notDisabledItemsInList
                     .All(i => IsItemSelectedByValue(GetItemOrValueFromProperty(i, ValueProperty)));
             }
 
-            return View != null && selectedItems.Count == View.Cast<object>().ToList()
-                    .Where(i => disabledPropertyGetter != null ? disabledPropertyGetter(i) as bool? != true : true).Count();
+            return View != null && notDisabledItemsInList.Count > 0 && selectedItems.Count == notDisabledItemsInList.Count;
         }
 
         /// <summary>


### PR DESCRIPTION
Fix IsAllSelected In DropdownBase is correct when disabled items exists
Added a check in the dropdownBase to check if there are any items to select. 
added unit tests for it.



Issue can easily occur in a picklist: 

<img width="643" alt="Screenshot 2025-02-07 141959" src="https://github.com/user-attachments/assets/8372c10a-9f76-4705-aba1-0f1aec4ba411" />
