### PR TITLE
(docs): Clarify that ShowHeader needs to be set to true if using NavigationTemplate

### DIFF
--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -67,6 +67,7 @@ namespace Radzen.Blazor
         /// Gets or sets the additional content to be rendered in place of the default navigation buttons in the scheduler.
         /// This property allows for complete customization of the navigation controls, replacing the native date navigation buttons (such as year, month, and day) with user-defined content or buttons.
         /// Use this to add custom controls or interactive elements that better suit your application's requirements.
+        /// This requires that the <c>ShowHeader</c> parameter to be set to true (enabled by default).
         /// </summary>
         /// <value>The custom navigation template to replace default navigation buttons.</value>
         [Parameter]


### PR DESCRIPTION
Hello. 
This is a proposal for just adding to the docs that ShowHeader needs to be set to true for NavigationTemplate to work.
I read the docs before I had updated the nuget and had been setting that parameter ShowHeader=false, without it doing anything really (because I was running older version). 

But today when I bumped up the package I could not understand why NavigationTemplate was not rendered anymore. It took me some tries but I went to the source code and saw the condition ShowHeader. But it is not obvious in the docs that it needs to be set to be used AFAIK :)