### PR TITLE
Enhance dialog options with property change notifications to support automatic UI updates

### DIFF
--- a/Radzen.Blazor.Tests/DialogServiceTests.cs
+++ b/Radzen.Blazor.Tests/DialogServiceTests.cs
@@ -1,0 +1,287 @@
+﻿using Radzen;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+	public class DialogServiceTests
+	{
+		public class OpenDialogTests
+		{
+			[Fact(DisplayName = "DialogOptions default values are set correctly")]
+			public void DialogOptions_DefaultValues_AreSetCorrectly()
+			{
+				// Arrange
+				var options = new DialogOptions();
+				var dialogService = new DialogService(null, null);
+
+				// Act
+				dialogService.OpenDialog<DialogServiceTests>("Test", [], options);
+
+				// Assert
+				Assert.Equal("600px", options.Width);
+				Assert.Equal("", options.Left);
+				Assert.Equal("", options.Top);
+				Assert.Equal("", options.Bottom);
+				Assert.Equal("", options.Height);
+				Assert.Equal("", options.Style);
+				Assert.Equal("", options.CssClass);
+				Assert.Equal("", options.WrapperCssClass);
+				Assert.Equal("", options.ContentCssClass);
+			}
+
+			[Fact(DisplayName = "DialogOptions values are retained after OpenDialog call")]
+			public void DialogOptions_Values_AreRetained_AfterOpenDialogCall()
+			{
+				// Arrange
+				var options = new DialogOptions
+				{
+					Width = "800px",
+					Left = "10px",
+					Top = "20px",
+					Bottom = "30px",
+					Height = "400px",
+					Style = "background-color: red;",
+					CssClass = "custom-class",
+					WrapperCssClass = "wrapper-class",
+					ContentCssClass = "content-class"
+				};
+				var dialogService = new DialogService(null, null);
+
+				// Act
+				dialogService.OpenDialog<DialogServiceTests>("Test", [], options);
+
+				// Assert
+				Assert.Equal("800px", options.Width);
+				Assert.Equal("10px", options.Left);
+				Assert.Equal("20px", options.Top);
+				Assert.Equal("30px", options.Bottom);
+				Assert.Equal("400px", options.Height);
+				Assert.Equal("background-color: red;", options.Style);
+				Assert.Equal("custom-class", options.CssClass);
+				Assert.Equal("wrapper-class", options.WrapperCssClass);
+				Assert.Equal("content-class", options.ContentCssClass);
+			}
+
+			[Fact(DisplayName = "DialogOptions is null and default values are set correctly")]
+			public void DialogOptions_IsNull_DefaultValues_AreSetCorrectly()
+			{
+				// Arrange
+				DialogOptions resultingOptions = null;
+				var dialogService = new DialogService(null, null);
+				dialogService.OnOpen += (title, type, parameters, options) => resultingOptions = options;
+
+				// Act
+				dialogService.OpenDialog<DialogServiceTests>("Test", [], null);
+
+				// Assert
+				Assert.NotNull(resultingOptions);
+				Assert.Equal("600px", resultingOptions.Width);
+				Assert.Equal("", resultingOptions.Left);
+				Assert.Equal("", resultingOptions.Top);
+				Assert.Equal("", resultingOptions.Bottom);
+				Assert.Equal("", resultingOptions.Height);
+				Assert.Equal("", resultingOptions.Style);
+				Assert.Equal("", resultingOptions.CssClass);
+				Assert.Equal("", resultingOptions.WrapperCssClass);
+				Assert.Equal("", resultingOptions.ContentCssClass);
+			}
+		}
+
+		public class ConfirmTests
+		{
+			[Fact(DisplayName = "ConfirmOptions is null and default values are set correctly")]
+			public async Task ConfirmOptions_IsNull_AreSetCorrectly()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				ConfirmOptions resultingOptions = null;
+				dialogService.OnOpen += (title, type, parameters, options) => resultingOptions = options as ConfirmOptions;
+
+				using var cancellationTokenSource = new CancellationTokenSource();
+				cancellationTokenSource.Cancel();
+
+				// Act
+				try
+				{
+					await dialogService.Confirm(cancellationToken: cancellationTokenSource.Token);
+				}
+				catch (TaskCanceledException)
+				{
+					// this is expected
+				}
+
+				// Assert
+				Assert.NotNull(resultingOptions);
+				Assert.Equal("600px", resultingOptions.Width);
+				Assert.Equal("", resultingOptions.Style);
+				Assert.Equal("rz-dialog-confirm", resultingOptions.CssClass);
+				Assert.Equal("rz-dialog-wrapper", resultingOptions.WrapperCssClass);
+			}
+
+			[Fact(DisplayName = "ConfirmOptions default values are set correctly")]
+			public async Task ConfirmOptions_DefaultValues_AreSetCorrectly()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				ConfirmOptions resultingOptions = null;
+				dialogService.OnOpen += (title, type, parameters, options) => resultingOptions = options as ConfirmOptions;
+
+				using var cancellationTokenSource = new CancellationTokenSource();
+				cancellationTokenSource.Cancel();
+
+				// Act
+				try
+				{
+					await dialogService.Confirm(options: new(), cancellationToken: cancellationTokenSource.Token);
+				}
+				catch (TaskCanceledException)
+				{
+					// this is expected
+				}
+
+				// Assert
+				Assert.NotNull(resultingOptions);
+				Assert.Equal("600px", resultingOptions.Width);
+				Assert.Equal("", resultingOptions.Style);
+				Assert.Equal("rz-dialog-confirm", resultingOptions.CssClass);
+				Assert.Equal("rz-dialog-wrapper", resultingOptions.WrapperCssClass);
+			}
+			[Fact(DisplayName = "ConfirmOptions values are retained after Confirm call")]
+			public async Task Confirm_ProvidedValues_AreRetained()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var options = new ConfirmOptions
+				{
+					Width = "800px",
+					Style = "background-color: red;",
+					CssClass = "custom-class",
+					WrapperCssClass = "wrapper-class"
+				};
+				ConfirmOptions resultingOptions = null;
+				dialogService.OnOpen += (title, type, parameters, options) => resultingOptions = options as ConfirmOptions;
+
+				// We break out of the dialog immediately, but the options should still be set
+				using var cancellationTokenSource = new CancellationTokenSource();
+				cancellationTokenSource.Cancel();
+
+				// Act
+				try
+				{
+					await dialogService.Confirm("Confirm?", "Confirm", options, cancellationToken: cancellationTokenSource.Token);
+				}
+				catch (TaskCanceledException)
+				{
+					// this is expected
+				}
+
+				// Assert
+				Assert.NotNull(resultingOptions);
+				Assert.Equal("800px", resultingOptions.Width);
+				Assert.Equal("background-color: red;", resultingOptions.Style);
+				Assert.Equal("rz-dialog-confirm custom-class", resultingOptions.CssClass);
+				Assert.Equal("rz-dialog-wrapper wrapper-class", resultingOptions.WrapperCssClass);
+			}
+
+		}
+
+		public class AlertTests
+		{
+			[Fact(DisplayName = "AlertOptions is null and default values are set correctly")]
+			public async Task AlertOptions_IsNull_AreSetCorrectly()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				AlertOptions resultingOptions = null;
+				dialogService.OnOpen += (title, type, parameters, options) => resultingOptions = options as AlertOptions;
+
+				using var cancellationTokenSource = new CancellationTokenSource();
+				cancellationTokenSource.Cancel();
+
+				// Act
+				try
+				{
+					await dialogService.Alert(cancellationToken: cancellationTokenSource.Token);
+				}
+				catch (TaskCanceledException)
+				{
+					// this is expected
+				}
+
+				// Assert
+				Assert.NotNull(resultingOptions);
+				Assert.Equal("600px", resultingOptions.Width);
+				Assert.Equal("", resultingOptions.Style);
+				Assert.Equal("rz-dialog-alert", resultingOptions.CssClass);
+				Assert.Equal("rz-dialog-wrapper", resultingOptions.WrapperCssClass);
+			}
+
+			[Fact(DisplayName = "AlertOptions default values are set correctly")]
+			public async Task AlertOptions_DefaultValues_AreSetCorrectly()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				AlertOptions resultingOptions = null;
+				dialogService.OnOpen += (title, type, parameters, options) => resultingOptions = options as AlertOptions;
+
+				using var cancellationTokenSource = new CancellationTokenSource();
+				cancellationTokenSource.Cancel();
+
+				// Act
+				try
+				{
+					await dialogService.Alert(options: new(), cancellationToken: cancellationTokenSource.Token);
+				}
+				catch (TaskCanceledException)
+				{
+					// this is expected
+				}
+
+				// Assert
+				Assert.NotNull(resultingOptions);
+				Assert.Equal("600px", resultingOptions.Width);
+				Assert.Equal("", resultingOptions.Style);
+				Assert.Equal("rz-dialog-alert", resultingOptions.CssClass);
+				Assert.Equal("rz-dialog-wrapper", resultingOptions.WrapperCssClass);
+			}
+			[Fact(DisplayName = "AlertOptions values are retained after Alert call")]
+			public async Task Alert_ProvidedValues_AreRetained()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var options = new AlertOptions
+				{
+					Width = "800px",
+					Style = "background-color: red;",
+					CssClass = "custom-class",
+					WrapperCssClass = "wrapper-class"
+				};
+				AlertOptions resultingOptions = null;
+				dialogService.OnOpen += (title, type, parameters, options) => resultingOptions = options as AlertOptions;
+
+				// We break out of the dialog immediately, but the options should still be set
+				using var cancellationTokenSource = new CancellationTokenSource();
+				cancellationTokenSource.Cancel();
+
+				// Act
+				try
+				{
+					await dialogService.Alert("Alert?", "Alert", options, cancellationToken: cancellationTokenSource.Token);
+				}
+				catch (TaskCanceledException)
+				{
+					// this is expected
+				}
+
+				// Assert
+				Assert.NotNull(resultingOptions);
+				Assert.Equal("800px", resultingOptions.Width);
+				Assert.Equal("background-color: red;", resultingOptions.Style);
+				Assert.Equal("rz-dialog-alert custom-class", resultingOptions.CssClass);
+				Assert.Equal("rz-dialog-wrapper wrapper-class", resultingOptions.WrapperCssClass);
+			}
+		}
+	}
+}

