### PR TITLE
fix #2125 : add margin-block to 0 if is in stack

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_typography.scss
+++ b/Radzen.Blazor/themes/components/blazor/_typography.scss
@@ -81,6 +81,11 @@ $text: (
       #{$key}: var(--rz-text-#{$element}-#{$key});
     }
   }
+  .rz-stack {
+    .rz-text-#{$element} {
+      margin-block: 0;
+    }
+  }
 }
 
 // Text Align


### PR DESCRIPTION
In this pull request, I have added a CSS rule in the `_typography.scss` file to set `margin-block: 0` for text elements located within a stack. This change aims to improve layout by removing the default vertical margins of text elements, allowing for better control over spacing in stacked components.

**Changes Made:**

- **File:** `_typography.scss`
- **Addition:**
  ```scss
  .rz-stack {
    .rz-text {
      margin-block: 0;
    }
  }
  ```