### PR TITLE
Fix default button text regression in `DialogService`

### DIFF
--- a/Radzen.Blazor.Tests/DialogServiceTests.cs
+++ b/Radzen.Blazor.Tests/DialogServiceTests.cs
@@ -114,7 +114,9 @@ namespace Radzen.Blazor.Tests
 
 				// Assert
 				Assert.NotNull(resultingOptions);
-				Assert.Equal("600px", resultingOptions.Width);
+                Assert.Equal("Ok", resultingOptions.OkButtonText);
+                Assert.Equal("Cancel", resultingOptions.CancelButtonText);
+                Assert.Equal("600px", resultingOptions.Width);
 				Assert.Equal("", resultingOptions.Style);
 				Assert.Equal("rz-dialog-confirm", resultingOptions.CssClass);
 				Assert.Equal("rz-dialog-wrapper", resultingOptions.WrapperCssClass);
@@ -143,7 +145,9 @@ namespace Radzen.Blazor.Tests
 
 				// Assert
 				Assert.NotNull(resultingOptions);
-				Assert.Equal("600px", resultingOptions.Width);
+                Assert.Equal("Ok", resultingOptions.OkButtonText);
+                Assert.Equal("Cancel", resultingOptions.CancelButtonText);
+                Assert.Equal("600px", resultingOptions.Width);
 				Assert.Equal("", resultingOptions.Style);
 				Assert.Equal("rz-dialog-confirm", resultingOptions.CssClass);
 				Assert.Equal("rz-dialog-wrapper", resultingOptions.WrapperCssClass);
