### PR TITLE
Supply Appointment data to SchedulerSlotRenderEventArgs - #2050

### DIFF
--- a/Radzen.Blazor/IScheduler.cs
+++ b/Radzen.Blazor/IScheduler.cs
@@ -100,8 +100,9 @@ namespace Radzen.Blazor
         /// </summary>
         /// <param name="start">The start of the slot.</param>
         /// <param name="end">The end of the slot.</param>
+        /// <param name="appointments">The appointments for this range.</param>
         /// <returns>A dictionary containing the HTML attributes for the specified slot.</returns>
-        IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end);
+        IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end, IEnumerable<AppointmentData> appointments);
         /// <summary>
         /// Renders the appointment.
         /// </summary>

--- a/Radzen.Blazor/IScheduler.cs
+++ b/Radzen.Blazor/IScheduler.cs
@@ -100,9 +100,9 @@ namespace Radzen.Blazor
         /// </summary>
         /// <param name="start">The start of the slot.</param>
         /// <param name="end">The end of the slot.</param>
-        /// <param name="appointments">The appointments for this range.</param>
+        /// <param name="getAppointments">Function to return appointments for this range.</param>
         /// <returns>A dictionary containing the HTML attributes for the specified slot.</returns>
-        IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end, IEnumerable<AppointmentData> appointments);
+        IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end, Func<IEnumerable<AppointmentData>> getAppointments);
         /// <summary>
         /// Renders the appointment.
         /// </summary>

--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -370,9 +370,9 @@ namespace Radzen.Blazor
         }
 
         /// <inheritdoc />
-        public IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end)
+        public IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end, IEnumerable<AppointmentData> appointments)
         {
-            var args = new SchedulerSlotRenderEventArgs { Start = start, End = end, View = SelectedView };
+            var args = new SchedulerSlotRenderEventArgs { Start = start, End = end, Appointments = appointments, View = SelectedView };
 
             SlotRender?.Invoke(args);
 

--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -370,9 +370,9 @@ namespace Radzen.Blazor
         }
 
         /// <inheritdoc />
-        public IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end, IEnumerable<AppointmentData> appointments)
+        public IDictionary<string, object> GetSlotAttributes(DateTime start, DateTime end, Func<IEnumerable<AppointmentData>> getAppointments)
         {
-            var args = new SchedulerSlotRenderEventArgs { Start = start, End = end, Appointments = appointments, View = SelectedView };
+            var args = new SchedulerSlotRenderEventArgs { Start = start, End = end, getAppointments = getAppointments, View = SelectedView };
 
             SlotRender?.Invoke(args);
 

--- a/Radzen.Blazor/Rendering/DayView.razor
+++ b/Radzen.Blazor/Rendering/DayView.razor
@@ -81,7 +81,7 @@
 
     IDictionary<string, object> Attributes(DateTime date)
     {
-        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot), AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
+        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot), () => AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
         attributes["class"] = ClassList.Create("rz-slot").Add("rz-slot-minor", (date.Minute / MinutesPerSlot) % 2 == 1).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         return attributes;

--- a/Radzen.Blazor/Rendering/DayView.razor
+++ b/Radzen.Blazor/Rendering/DayView.razor
@@ -81,7 +81,7 @@
 
     IDictionary<string, object> Attributes(DateTime date)
     {
-        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot));
+        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot), AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
         attributes["class"] = ClassList.Create("rz-slot").Add("rz-slot-minor", (date.Minute / MinutesPerSlot) % 2 == 1).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         return attributes;

--- a/Radzen.Blazor/Rendering/MonthView.razor
+++ b/Radzen.Blazor/Rendering/MonthView.razor
@@ -207,7 +207,7 @@
 
     IDictionary<string, object> Attributes(DateTime start)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInSlot(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create("rz-slot").Add(attributes).ToString();
         attributes["dropzone"] = "move";
         return attributes;

--- a/Radzen.Blazor/Rendering/MonthView.razor
+++ b/Radzen.Blazor/Rendering/MonthView.razor
@@ -207,7 +207,7 @@
 
     IDictionary<string, object> Attributes(DateTime start)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInSlot(start, start.AddDays(1)));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), () => AppointmentsInSlot(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create("rz-slot").Add(attributes).ToString();
         attributes["dropzone"] = "move";
         return attributes;

--- a/Radzen.Blazor/Rendering/WeekView.razor
+++ b/Radzen.Blazor/Rendering/WeekView.razor
@@ -96,7 +96,7 @@
 
     IDictionary<string, object> Attributes(DateTime date)
     {
-        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot));
+        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot), AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
         attributes["class"] = ClassList.Create("rz-slot").Add("rz-slot-minor", (date.Minute / MinutesPerSlot) % 2 == 1).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         return attributes;

