### PR TITLE
Update RadzenDatePicker.razor.cs for abbreviated day names

### DIFF
--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -522,7 +522,8 @@ namespace Radzen.Blazor
             {
                 for (int current = (int)Culture.DateTimeFormat.FirstDayOfWeek, to = current + 7; current < to; current++)
                 {
-                    yield return Culture.DateTimeFormat.AbbreviatedDayNames[current % 7];
+                    string weekday = Culture.DateTimeFormat.AbbreviatedDayNames[current % 7];
+                    yield return weekday.Length <= 3 ? weekday : weekday[..3];
                 }
             }
         }


### PR DESCRIPTION
The names of the days of the week are not abbreviated in some cultures such as Portuguese (Portugal) or Portuguese (Brazil). 
I propose again this change that I have already tested in several different cultures.

Before:
![Screenshot 2025-02-19 123202](https://github.com/user-attachments/assets/b3e2b29a-ea17-4eba-946a-3638adb953e8)

After:
![Screenshot 2025-02-19 123048](https://github.com/user-attachments/assets/89617e6f-f90a-4c58-aa4b-5850f30e5ab0)

