### PR TITLE
!= null causing issues on KeyValuePart<string,int?>

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -757,7 +757,7 @@ namespace Radzen
                 itemIndex = itemIndex + 1 >= filteredItems.Count() ? 0 : itemIndex + 1;
                 var itemToSelect = filteredItems.ElementAtOrDefault(itemIndex);
 
-                if (itemToSelect != null)
+                if (itemToSelect is not null)
                 {
                     if (!Multiple)
                     {


### PR DESCRIPTION
We have an application with a dropdown, we bind it to` Dictioray<string,int?>` when we do a keypress in our dropdown, we got his issue: 

```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Operator '!=' cannot be applied to operands of type 'System.Collections.Generic.KeyValuePair<string,int?>' and '<null>'
   at CallSite.Target(Closure, CallSite, Object, Object)
   at Radzen.DropDownBase`1.HandleKeyPress(KeyboardEventArgs args, Boolean isFilter, Nullable`1 shouldSelectOnChange)
   at Radzen.DropDownBase`1.OnKeyPress(KeyboardEventArgs args, Nullable`1 shouldSelectOnChange)
   at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)
[15:48:36 ERR] ben@zabun.be /_blazor Unhandled exception in circuit 'dC9Mjmp1P6mnzaIrZojSa1p6pTcmpBHt2d6SIADIW9Y'. <s:Microsoft.AspNetCore.Components.Server.Circuits.CircuitHost>
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Operator '!=' cannot be applied to operands of type 'System.Collections.Generic.KeyValuePair<string,int?>' and '<null>'
   at CallSite.Target(Closure, CallSite, Object, Object)
   at Radzen.DropDownBase`1.HandleKeyPress(KeyboardEventArgs args, Boolean isFilter, Nullable`1 shouldSelectOnChange)
   at Radzen.DropDownBase`1.OnKeyPress(KeyboardEventArgs args, Nullable`1 shouldSelectOnChange)
```

after debugging radzen, we found out it was caused by the null check on line 760 in DropDownBase.cs, by replacing this by the new is not null check, it also works in our case, you can check the difference in this oneline fiddle [https://dotnetfiddle.net/U5lY1E](https://dotnetfiddle.net/U5lY1E) 

you can also test it like this

```blazor
<RadzenDropDown
    TValue="int?"
    @bind-Value="@selectedItem"
    AllowClear="true"
    AllowFiltering="true"
    Multiple="false"
    Data="@items"
    TextProperty="Key"
    ValueProperty="Value"
    Change="Callback"
>
</RadzenDropDown>
```

 ```c#
Dictionary<string, int ?> items = new Dictionary<string, int?>()
    {
        { "",null},
        { "A", 1 },
        { "B", 2 },
        { "C", 3 },
        { "D", 4 },
        { "E", 5 },
        { "F", 6 },
        { "G", 7 },
        { "H", 8 },
        { "I", 9 },
        { "J", 10 },
        { "K", 11 },
        { "L", 12 },
        { "M", 13 },
        { "N", 14 },
        { "O", 15 },
        { "P", 16 },
        { "Q", 17 },
        { "R", 18 },
        { "S", 19 },
        { "T", 20 },
        { "U", 21 },
        { "V", 22 },
        { "W", 23 },
        { "X", 24 },
        { "Y", 25 },
        { "Z", 26 }
    };
    
    int? selectedItem;
    
    private void Callback(object obj)
    {
        Console.WriteLine(selectedItem);
    }
```

