### PR TITLE
Fix IconColor in ProfileMenuItem

### DIFF
--- a/Radzen.Blazor/RadzenProfileMenuItem.razor
+++ b/Radzen.Blazor/RadzenProfileMenuItem.razor
@@ -23,7 +23,7 @@
                 <div class="rz-navigation-item-link" >
                     @if (!string.IsNullOrEmpty(Icon))
                     {
-                        <i class="notranslate rzi rz-navigation-item-icon">@Icon</i>
+                        <i class="notranslate rzi rz-navigation-item-icon" style="@(!string.IsNullOrEmpty(IconColor) ? $"color:{IconColor}" : null)">@Icon</i>
                     }
                     @if (!string.IsNullOrEmpty(Image))
                     {


### PR DESCRIPTION
In the RadzenProfileMenuItem component, the icon color was not taken into account if the Path was not specified.
Example:

```razor
<RadzenProfileMenu>
    <Template>
        <RadzenIcon Icon="more_horiz"/>
    </Template>
    <ChildContent>
        <RadzenProfileMenuItem Text="View" Icon="visibility" IconColor="var(--rz-primary)"/>
        <RadzenProfileMenuItem Text="Edit" Icon="edit" IconColor="var(--rz-success)"/>
        <RadzenProfileMenuItem Text="Delete" Icon="delete" IconColor="var(--rz-danger)"/>
    </ChildContent>
</RadzenProfileMenu>
```

Before:
<img width="146" height="202" alt="image" src="https://github.com/user-attachments/assets/fdd10ec1-624a-4c8c-86df-1a60fb5cfca6" />

After:
<img width="119" height="205" alt="image" src="https://github.com/user-attachments/assets/8f7c818d-0038-4d92-ac8e-b88811aedfa0" />

