### PR TITLE
fix #2071: allow single-with-menu and advanced mixed filter modes

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -979,7 +979,9 @@ namespace Radzen.Blazor
                 }
                 else
                 {
-                    await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{PopupID}{column.GetFilterProperty()}");
+                    var filterModePrefix = (column.FilterMode ?? FilterMode) == FilterMode.Advanced ? "adv-" : 
+                                          (column.FilterMode ?? FilterMode) == FilterMode.SimpleWithMenu ? "swm-" : "";
+                    await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{PopupID}{filterModePrefix}{column.GetFilterProperty()}");
                 }
             }
 
@@ -1016,7 +1018,9 @@ namespace Radzen.Blazor
 
             if (closePopup)
             {
-                await JSRuntime.InvokeVoidAsync("Radzen.closeAllPopups", $"{PopupID}{column.GetFilterProperty()}");
+                var filterModePrefix = (column.FilterMode ?? FilterMode) == FilterMode.Advanced ? "adv-" : 
+                                      (column.FilterMode ?? FilterMode) == FilterMode.SimpleWithMenu ? "swm-" : "";
+                await JSRuntime.InvokeVoidAsync("Radzen.closeAllPopups", $"{PopupID}{filterModePrefix}{column.GetFilterProperty()}");
             }
 
             if (shouldReload)
@@ -1038,14 +1042,18 @@ namespace Radzen.Blazor
                 }
                 else
                 {
-                    await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{PopupID}{column.GetFilterProperty()}");
+                    var filterModePrefix = (column.FilterMode ?? FilterMode) == FilterMode.Advanced ? "adv-" : 
+                                          (column.FilterMode ?? FilterMode) == FilterMode.SimpleWithMenu ? "swm-" : "";
+                    await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{PopupID}{filterModePrefix}{column.GetFilterProperty()}");
                 }
             }
             await OnFilter(new ChangeEventArgs() { Value = column.GetFilterValue() }, column, true);
 
             if (closePopup)
             {
-                await JSRuntime.InvokeVoidAsync("Radzen.closeAllPopups", $"{PopupID}{column.GetFilterProperty()}");
+                var filterModePrefix = (column.FilterMode ?? FilterMode) == FilterMode.Advanced ? "adv-" : 
+                                      (column.FilterMode ?? FilterMode) == FilterMode.SimpleWithMenu ? "swm-" : "";
+                await JSRuntime.InvokeVoidAsync("Radzen.closeAllPopups", $"{PopupID}{filterModePrefix}{column.GetFilterProperty()}");
             }
         }
 

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -1306,7 +1306,10 @@ namespace Radzen.Blazor
             {
                 await headerCell.CloseFilter();
             }
-            await Grid.GetJSRuntime().InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}{GetFilterProperty()}");
+
+            var filterModePrefix = (FilterMode ?? Grid.FilterMode) == Radzen.FilterMode.Advanced ? "adv-" :
+                                   (FilterMode ?? Grid.FilterMode) == Radzen.FilterMode.SimpleWithMenu ? "swm-" : "";
+            await Grid.GetJSRuntime().InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}{filterModePrefix}{GetFilterProperty()}");
         }
 
         string runtimeWidth;

--- a/Radzen.Blazor/RadzenDataGridFilterMenu.razor
+++ b/Radzen.Blazor/RadzenDataGridFilterMenu.razor
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
 @inject IJSRuntime JSRuntime
- <button title=@Column.GetFilterOperatorText(Column.GetFilterOperator()) class="@FilterIconStyle()" onclick="@($"Radzen.togglePopup(this.parentNode, '{Grid.PopupID}{Column.GetFilterProperty()}')")">
+ <button title=@Column.GetFilterOperatorText(Column.GetFilterOperator()) class="@FilterIconStyle()" onclick="@($"Radzen.togglePopup(this.parentNode, '{Grid.PopupID}swm-{Column.GetFilterProperty()}')")">
      <i class="notranslate rzi">@Grid.FilterIcon</i>
     @if (Column.GetFilterOperator() == FilterOperator.DoesNotContain)
     {
@@ -13,7 +13,7 @@
         @Column.GetFilterOperatorSymbol(Column.GetFilterOperator())
     }
 </button>
-<div id="@($"{Grid.PopupID}{Column.GetFilterProperty()}")" class="rz-overlaypanel"
+<div id="@($"{Grid.PopupID}swm-{Column.GetFilterProperty()}")" class="rz-overlaypanel"
         style="display:none;" tabindex="0">
     <div class="rz-overlaypanel-content">
         <ul class="rz-listbox-list">
@@ -166,7 +166,7 @@
             LogicalFilterOperator = Column.GetLogicalFilterOperator()
         });
 
-        await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}{Column.GetFilterProperty()}");
+        await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}swm-{Column.GetFilterProperty()}");
         await Grid.ReloadInternal();
     }
 
@@ -176,7 +176,7 @@
 
         Grid.SaveSettings();
 
-        await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}{Column.GetFilterProperty()}");
+        await JSRuntime.InvokeVoidAsync("Radzen.closePopup", $"{Grid.PopupID}swm-{Column.GetFilterProperty()}");
 
         await Grid.FilterCleared.InvokeAsync(new DataGridColumnFilterEventArgs<TItem>()
         {

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -442,8 +442,10 @@ else
     string getColumnPopupID()
     {
         var fiterProperty = Column.GetFilterProperty();
+        var filterModePrefix = (Column.FilterMode ?? Grid.FilterMode) == FilterMode.Advanced ? "adv-" : 
+                              (Column.FilterMode ?? Grid.FilterMode) == FilterMode.SimpleWithMenu ? "swm-" : "";
 
-        return $"{Grid.PopupID}{(string.IsNullOrEmpty(fiterProperty) ? Grid.allColumns.IndexOf(Column).ToString() : fiterProperty)}";
+        return $"{Grid.PopupID}{filterModePrefix}{(string.IsNullOrEmpty(fiterProperty) ? Grid.allColumns.IndexOf(Column).ToString() : fiterProperty)}";
     }
 
     protected override void OnParametersSet()

--- a/RadzenBlazorDemos/Pages/DataGridMixedAdvancedFilterPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridMixedAdvancedFilterPage.razor
@@ -5,7 +5,7 @@
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
     The column <code>FilterMode</code> property allows you to mix <code>Advanced</code> and <code>CheckBoxList</code> or <code>Simple</code> and <code>SimpleWithMenu</code> filter mode per column.
-    Advanced filter modes cannot be mixed with simple filter modes.
+    You can also mix Advanced and SimpleWithMenu modes.
 </RadzenText>
 
 <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.P" class="rz-pb-4">


### PR DESCRIPTION
As per the issue #2071 there seems to be no discriminating identifier between the both pop up menus of the Advanced or the SimpleWithMenu FilterMode. To get around this issue I created a logic to assign either 'swm-' prefix for SimpleWithMenu or the 'adv-' for Advanced.
This will seperate interaction from one another and doesn't create render issues as stated in #2071 .