### PR TITLE
add icon in Title Dialog

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -54,7 +54,25 @@ namespace Radzen
                 return reference;
             }
         }
+        /// <summary>
+        /// Gets or sets the icon in Title.
+        /// </summary>
+        /// <value>The icon.</value>
 
+        public string Icon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon color in Title.
+        /// </summary>
+        /// <value>The icon color.</value>
+
+        public string IconColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the CSS style of the Icon in Title.
+
+        /// </summary>
+        public string IconStyle { get; set; } = "margin-right: 0.75rem"
+        
         /// <summary>
         /// Gets or sets the URI helper.
         /// </summary>

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -9,6 +9,12 @@
         {
             <div class="rz-dialog-titlebar">
                 <div class="rz-dialog-title" id="rz-dialog-0-label">
+                    @if (!string.IsNullOrEmpty(Dialog.Options.Icon))
+                    {
+                        <RadzenIcon Icon="@Dialog.Options.Icon" 
+                                    IconColor="@(string.IsNullOrEmpty(Dialog.Options.IconColor) ? null : Dialog.Options.IconColor)" 
+                                    Style="@Dialog.Options.IconStyle" />
+                    }
                     @if (Dialog.Options.TitleContent != null)
                     {
                         @Dialog.Options.TitleContent(Service)


### PR DESCRIPTION
# Add Icon Support to Dialog Titles

## What
Added icon display functionality to Radzen dialog titles.

## Changes
- Added `Icon` property to `DialogOptions` - icon name to display
- Added `IconColor` property to `DialogOptions` - icon color 
- Added `IconStyle` property to `DialogOptions` - custom CSS for icon
- Updated dialog component to render icon when provided

## Examples
```csharp
await DialogService.OpenAsync<StateTransitionConfirmModal>(
    $"Change to {transition.DisplayName ?? transition.To}",
    parameters,
    new DialogOptions 
    { 
        Width = "600px", 
        CloseDialogOnOverlayClick = false,
        ShowTitle = true,
        ShowClose = true,
        Icon = "add",
        IconColor = Colors.Danger,
        IconStyle = "border: solid 1px"
    });
```
![image](https://github.com/user-attachments/assets/9047ebf2-770f-433f-a07c-41ac07b33d9b)


```
 await DialogService.OpenAsync<StateTransitionConfirmModal>(
     $"Cambiar a {transition.DisplayName ?? transition.To}",
     parameters,
     new DialogOptions
     {
         Width = "600px",
         CloseDialogOnOverlayClick = false,
         ShowTitle = true,
         ShowClose = true,
         Icon = "add",
         IconColor = Colors.Success,

     });

```
![image](https://github.com/user-attachments/assets/5dc1813f-9b0f-4375-a7e1-c74c958f24dc)


## Notes
- All new properties are optional