--- a/Radzen.Blazor/Rendering/WeekView.razor
+++ b/Radzen.Blazor/Rendering/WeekView.razor
@@ -96,7 +96,7 @@
 
     IDictionary<string, object> Attributes(DateTime date)
     {
-        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot), AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
+        var attributes = Scheduler.GetSlotAttributes(date, date.AddMinutes(MinutesPerSlot), () => AppointmentsInSlot(date, date.AddMinutes(MinutesPerSlot)));
         attributes["class"] = ClassList.Create("rz-slot").Add("rz-slot-minor", (date.Minute / MinutesPerSlot) % 2 == 1).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         return attributes;

--- a/Radzen.Blazor/Rendering/YearPlannerView.razor
+++ b/Radzen.Blazor/Rendering/YearPlannerView.razor
@@ -168,7 +168,7 @@
 
     IDictionary<string, object> Attributes(DateTime start, string className, bool slotInMonth)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInRange(start, start.AddDays(1)));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), () => AppointmentsInRange(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create(className).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         if (!slotInMonth)

--- a/Radzen.Blazor/Rendering/YearPlannerView.razor
+++ b/Radzen.Blazor/Rendering/YearPlannerView.razor
@@ -168,7 +168,7 @@
 
     IDictionary<string, object> Attributes(DateTime start, string className, bool slotInMonth)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInRange(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create(className).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         if (!slotInMonth)

--- a/Radzen.Blazor/Rendering/YearTimelineView.razor
+++ b/Radzen.Blazor/Rendering/YearTimelineView.razor
@@ -158,7 +158,7 @@
 
     IDictionary<string, object> Attributes(DateTime start, string className, bool slotInMonth)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInRange(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create(className).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         if (!slotInMonth)

--- a/Radzen.Blazor/Rendering/YearTimelineView.razor
+++ b/Radzen.Blazor/Rendering/YearTimelineView.razor
@@ -158,7 +158,7 @@
 
     IDictionary<string, object> Attributes(DateTime start, string className, bool slotInMonth)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInRange(start, start.AddDays(1)));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), () => AppointmentsInRange(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create(className).Add(attributes).ToString();
         attributes["dropzone"] = "move";
         if (!slotInMonth)

--- a/Radzen.Blazor/Rendering/YearView.razor
+++ b/Radzen.Blazor/Rendering/YearView.razor
@@ -101,7 +101,7 @@
 
     IDictionary<string, object> Attributes(DateTime start, string className, bool slotInMonth)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInRange(start, start.AddDays(1)));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), () => AppointmentsInRange(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create(className).Add(attributes).ToString();
         return attributes;
     }

--- a/Radzen.Blazor/Rendering/YearView.razor
+++ b/Radzen.Blazor/Rendering/YearView.razor
@@ -59,8 +59,8 @@
                                 var excessCount = appointments.Count();
                                 string classname = $"rz-slot-title {(day.Month != offSetMonth ? "rz-other-month" : "")} {(excessCount > 0 ? "rz-has-appointments" : "")} {(day == CurrentDate && month == CurrentMonth ? " rz-state-focused" : "")}".Trim();
 
-                                    <div @onclick=@(args => OnListClick(day, appointments)) @attributes=@Attributes(day, "rz-slot")>
-                                        <div class="@classname">
+                                    <div class="rz-slot" @onclick=@(args => OnListClick(day, appointments))>
+                                        <div @attributes=@Attributes(day, classname, day.Month == offSetMonth)>
                                             @day.Day
                                         </div>
                                     </div>
@@ -99,9 +99,9 @@
     [Parameter]
     public IEnumerable<AppointmentData> Appointments { get; set; }
 
-    IDictionary<string, object> Attributes(DateTime start, string className)
+    IDictionary<string, object> Attributes(DateTime start, string className, bool slotInMonth)
     {
-        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1));
+        var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), AppointmentsInRange(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create(className).Add(attributes).ToString();
         return attributes;
     }

--- a/Radzen.Blazor/Rendering/YearView.razor
+++ b/Radzen.Blazor/Rendering/YearView.razor
@@ -59,8 +59,8 @@
                                 var excessCount = appointments.Count();
                                 string classname = $"rz-slot-title {(day.Month != offSetMonth ? "rz-other-month" : "")} {(excessCount > 0 ? "rz-has-appointments" : "")} {(day == CurrentDate && month == CurrentMonth ? " rz-state-focused" : "")}".Trim();
 
-                                    <div class="rz-slot" @onclick=@(args => OnListClick(day, appointments))>
-                                        <div @attributes=@Attributes(day, classname, day.Month == offSetMonth)>
+                                    <div @onclick=@(args => OnListClick(day, appointments)) @attributes=@Attributes(day, "rz-slot")>
+                                        <div class="@classname">
                                             @day.Day
                                         </div>
                                     </div>
