### PR TITLE
Use HTML as Text in RadzenFormField

### DIFF
--- a/Radzen.Blazor/RadzenFormField.razor
+++ b/Radzen.Blazor/RadzenFormField.razor
@@ -13,7 +13,7 @@
         </div>
         }
         @ChildContent
-        <label class="rz-form-field-label rz-text-truncate" for=@Component>@Text</label>
+                <label class="rz-form-field-label rz-text-truncate" for=@Component>@((MarkupString)Text)</label>
         @if (End != null)
         {
         <div class="rz-form-field-end">


### PR DESCRIPTION
With this you can use HTML and thus, for example, leave an icon of another color or something else within the title of an input.


![image](https://github.com/user-attachments/assets/853b3fe3-a698-4e9d-aa97-de000e6d82e9)
![image](https://github.com/user-attachments/assets/c2b8c913-58bb-45e2-8359-96f3dc870974)
![image](https://github.com/user-attachments/assets/4708baf7-88e7-48f7-88ed-5268228f78d2)
