### PR TITLE
Add missing Type field when creating FilterDescriptors in RadzenDataGrid InvokeLoadData method

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2180,7 +2180,8 @@ namespace Radzen.Blazor
                     FilterOperator = c.GetFilterOperator(),
                     SecondFilterValue = c.GetSecondFilterValue(),
                     SecondFilterOperator = c.GetSecondFilterOperator(),
-                    LogicalFilterOperator = c.GetLogicalFilterOperator()
+                    LogicalFilterOperator = c.GetLogicalFilterOperator(),
+                    Type = c.GetType()
                 })
                 .ToList();
 


### PR DESCRIPTION
Added changes to fix null Type field in LoadDataArgs after  applying filter changes. 
![image](https://github.com/user-attachments/assets/bfb1c2ec-700b-44a5-a125-8afe8e1e032d)