### PR TITLE
Fix OnSideClose being called on open

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -210,9 +210,9 @@ namespace Radzen
             if (_sideDialogTask?.Task.IsCompleted == false)
             {
                 _sideDialogTask.TrySetResult(result);
+                OnSideClose?.Invoke(result);
             }
 
-            OnSideClose?.Invoke(result);
         }
 
         /// <summary>

--- a/RadzenBlazorDemos/Pages/DialogSide.razor
+++ b/RadzenBlazorDemos/Pages/DialogSide.razor
@@ -5,7 +5,7 @@
         <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
             <RadzenLabel Text="Position:" Component="Position" />
             <RadzenSelectBar @bind-Value="@position" TextProperty="Text" ValueProperty="Value" Name="Position"
-                            Data="@(Enum.GetValues(typeof(DialogPosition)).Cast<DialogPosition>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
+            Data="@(Enum.GetValues(typeof(DialogPosition)).Cast<DialogPosition>().Select(t => new { Text = $"{t}", Value = t }))" Size="ButtonSize.Small" />
         </RadzenStack>
         <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
             <RadzenLabel Text="Show mask:" Component="Mask" />
@@ -17,15 +17,28 @@
         </RadzenStack>
     </RadzenStack>
     <RadzenButton Text="Dialog on Side" ButtonStyle="ButtonStyle.Secondary" Click="@OpenSideDialog" />
+    <EventConsole @ref=@console />
 </div>
 
 @code {
+    EventConsole console;
     DialogPosition position;
     bool closeDialogOnOverlayClick;
     bool showMask;
 
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        DialogService.OnSideClose += OnSideClose;
+    }
+
     async Task OpenSideDialog()
     {
         await DialogService.OpenSideAsync<DialogSideContent>("Side Panel", options: new SideDialogOptions { CloseDialogOnOverlayClick = closeDialogOnOverlayClick, Position = position, ShowMask = showMask });
+    }
+
+    async void OnSideClose(dynamic _)
+    {
+        console.Log("Side dialog closed");
     }
 }


### PR DESCRIPTION
- Move invocation of OnSideClose to inside the if block that checks if the task is complete.
- Add Console to example to demonstrate event handler

Closes #1976 