### PR TITLE
#2011 Fix: Allow Space for Selection in DropDown

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -678,7 +678,32 @@ namespace Radzen
                     //
                 }
             }
-            else if (key == "Enter" || key == "NumpadEnter" || key == "Space")
+            else if(key == "Space")
+            {
+                preventKeydown = true;
+
+                if (selectedIndex >= 0 && selectedIndex <= items.Count() - 1)
+                {
+                    var itemToSelect = items.ElementAtOrDefault(selectedIndex);
+
+                    await JSRuntime.InvokeAsync<string>("Radzen.setInputValue", search, $"{searchText}".Trim());
+
+                    if (itemToSelect != null)
+                    {
+                        await OnSelectItem(itemToSelect, true);
+                    }
+                    var popupOpened = await JSRuntime.InvokeAsync<bool>("Radzen.popupOpened", PopupID);
+
+                    if (popupOpened)
+                    {
+                        if (!Multiple)
+                        {
+                            await ClosePopup(key);
+                        }
+                    }
+                }
+            }
+            else if (key == "Enter" || key == "NumpadEnter")
             {
                 preventKeydown = true;
 

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
-using Radzen.Blazor;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -654,7 +653,7 @@ namespace Radzen
             }
 
             var key = args.Code != null ? args.Code : args.Key;
-
+            
             if (!args.AltKey && (key == "ArrowDown" || key == "ArrowLeft" || key == "ArrowUp" || key == "ArrowRight"))
             {
                 preventKeydown = true;
@@ -679,7 +678,7 @@ namespace Radzen
                     //
                 }
             }
-            else if (key == "Enter" || key == "NumpadEnter")
+            else if (key == "Enter" || key == "NumpadEnter" || key == "Space")
             {
                 preventKeydown = true;
 

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -693,14 +693,6 @@ namespace Radzen
                         await OnSelectItem(itemToSelect, true);
                     }
                     var popupOpened = await JSRuntime.InvokeAsync<bool>("Radzen.popupOpened", PopupID);
-
-                    if (popupOpened)
-                    {
-                        if (!Multiple)
-                        {
-                            await ClosePopup(key);
-                        }
-                    }
                 }
             }
             else if (key == "Enter" || key == "NumpadEnter")

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components.Web;
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Radzen.Blazor
 {
@@ -282,6 +281,11 @@ namespace Radzen.Blazor
                     if (!Disabled)
                     {
                         await JSRuntime.InvokeVoidAsync("Radzen.preventArrows", Element);
+                        var preventSpaceExists = await JSRuntime.InvokeAsync<bool>("Boolean", "(typeof preventSpace !== 'undefined')");
+                        if (preventSpaceExists)
+                        {
+                            await JSRuntime.InvokeVoidAsync("Radzen.preventSpace", Element);
+                        }
                     }
 
                     if (reload)

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Web;
+using System.Collections.Generic;
+using System;
+using System.Xml.Linq;
 
 namespace Radzen.Blazor
 {
@@ -281,11 +283,16 @@ namespace Radzen.Blazor
                     if (!Disabled)
                     {
                         await JSRuntime.InvokeVoidAsync("Radzen.preventArrows", Element);
-                        var preventSpaceExists = await JSRuntime.InvokeAsync<bool>("Boolean", "(typeof preventSpace !== 'undefined')");
-                        if (preventSpaceExists)
+                        
+                        try
                         {
                             await JSRuntime.InvokeVoidAsync("Radzen.preventSpace", Element);
                         }
+                        catch(Exception)
+                        {
+                            //
+                        }
+
                     }
 
                     if (reload)

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -170,14 +170,15 @@ window.Radzen = {
     }
   },
   preventSpace: function (el) {
-    console.log("preventSpace function loaded");
-    el.addEventListener('keydown', function (e) {
-        if (e.keyCode === 32) {
-            console.log("Spacebar pressed, preventing default.");
-            e.preventDefault();
-            return false;
-        }
-    }, false);
+    var preventDefault = function (e) {
+      if (e.keyCode === 32) {
+        e.preventDefault();
+        return false;
+      }
+    };
+    if (el) {
+      el.addEventListener('keydown', preventDefault, false);
+    }
   },
   selectTab: function (id, index) {
     var el = document.getElementById(id);

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -169,6 +169,16 @@ window.Radzen = {
        el.addEventListener('keydown', preventDefault, false);
     }
   },
+  preventSpace: function (el) {
+    console.log("preventSpace function loaded");
+    el.addEventListener('keydown', function (e) {
+        if (e.keyCode === 32) {
+            console.log("Spacebar pressed, preventing default.");
+            e.preventDefault();
+            return false;
+        }
+    }, false);
+  },
   selectTab: function (id, index) {
     var el = document.getElementById(id);
     if (el && el.parentNode && el.parentNode.previousElementSibling) {

--- a/RadzenBlazorDemos/Pages/DropDownPage.razor
+++ b/RadzenBlazorDemos/Pages/DropDownPage.razor
@@ -87,7 +87,7 @@
         new KeyboardShortcut { Key = "UpArrow on closed popup", Action = "Select previous DropDown item." },
         new KeyboardShortcut { Key = "DownArrow in an opened popup", Action = "Focus next DropDown item." },
         new KeyboardShortcut { Key = "UpArrow in an opened popup", Action = "Focus previous DropDown item." },
-        new KeyboardShortcut { Key = "Enter in an opened popup", Action = "Select the focused DropDown item and close the popup." },
+        new KeyboardShortcut { Key = "Enter or Space in an opened popup", Action = "Select the focused DropDown item and close the popup." },
         new KeyboardShortcut { Key = "Esc or Alt + DownArrow in an opened popup", Action = "Close the DropDown popup." },
         new KeyboardShortcut { Key = "Alphanumeric", Action = "Focus next DropDown item starting with typed key." }
     };


### PR DESCRIPTION
This PR allows using the Spacebar to select items in multi-select RadzenDropDown. It also prevents page scrolling when pressing Space.

Backwards-compatible – falls back if Radzen.Blazor.js isn’t updated due to web browser caching.
Enter key behavior remains unchanged for form submissions.

Closes #2011.