### PR TITLE
Improve numeric input handling for all locales (including Persian and Arabic)

### DIFF
--- a/Radzen.Blazor/RadzenNumeric.razor.cs
+++ b/Radzen.Blazor/RadzenNumeric.razor.cs
@@ -346,11 +346,9 @@ namespace Radzen.Blazor
 
         private string RemoveNonNumericCharacters(object value)
         {
-            string valueStr = value as string;
-            if (valueStr == null)
-            {
-                valueStr = $"{value}";
-            }
+            string valueStr = value as string ?? $"{value}";
+
+            valueStr = NormalizeDigits(valueStr);
 
             if (!string.IsNullOrEmpty(Format))
             {
@@ -371,6 +369,28 @@ namespace Radzen.Blazor
 
             return new string(valueStr.Where(c => char.IsDigit(c) || char.IsPunctuation(c)).ToArray()).Replace("%", "");
         }
+
+        private static string NormalizeDigits(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+
+            var sb = new System.Text.StringBuilder(input.Length);
+            foreach (var ch in input)
+            {
+                if (char.GetUnicodeCategory(ch) == System.Globalization.UnicodeCategory.DecimalDigitNumber)
+                {
+                    var numeric = (int)char.GetNumericValue(ch); // 0..9
+                    if (numeric >= 0 && numeric <= 9)
+                    {
+                        sb.Append((char)('0' + numeric));
+                        continue;
+                    }
+                }
+                sb.Append(ch);
+            }
+            return sb.ToString();
+        }
+
 
         /// <summary>
         /// Gets or sets the function which returns TValue from string.

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -980,9 +980,9 @@ window.Radzen = {
           return;
     }
 
-    var ch = String.fromCharCode(e.charCode);
+    var ch = e.key;
 
-    if ((isInteger ? /^[-\d]$/ : /^[-\d,.]$/).test(ch)) {
+    if (/\p{Nd}/u.test(ch) || ch === '-' || (!isInteger && ch === decimalSeparator)) {
       return;
     }
 


### PR DESCRIPTION
This PR enhances the numeric input behavior to properly support digit characters from all languages using Unicode digit categories.

Previously, entering numbers in languages like Persian (e.g., ۳۴۵) or Arabic (e.g., ٤٥٦) was not accepted by the component, even though those digits are valid Unicode numerals.

 I had encountered this issue specifically with Persian and Arabic input, but instead of applying a language-specific fix, I implemented a general solution that uses the Unicode `\p{Nd}` character class to accept any kind of digit from any locale (e.g., Hindi, Bengali, etc.).

This makes the component language-agnostic, fully Unicode-compliant, and more robust for international use.