### PR TITLE
[FEAT] - Add Fill property to RadzenSeriesDataLabels for customizing text color, default behavior is preserved when Fill is not specified.

### DIFF
--- a/Radzen.Blazor/RadzenSeriesDataLabels.razor
+++ b/Radzen.Blazor/RadzenSeriesDataLabels.razor
@@ -35,7 +35,7 @@
                     builder.AddContent(1,
                             @<g>
                                 <Text @key="@($"{label.Position}-{Chart.Series.IndexOf(series)}")"
-                                    Value="@label.Text" Position="@label.Position" TextAnchor="@label.TextAnchor" class="rz-series-data-label" />
+                                        Value="@label.Text" Position="@label.Position" Fill="@Fill" TextAnchor="@label.TextAnchor" class="@GetSeriesDataLabelClass()" />
                             </g>
                     );
                 }

--- a/Radzen.Blazor/RadzenSeriesDataLabels.razor.cs
+++ b/Radzen.Blazor/RadzenSeriesDataLabels.razor.cs
@@ -41,5 +41,16 @@ namespace Radzen.Blazor
         /// <summary>Determines the visibility of the data labels. Set to <c>true</c> by default.</summary>
         [Parameter]
         public bool Visible { get; set; } = true;
+
+        /// <summary>Defines the fill color of the component.</summary>
+        [Parameter]
+        public string Fill { get; set; }
+
+        /// <summary>
+        /// Gets the CSS class for the data labels.
+        /// </summary>
+        /// <returns></returns>
+        public string GetSeriesDataLabelClass()
+                      => string.IsNullOrWhiteSpace(Fill) ? "rz-series-data-label" : "rz-series-data-label-fill";
     }
 }

--- a/Radzen.Blazor/Rendering/ChartDataLabel.cs
+++ b/Radzen.Blazor/Rendering/ChartDataLabel.cs
@@ -17,5 +17,9 @@ namespace  Radzen.Blazor.Rendering
         /// The text anchor of the label.
         /// </summary>
         public string TextAnchor { get; set; }
-   }
+        /// <summary>
+        /// Defines the fill color of the component.
+        /// </summary>
+        public string Fill { get; set; }
+    }
 }

--- a/RadzenBlazorDemos/Pages/StackedAreaChartConfig.razor
+++ b/RadzenBlazorDemos/Pages/StackedAreaChartConfig.razor
@@ -16,7 +16,7 @@
 
     <RadzenChart>
         <RadzenStackedAreaSeries Smooth="@smooth" Data="@revenue2023" CategoryProperty="Date" Title="2023" ValueProperty="Revenue">
-            <RadzenSeriesDataLabels Visible="@showDataLabels" />
+            <RadzenSeriesDataLabels Visible="@showDataLabels" Fill="#FB7185" />
         </RadzenStackedAreaSeries>
         <RadzenStackedAreaSeries Smooth="@smooth" Data="@revenue2024" CategoryProperty="Date" Title="2024" LineType="LineType.Dashed" ValueProperty="Revenue">
             <RadzenSeriesDataLabels Visible="@showDataLabels" />


### PR DESCRIPTION
### This PR introduces support for a Fill property in RadzenSeriesDataLabels, similar to what was done in #1789 for RadzenSeriesAnnotation.

**What's new**
Allows setting a custom text color for data labels using Fill="{color}"

This PR addresses [issue #2056](https://github.com/radzenhq/radzen-blazor/issues/2056), which requests support for customizing the text color of data labels in charts.

I’ve added the Fill support with this snippet:

```
<RadzenSeriesDataLabels Visible="@showDataLabels" Fill="white" />

<Text @key="@($"{label.Position}-{Chart.Series.IndexOf(series)}")"
      Value="@label.Text" Position="@label.Position" Fill="@Fill"
      TextAnchor="@label.TextAnchor" class="@GetSeriesDataLabelClass()" />

public string GetSeriesDataLabelClass() =>
    string.IsNullOrWhiteSpace(Fill) ? "rz-series-data-label" : "rz-series-data-label-fill";
```
https://github.com/user-attachments/assets/819b9e12-9add-470f-8a7a-1d13b4c8c6ec

Preserves existing styling when Fill is not set

Added logic in rendering to apply a new CSS class when Fill is used

**Tested**
Verified the rendering of different text colors with the new Fill attribute

Confirmed no impact on existing behavior when Fill is not specified

Let me know if you’d like me to include additional tests or documentation.

Thanks!