### PR TITLE
Make CloseAndFocus public and add documentation

### DIFF
--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -943,8 +943,11 @@ namespace Radzen.Blazor
                 await SelectItem(item);
             }
         }
-
-        async Task CloseAndFocus()
+        /// <summary>
+        /// Closes the dropdown popup and sets focus to the input element.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public async Task CloseAndFocus()
         {
             if (!Disabled && !Multiple)
             {


### PR DESCRIPTION
Changed access modifier of CloseAndFocus() method from private to public and added XML documentation to maintain codebase documentation standards.

Changes:
- Modified CloseAndFocus() access level from private to public
- Added XML documentation following project standards

Documentation added:
/// <summary>
/// Closes the dropdown popup and sets focus to the input element.
/// </summary>
/// <returns>A task that represents the asynchronous operation.</returns>

No behavioral changes - only accessibility and documentation updates.