### PR TITLE
Add support to render header template after column grouping/picker in a DataGrid

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -20,7 +20,7 @@
         @if (AllowGrouping || AllowColumnPicking)
         {
             <div class="rz-group-header" @onmouseup=@(args => EndColumnDropToGroup())>
-                @if (@HeaderTemplate != null && ShowHeader)
+                @if (@HeaderTemplate != null && ShowHeader && RenderHeaderTemplateFirst)
                 {
                     <div class="rz-custom-header" @onkeydown:stopPropagation>
                         @HeaderTemplate
@@ -61,6 +61,13 @@
                             TextProperty="ColumnPickerTitle" />
                     </div>
 
+                }
+
+                @if (@HeaderTemplate != null && ShowHeader && !RenderHeaderTemplateFirst)
+                {
+                    <div class="rz-custom-header" @onkeydown:stopPropagation>
+                        @HeaderTemplate
+                    </div>
                 }
             </div>
         }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -627,6 +627,13 @@ namespace Radzen.Blazor
         public RenderFragment HeaderTemplate { get; set; }
 
         /// <summary>
+        /// Indicates if HeaderTemplate should be rendered before or after Column Grouping / Column Picker.
+        /// Defaults to true to retain current behavior.
+        /// </summary>
+        [Parameter]
+        public bool RenderHeaderTemplateFirst { get; set; } = true;
+
+        /// <summary>
         /// Gives the grid a custom footer, allowing the adding of components to create custom tool bars or custom pagination
         /// </summary>
         [Parameter]


### PR DESCRIPTION
I have added a new parameter to control, if the header template should be rendered before or after Column grouping/Column Picker. It will retain current default behavior, where header template is rendered First before the column grouping/picker.

I needed this option to show a search text box after the column header picker. Since existing parameters, did not provide such option, added this support using new parameter.