### PR TITLE
Make RadzenDropDownDataGrid.OnChipRemove overridable

### DIFF
--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -969,7 +969,11 @@ namespace Radzen.Blazor
             OpenOnFocus = of;
         }
 
-        private async Task OnChipRemove(object item)
+        /// <summary>
+        /// Event handler for when an item is unselected by clicking a chip
+        /// </summary>
+        /// <param name="item">The item that is to be removed</param>
+        protected virtual async Task OnChipRemove(object item)
         {
             if (!Disabled)
             {


### PR DESCRIPTION
A small change to make RadzenDropDownDataGrid.OnChipRemove overridable.

This change will help work around one of the follow-up issues when working around #2121 (see Additional Context). I intend to use this to update the selected values outside the control.