### PR TITLE
fix: avoid accessing parameter view in SetParametersAsync after an async call to prevent a race condition

### DIFF
--- a/Radzen.Blazor/DataBoundFormComponent.cs
+++ b/Radzen.Blazor/DataBoundFormComponent.cs
@@ -301,19 +301,15 @@ namespace Radzen
         /// <returns>A Task representing the asynchronous operation.</returns>
         public override async Task SetParametersAsync(ParameterView parameters)
         {
-            // process all parameters first to prevent stale parameters
-            var searchTextChanged = parameters.DidParameterChange(nameof(SearchText), SearchText);
+            // check for changes before setting the properties through the base call
             var dataChanged = parameters.DidParameterChange(nameof(Data), Data);
             var disabledChanged = parameters.DidParameterChange(nameof(Disabled), Disabled);
-            var result = base.SetParametersAsync(parameters);
+            
+            // allow the base class to process parameters and set the properties
+            // after this call the parameters object should be considered stale
+            await base.SetParametersAsync(parameters);
 
-            if (searchTextChanged)
-            {
-                searchText = parameters.GetValueOrDefault<string>(SearchText);
-            }
-
-            // only call async code after all parameters have been processed
-            // and do not access any parameters afterwards as they may be stale
+            // handle changes
             if (dataChanged)
             {
                 await OnDataChanged();
@@ -330,8 +326,6 @@ namespace Radzen
             {
                 FormFieldContext?.DisabledChanged(Disabled);
             }
-
-            await result;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: https://forum.radzen.com/t/the-parameterview-instance-can-no-longer-be-read-because-it-has-expired/18912/7
See also: https://stackoverflow.com/questions/66717054/the-parameterview-instance-can-no-longer-be-read-because-it-has-expired-paramet