--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -2,6 +2,7 @@
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Reflection;
@@ -387,30 +388,20 @@ namespace Radzen
         private void OpenDialog<T>(string title, Dictionary<string, object> parameters, DialogOptions options)
         {
             dialogs.Add(new object());
-            OnOpen?.Invoke(title, typeof(T), parameters, new DialogOptions()
-            {
-                Width = options != null && !string.IsNullOrEmpty(options.Width) ? options.Width : "600px",
-                Left = options != null && !string.IsNullOrEmpty(options.Left) ? options.Left : "",
-                Top = options != null && !string.IsNullOrEmpty(options.Top) ? options.Top : "",
-                Bottom = options != null && !string.IsNullOrEmpty(options.Bottom) ? options.Bottom : "",
-                Height = options != null && !string.IsNullOrEmpty(options.Height) ? options.Height : "",
-                ShowTitle = options != null ? options.ShowTitle : true,
-                ShowClose = options != null ? options.ShowClose : true,
-                Resizable = options != null ? options.Resizable : false,
-                Draggable = options != null ? options.Draggable : false,
-                ChildContent = options?.ChildContent,
-                TitleContent = options?.TitleContent,
-                Style = options != null ? options.Style : "",
-                AutoFocusFirstElement = options != null ? options.AutoFocusFirstElement : true,
-                CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
-                CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
-                CssClass = options != null ? options.CssClass : "",
-                WrapperCssClass = options != null ? options.WrapperCssClass : "",
-                CloseTabIndex = options != null ? options.CloseTabIndex : 0,
-                ContentCssClass = options != null ? options.ContentCssClass : "",
-                Resize = options?.Resize,
-                Drag = options?.Drag
-            });
+
+            // Validate and set default values for the dialog options
+            options ??= new();
+			options.Width = !String.IsNullOrEmpty(options.Width) ? options.Width : "600px";
+			options.Left = !String.IsNullOrEmpty(options.Left) ? options.Left : "";
+			options.Top = !String.IsNullOrEmpty(options.Top) ? options.Top : "";
+			options.Bottom = !String.IsNullOrEmpty(options.Bottom) ? options.Bottom : "";
+			options.Height = !String.IsNullOrEmpty(options.Height) ? options.Height : "";
+			options.Style = !String.IsNullOrEmpty(options.Style) ? options.Style : "";
+			options.CssClass = !String.IsNullOrEmpty(options.CssClass) ? options.CssClass : "";
+			options.WrapperCssClass = !String.IsNullOrEmpty(options.WrapperCssClass) ? options.WrapperCssClass : "";
+			options.ContentCssClass = !String.IsNullOrEmpty(options.ContentCssClass) ? options.ContentCssClass : "";
+
+            OnOpen?.Invoke(title, typeof(T), parameters, options);
         }
 
         /// <summary>
