### PR TITLE
Fix consistency of the standard dark theme with other dark themes

### DIFF
--- a/Radzen.Blazor/themes/standard-dark-base.scss
+++ b/Radzen.Blazor/themes/standard-dark-base.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 @import 'mixins';
 $base: true;
-$dark: true;
+$theme-dark: true;
 $standard: true;
 $theme-name: standard-dark;
 

--- a/Radzen.Blazor/themes/standard-dark.scss
+++ b/Radzen.Blazor/themes/standard-dark.scss
@@ -1,6 +1,6 @@
 @import 'variables';
 @import 'mixins';
-$dark: true;
+$theme-dark: true;
 $standard: true;
 $theme-name: standard-dark;
 


### PR DESCRIPTION
I've noticed that the standard dark theme sometimes doesn't match the style of other dark themes. For example, the base text buttons become white on hover, not darker as in other themes.
It turned out that the standard dark theme is not recognized as dark by the css builder. Here's a fix for it.