### PR TITLE
Add SubmitForm method to RadzenTemplateForm class

### DIFF
--- a/Radzen.Blazor/RadzenTemplateForm.cs
+++ b/Radzen.Blazor/RadzenTemplateForm.cs
@@ -204,6 +204,18 @@ namespace Radzen.Blazor
             }
         }
 
+        /// <summary>
+        /// Submits the form. 
+        /// This can be used to programmatically submit the form by using the <b>@ref</b> to <see cref="RadzenTemplateForm{TItem}" />
+        /// </summary>
+        /// <remarks>
+        /// Validates the form and invokes the appropriate callback based on the validation result.
+        /// </remarks>
+        public async Task SubmitForm()
+        {
+            await OnSubmit();
+        }
+
         readonly List<IRadzenFormComponent> components = new List<IRadzenFormComponent>();
 
         /// <inheritdoc />


### PR DESCRIPTION
Introduces a new public method `SubmitForm` that allows for programmatic form submission form outside the `Component` by using `@ref`. The method includes XML documentation detailing its purpose and behavior, and it calls `OnSubmit()` to manage the submission process.