@@ -454,27 +445,16 @@ namespace Radzen
         /// <returns><c>true</c> if the user clicked the OK button, <c>false</c> otherwise.</returns>
         public virtual async Task<bool?> Confirm(string message = "Confirm?", string title = "Confirm", ConfirmOptions options = null)
         {
-            var dialogOptions = new DialogOptions()
-            {
-                Width = options != null ? !string.IsNullOrEmpty(options.Width) ? options.Width : "" : "",
-                Height = options != null ? options.Height : null,
-                Left = options != null ? options.Left : null,
-                Top = options != null ? options.Top : null,
-                Bottom = options != null ? options.Bottom : null,
-                ChildContent = options != null ? options.ChildContent : null,
-                ShowTitle = options != null ? options.ShowTitle : true,
-                ShowClose = options != null ? options.ShowClose : true,
-                Resizable = options != null ? options.Resizable : false,
-                Draggable = options != null ? options.Draggable : false,
-                Style = options != null ? options.Style : "",
-                AutoFocusFirstElement = options != null ? options.AutoFocusFirstElement : true,
-                CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
-                CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
-                CssClass = options != null ? $"rz-dialog-confirm {options.CssClass}" : "rz-dialog-confirm",
-                WrapperCssClass = options != null ? $"rz-dialog-wrapper {options.WrapperCssClass}" : "rz-dialog-wrapper",
-                CloseTabIndex = options != null ? options.CloseTabIndex : 0,
-            };
+            var useDefault = options == null;
 
+            // Validate and set default values for the dialog options
+            options ??= new();
+
+            options.Width = !String.IsNullOrEmpty(options.Width) ? options.Width : "";
+            options.Style = !String.IsNullOrEmpty(options.Style) ? options.Style : "";
+            options.CssClass = !useDefault ? $"rz-dialog-confirm ${options.CssClass}" : "rz-dialog-confirm";
+            options.WrapperCssClass = !useDefault ? $"rz-dialog-wrapper ${options.WrapperCssClass}" : "rz-dialog-wrapper";
+            
             return await OpenAsync(title, ds =>
             {
                 RenderFragment content = b =>
@@ -502,7 +482,7 @@ namespace Radzen
                     b.CloseElement();
                 };
                 return content;
-            }, dialogOptions);
+            }, options);
         }
 
         /// <summary>
