### PR TITLE
Add cascading value support to dialog components

### DIFF
--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -125,21 +125,30 @@
     public bool ShowMask { get; set; } = true;
 
     RenderFragment ChildContent => new RenderFragment(builder =>
+    {
+        // Wrap the Dialog component in a CascadingValue
+
+        builder.OpenComponent<CascadingValue<Dialog>>(0); // Open CascadingValue
+        builder.AddAttribute(1, "Value", Dialog);
+        builder.AddAttribute(2, "IsFixed", true);
+        builder.AddAttribute(3, "ChildContent", (RenderFragment)((builder2) =>
         {
-            builder.OpenComponent(0, Dialog.Type);
+            builder2.OpenComponent(0, Dialog.Type); // Open Dialog
 
             if (Dialog.Parameters != null)
             {
                 foreach (var parameter in Dialog.Parameters)
                 {
-                    builder.AddAttribute(1, parameter.Key, parameter.Value);
+                    builder2.AddAttribute(1, parameter.Key, parameter.Value);
                 }
             }
 
-            builder.AddComponentReferenceCapture(2, component => reference = component);
+            builder2.AddComponentReferenceCapture(2, component => reference = component); // Capture reference
+            builder2.CloseComponent(); // Close Dialog
 
-            builder.CloseComponent();
-        });
+        }));
+        builder.CloseComponent(); // Close CascadingValue
+    });
 
     object reference;
 

--- a/RadzenBlazorDemos/Pages/DialogPage.razor
+++ b/RadzenBlazorDemos/Pages/DialogPage.razor
@@ -65,3 +65,16 @@
 <RadzenExample ComponentName="Dialog" Example="DialogCss">
     <DialogCss />
 </RadzenExample>
+
+<RadzenText Anchor="dialog#cascading-value" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
+    Dialog with cascading value
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    Use the <code>Dialog</code> 
+    <RadzenLink Text="Cascading Value" Path="https://learn.microsoft.com/en-us/aspnet/core/blazor/components/cascading-values-and-parameters#cascadingvalue-component" target="_blank" />
+    to update the dialog title content
+</RadzenText>
+
+<RadzenExample ComponentName="Dialog" Example="DialogWithCascadingValueCaller" AdditionalSourceCodePages=@(new List<string>() { "DialogWithCascadingValueImplementation.razor" })>
+    <DialogWithCascadingValueCaller />
+</RadzenExample>

--- a/RadzenBlazorDemos/Pages/DialogWithCascadingValueCaller.razor
+++ b/RadzenBlazorDemos/Pages/DialogWithCascadingValueCaller.razor
@@ -1,0 +1,11 @@
+﻿@inject DialogService DialogService
+
+<div class="rz-p-12 rz-text-align-center">
+	<RadzenButton Text="Dialog with cascading value" ButtonStyle="ButtonStyle.Secondary" Click=@OpenDialog />
+</div>
+@code {
+	private async Task OpenDialog()
+	{
+		await DialogService.OpenAsync<DialogWithCascadingValueImplementation>("Loading...");
+	}
+}

--- a/RadzenBlazorDemos/Pages/DialogWithCascadingValueImplementation.razor
+++ b/RadzenBlazorDemos/Pages/DialogWithCascadingValueImplementation.razor
@@ -1,0 +1,37 @@
+﻿<div class="rz-p-12 rz-text-align-center">
+	<RadzenButton Text="Update counter from dialog" ButtonStyle="ButtonStyle.Secondary" Click=@UpdateCounter />
+</div>
+
+@code {
+
+	[CascadingParameter] private Dialog _dialog { get; set; }
+	[Inject] private DialogService _dialogService { get; set; }
+	int _counter { get; set; }
+
+	protected override void OnInitialized()
+	{
+		// Change the dialog title content
+		_dialog.Options.TitleContent = service => @<RadzenCard>
+			<RadzenStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Start" Wrap="FlexWrap.Wrap">
+				<RadzenText TextStyle="TextStyle.Subtitle1">
+					Title with a counter: @_counter
+				</RadzenText>
+				<RadzenRow>
+					<RadzenButton Text="Update counter from title" ButtonStyle="ButtonStyle.Secondary" Click=@UpdateCounter />
+				</RadzenRow>
+			</RadzenStack>
+		</RadzenCard>;
+
+		// reflect the changes
+		_dialogService.Refresh();
+	}
+
+
+	void UpdateCounter()
+	{
+		_counter++;
+		_dialogService.Refresh();
+	}
+
+
+}


### PR DESCRIPTION
Added `Dialog` `CascadingValue` to `DialogContainer` to enable update dialog title from within the dialog content.

- Updated `DialogContainer.razor` to wrap the `Dialog` in a `CascadingValue`, enabling access to cascading parameters.
- Enhanced `DialogPage.razor` with explanatory text and a link to documentation regarding cascading values.
- Introduced `DialogWithCascadingValueCaller.razor` to provide a button for opening a dialog that uses cascading values.
- Created `DialogWithCascadingValueImplementation.razor` to implement dynamic dialog functionality with a counter that updates the title.

![image](https://github.com/user-attachments/assets/7ba5f08f-bc45-497a-b9cf-140f2fcb7293)

![image](https://github.com/user-attachments/assets/981ed72a-75e2-4335-bb0b-98235d21d3aa)
