### PR TITLE
Reset select on filter

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -215,7 +215,7 @@ namespace Radzen
         /// <summary>
         /// Gets or sets a value indicating the selected index should reset to the top item when filtering, resulting in a down arrow action will start moving from the top.
         /// </summary>
-        /// <value><c>true</c> to reset selected index to -1 when filtering; otherwist, <c>false</c>.</value>
+        /// <value><c>true</c> to reset selected index to -1 when filtering; otherwise, <c>false</c>.</value>
         [Parameter]
         public bool ResetSelectedIndexOnFilter { get; set; }
 
@@ -748,11 +748,12 @@ namespace Radzen
             }
             else if (AllowFiltering && isFilter && FilterAsYouType)
             {
+                preventKeydown = true;
+
                 if (ResetSelectedIndexOnFilter)
                 {
                     selectedIndex = -1;
-                }                
-                preventKeydown = true;
+                }                                
 
                 Debounce(DebounceFilter, FilterDelay);
             }


### PR DESCRIPTION
PR for fixing a space issue in filtering a dropdown.
see: #2174 

When you are typing in the filter and an item in the dropdown is already selected a press on the spacebar will result in the item being reselected and the space being eaten/ignored. 

When typing the assumption is you want to select something else, so resetting the selected index to -1 will make sure you can still type a space. Moving with the arrowkeys and then space still works. Made it a parameter so its opt-in to prevent unforseen and unwanted behavior in other usecases.