### PR TITLE
Added SameSite and Secure options for theme cookie.

### DIFF
--- a/Radzen.Blazor/CookieThemeService.cs
+++ b/Radzen.Blazor/CookieThemeService.cs
@@ -8,6 +8,25 @@ using Microsoft.JSInterop;
 namespace Radzen
 {
     /// <summary>
+    /// Specifies the SameSite attribute for the cookie.
+    /// </summary>
+    public enum CookieThemeServiceOptionsSameSiteMode
+    {
+        /// <summary>
+        /// No SameSite attribute.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Lax SameSite attribute.
+        /// </summary>
+        Lax,
+        /// <summary>
+        /// Strict SameSite attribute.
+        /// </summary>
+        Strict
+    }
+
+    /// <summary>
     /// Options for the <see cref="CookieThemeService" />.
     /// </summary>
     public class CookieThemeServiceOptions
@@ -21,6 +40,16 @@ namespace Radzen
         /// Gets or sets the cookie duration.
         /// </summary>
         public TimeSpan Duration { get; set; } = TimeSpan.FromDays(365);
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use secure cookies.
+        /// </summary>
+        public bool IsSecure { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the SameSite attribute for the cookie.
+        /// </summary>
+        public CookieThemeServiceOptionsSameSiteMode? SameSite { get; set; } = null;
     }
 
     /// <summary>
@@ -75,8 +104,19 @@ namespace Radzen
         private void OnThemeChanged()
         {
             var expiration = DateTime.Now.Add(options.Duration);
+            var cookie = $"{options.Name}={themeService.Theme}; expires={expiration:R}; path=/";
 
-            _ = jsRuntime.InvokeVoidAsync("eval", $"document.cookie = \"{options.Name}={themeService.Theme}; expires={expiration:R}; path=/\"");
+            if (options.SameSite.HasValue)
+            {
+                cookie += $"; SameSite={options.SameSite}";
+            }
+
+            if (options.IsSecure)
+            {
+                cookie += "; Secure";
+            }
+
+            _ = jsRuntime.InvokeVoidAsync("eval", $"document.cookie = \"{cookie}\"");
         }
     }
 

--- a/Radzen.Blazor/CookieThemeService.cs
+++ b/Radzen.Blazor/CookieThemeService.cs
@@ -10,7 +10,7 @@ namespace Radzen
     /// <summary>
     /// Specifies the SameSite attribute for the cookie.
     /// </summary>
-    public enum CookieThemeServiceOptionsSameSiteMode
+    public enum CookieSameSiteMode
     {
         /// <summary>
         /// No SameSite attribute.
@@ -49,7 +49,7 @@ namespace Radzen
         /// <summary>
         /// Gets or sets the SameSite attribute for the cookie.
         /// </summary>
-        public CookieThemeServiceOptionsSameSiteMode? SameSite { get; set; } = null;
+        public CookieSameSiteMode? SameSite { get; set; } = null;
     }
 
     /// <summary>


### PR DESCRIPTION
Added SameSite and Secure options for theme cookie. 
This allows you to set the theme cookie with a SameSite attribute and thus hide the warning that is displayed in Chrome, for example. In addition, the new IsSecure option can be used to set the “Secure” flag of the cookie (only HTTPS requests are then possible).

Please note that I have created a new enum "CookieThemeServiceOptionsSameSiteMode" instead of using the built-in "SameSiteMode" enum defined in Microsoft.AspNetCore.Http because it is not yet referenced in the project and I didn't want to change that.

Regards
Frank