### PR TITLE
Update RadzenDatePicker.razor.cs

### DIFF
--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -522,7 +522,7 @@ namespace Radzen.Blazor
             {
                 for (int current = (int)Culture.DateTimeFormat.FirstDayOfWeek, to = current + 7; current < to; current++)
                 {
-                    yield return Culture.DateTimeFormat.AbbreviatedDayNames[current % 7];
+                    yield return Culture.DateTimeFormat.AbbreviatedDayNames[current % 7][..3].ToUpper();
                 }
             }
         }


### PR DESCRIPTION
In some cultures, such as Portuguese (Portugal), the name of the day of the week appears in full, overlapping one another. This change forces the abbreviation of the name of the day of the week.

Before:
![Screenshot 2025-02-19 123202](https://github.com/user-attachments/assets/8df51019-8f02-4cce-b830-662dff8aa0a6)

After:
![Screenshot 2025-02-19 123048](https://github.com/user-attachments/assets/c00f5e60-5079-4623-b67f-7aaf8de63d0f)
