### PR TITLE
Fix for tab rerendering every time content is clicked

### DIFF
--- a/Radzen.Blazor/RadzenTabs.razor
+++ b/Radzen.Blazor/RadzenTabs.razor
@@ -5,9 +5,8 @@
 @if (Visible)
 {
     <div @ref=@Element style=@Style @attributes=@Attributes class=@GetCssClass() id=@GetId()
-         tabindex=0 @onkeydown="@(args => OnKeyPress(args))" @onkeydown:preventDefault=preventKeyPress @onkeydown:stopPropagation
-         @onfocus=@(args => focusedIndex = focusedIndex == -1 ? 0: focusedIndex)>
-        <ul role="tablist" class="rz-tabview-nav">
+         tabindex=0 @onkeydown="@(args => OnKeyPress(args))" @onkeydown:preventDefault=preventKeyPress @onkeydown:stopPropagation>
+        <ul role="tablist" class="rz-tabview-nav" @onfocus=@(args => focusedIndex = focusedIndex == -1 ? 0: focusedIndex)>
             @Tabs
         </ul>
         <div class="rz-tabview-panels">

--- a/Radzen.Blazor/RadzenTabs.razor.cs
+++ b/Radzen.Blazor/RadzenTabs.razor.cs
@@ -187,7 +187,7 @@ namespace Radzen.Blazor
             {
                 positionCSS = "rz-tabview-left";
             }
-            else if(TabPosition == TabPosition.TopRight)
+            else if (TabPosition == TabPosition.TopRight)
             {
                 positionCSS = "rz-tabview-top rz-tabview-top-right";
             }


### PR DESCRIPTION
RadzenTabs has an "onfocus" event on the outer `<div>` that was causing each tab to rerender every time you click within a tab if the tab contains any type of complex content.

I couldn't see a reason why the onfocus event needed to apply to the entire outer `<div>`, so I moved it to apply only to the `<ul>` that creates the clickable tabs. That solves the problem and doesn't seem to break anything.

Everything seems to work correctly when testing, but you might want to verify that there wasn't some good reason for the onfocus to be where it was previously.

This fixes this issue:
https://forum.radzen.com/t/radzentabs-re-renders-when-clicking-inside-an-empty-space/20011/3
