### PR TITLE
Error in the case where a non-generic class

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -268,8 +268,8 @@ namespace Radzen
             var parts = property.Split(new char[] { '.' }, 2);
             string currentPart = parts[0];
             Expression member;
-
-            if (expression.Type.IsGenericType && typeof(IDictionary<,>).IsAssignableFrom(expression.Type.GetGenericTypeDefinition()))
+                
+            if (typeof(IDictionary).IsAssignableFrom(expression.Type))
             {
                 var key = currentPart.Split('"')[1];
                 var typeString = currentPart.Split('(')[0];


### PR DESCRIPTION
If a class is not generic but still implements the IDictionary<,> or IDictionary interface, the previous line of code would not work correctly.

For example, with a class like:

```
public class NonGeneric : IDictionary<string,object>
{
    // ... implementation ...
}
```