### PR TITLE
Fix type assignment in RadzenDataGrid to get the correct type

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2181,7 +2181,7 @@ namespace Radzen.Blazor
                     SecondFilterValue = c.GetSecondFilterValue(),
                     SecondFilterOperator = c.GetSecondFilterOperator(),
                     LogicalFilterOperator = c.GetLogicalFilterOperator(),
-                    Type = c.GetType()
+                    Type = c.Type
                 })
                 .ToList();
 

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2180,7 +2180,8 @@ namespace Radzen.Blazor
                     FilterOperator = c.GetFilterOperator(),
                     SecondFilterValue = c.GetSecondFilterValue(),
                     SecondFilterOperator = c.GetSecondFilterOperator(),
-                    LogicalFilterOperator = c.GetLogicalFilterOperator()
+                    LogicalFilterOperator = c.GetLogicalFilterOperator(),
+                    Type = c.GetType()
                 })
                 .ToList();
 


### PR DESCRIPTION
I've made a mistake in my previous pull request and assigned Type of the column instead of the Type property which stores column's data type. Now the filters should correctly fill with the type of data they filter