@@ -514,27 +494,16 @@ namespace Radzen
         /// <returns><c>true</c> if the user clicked the OK button, <c>false</c> otherwise.</returns>
         public virtual async Task<bool?> Alert(string message = "", string title = "Message", AlertOptions options = null)
         {
-            var dialogOptions = new DialogOptions()
-            {
-                Width = options != null ? !string.IsNullOrEmpty(options.Width) ? options.Width : "" : "",
-                Height = options != null ? options.Height : null,
-                Left = options != null ? options.Left : null,
-                Top = options != null ? options.Top : null,
-                Bottom = options != null ? options.Bottom : null,
-                ChildContent = options != null ? options.ChildContent : null,
-                ShowTitle = options != null ? options.ShowTitle : true,
-                ShowClose = options != null ? options.ShowClose : true,
-                Resizable = options != null ? options.Resizable : false,
-                Draggable = options != null ? options.Draggable : false,
-                Style = options != null ? options.Style : "",
-                AutoFocusFirstElement = options != null ? options.AutoFocusFirstElement : true,
-                CloseDialogOnOverlayClick = options != null ? options.CloseDialogOnOverlayClick : false,
-                CloseDialogOnEsc = options != null ? options.CloseDialogOnEsc : true,
-                CssClass = options != null ? $"rz-dialog-alert {options.CssClass}" : "rz-dialog-alert",
-                WrapperCssClass = options != null ? $"rz-dialog-wrapper {options.WrapperCssClass}" : "rz-dialog-wrapper",
-                ContentCssClass = options != null ? $"rz-dialog-content {options.ContentCssClass}" : "rz-dialog-content",
-                CloseTabIndex = options != null ? options.CloseTabIndex : 0,
-            };
+            // Validate and set default values for the dialog options
+            var useDefault = options == null;
+
+            options ??= new();
+
+            options.Width = !String.IsNullOrEmpty(options.Width) ? options.Width : "";  
+            options.Style = !String.IsNullOrEmpty(options.Style) ? options.Style : "";
+            options.CssClass = !useDefault ? $"rz-dialog-alert ${options.CssClass}" : "rz-dialog-alert";
+            options.WrapperCssClass = !useDefault ? $"rz-dialog-wrapper ${options.WrapperCssClass}" : "rz-dialog-wrapper";
+            options.ContentCssClass = !useDefault ? $"rz-dialog-content ${options.ContentCssClass}" : "rz-dialog-content";
 
             return await OpenAsync(title, ds =>
             {
@@ -557,67 +526,204 @@ namespace Radzen
                     b.CloseElement();
                 };
                 return content;
-            }, dialogOptions);
+            }, options);
         }
     }
 
