### PR TITLE
Form field: styling fixes and tweaks

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -155,7 +155,7 @@ namespace Radzen.Blazor.Tests
                 parameters.Add<bool>(p => p.AllowClear, true);
             });
 
-            Assert.Contains(@$"<i class=""notranslate rz-dropdown-clear-icon rzi rzi-times""", component.Markup);
+            Assert.Contains(@$"<i class=""notranslate rz-clear-field-icon rzi rzi-times""", component.Markup);
         }
 
         [Fact]

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -15,7 +15,7 @@
             <div class="rz-field-icon-wrapper">
                 @if (AllowClear && !Disabled && HasValue)
                 {
-                    <i class="notranslate rz-clear-icon rzi rzi-times" @onclick="@Clear" @onclick:stopPropagation="true"></i>
+                    <i class="notranslate rz-clear-field-icon rzi rzi-times" @onclick="@Clear" @onclick:stopPropagation="true"></i>
                 }
                 @if (ShowButton)
                 {

--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -12,16 +12,18 @@
             <input @ref="@input" @attributes="InputAttributes" disabled="@Disabled" readonly="@IsReadonly" value="@FormattedValue" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
                     @onchange="@ParseDate" autocomplete="off" type="text" name="@Name" @onkeydown="@(args => OnKeyPress(args))" @onkeydown:preventDefault=preventKeyPress @onkeydown:stopPropagation
                    class="rz-inputtext @InputClass @(ReadOnly ? "rz-readonly" : "") @(!ShowButton ? "rz-input-trigger" : "")" id="@Name" placeholder="@CurrentPlaceholder" />
-            @if (ShowButton)
-            {
-                <button aria-label="@ToggleAriaLabel" @onmousedown=@OnToggle class="@($"rz-datepicker-trigger rz-button rz-button-icon-only{(Disabled ? " rz-state-disabled" : "")} {ButtonClass}")" tabindex="-1" type="button">
-                    <span aria-hidden="true" class="@ButtonClasses"></span><span class="rz-button-text"></span>
-                </button>
-            }
-            @if (AllowClear && HasValue)
-            {
-                <i class="notranslate rz-dropdown-clear-icon rzi rzi-times" @onclick="@Clear" @onclick:stopPropagation="true"></i>
-            }
+            <div class="rz-field-icon-wrapper">
+                @if (AllowClear && !Disabled && HasValue)
+                {
+                    <i class="notranslate rz-clear-icon rzi rzi-times" @onclick="@Clear" @onclick:stopPropagation="true"></i>
+                }
+                @if (ShowButton)
+                {
+                    <button aria-label="@ToggleAriaLabel" @onmousedown=@OnToggle class="@($"rz-datepicker-trigger rz-button rz-button-icon-only{(Disabled ? " rz-state-disabled" : "")} {ButtonClass}")" tabindex="-1" type="button">
+                        <span aria-hidden="true" class="@ButtonClasses"></span><span class="rz-button-text"></span>
+                    </button>
+                }
+            </div>
         }
 
         <Popup id="@PopupID" Lazy=@(PopupRenderMode == PopupRenderMode.OnDemand) @ref=@popup style=@PopupStyle class="@($"{(Inline ? "rz-datepicker-inline-container " : "rz-datepicker-popup-container ")}")">

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -988,6 +988,7 @@ namespace Radzen.Blazor
         {
             return ClassList.Create("rz-datepicker")
                             .Add("rz-datepicker-inline", Inline)
+                            .Add("rz-clear", AllowClear)
                             .AddDisabled(Disabled)
                             .Add("rz-state-empty", !HasValue)
                             .Add(FieldIdentifier, EditContext)

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -110,7 +110,7 @@
             {
                 <i class="notranslate rz-clear-field-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
             }
-            <span class="notranslate rz-multiselect-trigger-icon rzi rzi-chevron-down"></span>
+            <span class="notranslate rz-dropdown-trigger-icon rzi rzi-chevron-down"></span>
         </div>
 
         <div id="@PopupID" class="@(Multiple ? "rz-multiselect-panel" : "rz-dropdown-panel")"

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -105,8 +105,12 @@
             </span>
         }
 
-        <div class="rz-dropdown-trigger rz-corner-right">
-            <span class="notranslate rz-dropdown-trigger-icon rzi rzi-chevron-down"></span>
+        <div class="rz-field-icon-wrapper">
+            @if (AllowClear && !Disabled && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
+            {
+                <i class="notranslate rz-clear-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
+            }
+            <span class="notranslate rz-multiselect-trigger-icon rzi rzi-chevron-down"></span>
         </div>
 
         <div id="@PopupID" class="@(Multiple ? "rz-multiselect-panel" : "rz-dropdown-panel")"
@@ -178,10 +182,6 @@
                 }
             </div>
         </div>
