### PR TITLE
Add TextTemplate parameter to RadzenFormField Blazor component

### DIFF
--- a/Radzen.Blazor/RadzenFormField.razor
+++ b/Radzen.Blazor/RadzenFormField.razor
@@ -13,7 +13,7 @@
         </div>
         }
         @ChildContent
-        <label class="rz-form-field-label rz-text-truncate" for=@Component>@Text</label>
+        <label class="rz-form-field-label rz-text-truncate" for=@Component>  @if (TextTemplate is null) {@Text} else {@TextTemplate} </label>
         @if (End != null)
         {
         <div class="rz-form-field-end">

--- a/Radzen.Blazor/RadzenFormField.razor.cs
+++ b/Radzen.Blazor/RadzenFormField.razor.cs
@@ -106,7 +106,13 @@ namespace Radzen.Blazor
         /// </example>
         [Parameter]
         public RenderFragment Helper { get; set; }
+        /// <summary>
+        /// Gets or sets the custom content for the label using a Razor template.
+        /// When provided, this template will be rendered instead of the plain text specified in the Text parameter.
+        /// </summary>
 
+        [Parameter]
+        public RenderFragment TextTemplate { get; set; }
         /// <summary>
         /// Gets or sets the label text.
         /// </summary>


### PR DESCRIPTION
A change was made to not use MarkupString but to be able to send a RenderFragment and in this way you can have the same functionality as using MarkupString
![image](https://github.com/user-attachments/assets/7f889e3e-c59b-4047-9c97-e071ed296ff4)

![image](https://github.com/user-attachments/assets/9e90a7ee-27cc-4ea0-a509-6349ef7efee0)

In case it is not an allowed solution, please let me know if I can receive feedback so I can go down the right path.