-    /// <summary>
-    /// Base Class for dialog options
-    /// </summary>
-    public abstract class DialogOptionsBase
-    {
+	/// <summary>
+	/// Base Class for dialog options
+	/// </summary>
+	public abstract class DialogOptionsBase : INotifyPropertyChanged
+	{
+		/// <summary>
+		/// Occurs when a property value changes.
+		/// </summary>
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		/// <summary>
+		/// Raises the <see cref="PropertyChanged" /> event.
+		/// </summary>
+		/// <param name="propertyName">The name of the property that changed.</param>
+		protected virtual void OnPropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		private bool showTitle = true;
         /// <summary>
         /// Gets or sets a value indicating whether to show the title bar. Set to <c>true</c> by default.
         /// </summary>
-        /// <value><c>true</c> if title bar is shown; otherwise, <c>false</c>.</value>
-        public bool ShowTitle { get; set; } = true;
+        /// <value><c>true</c> if title bar is shown; otherwise, <c>false</c>. Default is <c>true</c>.</value>
+        public bool ShowTitle
+		{
+			get => showTitle;
+			set
+			{
+				if (showTitle != value)
+				{
+					showTitle = value;
+					OnPropertyChanged(nameof(ShowTitle));
+				}
+			}
+		}
 
+		private bool showClose = true;
         /// <summary>
         /// Gets or sets a value indicating whether to show the close button. Set to <c>true</c> by default.
         /// </summary>
-        /// <value><c>true</c> if the close button is shown; otherwise, <c>false</c>.</value>
-        public bool ShowClose { get; set; } = true;
-        /// <summary>
-        /// Gets or sets the width of the dialog.
-        /// </summary>
-        /// <value>The width.</value>
-        public string Width { get; set; }
-        /// <summary>
-        /// Gets or sets the height of the dialog.
-        /// </summary>
-        /// <value>The height.</value>
-        public string Height { get; set; }
-        /// <summary>
-        /// Gets or sets the CSS style of the dialog
-        /// </summary>
-        /// <value>The style.</value>
-        public string Style { get; set; }
+        /// <value><c>true</c> if the close button is shown; otherwise, <c>false</c>. Default is <c>true</c>.</value>
+        public bool ShowClose
+		{
+			get => showClose;
+			set
+			{
+				if (showClose != value)
+				{
+					showClose = value;
+					OnPropertyChanged(nameof(ShowClose));
+				}
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets a value indicating whether the dialog should be closed by clicking the overlay.
-        /// </summary>
-        /// <value><c>true</c> if closeable; otherwise, <c>false</c>.</value>
-        public bool CloseDialogOnOverlayClick { get; set; } = false;
+		private string width;
+		/// <summary>
+		/// Gets or sets the width of the dialog.
+		/// </summary>
+		/// <value>The width.</value>
+		public string Width
+		{
+			get => width;
+			set
+			{
+				if (width != value)
+				{
+					width = value;
+					OnPropertyChanged(nameof(Width));
+				}
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets dialog box custom class
-        /// </summary>
-        public string CssClass { get; set; }
+		private string height;
+		/// <summary>
+		/// Gets or sets the height of the dialog.
+		/// </summary>
+		/// <value>The height.</value>
+		public string Height
+		{
+			get => height;
+			set
+			{
+				if (height != value)
+				{
+					height = value;
+					OnPropertyChanged(nameof(Height));
+				}
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the CSS classes added to the dialog's wrapper element.
-        /// </summary>
-        public string WrapperCssClass { get; set; }
+		private string style;
+		/// <summary>
+		/// Gets or sets the CSS style of the dialog
+		/// </summary>
+		/// <value>The style.</value>
+		public string Style
+		{
+			get => style;
+			set
+			{
+				if (style != value)
+				{
+					style = value;
+					OnPropertyChanged(nameof(Style));
+				}
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the CSS classes added to the dialog's content element.
-        /// </summary>
-        public string ContentCssClass { get; set; }
+		private bool closeDialogOnOverlayClick = false;
+		/// <summary>
+		/// Gets or sets a value indicating whether the dialog should be closed by clicking the overlay.
+		/// </summary>
+		/// <value><c>true</c> if closeable; otherwise, <c>false</c>.</value>
+		public bool CloseDialogOnOverlayClick
+		{
+			get => closeDialogOnOverlayClick;
+			set
+			{
+				if (closeDialogOnOverlayClick != value)
+				{
+					closeDialogOnOverlayClick = value;
+					OnPropertyChanged(nameof(CloseDialogOnOverlayClick));
+				}
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets a value the dialog escape tabindex. Set to <c>0</c> by default.
-        /// </summary>
-        public int CloseTabIndex { get; set; } = 0;
+		private string cssClass;
+		/// <summary>
+		/// Gets or sets dialog box custom class
+		/// </summary>
+		public string CssClass
+		{
+			get => cssClass;
+			set
+			{
+				if (cssClass != value)
+				{
+					cssClass = value;
+					OnPropertyChanged(nameof(CssClass));
+				}
+			}
+		}
+
+		private string wrapperCssClass;
+		/// <summary>
+		/// Gets or sets the CSS classes added to the dialog's wrapper element.
+		/// </summary>
+		public string WrapperCssClass
+		{
+			get => wrapperCssClass;
+			set
+			{
+				if (wrapperCssClass != value)
+				{
+					wrapperCssClass = value;
+					OnPropertyChanged(nameof(WrapperCssClass));
+				}
+			}
+		}
+
+		private string contentCssClass;
+		/// <summary>
+		/// Gets or sets the CSS classes added to the dialog's content element.
+		/// </summary>
+		public string ContentCssClass
+		{
+			get => contentCssClass;
+			set
+			{
+				if (contentCssClass != value)
+				{
+					contentCssClass = value;
+					OnPropertyChanged(nameof(ContentCssClass));
+				}
+			}
+		}
+
+		private int closeTabIndex = 0;
+		/// <summary>
+		/// Gets or sets a value the dialog escape tabindex. Set to <c>0</c> by default.
+		/// </summary>
+		public int CloseTabIndex
+		{
+			get => closeTabIndex;
+			set
+			{
+				if (closeTabIndex != value)
+				{
+					closeTabIndex = value;
+					OnPropertyChanged(nameof(CloseTabIndex));
+				}
+			}
+        }
     }
 
     /// <summary>
@@ -625,25 +731,78 @@ namespace Radzen
     /// </summary>
     public class SideDialogOptions : DialogOptionsBase
     {
+        private string title;
+
         /// <summary>
         /// The title displayed on the dialog.
         /// </summary>
-        public string Title { get; set; }
+        public string Title
+        {
+            get => title;
+            set
+            {
+                if (title != value)
+                {
+                    title = value;
+                    OnPropertyChanged(nameof(Title));
+                }
+            }
+        }
+
+        private DialogPosition position = DialogPosition.Right;
 
         /// <summary>
         /// The Position on which the dialog will be positioned
         /// </summary>
-        public DialogPosition Position { get; set; } = DialogPosition.Right;
+        public DialogPosition Position
+        {
+            get => position;
+            set
+            {
+                if (position != value)
+                {
+                    position = value;
+                    OnPropertyChanged(nameof(Position));
+                }
+            }
+        }
+
+        private bool showMask = true;
+
 
         /// <summary>
-        /// Whether to show a mask on the background or not
+        /// Whether to show a mask on the background or not. Set to <c>true</c> by default.
         /// </summary>
-        public bool ShowMask { get; set; } = true;
+        public bool ShowMask
+        {
+            get => showMask;
+            set
+            {
+                if (showMask != value)
+                {
+                    showMask = value;
+                    OnPropertyChanged(nameof(ShowMask));
+                }
+            }
+        }
+
+        private bool autoFocusFirstElement = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether to focus the first focusable HTML element. Set to <c>true</c> by default.
         /// </summary>
-        public bool AutoFocusFirstElement { get; set; } = false;
+        public bool AutoFocusFirstElement
+        {
+            get => autoFocusFirstElement;
+            set
+            {
+                if (autoFocusFirstElement != value)
+                {
+                    autoFocusFirstElement = value;
+                    OnPropertyChanged(nameof(AutoFocusFirstElement));
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -669,80 +828,242 @@ namespace Radzen
         Bottom
     }
 
-    /// <summary>
-    /// Class DialogOptions.
-    /// </summary>
-    public class DialogOptions : DialogOptionsBase
-    {
-        /// <summary>
-        /// Gets or sets a value indicating whether the dialog is resizable. Set to <c>false</c> by default.
-        /// </summary>
-        /// <value><c>true</c> if resizable; otherwise, <c>false</c>.</value>
-        public bool Resizable { get; set; } = false;
+	/// <summary>
+	/// Class DialogOptions.
+	/// </summary>
+	public class DialogOptions : DialogOptionsBase
+	{
+		private bool resizable;
+		/// <summary>
+		/// Gets or sets a value indicating whether the dialog is resizable. Set to <c>false</c> by default.
+		/// </summary>
+		/// <value><c>true</c> if resizable; otherwise, <c>false</c>.</value>
+		public bool Resizable
+		{
+			get => resizable;
+			set
+			{
+				if (resizable != value)
+				{
+					resizable = value;
+					OnPropertyChanged(nameof(Resizable));
+				}
+			}
+		}
+
+        private Action<Size> resize;
 
         /// <summary>
         /// Gets or sets the change.
         /// </summary>
         /// <value>The change.</value>
-        public Action<Size> Resize { get; set; }
+        public Action<Size> Resize
+		{
+			get => resize;
+			set
+			{
+				if (resize != value)
+				{
+					resize = value;
+					OnPropertyChanged(nameof(Resize));
+				}
+			}
+		}
+
+        private bool draggable;
 
         /// <summary>
         /// Gets or sets a value indicating whether the dialog is draggable. Set to <c>false</c> by default.
         /// </summary>
         /// <value><c>true</c> if draggable; otherwise, <c>false</c>.</value>
-        public bool Draggable { get; set; } = false;
+        public bool Draggable
+		{
+			get => draggable;
+			set
+			{
+				if (draggable != value)
+				{
+					draggable = value;
+					OnPropertyChanged(nameof(Draggable));
+				}
+			}
+		}
+
+        private Action<Point> drag;
 
         /// <summary>
         /// Gets or sets the change.
         /// </summary>
         /// <value>The change.</value>
-        public Action<Point> Drag { get; set; }
+        public Action<Point> Drag
+		{
+			get => drag;
+			set
+			{
+				if (drag != value)
+				{
+					drag = value;
+					OnPropertyChanged(nameof(Drag));
+				}
+			}
+		}
+
+        private string left;
 
         /// <summary>
         /// Gets or sets the X coordinate of the dialog. Maps to the <c>left</c> CSS attribute.
         /// </summary>
         /// <value>The left.</value>
-        public string Left { get; set; }
+        public string Left
+		{
+			get => left;
+			set
+			{
+				if (left != value)
+				{
+					left = value;
+					OnPropertyChanged(nameof(Left));
+				}
+			}
+		}
+
+        private string top;
+
         /// <summary>
         /// Gets or sets the Y coordinate of the dialog. Maps to the <c>top</c> CSS attribute.
         /// </summary>
         /// <value>The top.</value>
-        public string Top { get; set; }
+        public string Top
+		{
+			get => top;
+			set
+			{
+				if (top != value)
+				{
+					top = value;
+					OnPropertyChanged(nameof(Top));
+				}
+			}
+		}
+
+        private string bottom;
+
         /// <summary>
         /// Specifies the <c>bottom</c> CSS attribute.
         /// </summary>
         /// <value>The bottom.</value>
-        public string Bottom { get; set; }
+        public string Bottom
+		{
+			get => bottom;
+			set
+			{
+				if (bottom != value)
+				{
+					bottom = value;
+					OnPropertyChanged(nameof(Bottom));
+				}
+			}
+		}
+
+        private RenderFragment<DialogService> childContent;
+
         /// <summary>
         /// Gets or sets the child content.
         /// </summary>
         /// <value>The child content.</value>
-        public RenderFragment<DialogService> ChildContent { get; set; }
+        public RenderFragment<DialogService> ChildContent
+		{
+			get => childContent;
+			set
+			{
+				if (childContent != value)
+				{
+					childContent = value;
+					OnPropertyChanged(nameof(ChildContent));
+				}
+			}
+		}
+
+        private RenderFragment<DialogService> titleContent;
+
         /// <summary>
         /// Gets or sets the title content.
         /// </summary>
         /// <value>The title content.</value>
-        public RenderFragment<DialogService> TitleContent { get; set; }
+        public RenderFragment<DialogService> TitleContent
+		{
+			get => titleContent;
+			set
+			{
+				if (titleContent != value)
+				{
+					titleContent = value;
+					OnPropertyChanged(nameof(TitleContent));
+				}
+			}
+		}
+
+        private bool autoFocusFirstElement = true;
+
         /// <summary>
-        /// Gets or sets a value indicating whether to focus the first focusable HTML element. Set to <c>true</c> by default.
+        /// Gets or sets a value indicating whether to focus the first focusable HTML element. 
         /// </summary>
-        public bool AutoFocusFirstElement { get; set; } = true;
+        /// <value><c>true</c> if the first focusable element is focused; otherwise, <c>false</c>. Default is <c>true</c>.</value>
+        public bool AutoFocusFirstElement
+		{
+			get => autoFocusFirstElement;
+			set
+			{
+				if (autoFocusFirstElement != value)
+				{
+					autoFocusFirstElement = value;
+					OnPropertyChanged(nameof(AutoFocusFirstElement));
+				}
+			}
+		}
+
+        private bool closeDialogOnEsc = true;
+
         /// <summary>
         /// Gets or sets a value indicating whether the dialog should be closed on ESC key press.
         /// </summary>
-        /// <value><c>true</c> if closeable; otherwise, <c>false</c>.</value>
-        public bool CloseDialogOnEsc { get; set; } = true;
-    }
+        /// <value><c>true</c> if closeable; otherwise, <c>false</c>. Default is <c>true</c>.</value>
+        public bool CloseDialogOnEsc
+		{
+			get => closeDialogOnEsc;
+			set
+			{
+				if (closeDialogOnEsc != value)
+				{
+					closeDialogOnEsc = value;
+					OnPropertyChanged(nameof(CloseDialogOnEsc));
+				}
+			}
+		}
+	}
 
     /// <summary>
     /// Class ConfirmOptions.
     /// </summary>
     public class AlertOptions : DialogOptions
     {
+        private string okButtonText;
+
         /// <summary>
         /// Gets or sets the text of the OK button.
         /// </summary>
-        public string OkButtonText { get; set; }
+        public string OkButtonText
+        {
+            get => okButtonText;
+            set
+            {
+                if (okButtonText != value)
+                {
+                    okButtonText = value;
+                    OnPropertyChanged(nameof(OkButtonText));
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -750,36 +1071,118 @@ namespace Radzen
     /// </summary>
     public class ConfirmOptions : AlertOptions
     {
+        private string cancelButtonText;
+
         /// <summary>
         /// Gets or sets the text of the Cancel button.
         /// </summary>
-        public string CancelButtonText { get; set; }
+        public string CancelButtonText
+        {
+            get => cancelButtonText;
+            set
+            {
+                if (cancelButtonText != value)
+                {
+                    cancelButtonText = value;
+                    OnPropertyChanged(nameof(CancelButtonText));
+                }
+            }
+        }
     }
 
     /// <summary>
     /// Class Dialog.
     /// </summary>
-    public class Dialog
-    {
-        /// <summary>
-        /// Gets or sets the title.
-        /// </summary>
-        /// <value>The title.</value>
-        public string Title { get; set; }
+    public class Dialog : INotifyPropertyChanged
+	{
+		private string title;
+	
+		/// <summary>
+		/// Gets or sets the title.
+		/// </summary>
+		/// <value>The title.</value>
+		public string Title
+		{
+			get => title;
+			set
+			{
+				if (title != value)
+				{
+					title = value;
+					OnPropertyChanged(nameof(Title));
+				}
+			}
+		}
+
+        private Type type;
+
         /// <summary>
         /// Gets or sets the type.
         /// </summary>
         /// <value>The type.</value>
-        public Type Type { get; set; }
+        public Type Type
+		{
+			get => type;
+			set
+			{
+				if (type != value)
+				{
+					type = value;
+					OnPropertyChanged(nameof(Type));
+				}
+			}
+		}
+
+        private Dictionary<string, object> parameters;
+
         /// <summary>
         /// Gets or sets the parameters.
         /// </summary>
         /// <value>The parameters.</value>
-        public Dictionary<string, object> Parameters { get; set; }
+        public Dictionary<string, object> Parameters
+		{
+			get => parameters;
+			set
+			{
+				if (parameters != value)
+				{
+					parameters = value;
+					OnPropertyChanged(nameof(Parameters));
+				}
+			}
+		}
+
+        private DialogOptions options;
+
         /// <summary>
         /// Gets or sets the options.
         /// </summary>
         /// <value>The options.</value>
-        public DialogOptions Options { get; set; }
-    }
+        public DialogOptions Options
+		{
+			get => options;
+			set
+			{
+				if (options != value)
+				{
+                    options = value;
+                    OnPropertyChanged(nameof(Options));
+				}
+			}
+		}
+
+		/// <summary>
+		/// Occurs when a property value changes.
+		/// </summary>
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		/// <summary>
+		/// Raises the <see cref="PropertyChanged"/> event.
+		/// </summary>
+		/// <param name="propertyName">The name of the property that changed.</param>
+		protected virtual void OnPropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
 }

--- a/Radzen.Blazor/Radzen.Blazor.csproj
+++ b/Radzen.Blazor/Radzen.Blazor.csproj
@@ -73,4 +73,10 @@
     <Move SourceFiles="@(CssFile)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/css/" />
   </Target>
 
+  <ItemGroup Label="Allow internal method to be visible to the unit tests">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Radzen.Blazor.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
 </Project>

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -1,5 +1,6 @@
 @using Microsoft.JSInterop
 @using System.Reflection;
+@using System.ComponentModel
 @inject IJSRuntime JSRuntime
 @implements IDisposable
 <div class="@WrapperCssClass">
@@ -206,6 +207,23 @@
     protected override void OnInitialized()
     {
         Service.OnRefresh += OnRefresh;
+
+		// Subscribe to PropertyChanged event to auto refresh the dialog when properties change
+        Dialog.PropertyChanged += OnPropertyChanged;
+
+		// Subscribe to PropertyChanged event to auto refresh the dialog when properties change
+		if (Dialog.Options != null)
+			Dialog.Options.PropertyChanged += OnPropertyChanged;
+    }
+
+    /// <summary>
+    /// Handles the property changed event and triggers a refresh.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">The <see cref="PropertyChangedEventArgs"/> instance containing the event data.</param>
+    void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        OnRefresh();
     }
 
     void OnRefresh()
@@ -223,6 +241,14 @@
     public void Dispose()
     {
         Service.OnRefresh -= OnRefresh;
+
+		// Unsubscribe from PropertyChanged event
+        Dialog.PropertyChanged -= OnPropertyChanged;
+
+		// Unsubscribe from PropertyChanged event
+        if (Dialog.Options != null)
+            Dialog.Options.PropertyChanged -= OnPropertyChanged;
+
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/RadzenBlazorDemos/Pages/DialogPage.razor
+++ b/RadzenBlazorDemos/Pages/DialogPage.razor
@@ -67,12 +67,12 @@
 </RadzenExample>
 
 <RadzenText Anchor="dialog#cascading-value" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
-    Dialog with cascading value
+    Update dialog properties
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
     Use the <code>Dialog</code> 
     <RadzenLink Text="Cascading Value" Path="https://learn.microsoft.com/en-us/aspnet/core/blazor/components/cascading-values-and-parameters#cascadingvalue-component" target="_blank" />
-    to update the dialog title content
+    to update dialog properties
 </RadzenText>
 
 <RadzenExample ComponentName="Dialog" Example="DialogWithCascadingValueCaller" AdditionalSourceCodePages=@(new List<string>() { "DialogWithCascadingValueImplementation.razor" })>

--- a/RadzenBlazorDemos/Pages/DialogWithCascadingValueCaller.razor
+++ b/RadzenBlazorDemos/Pages/DialogWithCascadingValueCaller.razor
@@ -1,11 +1,11 @@
 ﻿@inject DialogService DialogService
 
 <div class="rz-p-12 rz-text-align-center">
-	<RadzenButton Text="Dialog with cascading value" ButtonStyle="ButtonStyle.Secondary" Click=@OpenDialog />
+	<RadzenButton Text="Update dialog properties" ButtonStyle="ButtonStyle.Secondary" Click=@OpenDialog />
 </div>
 @code {
 	private async Task OpenDialog()
 	{
-		await DialogService.OpenAsync<DialogWithCascadingValueImplementation>("Loading...");
+		await DialogService.OpenAsync<DialogWithCascadingValueImplementation>("Original title text");
 	}
 }

--- a/RadzenBlazorDemos/Pages/DialogWithCascadingValueImplementation.razor
+++ b/RadzenBlazorDemos/Pages/DialogWithCascadingValueImplementation.razor
@@ -1,16 +1,28 @@
 ﻿<div class="rz-p-12 rz-text-align-center">
-	<RadzenButton Text="Update counter from dialog" ButtonStyle="ButtonStyle.Secondary" Click=@UpdateCounter />
+	<RadzenButton Text="Set title (static text)" ButtonStyle="ButtonStyle.Primary" Click=@SetTitle />
+	<RadzenButton Text="Set title (RenderFragment)" ButtonStyle="ButtonStyle.Primary" Click=@SetTitleContent />
+	<RadzenButton Text="Update counter" ButtonStyle="ButtonStyle.Secondary" Click=@UpdateCounter />
+	<hr />
+	<RadzenButton Text="Toggle close" ButtonStyle="ButtonStyle.Primary" Click=@ToggleClose />
+	<RadzenButton Text="Toggle close on overlay click" ButtonStyle="ButtonStyle.Primary" Click=@ToggleCloseOnOverlayClick />
 </div>
 
 @code {
-
 	[CascadingParameter] private Dialog _dialog { get; set; }
 	[Inject] private DialogService _dialogService { get; set; }
+
 	int _counter { get; set; }
 
-	protected override void OnInitialized()
+	void SetTitle()
 	{
-		// Change the dialog title content
+		// Set dialog title (static text)
+		_dialog.Title = $"Title with a counter: {_counter}";
+		_dialog.Options.TitleContent = null;
+	}
+	void SetTitleContent()
+	{
+		// Set dialog title (RenderFragment)
+		_dialog.Title = null;
 		_dialog.Options.TitleContent = service => @<RadzenCard>
 			<RadzenStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Start" Wrap="FlexWrap.Wrap">
 				<RadzenText TextStyle="TextStyle.Subtitle1">
@@ -20,18 +32,26 @@
 					<RadzenButton Text="Update counter from title" ButtonStyle="ButtonStyle.Secondary" Click=@UpdateCounter />
 				</RadzenRow>
 			</RadzenStack>
-		</RadzenCard>;
-
-		// reflect the changes
-		_dialogService.Refresh();
+		</RadzenCard>
+	;
 	}
-
 
 	void UpdateCounter()
 	{
+		// Increment the counter
 		_counter++;
+
+		// Notify Blazor that the state has changed and the component needs to be re-rendered (in case of a RenderFragment)
 		_dialogService.Refresh();
 	}
 
+	void ToggleClose()
+	{
+		_dialog.Options.ShowClose = !_dialog.Options.ShowClose;
+	}
 
+	void ToggleCloseOnOverlayClick()
+	{
+		_dialog.Options.CloseDialogOnOverlayClick = !_dialog.Options.CloseDialogOnOverlayClick;
+	}
 }


### PR DESCRIPTION
**Implemented `INotifyPropertyChanged` in `DialogOptionsBase` and `DialogOptions` to support automatic UI updates for dialog properties.**

- The `DialogOptionsBase` and `DialogOptions` classes now implement `INotifyPropertyChanged`, allowing dynamic updates to dialog properties to reflect immediately in the UI.
- Subscribed to the `PropertyChanged` event in `DialogContainer.razor`, triggering `StateHasChanged()` automatically when any dialog property changes.
- As a result, calling `DialogService.Refresh();` manually after changing a dialog property is no longer necessary — UI updates will happen automatically.

### Updates to Dialog Methods

- The `OpenDialog`, `Confirm`, and `Alert` methods previously **created a new `DialogOptions` instance based on an existing one**, which resulted in property values being reset.
- This behavior has been changed: the **original `DialogOptions` instance is now used** if provided, ensuring that `PropertyChanged` subscriptions remain intact.
- If no `DialogOptions` are passed, a new instance will still be created — the same null-check logic and default value assignments remain in place.
- In `DialogService.cs`, method signatures for `OpenAsync`, `Confirm`, and `Alert` are updated to include an optional `CancellationToken` parameter for cancellation control (used in unit tests)
- The visibility of the `private` `OpenDialog` method is changed to `internal`, making it accessible for testing.

### Updated `Dialog` page to reflect changes

![image](https://github.com/user-attachments/assets/270f60ea-bde1-448b-80c9-7957691ba9ac)

### Unit tests

- Allow `internal` methods visibility for unit tests
  - Added an `ItemGroup` in the project file to include an `InternalsVisibleTo` attribute for the `Radzen.Blazor.Tests` assembly, enabling unit tests to access internal methods.
- Add unit tests and improve DialogService options handling
  -  Focusing on `DialogOptions`, `ConfirmOptions`, and `AlertOptions`. The tests ensure default values are set correctly, provided values are retained, and null options are handled.

![image](https://github.com/user-attachments/assets/6dd26e21-e514-4cfb-9090-3d555f84d3fe)

### Question ❓

Is there a specific reason the original implementation created a *new* instance of `DialogOptions`, even when one was already provided?  
As far as I can tell, this was primarily to ensure default values were applied — but I'm wondering if there are any other reasons I might have overlooked.