@@ -99,7 +99,7 @@
     [Parameter]
     public IEnumerable<AppointmentData> Appointments { get; set; }
 
-    IDictionary<string, object> Attributes(DateTime start, string className, bool slotInMonth)
+    IDictionary<string, object> Attributes(DateTime start, string className)
     {
         var attributes = Scheduler.GetSlotAttributes(start, start.AddDays(1), () => AppointmentsInRange(start, start.AddDays(1)));
         attributes["class"] = ClassList.Create(className).Add(attributes).ToString();

--- a/Radzen.Blazor/SchedulerSlotRenderEventArgs.cs
+++ b/Radzen.Blazor/SchedulerSlotRenderEventArgs.cs
@@ -18,6 +18,10 @@ namespace Radzen
         /// </summary>
         public DateTime End { get; set; }
         /// <summary>
+        /// List of appointments.
+        /// </summary>
+        public IEnumerable<AppointmentData> Appointments { get; set; }
+        /// <summary>
         /// HTML attributes to apply to the slot element.
         /// </summary>
         public IDictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();

--- a/Radzen.Blazor/SchedulerSlotRenderEventArgs.cs
+++ b/Radzen.Blazor/SchedulerSlotRenderEventArgs.cs
@@ -23,7 +23,7 @@ namespace Radzen
         /// <summary>
         /// List of appointments.
         /// </summary>
-        public IEnumerable<AppointmentData> Appointments => appointments ?? (appointments = getAppointments());
+        public IEnumerable<AppointmentData> Appointments => appointments ??= getAppointments();
         /// <summary>
         /// HTML attributes to apply to the slot element.
         /// </summary>

--- a/Radzen.Blazor/SchedulerSlotRenderEventArgs.cs
+++ b/Radzen.Blazor/SchedulerSlotRenderEventArgs.cs
@@ -17,10 +17,13 @@ namespace Radzen
         /// The end of the slot.
         /// </summary>
         public DateTime End { get; set; }
+        // used to pass a function to get appointments on demand.
+        internal Func<IEnumerable<AppointmentData>> getAppointments;
+        private IEnumerable<AppointmentData> appointments;
         /// <summary>
         /// List of appointments.
         /// </summary>
-        public IEnumerable<AppointmentData> Appointments { get; set; }
+        public IEnumerable<AppointmentData> Appointments => appointments ?? (appointments = getAppointments());
         /// <summary>
         /// HTML attributes to apply to the slot element.
         /// </summary>
@@ -29,5 +32,6 @@ namespace Radzen
         /// The current view.
         /// </summary>
         public ISchedulerView View { get; set;}
+
     }
 }

--- a/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
+++ b/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
@@ -6,8 +6,8 @@
 </RadzenStack>
 
 <RadzenScheduler @ref=@scheduler SlotRender=@OnSlotRender style="height: 768px;" TItem="Appointment" Data=@appointments StartProperty="Start" EndProperty="End"
-    TextProperty="Text" SelectedIndex="1"
-    SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender MonthSelect=@OnMonthSelect>
+TextProperty="Text" SelectedIndex="1"
+SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRender=@OnAppointmentRender MonthSelect=@OnMonthSelect>
     <RadzenMonthView />
     <RadzenYearPlannerView StartMonth="@startMonth" />
     <RadzenYearTimelineView StartMonth="@startMonth" />
@@ -30,7 +30,33 @@
         new Appointment { Start = DateTime.Today.AddHours(10), End = DateTime.Today.AddHours(12), Text = "Online meeting" },
         new Appointment { Start = DateTime.Today.AddHours(10), End = DateTime.Today.AddHours(13), Text = "Skype call" },
         new Appointment { Start = DateTime.Today.AddHours(14), End = DateTime.Today.AddHours(14).AddMinutes(30), Text = "Dentist appointment" },
