### PR TITLE
DropDownDataGrid null check to prevent error that occurs when using AllowFilteringByAllStringColumns="true"

### DIFF
--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -456,10 +456,17 @@ namespace Radzen.Blazor
             if (column.Type == typeof(string)) return true;
 
             var property = column.GetFilterProperty();
-            var itemType = Data != null ? Data.AsQueryable().ElementType : typeof(object);
-            var type = PropertyAccess.GetPropertyType(itemType, property);
+            if(property is not null)
+            {
+                var itemType = Data != null ? Data.AsQueryable().ElementType : typeof(object);
+                var type = PropertyAccess.GetPropertyType(itemType, property);
 
-            return type == typeof(string);
+                return type == typeof(string);
+            }
+            else
+            {
+                return false;
+            }
         }
 
         string prevSearch;


### PR DESCRIPTION
To replicate this bug: 
Just add AllowFilteringByAllStringColumns="true" to the Multiple Selection example for DropDownDataGrid, and then type text into the filter box.