### PR TITLE
Allow AutoComplete with OpenOnFocus to show items even without user input

### DIFF
--- a/Radzen.Blazor/RadzenAutoComplete.razor
+++ b/Radzen.Blazor/RadzenAutoComplete.razor
@@ -27,7 +27,7 @@
         }
         <div id="@PopupID" class="rz-autocomplete-panel" style="@PopupStyle">
             <ul @ref="@list" class="rz-autocomplete-items rz-autocomplete-list" role="listbox">
-                @if (!string.IsNullOrEmpty(searchText) || !string.IsNullOrEmpty(customSearchText))
+                @if (OpenOnFocus || (!string.IsNullOrEmpty(searchText) || !string.IsNullOrEmpty(customSearchText)))
                 {
                     @foreach (var item in LoadData.HasDelegate ? Data != null ? Data : Enumerable.Empty<object>() : (View != null ? View : Enumerable.Empty<object>()))
                     {

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -224,7 +224,7 @@ namespace Radzen.Blazor
         {
             get
             {
-                return Data != null && !string.IsNullOrEmpty(searchText) ? Data.AsQueryable() : null;
+                return Data != null && (OpenOnFocus || !string.IsNullOrEmpty(searchText)) ? Data.AsQueryable() : null;
             }
         }
 
@@ -241,6 +241,9 @@ namespace Radzen.Blazor
                     string filterCaseSensitivityOperator = FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? ".ToLower()" : "";
 
                     string textProperty = string.IsNullOrEmpty(TextProperty) ? string.Empty : $".{TextProperty}";
+
+                    if (OpenOnFocus && string.IsNullOrEmpty(searchText))
+                        return Query;
 
                     return Query.Where(DynamicLinqCustomTypeProvider.ParsingConfig, $"o=>o{textProperty}{filterCaseSensitivityOperator}.{Enum.GetName(typeof(StringFilterOperator), FilterOperator)}(@0)",
                         FilterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive ? searchText.ToLower() : searchText);

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -182,8 +182,8 @@ namespace Radzen.Blazor
             var value = await JSRuntime.InvokeAsync<string>("Radzen.getInputValue", search);
 
             value = $"{value}";
-
-            if (value.Length < MinLength)
+            
+            if (value.Length < MinLength && !OpenOnFocus)
             {
                 await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID);
                 return;

--- a/RadzenBlazorDemos/Pages/AutoCompleteOpenOnFocus.razor
+++ b/RadzenBlazorDemos/Pages/AutoCompleteOpenOnFocus.razor
@@ -1,0 +1,23 @@
+@using RadzenBlazorDemos.Data
+@using RadzenBlazorDemos.Models.Northwind
+
+@inherits DbContextPage
+
+<div class="rz-p-12 rz-text-align-center">
+    <RadzenAutoComplete @bind-Value=@companyName Data=@customers TextProperty="@nameof(Customer.CompanyName)" OpenOnFocus="true" Style="width: 13rem" InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", "Company Name" }})" />
+    <RadzenText TextStyle="TextStyle.Body2">Start typing e.g. France
+        @((MarkupString)(!string.IsNullOrEmpty(companyName) ? $", Value is: <strong>{companyName}</strong>" : ""))</RadzenText>
+</div>
+
+@code {
+    string companyName;
+
+    IEnumerable<Customer> customers;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        customers = dbContext.Customers;
+    }
+}

--- a/RadzenBlazorDemos/Pages/AutoCompletePage.razor
+++ b/RadzenBlazorDemos/Pages/AutoCompletePage.razor
@@ -80,6 +80,13 @@
     <AutoCompleteWithMultilines />
 </RadzenExample>
 
+<RadzenText Anchor="autocomplete#open-on-focus" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
+    Open on Focus
+</RadzenText>
+<RadzenExample ComponentName="AutoComplete" Example="AutoCompleteOpenOnFocus">
+    <AutoCompleteOpenOnFocus />
+</RadzenExample>
+
 <RadzenText Anchor="autocomplete#disabled-autocomplete" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
     Disabled AutoComplete
 </RadzenText>


### PR DESCRIPTION
This pull request alters RadzenAutoComplete so that OpenOnFocus now lets you view items in the dropdown even if you have not provided any searchText. This is for the case where you want the autocomplete but the user does/may not know what it is they want to complete/what options are available. Without this a user has to type at least one character, which then affects their suggestions, to know what options are available. 

A demo of this functionality has also been added to the demos page for AutoComplete. 

Please let me know if anything needs to be changed or you have any feedback. 