### PR TITLE
RadzenChart: Fix negative step

### DIFF
--- a/Radzen.Blazor/LinearScale.cs
+++ b/Radzen.Blazor/LinearScale.cs
@@ -113,12 +113,12 @@ namespace Radzen.Blazor
                 Round = false;
             }
 
-            if (step <= 0)
+            if (step == 0)
             {
-                throw new ArgumentOutOfRangeException("Step must be greater than zero");
+                throw new ArgumentOutOfRangeException("Step must be non-zero");
             }
 
-            return (start, end, step);
+            return (start, end, Math.Abs(step));
         }
     }
 }


### PR DESCRIPTION
When a value series only has negative values, this happens:

```
Exception: System.ArgumentOutOfRangeException: Arg_ArgumentOutOfRangeException Arg_ParamName_Name, Step must be greater than zero
          at Radzen.Blazor.LinearScale.Ticks(Int32 distance)
          at Radzen.Blazor.Rendering.AxisMeasurer.YAxis(ScaleBase scale, AxisBase axis, RadzenAxisTitle title)
          at Radzen.Blazor.RadzenValueAxis.Measure(RadzenChart chart)
          at Radzen.Blazor.RadzenChart.UpdateScales()
          at Radzen.Blazor.RadzenChart.Refresh(Boolean force)
          at Radzen.Blazor.CartesianSeries`1.<SetParametersAsync>d__74[[...]].MoveNext()
```

My change should fix that.