### PR TITLE
AutoComplete, Numeric: fix font family in inputs

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_autocomplete.scss
+++ b/Radzen.Blazor/themes/components/blazor/_autocomplete.scss
@@ -25,6 +25,7 @@
   padding-inline: var(--rz-input-padding-inline);
   background-color: transparent;
   color: var(--rz-input-value-color);
+  font-family: inherit;
   box-shadow: var(--rz-input-shadow);
   border: none;
   height: var(--rz-input-height);

--- a/Radzen.Blazor/themes/components/blazor/_numeric.scss
+++ b/Radzen.Blazor/themes/components/blazor/_numeric.scss
@@ -25,6 +25,7 @@ $numeric-button-disabled-color: var(--rz-text-disabled-color) !default;
     height: 100%;
     border: none;
     background-color: transparent;
+    font-family: inherit;
     line-height: var(--rz-numeric-line-height);
     padding-block: var(--rz-numeric-input-padding-block);
     padding-inline: var(--rz-numeric-input-padding-inline);


### PR DESCRIPTION
Fixes inconsistency of font families used in AutoComplete and Numeric inputs.
Before this change, it looked like this:
![image](https://github.com/user-attachments/assets/13959427-4d7c-45c3-b800-0bf6182e6f2e)
