### PR TITLE
Added ShowInput property to RadzenDatePicker

### DIFF
--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -9,16 +9,19 @@
     <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" style="@getStyle()" id="@GetId()">
         @if (!Inline)
         {
-            <input @ref="@input" @attributes="InputAttributes" disabled="@Disabled" readonly="@IsReadonly" value="@FormattedValue" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-                    @onchange="@ParseDate" autocomplete="off" type="text" name="@Name" @onkeydown="@(args => OnKeyPress(args))" @onkeydown:preventDefault=preventKeyPress @onkeydown:stopPropagation
-                   class="rz-inputtext @InputClass @(ReadOnly ? "rz-readonly" : "") @(!ShowButton ? "rz-input-trigger" : "")" id="@Name" placeholder="@CurrentPlaceholder" />
+            @if (ShowInput || !ShowButton)
+            {
+                <input @ref="@input" @attributes="InputAttributes" disabled="@Disabled" readonly="@IsReadonly" value="@FormattedValue" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
+                        @onchange="@ParseDate" autocomplete="off" type="text" name="@Name" @onkeydown="@(args => OnKeyPress(args))" @onkeydown:preventDefault=preventKeyPress @onkeydown:stopPropagation
+                       class="rz-inputtext @InputClass @(ReadOnly ? "rz-readonly" : "") @(!ShowButton ? "rz-input-trigger" : "")" id="@Name" placeholder="@CurrentPlaceholder" />
+            }
             @if (ShowButton)
             {
-                <button aria-label="@ToggleAriaLabel" @onmousedown=@OnToggle class="@($"rz-datepicker-trigger rz-button rz-button-icon-only{(Disabled ? " rz-state-disabled" : "")} {ButtonClass}")" tabindex="-1" type="button">
+                <button aria-label="@ToggleAriaLabel" @onmousedown=@OnToggle class="@($"rz-datepicker-trigger{(ShowInput ? " rz-datepicker-field-button" : "")} rz-button rz-button-icon-only{(Disabled ? " rz-state-disabled" : "")} {ButtonClass}")" tabindex="-1" type="button">
                     <span aria-hidden="true" class="@ButtonClasses"></span><span class="rz-button-text"></span>
                 </button>
             }
-            @if (AllowClear && HasValue)
+            @if (AllowClear && HasValue && (ShowInput || !ShowButton))
             {
                 <i class="notranslate rz-dropdown-clear-icon rzi rzi-times" @onclick="@Clear" @onclick:stopPropagation="true"></i>
             }

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -770,6 +770,13 @@ namespace Radzen.Blazor
         [Parameter]
         public bool ShowButton { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the input box is shown. Ignored if ShowButton is false.
+        /// </summary>
+        /// <value><c>true</c> to show the input box; <c>false</c> to hide the input box.</value>
+        [Parameter]
+        public bool ShowInput { get; set; } = true;
+
         private bool IsReadonly => ReadOnly || !AllowInput;
 
         /// <summary>
@@ -1344,12 +1351,17 @@ namespace Radzen.Blazor
         /// <inheritdoc/>
         public async ValueTask FocusAsync()
         {
-           try
-           {
-               await input.FocusAsync();
+            // If ShowButton is false, the input box is always shown
+            if (ShowInput || !ShowButton)
+            {
+                try
+                {
+                    await input.FocusAsync();
+                }
+                catch
+                { }
             }
-            catch
-            {}
+            
         }
     }
 }

--- a/Radzen.Blazor/themes/components/blazor/_datepicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_datepicker.scss
@@ -112,10 +112,6 @@ $timepicker-border: none !default;
 
 .rz-datepicker-trigger {
   box-shadow: none;
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-end: 0.625rem;
-  transform: translateY(-50%);
   background-color: transparent;
   padding: 0;
   vertical-align: text-top;
@@ -164,6 +160,13 @@ $timepicker-border: none !default;
   .rz-button-text {
     display: none;
   }
+}
+
+.rz-datepicker-field-button {
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-end: 0.625rem;
+    transform: translateY(-50%);
 }
 
 .rz-datepicker-popup-container {

--- a/RadzenBlazorDemos/Pages/DatePickerNoButton.razor
+++ b/RadzenBlazorDemos/Pages/DatePickerNoButton.razor
@@ -1,0 +1,8 @@
+﻿<RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.Center" AlignItems="AlignItems.Center" Gap="0.5rem" class="rz-p-12">
+    <RadzenLabel Text="Select Date" Component="DatePickerNoButton" />
+    <RadzenDatePicker @bind-Value=@value Name="DatePickerNoButton" AllowClear="true" ShowButton="false" />
+</RadzenStack>
+
+@code {
+    DateOnly? value;
+}

--- a/RadzenBlazorDemos/Pages/DatePickerNoInputBox.razor
+++ b/RadzenBlazorDemos/Pages/DatePickerNoInputBox.razor
@@ -1,0 +1,9 @@
+﻿<RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.Center" AlignItems="AlignItems.Center" Gap="0.5rem" class="rz-p-12">
+    <RadzenLabel Text="Select Date" Component="DatePickerNoInputBox" />
+    <RadzenDatePicker @bind-Value=@value Name="DatePickerNoInputBox" AllowClear="true" ShowInput="false" />
+</RadzenStack>
+<RadzenText TextAlign="TextAlign.Center">You selected <strong>@(value == null ? "(no date)" : value.Value.ToShortDateString())</strong>.</RadzenText>
+
+@code {
+    DateTime? value;
+}

--- a/RadzenBlazorDemos/Pages/DatePickerPage.razor
+++ b/RadzenBlazorDemos/Pages/DatePickerPage.razor
@@ -70,6 +70,20 @@
     <DatePickerMinMax />
 </RadzenExample>
 
+<RadzenText Anchor="datepicker#no-button" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
+    DatePicker with no button
+</RadzenText>
+<RadzenExample ComponentName="DatePicker" Example="DatePickerNoButton">
+    <DatePickerNoButton />
+</RadzenExample>
+
+<RadzenText Anchor="datepicker#no-inputbox" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
+    DatePicker with no input box
+</RadzenText>
+<RadzenExample ComponentName="DatePicker" Example="DatePickerNoInputBox">
+    <DatePickerNoInputBox />
+</RadzenExample>
+
 <RadzenText Anchor="datepicker#custom-footer" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
     DatePicker with custom footer
 </RadzenText>


### PR DESCRIPTION
Added a ShowDateBox property to RadzenDatePicker to allow only the button to be shown. See the demo for an example.
Added demos for ShowButton and ShowDateBox options.

