### PR TITLE
Added “YearFormatter” property in RadzenDatePicker to allow custom formatting of Year

### DIFF
--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -285,7 +285,7 @@ namespace Radzen.Blazor
             YearTo = max.HasValue ? max.Value.Year : int.Parse(YearRange.Split(':').Last());
             months = Enumerable.Range(1, 12).Select(i => new NameValue() { Name = Culture.DateTimeFormat.GetMonthName(i), Value = i }).ToList();
             years = Enumerable.Range(YearFrom, YearTo - YearFrom + 1)
-                .Select(i => new NameValue() { Name = YearFormatter is null ? FormatYear(i) : YearFormatter(i), Value = i }).ToList();
+                .Select(i => new NameValue() { Name = YearFormatter(i), Value = i }).ToList();
         }
 
         private string FormatYear(int year)
@@ -297,12 +297,17 @@ namespace Radzen.Blazor
             return date.ToString(YearFormat, Culture);
         }
 
+        public RadzenDatePicker()
+        {
+            YearFormatter = FormatYear;
+        }
+
         /// <summary>
-        /// Gets or sets the year formatter. Set to <c>null</c> by default.
+        /// Gets or sets the year formatter. Set to <c>FormatYear</c> by default.
         /// If set, this function will take precedence over <see cref="YearFormat"/>.
         /// </summary>
         [Parameter]
-        public Func<int, string> YearFormatter { get; set; } = null;
+        public Func<int, string> YearFormatter { get; set; }
 
         /// <summary>
         /// Gets ot sets the year format. Set to <c>yyyy</c> by default.

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -285,7 +285,7 @@ namespace Radzen.Blazor
             YearTo = max.HasValue ? max.Value.Year : int.Parse(YearRange.Split(':').Last());
             months = Enumerable.Range(1, 12).Select(i => new NameValue() { Name = Culture.DateTimeFormat.GetMonthName(i), Value = i }).ToList();
             years = Enumerable.Range(YearFrom, YearTo - YearFrom + 1)
-                .Select(i => new NameValue() { Name = FormatYear(i), Value = i }).ToList();
+                .Select(i => new NameValue() { Name = YearFormatter is null ? FormatYear(i) : YearFormatter(i), Value = i }).ToList();
         }
 
         private string FormatYear(int year)
@@ -296,6 +296,13 @@ namespace Radzen.Blazor
 
             return date.ToString(YearFormat, Culture);
         }
+
+        /// <summary>
+        /// Gets or sets the year formatter. Set to <c>null</c> by default.
+        /// If set, this function will take precedence over <see cref="YearFormat"/>.
+        /// </summary>
+        [Parameter]
+        public Func<int, string> YearFormatter { get; set; } = null;
 
         /// <summary>
         /// Gets ot sets the year format. Set to <c>yyyy</c> by default.

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -297,6 +297,9 @@ namespace Radzen.Blazor
             return date.ToString(YearFormat, Culture);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadzenDatePicker{TValue}"/> class.
+        /// </summary>
         public RadzenDatePicker()
         {
             YearFormatter = FormatYear;


### PR DESCRIPTION
This enhancement aims to enable immediate response to changes in the era name without relying on .NET’s built-in implementation.