@@ -155,7 +159,9 @@ namespace Radzen.Blazor.Tests
 				var dialogService = new DialogService(null, null);
 				var options = new ConfirmOptions
 				{
-					Width = "800px",
+                    OkButtonText = "XXX",
+                    CancelButtonText = "YYY",
+                    Width = "800px",
 					Style = "background-color: red;",
 					CssClass = "custom-class",
 					WrapperCssClass = "wrapper-class"
@@ -179,7 +185,9 @@ namespace Radzen.Blazor.Tests
 
 				// Assert
 				Assert.NotNull(resultingOptions);
-				Assert.Equal("800px", resultingOptions.Width);
+                Assert.Equal("XXX", resultingOptions.OkButtonText);
+                Assert.Equal("YYY", resultingOptions.CancelButtonText);
+                Assert.Equal("800px", resultingOptions.Width);
 				Assert.Equal("background-color: red;", resultingOptions.Style);
 				Assert.Equal("rz-dialog-confirm custom-class", resultingOptions.CssClass);
 				Assert.Equal("rz-dialog-wrapper wrapper-class", resultingOptions.WrapperCssClass);
@@ -212,6 +220,7 @@ namespace Radzen.Blazor.Tests
 
 				// Assert
 				Assert.NotNull(resultingOptions);
+                Assert.Equal("Ok", resultingOptions.OkButtonText);
 				Assert.Equal("600px", resultingOptions.Width);
 				Assert.Equal("", resultingOptions.Style);
 				Assert.Equal("rz-dialog-alert", resultingOptions.CssClass);
@@ -241,6 +250,7 @@ namespace Radzen.Blazor.Tests
 
 				// Assert
 				Assert.NotNull(resultingOptions);
+                Assert.Equal("Ok", resultingOptions.OkButtonText);
 				Assert.Equal("600px", resultingOptions.Width);
 				Assert.Equal("", resultingOptions.Style);
 				Assert.Equal("rz-dialog-alert", resultingOptions.CssClass);
@@ -253,6 +263,7 @@ namespace Radzen.Blazor.Tests
 				var dialogService = new DialogService(null, null);
 				var options = new AlertOptions
 				{
+                    OkButtonText = "XXX",
 					Width = "800px",
 					Style = "background-color: red;",
 					CssClass = "custom-class",
@@ -277,6 +288,7 @@ namespace Radzen.Blazor.Tests
 
 				// Assert
 				Assert.NotNull(resultingOptions);
+				Assert.Equal("XXX", resultingOptions.OkButtonText);
 				Assert.Equal("800px", resultingOptions.Width);
 				Assert.Equal("background-color: red;", resultingOptions.Style);
 				Assert.Equal("rz-dialog-alert custom-class", resultingOptions.CssClass);

--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -457,7 +457,9 @@ namespace Radzen
         public virtual async Task<bool?> Confirm(string message = "Confirm?", string title = "Confirm", ConfirmOptions options = null, CancellationToken? cancellationToken = null)
         {
             // Validate and set default values for the dialog options
-            options ??= new() { OkButtonText = "Ok", CancelButtonText = "Cancel" };
+            options ??= new();
+            options.OkButtonText = !String.IsNullOrEmpty(options.OkButtonText) ? options.OkButtonText : "Ok";
+            options.CancelButtonText = !String.IsNullOrEmpty(options.CancelButtonText) ? options.CancelButtonText : "Cancel";
             options.Width = !String.IsNullOrEmpty(options.Width) ? options.Width : ""; // Width is set to 600px by default by OpenAsync
             options.Style = !String.IsNullOrEmpty(options.Style) ? options.Style : "";
             options.CssClass = !String.IsNullOrEmpty(options.CssClass) ? $"rz-dialog-confirm {options.CssClass}" : "rz-dialog-confirm";
@@ -477,12 +479,12 @@ namespace Radzen
                     b.AddAttribute(i++, "class", "rz-dialog-confirm-buttons");
 
                     b.OpenComponent<Blazor.RadzenButton>(i++);
-                    b.AddAttribute(i++, "Text", options != null ? options.OkButtonText : "Ok");
+                    b.AddAttribute(i++, "Text", options.OkButtonText);
                     b.AddAttribute(i++, "Click", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, () => ds.Close(true)));
                     b.CloseComponent();
 
                     b.OpenComponent<Blazor.RadzenButton>(i++);
-                    b.AddAttribute(i++, "Text", options != null ? options.CancelButtonText : "Cancel");
+                    b.AddAttribute(i++, "Text", options.CancelButtonText);
                     b.AddAttribute(i++, "ButtonStyle", ButtonStyle.Base);
                     b.AddAttribute(i++, "Click", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, () => ds.Close(false)));
                     b.CloseComponent();
@@ -504,7 +506,8 @@ namespace Radzen
         public virtual async Task<bool?> Alert(string message = "", string title = "Message", AlertOptions options = null, CancellationToken? cancellationToken = null)
         {
             // Validate and set default values for the dialog options
-            options ??= new() { OkButtonText = "Ok" };
+            options ??= new();
+            options.OkButtonText = !String.IsNullOrEmpty(options.OkButtonText) ? options.OkButtonText : "Ok";
             options.Width = !String.IsNullOrEmpty(options.Width) ? options.Width : "";  
             options.Style = !String.IsNullOrEmpty(options.Style) ? options.Style : "";
             options.CssClass = !String.IsNullOrEmpty(options.CssClass) ? $"rz-dialog-alert {options.CssClass}" : "rz-dialog-alert";
@@ -525,7 +528,7 @@ namespace Radzen
                     b.AddAttribute(i++, "class", "rz-dialog-alert-buttons");
 
                     b.OpenComponent<Blazor.RadzenButton>(i++);
-                    b.AddAttribute(i++, "Text", options != null ? options.OkButtonText : "Ok");
+                    b.AddAttribute(i++, "Text", options.OkButtonText);
                     b.AddAttribute(i++, "Click", EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, () => ds.Close(true)));
                     b.CloseComponent();
 


### PR DESCRIPTION
### Fix default button text regression in `DialogService`

This PR addresses a regression introduced in [#2051](https://github.com/radzenhq/radzen-blazor/pull/2051), where the default values for `OkButtonText` and `CancelButtonText` in `ConfirmOptions` and `AlertOptions` were not being set when omitted.

A fix for the regression was introduced in [92d69d9](https://github.com/radzenhq/radzen-blazor/commit/92d69d90536d0753024c411e71ba8b6717c4be6b).  
However, while validating that fix in the unit tests, I found that when a `DialogOptions` object is supplied with `null` values for the button text, those values were not replaced by the default.  

### Changes

- **DialogService.cs**: Ensures `OkButtonText` and `CancelButtonText` are initialized with default values `"Ok"` and `"Cancel"` when not explicitly provided.
- **DialogServiceTests.cs**: Added unit tests to assert default and custom values of `OkButtonText` and `CancelButtonText` in both `ConfirmOptions` and `AlertOptions`.

This PR ensures that `null` values still result in a fallback to `"Ok"` and `"Cancel"`, to guarantee that buttons always have a visible label.
