### PR TITLE
Add Diacritics Filtering Option to Components with List Support

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -1894,6 +1894,20 @@ namespace Radzen
         /// </summary>
         CaseInsensitive
     }
+    /// <summary>
+    /// Specifies the filter ignore diacritics of a component.
+    /// </summary>
+    public enum FilterIgnoreDiactritics
+    {
+        /// <summary>
+        /// Relies on the underlying provider (LINQ to Objects, Entity Framework etc.) to handle diacritics. LINQ to Objects is case sensitive. Entity Framework relies on the database collection settings.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Filters are case insensitive regardless of the underlying provider.
+        /// </summary>
+        IgnoreDiactritics
+    }
 
     /// <summary>
     /// Specifies the logical operator between filters.

--- a/Radzen.Blazor/DataBoundFormComponent.cs
+++ b/Radzen.Blazor/DataBoundFormComponent.cs
@@ -36,6 +36,11 @@ namespace Radzen
         public FilterCaseSensitivity FilterCaseSensitivity { get; set; } = FilterCaseSensitivity.Default;
 
         /// <summary>
+        /// Gets or sets the filter ignore diactritics.
+        /// </summary>
+        [Parameter]
+        public FilterIgnoreDiactritics FilterIgnoreDiactritics { get; set; } = FilterIgnoreDiactritics.Default;
+        /// <summary>
         /// Gets or sets the filter operator.
         /// </summary>
         /// <value>The filter operator.</value>
@@ -259,7 +264,7 @@ namespace Radzen
                 {
                     if (!string.IsNullOrEmpty(searchText))
                     {
-                        _view = Query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity);
+                        _view = Query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity, FilterIgnoreDiactritics);
                     }
                     else
                     {

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -743,7 +743,7 @@ namespace Radzen
             else
             {
                 var filteredItems = (!string.IsNullOrEmpty(TextProperty) ?
-                    Query.Where(TextProperty, args.Key, StringFilterOperator.StartsWith, FilterCaseSensitivity.CaseInsensitive) :
+                    Query.Where(TextProperty, args.Key, StringFilterOperator.StartsWith, FilterCaseSensitivity.CaseInsensitive, FilterIgnoreDiactritics.IgnoreDiactritics) :
                     Query)
                     .Cast(Query.ElementType).Cast<dynamic>().ToList();
 
@@ -1057,7 +1057,7 @@ namespace Radzen
             {
                 if (_view == null && Query != null)
                 {
-                    _view = Query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity);
+                    _view = Query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity, FilterIgnoreDiactritics);
                 }
 
                 return _view;

--- a/Radzen.Blazor/Extensions.cs
+++ b/Radzen.Blazor/Extensions.cs
@@ -70,5 +70,23 @@ namespace Radzen.Blazor
                 .Trim().ToLower();
         }
     }
+    /// <summary>
+    /// Class StringExtensions.
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Removes the diacritics.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public static string RemoveDiacritics(this string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text;
+            text = text.Normalize(System.Text.NormalizationForm.FormD);
+            var chars = text.Where(c => System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c) != System.Globalization.UnicodeCategory.NonSpacingMark).ToArray();
+            return new string(chars).Normalize(System.Text.NormalizationForm.FormC);
+        }
+    }
 }
 

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -237,7 +237,7 @@ namespace Radzen.Blazor
             {
                 if (Query != null)
                 {
-                    return Query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity);
+                    return Query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity, FilterIgnoreDiactritics);
                 }
 
                 return null;

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -242,7 +242,7 @@ else
             if(!string.IsNullOrEmpty(loadDataArgs.Filter))
             {
                 query = Column.Grid.Data.AsQueryable().Where<TItem>(Column.Grid.allColumns.Where(c => c != Column))
-                    .Where(property, loadDataArgs.Filter, StringFilterOperator.Contains, FilterCaseSensitivity.CaseInsensitive);
+                    .Where(property, loadDataArgs.Filter, StringFilterOperator.Contains, FilterCaseSensitivity.CaseInsensitive, FilterIgnoreDiactritics.Default);
             }
             else
             {

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -510,12 +510,12 @@ namespace Radzen.Blazor
 
                             foreach (string word in words)
                             {
-                                query = query.Where(TextProperty, word, FilterOperator, FilterCaseSensitivity);
+                                query = query.Where(TextProperty, word, FilterOperator, FilterCaseSensitivity, FilterIgnoreDiactritics);
                             }
                         }
                         else
                         {
-                            query = query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity);
+                            query = query.Where(TextProperty, searchText, FilterOperator, FilterCaseSensitivity, FilterIgnoreDiactritics);
                         }
                     }
                 }


### PR DESCRIPTION
Summary
This update introduces diacritics handling in filtering logic across various components, allowing users to specify whether diacritics should be ignored.

Changes Implemented:

-  Introduced FilterIgnoreDiacritics Enum in Common.cs to specify diacritics handling.
-  Added FilterIgnoreDiacritics Parameter to DataBoundFormComponent.cs.
-  Updated QueryableExtension.cs to handle diacritics in the Where method.
-  Created StringExtensions in Extensions.cs with a RemoveDiacritics method for diacritic removal.
-  Modified DropDownBase.cs to apply FilterIgnoreDiacritics in filtering logic.
-  Enhanced RadzenAutoComplete.razor.cs & RadzenDropDownDataGrid.razor.cs to support diacritics filtering.
-  Updated RadzenDataGridHeaderCell.razor to integrate diacritics filtering in column headers.
![image](https://github.com/user-attachments/assets/15c111fc-4483-4027-9277-249ce1b370f1)

