### PR TITLE
Fix 'Numeric_Supports_IComparable' test

### DIFF
--- a/Radzen.Blazor.Tests/Dollars.cs
+++ b/Radzen.Blazor.Tests/Dollars.cs
@@ -43,7 +43,7 @@ public class DollarsTypeConverter : TypeConverter
             return new Dollars(d);
 
         if (value is string s)
-            return decimal.TryParse(s, out var val) ? new Dollars(val) : null;
+            return decimal.TryParse(s, culture, out var val) ? new Dollars(val) : null;
         
         return base.ConvertFrom(context, culture, value);
     }

--- a/Radzen.Blazor.Tests/NumericTests.cs
+++ b/Radzen.Blazor.Tests/NumericTests.cs
@@ -612,10 +612,10 @@ namespace Radzen.Blazor.Tests
                 });
             });
             
-            component.Find("input").Change("13.53");
+            component.Find("input").Change(13.53);
 
-            var maxDollars = new Dollars(2);
-            Assert.Contains($" value=\"{maxDollars.ToString()}\"", component.Markup);
+            var maxDollars = new Dollars(maxValue);
+            Assert.Contains($" value=\"{maxDollars}\"", component.Markup);
             Assert.Equal(component.Instance.Value, maxDollars);
         }
 


### PR DESCRIPTION
The test `Numeric_Supports_IComparable` should no longer fail if the user's culture doesn't use a dot as a decimal separator.
Also, the `Dollar.ConvertFrom` method will respect the culture passed as an argument if the value to convert is a `string`.