-        @if (AllowClear && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
-        {
-            <i class="notranslate rz-dropdown-clear-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
-        }
     </div>
 }
 @code {

--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -108,7 +108,7 @@
         <div class="rz-field-icon-wrapper">
             @if (AllowClear && !Disabled && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
             {
-                <i class="notranslate rz-clear-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
+                <i class="notranslate rz-clear-field-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
             }
             <span class="notranslate rz-multiselect-trigger-icon rzi rzi-chevron-down"></span>
         </div>

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -110,7 +110,7 @@
         <div class="rz-field-icon-wrapper">
             @if (AllowClear && !Disabled && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
             {
-                <i class="notranslate rz-clear-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
+                <i class="notranslate rz-clear-field-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
             }
             <span class="notranslate rz-dropdown-trigger-icon rzi rzi-chevron-down"></span>
         </div>

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor
@@ -107,7 +107,11 @@
             </span>
         }
 
-        <div class="rz-dropdown-trigger  rz-corner-right">
+        <div class="rz-field-icon-wrapper">
+            @if (AllowClear && !Disabled && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
+            {
+                <i class="notranslate rz-clear-icon rzi rzi-times" @onclick="@ClearAll" @onclick:stopPropagation="true"></i>
+            }
             <span class="notranslate rz-dropdown-trigger-icon rzi rzi-chevron-down"></span>
         </div>
 
@@ -186,11 +190,6 @@
                 }
             </div>
         </div>
-
-        @if (AllowClear && (!Multiple && HasValue || Multiple && (selectedItems.Count > 0 || SelectedValue is IEnumerable)))
-        {
-            <i class="notranslate rz-dropdown-clear-icon rzi rzi-times" @onclick="@Clear" @onclick:stopPropagation="true"></i>
-        }
     </div>
 }
 @code {

--- a/Radzen.Blazor/themes/_css-variables.scss
+++ b/Radzen.Blazor/themes/_css-variables.scss
@@ -1185,4 +1185,8 @@
   --rz-upload-cancel-background-color: #{$upload-cancel-background-color};
   --rz-upload-cancel-color: #{$upload-cancel-color};
   --rz-upload-button-background-color: #{$upload-button-background-color};
+
+  /* Utility: ClearIcon */
+  --clear-icon-width: #{$clear-icon-width};
+  --clear-icon-height: #{$clear-icon-height};
 }

--- a/Radzen.Blazor/themes/_css-variables.scss
+++ b/Radzen.Blazor/themes/_css-variables.scss
@@ -1186,7 +1186,7 @@
   --rz-upload-cancel-color: #{$upload-cancel-color};
   --rz-upload-button-background-color: #{$upload-button-background-color};
 
-  /* Utility: ClearIcon */
-  --clear-icon-width: #{$clear-icon-width};
-  --clear-icon-height: #{$clear-icon-height};
+  /* Utility: ClearFieldIcon */
+  --rz-clear-field-icon-width: #{$clear-field-icon-width};
+  --rz-clear-field-icon-height: #{$clear-field-icon-height};
 }

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -59,62 +59,62 @@ $timepicker-separator-margin: 0 0.5rem !default;
 $timepicker-border: none !default;
 
 .rz-datepicker {
-    display: inline-block;
-    position: relative;
+  display: inline-block;
+  position: relative;
 
-    &:has(>.rz-inputtext:not(:disabled):not(.rz-state-disabled):focus) {
-        outline: none; // unify .invalid styles with other forms components
+  &:has(>.rz-inputtext:not(:disabled):not(.rz-state-disabled):focus) {
+    outline: none; // unify .invalid styles with other forms components
+  }
+
+  .rz-readonly {
+    cursor: pointer;
+  }
+
+  > .rz-inputtext {
+    @extend %input;
+    width: 100%;
+    line-height: var(--rz-datepicker-line-height);
+  }
+
+  &:has(.rz-datepicker-trigger) > .rz-inputtext {
+    padding-inline-end: calc(1rem + var(--rz-datepicker-trigger-icon-width));
+  }
+
+  &:has(.rz-clear-icon) > .rz-inputtext {
+    padding-inline-end: calc(1rem + var(--rz-clear-icon-width));
+  }
+
+  &:has(.rz-datepicker-trigger):has(.rz-clear-icon) > .rz-inputtext {
+    padding-inline-end: calc(1rem + var(--rz-clear-icon-width) + var(--rz-datepicker-trigger-icon-width));
+  }
+
+  &:not(.rz-state-disabled) {
+    &:hover {
+      .rz-datepicker-trigger {
+        box-shadow: none;
+        color: var(--rz-datepicker-trigger-icon-hover-color);
+      }
     }
+  }
 
-    .rz-readonly {
-        cursor: pointer;
-    }
-
+  &.rz-state-disabled {
     > .rz-inputtext {
-        @extend %input;
-        width: 100%;
-        line-height: var(--rz-datepicker-line-height);
-    }
+      color: var(--rz-input-disabled-color);
+      box-shadow: var(--rz-input-disabled-shadow);
+      background-color: var(--rz-input-disabled-background-color);
+      border: var(--rz-input-disabled-border);
+      opacity: var(--rz-input-disabled-opacity);
 
-    &:has(.rz-datepicker-trigger) > .rz-inputtext {
-        padding-inline-end: calc(1rem + var(--rz-datepicker-trigger-icon-width));
+      &::placeholder {
+        color: var(--rz-input-disabled-placeholder-color);
+      }
     }
+  }
 
-    &:has(.rz-clear-icon) > .rz-inputtext {
-        padding-inline-end: calc(1rem + var(--rz-clear-icon-width));
-    }
-
-    &:has(.rz-datepicker-trigger):has(.rz-clear-icon) > .rz-inputtext {
-        padding-inline-end: calc(1rem + var(--rz-clear-icon-width) + var(--rz-datepicker-trigger-icon-width));
-    }
-
-    &:not(.rz-state-disabled) {
-        &:hover {
-            .rz-datepicker-trigger {
-                box-shadow: none;
-                color: var(--rz-datepicker-trigger-icon-hover-color);
-            }
-        }
-    }
-
-    &.rz-state-disabled {
-        > .rz-inputtext {
-            color: var(--rz-input-disabled-color);
-            box-shadow: var(--rz-input-disabled-shadow);
-            background-color: var(--rz-input-disabled-background-color);
-            border: var(--rz-input-disabled-border);
-            opacity: var(--rz-input-disabled-opacity);
-
-            &::placeholder {
-                color: var(--rz-input-disabled-placeholder-color);
-            }
-        }
-    }
-
-    > .rz-field-icon-wrapper {
-        inset-inline-end: 0.625rem;
-        display: flex;
-    }
+  > .rz-field-icon-wrapper {
+    inset-inline-end: 0.625rem;
+    display: flex;
+  }
 }
 
 

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -59,51 +59,64 @@ $timepicker-separator-margin: 0 0.5rem !default;
 $timepicker-border: none !default;
 
 .rz-datepicker {
-  display: inline-block;
-  position: relative;
-  border-radius: var(--rz-input-border-radius);
+    display: inline-block;
+    position: relative;
 
-  &:has(>.rz-inputtext:not(:disabled):not(.rz-state-disabled):focus) {
-    outline: none; // unify .invalid styles with other forms components
-  }
-
-  .rz-readonly {
-      cursor: pointer;
-  }
-
-  > .rz-inputtext {
-    @extend %input;
-    width: 100%;
-    line-height: var(--rz-datepicker-line-height);
-  }
-
-  &:has(.rz-datepicker-trigger) > .rz-inputtext {
-    padding-inline-end: calc(1rem + var(--rz-datepicker-trigger-icon-width));
-  }
-
-  &:not(.rz-state-disabled) {
-    &:hover {
-      .rz-datepicker-trigger {
-        box-shadow: none;
-        color: var(--rz-datepicker-trigger-icon-hover-color);
-      }
+    &:has(>.rz-inputtext:not(:disabled):not(.rz-state-disabled):focus) {
+        outline: none; // unify .invalid styles with other forms components
     }
-  }
 
-  &.rz-state-disabled {
+    .rz-readonly {
+        cursor: pointer;
+    }
+
     > .rz-inputtext {
-      color: var(--rz-input-disabled-color);
-      box-shadow: var(--rz-input-disabled-shadow);
-      background-color: var(--rz-input-disabled-background-color);
-      border: var(--rz-input-disabled-border);
-      opacity: var(--rz-input-disabled-opacity);
-
-      &::placeholder {
-        color: var(--rz-input-disabled-placeholder-color);
-      }
+        @extend %input;
+        width: 100%;
+        line-height: var(--rz-datepicker-line-height);
     }
-  }
+
+    &:has(.rz-datepicker-trigger) > .rz-inputtext {
+        padding-inline-end: calc(1rem + var(--rz-datepicker-trigger-icon-width));
+    }
+
+    &:has(.rz-clear-icon) > .rz-inputtext {
+        padding-inline-end: calc(1rem + var(--rz-clear-icon-width));
+    }
+
+    &:has(.rz-datepicker-trigger):has(.rz-clear-icon) > .rz-inputtext {
+        padding-inline-end: calc(1rem + var(--rz-clear-icon-width) + var(--rz-datepicker-trigger-icon-width));
+    }
+
+    &:not(.rz-state-disabled) {
+        &:hover {
+            .rz-datepicker-trigger {
+                box-shadow: none;
+                color: var(--rz-datepicker-trigger-icon-hover-color);
+            }
+        }
+    }
+
+    &.rz-state-disabled {
+        > .rz-inputtext {
+            color: var(--rz-input-disabled-color);
+            box-shadow: var(--rz-input-disabled-shadow);
+            background-color: var(--rz-input-disabled-background-color);
+            border: var(--rz-input-disabled-border);
+            opacity: var(--rz-input-disabled-opacity);
+
+            &::placeholder {
+                color: var(--rz-input-disabled-placeholder-color);
+            }
+        }
+    }
+
+    > .rz-field-icon-wrapper {
+        inset-inline-end: 0.625rem;
+        display: flex;
+    }
 }
+
 
 .rz-datepicker-inline {
   background-color: var(--rz-datepicker-panel-background-color);
@@ -112,13 +125,8 @@ $timepicker-border: none !default;
 
 .rz-datepicker-trigger {
   box-shadow: none;
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-end: 0.625rem;
-  transform: translateY(-50%);
   background-color: transparent;
   padding: 0;
-  vertical-align: text-top;
 
   &.rz-state-disabled {
     border: none;

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -76,16 +76,16 @@ $timepicker-border: none !default;
     line-height: var(--rz-datepicker-line-height);
   }
 
-  &:has(.rz-datepicker-trigger) > .rz-inputtext {
+  & > .rz-inputtext:has(~ .rz-field-icon-wrapper > .rz-datepicker-trigger) {
     padding-inline-end: calc(1rem + var(--rz-datepicker-trigger-icon-width));
   }
 
-  &:has(.rz-clear-icon) > .rz-inputtext {
-    padding-inline-end: calc(1rem + var(--rz-clear-icon-width));
+  &.rz-clear > .rz-inputtext {
+    padding-inline-end: calc(1rem + var(--rz-clear-field-icon-width));
   }
 
-  &:has(.rz-datepicker-trigger):has(.rz-clear-icon) > .rz-inputtext {
-    padding-inline-end: calc(1rem + var(--rz-clear-icon-width) + var(--rz-datepicker-trigger-icon-width));
+  &.rz-clear > .rz-inputtext:has(~ .rz-field-icon-wrapper > .rz-datepicker-trigger) {
+    padding-inline-end: calc(0.625rem + var(--rz-clear-field-icon-width) + var(--rz-datepicker-trigger-icon-width));
   }
 
   &:not(.rz-state-disabled) {

--- a/Radzen.Blazor/themes/components/blazor/_dropdown.scss
+++ b/Radzen.Blazor/themes/components/blazor/_dropdown.scss
@@ -258,6 +258,6 @@ $multiselect-checkbox-margin-inline: 0 0.5rem !default;
 .rz-clear {
   .rz-multiselect-label-container,
   .rz-dropdown-label {
-    padding-inline-end: calc(var(--rz-dropdown-trigger-icon-width) + var(--rz-clear-icon-width));
+    padding-inline-end: calc(var(--rz-dropdown-trigger-icon-width) + var(--rz-clear-field-icon-width));
   }
 }

--- a/Radzen.Blazor/themes/components/blazor/_dropdown.scss
+++ b/Radzen.Blazor/themes/components/blazor/_dropdown.scss
@@ -70,14 +70,7 @@ $multiselect-checkbox-margin-inline: 0 0.5rem !default;
 }
 
 %dropdown-trigger {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  inset-inline-end: 0;
-  inset-block-start: 0;
-  inset-block-end: 0;
-
-  .rzi {
+  &.rzi {
     width: var(--rz-dropdown-trigger-icon-width);
     height: var(--rz-dropdown-trigger-icon-height);
     font-size: var(--rz-dropdown-trigger-icon-height);
@@ -85,41 +78,16 @@ $multiselect-checkbox-margin-inline: 0 0.5rem !default;
     margin-inline: var(--rz-dropdown-trigger-icon-margin-inline);
   }
 
-  .rzi-chevron-down {
-    &:before {
-      content: $dropdown-trigger-icon;
-    }
+  &.rzi-chevron-down:before {
+    content: $dropdown-trigger-icon;
   }
 }
 
-.rz-dropdown-trigger {
+.rz-dropdown-trigger-icon {
   @extend %dropdown-trigger;
 }
 
-.rz-dropdown-clear-icon {
-  position: absolute;
-  inset-inline-end: calc(var(--rz-dropdown-trigger-icon-width) + 0.5rem);
-  inset-block-start: 0;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  font-size: var(--rz-dropdown-trigger-icon-height);
-  opacity: 0.4;
-
-  &:before {
-    content: 'close';
-  }
-
-  &:hover {
-    opacity: 1;
-  }
-
-  .rz-state-disabled > & {
-    display: none;
-  }
-}
-
-.rz-multiselect-trigger {
+.rz-multiselect-trigger-icon {
   @extend %dropdown-trigger;
 }
 
@@ -290,6 +258,6 @@ $multiselect-checkbox-margin-inline: 0 0.5rem !default;
 .rz-clear {
   .rz-multiselect-label-container,
   .rz-dropdown-label {
-    padding-inline-end: calc(2 * var(--rz-dropdown-trigger-icon-width));
+    padding-inline-end: calc(var(--rz-dropdown-trigger-icon-width) + var(--rz-clear-icon-width));
   }
 }

--- a/Radzen.Blazor/themes/components/blazor/_form-field.scss
+++ b/Radzen.Blazor/themes/components/blazor/_form-field.scss
@@ -156,6 +156,14 @@ $form-field-helper-padding: 0 0.5rem !default;
       .rz-textarea {
         margin-top: 1rem;
       }
+
+      > * > .rz-field-icon-wrapper {
+        transition: padding-block var(--rz-transition);
+      }
+      
+      > .rz-state-empty:not(:focus-within) > .rz-field-icon-wrapper {
+        padding-block: 0;
+      }
     }
   }
 
@@ -288,17 +296,6 @@ $form-field-helper-padding: 0 0.5rem !default;
         border-inline-start-width: var(--rz-border-width);
         border-inline-end-width: var(--rz-border-width);
       }
-    }
-  }
-
-  &.rz-variant-outlined,
-  &.rz-variant-filled {
-    .rz-field-icon-wrapper {
-      transition: padding-block var(--rz-transition);
-    }
-
-    .rz-state-empty:not(:focus-within) > .rz-field-icon-wrapper {
-      padding-block: 0;
     }
   }
 

--- a/Radzen.Blazor/themes/components/blazor/_form-field.scss
+++ b/Radzen.Blazor/themes/components/blazor/_form-field.scss
@@ -31,384 +31,382 @@ $form-field-label-floating-background-color: var(--rz-input-background-color) !d
 $form-field-helper-padding: 0 0.5rem !default;
 
 .rz-form-field-helper {
-    padding: var(--rz-form-field-helper-padding);
+  padding: var(--rz-form-field-helper-padding);
 }
 
 .rz-form-field-content {
-    @extend %input-no-padding;
+  @extend %input-no-padding;
 
-    position: relative;
-    display: inline-flex;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: top;
+  margin-block: var(--rz-form-field-margin-block);
+  margin-inline: var(--rz-form-field-margin-inline);
+  box-shadow: var(--rz-form-field-shadow);
+  transition: var(--rz-input-transition);
+
+  & > *,
+  & > .rz-autocomplete,
+  & > .rz-autocomplete.rz-state-disabled > .rz-inputtext,
+  & input,
+  & .rz-inputtext,
+  & .rz-inputtext.rz-state-disabled,
+  & .rz-datepicker.rz-state-disabled > .rz-inputtext {
+    @extend %input-blank;
+
+    flex: 1;
+  }
+  
+  & > input {
+    width: 100%;
+  }
+
+  .rz-form-field-start,
+  .rz-form-field-end {
+    display: flex;
+    flex: 0;
     align-items: center;
-    vertical-align: top;
-    margin-block: var(--rz-form-field-margin-block);
-    margin-inline: var(--rz-form-field-margin-inline);
-    box-shadow: var(--rz-form-field-shadow);
-    transition: var(--rz-input-transition);
-
-    & > *,
-    & > .rz-autocomplete,
-    & > .rz-autocomplete.rz-state-disabled > .rz-inputtext,
-    & input,
-    & .rz-inputtext,
-    & .rz-inputtext.rz-state-disabled,
-    & .rz-datepicker.rz-state-disabled > .rz-inputtext {
-        @extend %input-blank;
-
-        flex: 1;
-    }
-    
-    & > input {
-        width: 100%;
-    }
-
-    .rz-form-field-start,
-    .rz-form-field-end {
-        display: flex;
-        flex: 0;
-        align-items: center;
-        white-space: nowrap;
-        padding-block: var(--rz-form-field-start-end-padding-block);
-        padding-inline: var(--rz-form-field-start-end-padding-inline);
-    }
-
+    white-space: nowrap;
+    padding-block: var(--rz-form-field-start-end-padding-block);
+    padding-inline: var(--rz-form-field-start-end-padding-inline);
+  }
 }
 
 .rz-form-field {
-    box-sizing: border-box;
-    display: inline-flex;
-    flex-direction: column;
-    vertical-align: top;
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: top;
 
-    &:hover {
-        .rz-form-field-content {
-            @extend %input-hover;
-            box-shadow: var(--rz-form-field-hover-shadow);
-        }
+  &:hover {
+    .rz-form-field-content {
+      @extend %input-hover;
+      box-shadow: var(--rz-form-field-hover-shadow);
     }
+  }
 
-    &.rz-state-focused {
-        .rz-form-field-content {
-            @extend %input-focus;
-            box-shadow: var(--rz-form-field-focus-shadow);
-        }
+  &.rz-state-focused {
+    .rz-form-field-content {
+      @extend %input-focus;
+      box-shadow: var(--rz-form-field-focus-shadow);
     }
+  }
 
-    &.rz-state-disabled {
-        .rz-form-field-content {
-            color: var(--rz-input-disabled-color);
-            box-shadow: var(--rz-input-disabled-shadow);
-        }
-
-        &.rz-variant-outlined,
-        &.rz-variant-filled,
-        &.rz-variant-flat {
-            .rz-form-field-content {
-                border: var(--rz-input-disabled-border);
-            }
-        }
-
-        :not(.rz-button).rz-state-disabled,
-        :not(.rz-button):disabled {
-            color: var(--rz-input-disabled-color);
-            opacity: 1;
-
-            &::placeholder {
-                color: var(--rz-input-disabled-placeholder-color);
-            }
-        }
+  &.rz-state-disabled {
+    .rz-form-field-content {
+      color: var(--rz-input-disabled-color);
+      box-shadow: var(--rz-input-disabled-shadow);
     }
 
     &.rz-variant-outlined,
     &.rz-variant-filled,
     &.rz-variant-flat {
-        .rz-form-field-start {
-            padding-inline-end: 0;
-        }
-    
-        .rz-form-field-end {
-            padding-inline-start: 0;
-        }
+      .rz-form-field-content {
+        border: var(--rz-input-disabled-border);
+      }
     }
 
-    &.rz-variant-filled,
-    &.rz-variant-flat {
+    :not(.rz-button).rz-state-disabled,
+    :not(.rz-button):disabled {
+      color: var(--rz-input-disabled-color);
+      opacity: 1;
+
+      &::placeholder {
+        color: var(--rz-input-disabled-placeholder-color);
+      }
+    }
+  }
+
+  &.rz-variant-outlined,
+  &.rz-variant-filled,
+  &.rz-variant-flat {
+    .rz-form-field-start {
+      padding-inline-end: 0;
+    }
+  
+    .rz-form-field-end {
+      padding-inline-start: 0;
+    }
+  }
+
+  &.rz-variant-filled,
+  &.rz-variant-flat {
+    .rz-form-field-content {
+      margin: 0;
+      --rz-input-height: var(--rz-form-field-filled-height);
+      --rz-input-padding-block: var(--rz-form-field-filled-padding-block);
+      --rz-input-padding-inline: var(--rz-form-field-filled-padding-inline);
+      --rz-dropdown-chips-padding-block: var(--rz-form-field-filled-padding-block);
+      --rz-dropdown-chips-padding-inline: var(--rz-form-field-filled-padding-inline);
+      --rz-numeric-input-padding-block: var(--rz-form-field-filled-numeric-padding-block);
+      --rz-numeric-input-padding-inline: var(--rz-form-field-filled-numeric-padding-inline);
+      --rz-form-field-label-floating-top: var(--rz-form-field-filled-label-floating-top);
+      box-shadow: var(--rz-input-shadow);
+
+      .rz-numeric-up {
+        top: calc(var(--rz-numeric-button-offset) + 1rem);
+      }
+
+      .rz-form-field-start,
+      .rz-form-field-end {
+        padding-top: 1rem;
+      }
+
+      .rz-textarea {
+        margin-top: 1rem;
+      }
+    }
+  }
+
+  &.rz-variant-flat {
+    &:not(.rz-state-disabled) {
+      &:hover {
         .rz-form-field-content {
-            margin: 0;
-            --rz-input-height: var(--rz-form-field-filled-height);
-            --rz-input-padding-block: var(--rz-form-field-filled-padding-block);
-            --rz-input-padding-inline: var(--rz-form-field-filled-padding-inline);
-            --rz-dropdown-chips-padding-block: var(--rz-form-field-filled-padding-block);
-            --rz-dropdown-chips-padding-inline: var(--rz-form-field-filled-padding-inline);
-            --rz-numeric-input-padding-block: var(--rz-form-field-filled-numeric-padding-block);
-            --rz-numeric-input-padding-inline: var(--rz-form-field-filled-numeric-padding-inline);
-            --rz-form-field-label-floating-top: var(--rz-form-field-filled-label-floating-top);
-            box-shadow: var(--rz-input-shadow);
-
-            .rz-numeric-up {
-                top: calc(var(--rz-numeric-button-offset) + 1rem);
-            }
-
-            .rz-form-field-start,
-            .rz-form-field-end {
-                padding-top: 1rem;
-            }
-
-            .rz-textarea {
-                margin-top: 1rem;
-
-            }
-
-            .rz-datepicker-trigger {
-                top: calc(50% + 0.4375rem);
-            }
+          border: var(--rz-input-hover-border);
+          box-shadow: var(--rz-input-hover-shadow);
         }
-    }
-
-    &.rz-variant-flat {
-        &:not(.rz-state-disabled) {
-            &:hover {
-                .rz-form-field-content {
-                    border: var(--rz-input-hover-border);
-                    box-shadow: var(--rz-input-hover-shadow);
-                }
-            }
-        
-            &.rz-state-focused {
-                .rz-form-field-content {
-                    border: var(--rz-input-focus-border);
-                    box-shadow: var(--rz-input-focus-shadow);
-                }
-            }
-        }
-    }
-
-    &.rz-variant-filled {
-        .rz-form-field-content {
-            border: var(--rz-form-field-filled-border);
-            border-radius: var(--rz-form-field-filled-border-radius);
-            background-color: var(--rz-form-field-filled-background-color);
-
-            &:before,
-            &:after {
-                display: var(--rz-form-field-filled-underline-display);
-            }
-        }
-
-        &:not(.rz-state-disabled) {
-            &:hover {
-                .rz-form-field-content {
-                    border: var(--rz-form-field-filled-hover-border);
-                    box-shadow: var(--rz-form-field-filled-hover-shadow);
-                    background-color: var(--rz-form-field-filled-hover-background-color);
-                }
-            }
-        
-            &.rz-state-focused,
-            &.rz-state-focused:hover {
-                .rz-form-field-content {
-                    border: var(--rz-form-field-filled-focus-border);
-                    box-shadow: var(--rz-form-field-filled-focus-shadow);
-                    background-color: var(--rz-form-field-filled-background-color);
-                }
-            }
-        }
-    }
-
-    &.rz-variant-text {
-        .rz-form-field-content {
-            border-color: transparent;
-            box-shadow: none;
-            --rz-input-background-color: transparent;
-            --rz-input-border-radius: 0;
-            --rz-input-padding-block: 0.4375rem;
-            --rz-input-padding-inline: 0;
-            --rz-numeric-input-padding-block: 0.5rem 0.5rem;
-            --rz-numeric-input-padding-inline: 0 1.25rem;
-            --rz-text-area-padding-block: 0.4375rem;
-            --rz-text-area-padding-inline: 0;
-            --rz-form-field-label-inset-inline-start: 0;
-            --rz-form-field-label-padding: var(--rz-form-field-text-label-padding);
-
-            & ~ .rz-form-field-helper {
-                padding: 0;
-            }
-        }
-
-        .rz-form-field-start {
-            padding-inline-start: 0;
-        }
+      }
     
-        .rz-form-field-end {
-            padding-inline-end: 0;
-        }
-    }
-
-    &.rz-variant-filled,
-    &.rz-variant-text {
+      &.rz-state-focused {
         .rz-form-field-content {
-            &:before {
-                content: "";
-                position: absolute;
-                z-index: 1;
-                inset-inline-start: 50%;
-                inset-inline-end: 50%;
-                bottom: calc(-1 * var(--rz-border-width));
-                height: calc(var(--rz-border-width) + 1px);
-                border: var(--rz-input-focus-border);
-                border-inline-start-width: 0;
-                border-inline-end-width: 0;
-                transition: inset-inline-start var(--rz-transition),
-                            inset-inline-end var(--rz-transition), 
-                            border-width var(--rz-transition);
-            }
-        
-            &:after {
-                content: "";
-                position: absolute;
-                inset: calc(-1 * var(--rz-border-width));
-                top: auto;
-                height: var(--rz-border-width);
-                border-bottom: var(--rz-input-border);
-            }
+          border: var(--rz-input-focus-border);
+          box-shadow: var(--rz-input-focus-shadow);
         }
+      }
+    }
+  }
+
+  &.rz-variant-filled {
+    .rz-form-field-content {
+      border: var(--rz-form-field-filled-border);
+      border-radius: var(--rz-form-field-filled-border-radius);
+      background-color: var(--rz-form-field-filled-background-color);
+
+      &:before,
+      &:after {
+        display: var(--rz-form-field-filled-underline-display);
+      }
+    }
+
+    &:not(.rz-state-disabled) {
+      &:hover {
+        .rz-form-field-content {
+          border: var(--rz-form-field-filled-hover-border);
+          box-shadow: var(--rz-form-field-filled-hover-shadow);
+          background-color: var(--rz-form-field-filled-hover-background-color);
+        }
+      }
     
-        &:hover {
-            .rz-form-field-content:after {
-                border-bottom: var(--rz-input-hover-border);
-            }
+      &.rz-state-focused,
+      &.rz-state-focused:hover {
+        .rz-form-field-content {
+          border: var(--rz-form-field-filled-focus-border);
+          box-shadow: var(--rz-form-field-filled-focus-shadow);
+          background-color: var(--rz-form-field-filled-background-color);
         }
+      }
+    }
+  }
 
-        &.rz-state-disabled,
-        &.rz-state-disabled:hover {
-            .rz-form-field-content:after {
-                border-bottom: var(--rz-input-disabled-border);
-            }
-        }
+  &.rz-variant-text {
+    .rz-form-field-content {
+      border-color: transparent;
+      box-shadow: none;
+      --rz-input-background-color: transparent;
+      --rz-input-border-radius: 0;
+      --rz-input-padding-block: 0.4375rem;
+      --rz-input-padding-inline: 0;
+      --rz-numeric-input-padding-block: 0.5rem 0.5rem;
+      --rz-numeric-input-padding-inline: 0 1.25rem;
+      --rz-text-area-padding-block: 0.4375rem;
+      --rz-text-area-padding-inline: 0;
+      --rz-form-field-label-inset-inline-start: 0;
+      --rz-form-field-label-padding: var(--rz-form-field-text-label-padding);
+
+      & ~ .rz-form-field-helper {
+        padding: 0;
+      }
+    }
+
+    .rz-form-field-start {
+      padding-inline-start: 0;
+    }
+  
+    .rz-form-field-end {
+      padding-inline-end: 0;
+    }
+  }
+
+  &.rz-variant-filled,
+  &.rz-variant-text {
+    .rz-form-field-content {
+      &:before {
+        content: "";
+        position: absolute;
+        z-index: 1;
+        inset-inline-start: 50%;
+        inset-inline-end: 50%;
+        bottom: calc(-1 * var(--rz-border-width));
+        height: calc(var(--rz-border-width) + 1px);
+        border: var(--rz-input-focus-border);
+        border-inline-start-width: 0;
+        border-inline-end-width: 0;
+        transition: inset-inline-start var(--rz-transition),
+                    inset-inline-end var(--rz-transition), 
+                    border-width var(--rz-transition);
+      }
     
-        &.rz-state-focused:not(.rz-state-disabled) {
-            .rz-form-field-content:before {
-                inset-inline-start: calc(-1 * var(--rz-border-width));
-                inset-inline-end: calc(-1 * var(--rz-border-width));
-                border: var(--rz-input-focus-border);
-                border-inline-start-width: var(--rz-border-width);
-                border-inline-end-width: var(--rz-border-width);
-            }
-        }
+      &:after {
+        content: "";
+        position: absolute;
+        inset: calc(-1 * var(--rz-border-width));
+        top: auto;
+        height: var(--rz-border-width);
+        border-bottom: var(--rz-input-border);
+      }
+    }
+  
+    &:hover {
+      .rz-form-field-content:after {
+        border-bottom: var(--rz-input-hover-border);
+      }
     }
 
-    .rz-numeric-button {
-        display: none;
+    &.rz-state-disabled,
+    &.rz-state-disabled:hover {
+      .rz-form-field-content:after {
+        border-bottom: var(--rz-input-disabled-border);
+      }
+    }
+  
+    &.rz-state-focused:not(.rz-state-disabled) {
+      .rz-form-field-content:before {
+        inset-inline-start: calc(-1 * var(--rz-border-width));
+        inset-inline-end: calc(-1 * var(--rz-border-width));
+        border: var(--rz-input-focus-border);
+        border-inline-start-width: var(--rz-border-width);
+        border-inline-end-width: var(--rz-border-width);
+      }
+    }
+  }
+
+  &.rz-variant-outlined,
+  &.rz-variant-filled {
+    .rz-field-icon-wrapper {
+      transition: padding-block var(--rz-transition);
     }
 
-    .rz-numeric:focus-within .rz-numeric-button {
-        display: block;
+    .rz-state-empty:not(:focus-within) > .rz-field-icon-wrapper {
+      padding-block: 0;
     }
+  }
 
+  .rz-numeric-button {
+    display: none;
+  }
+
+  .rz-numeric:focus-within .rz-numeric-button {
+    display: block;
+  }
 }
 
 .rz-form-field-label {
 
-    .rz-state-disabled .rz-form-field-content > & {
-        color: var(--rz-input-disabled-color) !important;
-    }
+  .rz-state-disabled .rz-form-field-content > & {
+    color: var(--rz-input-disabled-color) !important;
+  }
 
-    position: absolute;
-    pointer-events: none;
-    padding: var(--rz-form-field-label-padding);
-    inset-block-start: 50%;
+  position: absolute;
+  pointer-events: none;
+  padding: var(--rz-form-field-label-padding);
+  inset-block-start: 50%;
+  inset-inline-end: auto;
+  border-radius: var(--rz-border-radius);
+  inset-inline-start: var(--rz-form-field-label-inset-inline-start);
+  max-width: calc(100% - 1.5rem);
+  transform: translate(0, -50%);
+  background-color: transparent;
+  transition: inset-block-start var(--rz-transition),
+              transform var(--rz-transition), 
+              color var(--rz-transition),
+              font-size var(--rz-transition), 
+              max-width var(--rz-transition);
+
+  &:last-child {
+    inset-inline-end: 1.5rem;
+  }
+
+  .rz-textarea ~ & {
+    inset-block-start: var(--rz-form-field-label-textarea-top);
+    transform: translate(0, 0);
+
+    .rz-form-field.rz-variant-filled &,
+    .rz-form-field.rz-variant-flat & {
+      transform: translate(0, 0.625rem);
+    }
+  }
+
+  .rz-form-field:not(.rz-floating-label) &,
+  .rz-textbox:focus ~ &,
+  .rz-textarea:focus ~ &,
+  .rz-numeric:focus-within ~ &,
+  .rz-autocomplete:focus-within ~ &,
+  .rz-textbox:not(:placeholder-shown) ~ &,
+  :not(.rz-state-empty) ~ &,
+  .rz-form-field.rz-variant-filled .rz-textarea:focus ~ &,
+  .rz-form-field.rz-variant-flat .rz-textarea:focus ~ &,
+  .rz-form-field.rz-variant-filled :not(.rz-state-empty) ~ &,
+  .rz-form-field.rz-variant-flat :not(.rz-state-empty) ~ &,
+  .rz-radio-button-list-vertical ~ &,
+  .rz-radio-button-list-horizontal ~ &,
+  .rz-checkbox-list-vertical ~ &,
+  .rz-checkbox-list-horizontal ~ &,
+  .rz-chkbox ~ &,
+  .rz-fileupload ~ &,
+  .rz-state-empty:has(.rz-placeholder) ~ &,
+  .rz-form-field.rz-state-focused & {
     inset-inline-end: auto;
-    border-radius: var(--rz-border-radius);
-    inset-inline-start: var(--rz-form-field-label-inset-inline-start);
+    inset-block-start: var(--rz-form-field-label-floating-top);
+    padding-block-start: 0;
+    padding-block-end: 0;
+    transform: translate(0, 0);
+    color: var(--rz-input-placeholder-color);
+    background-color: var(--rz-form-field-label-floating-background-color);
+    font-size: 0.75rem;
+    line-height: 1rem;
     max-width: calc(100% - 1.5rem);
-    transform: translate(0, -50%);
-    background-color: transparent;
-    transition: inset-block-start var(--rz-transition),
-                transform var(--rz-transition), 
-                color var(--rz-transition),
-                font-size var(--rz-transition), 
-                max-width var(--rz-transition);
+  }
 
-    &:last-child {
-        inset-inline-end: 1.5rem;
-    }
+  .rz-form-field:not(.rz-variant-outlined):not(.rz-floating-label) &,
+  .rz-form-field:not(.rz-variant-outlined) *:focus ~ &,
+  .rz-form-field:not(.rz-variant-outlined) *:focus-within ~ &,
+  .rz-form-field:not(.rz-variant-outlined) :not(.rz-state-empty) ~ &,
+  .rz-form-field:not(.rz-variant-outlined) .rz-radio-button-list-vertical ~ &,
+  .rz-form-field:not(.rz-variant-outlined) .rz-radio-button-list-horizontal ~ &,
+  .rz-form-field:not(.rz-variant-outlined) .rz-checkbox-list-vertical ~ &,
+  .rz-form-field:not(.rz-variant-outlined) .rz-checkbox-list-horizontal ~ &,
+  .rz-form-field:not(.rz-variant-outlined) .rz-chkbox ~ &,
+  .rz-form-field:not(.rz-variant-outlined) .rz-fileupload ~ &,
+  .rz-form-field:not(.rz-variant-outlined) .rz-state-empty:has(.rz-placeholder) ~ &,
+  .rz-form-field:not(.rz-variant-outlined).rz-state-focused & {
+    background-color: inherit !important;
+  }
 
-    .rz-textarea ~ & {
-        inset-block-start: var(--rz-form-field-label-textarea-top);
-        transform: translate(0, 0);
+  .invalid ~ & {
+    color: var(--rz-danger) !important;
+  }
 
-        .rz-variant-filled &,
-        .rz-variant-flat & {
-            transform: translate(0, 0.625rem);
-        }
-    }
-
-    .rz-form-field:not(.rz-floating-label) &,
-    .rz-textbox:focus ~ &,
-    .rz-textarea:focus ~ &,
-    .rz-numeric:focus-within ~ &,
-    .rz-autocomplete:focus-within ~ &,
-    .rz-textbox:not(:placeholder-shown) ~ &,
-    :not(.rz-state-empty) ~ &,
-    .rz-variant-filled .rz-textarea:focus ~ &,
-    .rz-variant-flat .rz-textarea:focus ~ &,
-    .rz-variant-filled :not(.rz-state-empty) ~ &,
-    .rz-variant-flat :not(.rz-state-empty) ~ &,
-    .rz-radio-button-list-vertical ~ &,
-    .rz-radio-button-list-horizontal ~ &,
-    .rz-checkbox-list-vertical ~ &,
-    .rz-checkbox-list-horizontal  ~ &,
-    .rz-chkbox ~ &,
-    .rz-fileupload ~ &,
-    .rz-state-empty:has(.rz-placeholder) ~ &,
-    .rz-form-field.rz-state-focused & {
-        inset-inline-end: auto;
-        inset-block-start: var(--rz-form-field-label-floating-top);
-        padding-block-start: 0;
-        padding-block-end: 0;
-        transform: translate(0, 0);
-        color: var(--rz-input-placeholder-color);
-        background-color: var(--rz-form-field-label-floating-background-color);
-        font-size: 0.75rem;
-        line-height: 1rem;
-        max-width: calc(100% - 1.5rem);
-    }
-
-    .rz-form-field:not(.rz-variant-outlined):not(.rz-floating-label) &,
-    .rz-form-field:not(.rz-variant-outlined) *:focus ~ &,
-    .rz-form-field:not(.rz-variant-outlined) *:focus-within ~ &,
-    .rz-form-field:not(.rz-variant-outlined) :not(.rz-state-empty) ~ &,
-    .rz-form-field:not(.rz-variant-outlined) .rz-radio-button-list-vertical ~ &,
-    .rz-form-field:not(.rz-variant-outlined) .rz-radio-button-list-horizontal ~ &,
-    .rz-form-field:not(.rz-variant-outlined) .rz-checkbox-list-vertical ~ &,
-    .rz-form-field:not(.rz-variant-outlined) .rz-checkbox-list-horizontal  ~ &,
-    .rz-form-field:not(.rz-variant-outlined) .rz-chkbox ~ &,
-    .rz-form-field:not(.rz-variant-outlined) .rz-fileupload ~ &,
-    .rz-form-field:not(.rz-variant-outlined) .rz-state-empty:has(.rz-placeholder) ~ &,
-    .rz-form-field:not(.rz-variant-outlined).rz-state-focused & {
-        background-color: inherit !important;
-    }
-
-    .invalid ~ & {
-        color: var(--rz-danger) !important;
-    }
-
-    .rz-state-focused &,
-    .rz-variant-filled.rz-state-focused &,
-    .rz-variant-flat.rz-state-focused &,
-    .rz-form-field.rz-state-focused & {
-        color: var(--rz-form-field-label-focus-color);
-    }
-
-    .rz-textbox:focus ~ &,
-    .rz-textarea:focus ~ &,
-    .rz-numeric:focus-within ~ &,
-    .rz-autocomplete:focus-within ~ &  {
-        color: var(--rz-form-field-label-focus-color);
-
-        .rz-variant-filled &,
-        .rz-variant-flat & {
-            color: var(--rz-form-field-label-focus-color);
-        }
-    }
+  .rz-state-focused &,
+  .rz-form-field.rz-state-focused &,
+  .rz-form-field.rz-variant-filled.rz-state-focused ~ &,
+  .rz-form-field.rz-variant-flat.rz-state-focused ~ &,
+  .rz-textbox:focus ~ &,
+  .rz-textarea:focus ~ &,
+  .rz-numeric:focus-within ~ &,
+  .rz-autocomplete:focus-within ~ &,
+  .rz-form-field.rz-variant-filled .rz-textbox:focus ~ &,
+  .rz-form-field.rz-variant-flat .rz-textbox:focus ~ & {
+    color: var(--rz-form-field-label-focus-color);
+  }
 }

--- a/Radzen.Blazor/themes/components/blazor/_utilities.scss
+++ b/Radzen.Blazor/themes/components/blazor/_utilities.scss
@@ -561,3 +561,36 @@ $border: border, border-start, border-end, border-left, border-right, border-top
 .rz-ripple {
   @include rz-ripple($pseudo: true);
 }
+
+// Field icon wrapper
+.rz-field-icon-wrapper {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-block: var(--rz-input-padding-block);
+}
+
+// Clear field icon
+$clear-icon-width: var(--rz-icon-size) !default;
+$clear-icon-height: $clear-icon-width !default;
+
+.rz-clear-icon {
+  opacity: 0.4;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &.rzi {
+    width: var(--rz-clear-icon-width);
+    height: var(--rz-clear-icon-width);
+    font-size: var(--clear-icon-width);
+  }
+
+  &.rzi-times:before {
+    content: 'close';
+  }
+}

--- a/Radzen.Blazor/themes/components/blazor/_utilities.scss
+++ b/Radzen.Blazor/themes/components/blazor/_utilities.scss
@@ -574,10 +574,11 @@ $border: border, border-start, border-end, border-left, border-right, border-top
 }
 
 // Clear field icon
-$clear-icon-width: var(--rz-icon-size) !default;
-$clear-icon-height: $clear-icon-width !default;
+$clear-field-icon: 'close' !default;
+$clear-field-icon-width: var(--rz-icon-size) !default;
+$clear-field-icon-height: $clear-field-icon-width !default;
 
-.rz-clear-icon {
+.rz-clear-field-icon {
   opacity: 0.4;
 
   &:hover {
@@ -585,12 +586,12 @@ $clear-icon-height: $clear-icon-width !default;
   }
 
   &.rzi {
-    width: var(--rz-clear-icon-width);
-    height: var(--rz-clear-icon-width);
-    font-size: var(--clear-icon-width);
+    width: var(--rz-clear-field-icon-width);
+    height: var(--rz-clear-field-icon-width);
+    font-size: var(--rz-clear-field-icon-width);
   }
 
   &.rzi-times:before {
-    content: 'close';
+    content: $clear-field-icon;
   }
 }

--- a/RadzenBlazorDemos/Pages/FormFieldInputTypes.razor
+++ b/RadzenBlazorDemos/Pages/FormFieldInputTypes.razor
@@ -19,20 +19,20 @@
                     <RadzenPassword @bind-Value="@value" />
                 </RadzenFormField>
                 <RadzenFormField Text="RadzenDropDown" Variant="@variant">
-                    <RadzenDropDown Data=@companyNames @bind-Value="@dropDownValue" />
+                    <RadzenDropDown Data=@companyNames @bind-Value="@dropDownValue" AllowClear />
                 </RadzenFormField>
                 <RadzenFormField Text="RadzenAutoComplete" Variant="@variant">
                     <RadzenAutoComplete Data=@companyNames @bind-Value="@autoCompleteValue" />
                 </RadzenFormField>
                 <RadzenFormField Text="RadzenDropDownDataGrid" Variant="@variant">
-                    <RadzenDropDownDataGrid Data=@companyNames @bind-Value="@dropDownDataGridValue" />
+                    <RadzenDropDownDataGrid Data=@companyNames @bind-Value="@dropDownDataGridValue" AllowClear />
                 </RadzenFormField>
             </RadzenStack>
         </RadzenColumn>
         <RadzenColumn Size="12" SizeSM="6">
             <RadzenStack>
                 <RadzenFormField Text="RadzenDatePicker" Variant="@variant">
-                    <RadzenDatePicker @bind-Value="@date" ShowTime="@true" />
+                    <RadzenDatePicker @bind-Value="@date" ShowTime="@true" AllowClear />
                 </RadzenFormField>
                 <RadzenFormField Text="RadzenColorPicker" Variant="@variant">
                     <RadzenColorPicker @bind-Value="@color" />


### PR DESCRIPTION
- ~if a form field is a container element that has its own variant, this variant no longer affects the form field style, e.g. breaking placement of labels inside empty text areas:~ Moved to https://github.com/radzenhq/radzen-blazor/pull/2002
![misplaced textarea label](https://github.com/user-attachments/assets/709bafc6-d12a-4baa-8777-adc27cf04420)
- icons inside drop downs, drop down data grids, and date pickers behave more consistently for flat and filled variants:
  - if the field is empty, they're centered vertically towards the whole field,
  - otherwise, they are centered verticaly towards the value, effectively going down.
Current setup:
![Current form field icons](https://github.com/user-attachments/assets/0ad05bdd-58e1-401c-a1f0-34dc33ea6ab2)
New setup:
![More consistent form field icons](https://github.com/user-attachments/assets/916af7ff-a6af-4a74-b9b9-cea1644cca0a)

I hope the new setup will make it easier to implement *clear* and other action buttons in other field components.