-        new Appointment { Start = DateTime.Today.AddDays(1), End = DateTime.Today.AddDays(12), Text = "Vacation" },
+        new Appointment { Start = DateTime.Today.AddDays(1), End = DateTime.Today.AddDays(7), Text = "Vacation" },
+        new Appointment { Start = DateTime.Today.AddDays(21).AddHours(10), End = DateTime.Today.AddDays(21).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(21).AddHours(11), End = DateTime.Today.AddDays(21).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(21).AddHours(12), End = DateTime.Today.AddDays(21).AddHours(13), Text = "Client #3" },
+        new Appointment { Start = DateTime.Today.AddDays(21).AddHours(13), End = DateTime.Today.AddDays(21).AddHours(14), Text = "Client #4" },
+        new Appointment { Start = DateTime.Today.AddDays(17).AddHours(10), End = DateTime.Today.AddDays(17).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(17).AddHours(11), End = DateTime.Today.AddDays(17).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(18).AddHours(10), End = DateTime.Today.AddDays(18).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(18).AddHours(11), End = DateTime.Today.AddDays(18).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(18).AddHours(12), End = DateTime.Today.AddDays(18).AddHours(13), Text = "Client #3" },
+        new Appointment { Start = DateTime.Today.AddDays(18).AddHours(13), End = DateTime.Today.AddDays(18).AddHours(14), Text = "Client #4" },
+        new Appointment { Start = DateTime.Today.AddDays(18).AddHours(14), End = DateTime.Today.AddDays(23).AddHours(15), Text = "Client #5" },
+        new Appointment { Start = DateTime.Today.AddDays(6).AddHours(10), End = DateTime.Today.AddDays(6).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(6).AddHours(11), End = DateTime.Today.AddDays(6).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(6).AddHours(12), End = DateTime.Today.AddDays(6).AddHours(13), Text = "Client #3" },
+        new Appointment { Start = DateTime.Today.AddDays(6).AddHours(13), End = DateTime.Today.AddDays(6).AddHours(14), Text = "Client #4" },
+        new Appointment { Start = DateTime.Today.AddDays(7).AddHours(10), End = DateTime.Today.AddDays(7).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(7).AddHours(11), End = DateTime.Today.AddDays(7).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(8).AddHours(10), End = DateTime.Today.AddDays(8).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(8).AddHours(11), End = DateTime.Today.AddDays(8).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(9).AddHours(10), End = DateTime.Today.AddDays(9).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(9).AddHours(11), End = DateTime.Today.AddDays(9).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(13).AddHours(10), End = DateTime.Today.AddDays(16).AddHours(11), Text = "Client #1" },
+        new Appointment { Start = DateTime.Today.AddDays(13).AddHours(11), End = DateTime.Today.AddDays(16).AddHours(12), Text = "Client #2" },
+        new Appointment { Start = DateTime.Today.AddDays(13).AddHours(12), End = DateTime.Today.AddDays(13).AddHours(13), Text = "Client #3" },
+        new Appointment { Start = DateTime.Today.AddDays(13).AddHours(13), End = DateTime.Today.AddDays(16).AddHours(14), Text = "Client #4" },
+        new Appointment { Start = DateTime.Today.AddDays(13).AddHours(14), End = DateTime.Today.AddDays(16).AddHours(15), Text = "Client #5" },
     };
 
     void OnSlotRender(SchedulerSlotRenderEventArgs args)
@@ -45,6 +71,23 @@
         if ((args.View.Text == "Planner" || args.View.Text == "Timeline") && args.Start.Month == 12 && startMonth != Month.January)
         {
             args.Attributes["style"] = "border-bottom: thick double var(--rz-base-600);";
+        }
+
+        // In Year View, color the day depending on number of appointments
+        if (args.View.Text == "Year")
+        {
+            if (args.Appointments.Count() >= 5)
+            {
+                args.Attributes["style"] = "background: darkred;";
+            }
+            else if (args.Appointments.Count() >= 3)
+            {
+                args.Attributes["style"] = "background: darkorange;";
+            }
+            else if (args.Appointments.Count() > 1)
+            {
+                args.Attributes["style"] = "background: darkgreen;";
+            }
         }
     }
 

--- a/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
+++ b/RadzenBlazorDemos/Pages/SchedulerPlannerTimeline.razor
@@ -73,21 +73,18 @@ SlotSelect=@OnSlotSelect AppointmentSelect=@OnAppointmentSelect AppointmentRende
             args.Attributes["style"] = "border-bottom: thick double var(--rz-base-600);";
         }
 
-        // In Year View, color the day depending on number of appointments
-        if (args.View.Text == "Year")
+        // Color the slot depending on number of appointments for that day
+        if (args.Appointments.Count() > 4)
         {
-            if (args.Appointments.Count() >= 5)
-            {
-                args.Attributes["style"] = "background: darkred;";
-            }
-            else if (args.Appointments.Count() >= 3)
-            {
-                args.Attributes["style"] = "background: darkorange;";
-            }
-            else if (args.Appointments.Count() > 1)
-            {
-                args.Attributes["style"] = "background: darkgreen;";
-            }
+            args.Attributes["style"] = "background: #ffabab;";
+        }
+        else if (args.Appointments.Count() > 2)
+        {
+            args.Attributes["style"] = "background: #ffc988;";
+        }
+        else if (args.Appointments.Count() > 0)
+        {
+            args.Attributes["style"] = "background: #c3ffc3;";
         }
     }
 


### PR DESCRIPTION
As per request [#2050](https://github.com/radzenhq/radzen-blazor/issues/2050), pass `AppointmentData` as a property in `SchedulerSlotRenderEventArgs` class.

Update demo site `Year` view to highlight this change.

Regards

Paul