### PR TITLE
Ignore serialize FilterDescriptor Type property

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -15,6 +15,7 @@ using System.Reflection.Metadata;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -2376,6 +2377,7 @@ namespace Radzen
         /// Gets or sets the property type.
         /// </summary>
         /// <value>The property type.</value>
+        [JsonIgnore]
         public Type Type { get; set; }
 
         /// <summary>


### PR DESCRIPTION
System.Type cannot be serialized out of the box in C# (possible security issue)

By ignoring the Type property, FilterDescriptor can be used for custom server-side filtering.