### PR TITLE
Fixed timing problem in RadzenTreeItem OnInitializedAsync

### DIFF
--- a/Radzen.Blazor/RadzenTreeItem.razor.cs
+++ b/Radzen.Blazor/RadzenTreeItem.razor.cs
@@ -264,6 +264,20 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         override protected async Task OnInitializedAsync()
         {
+            if (Tree != null && ParentItem == null)
+            {
+                Tree.AddItem(this);
+            }
+
+            if (ParentItem != null)
+            {
+                ParentItem.AddItem(this);
+
+                var currentItems = Tree.items;
+
+                Tree.InsertInCurrentItems(currentItems.IndexOf(ParentItem) + (ParentItem != null ? ParentItem.items.Count : 0), this);
+            }
+
             expanded = Expanded;
             clientExpanded = expanded;
 
@@ -277,20 +291,6 @@ namespace Radzen.Blazor
             if (selected)
             {
                 await Tree?.SelectItem(this);
-            }
-
-            if (Tree != null && ParentItem == null)
-            {
-                Tree.AddItem(this);
-            }
-
-            if (ParentItem != null)
-            {
-                ParentItem.AddItem(this);
-
-                var currentItems = Tree.items;
-
-                Tree.InsertInCurrentItems(currentItems.IndexOf(ParentItem) + (ParentItem != null ? ParentItem.items.Count : 0), this);
             }
         }
 


### PR DESCRIPTION
Fixed an issue that the order of CurrentItems could be wrong when items are expanded simultaneously.

There is a problem that the order of the nodes in RadzenTree.CurrentItems may not be correct if several nodes are to be expanded initially and the expansion takes different amounts of time.
The problem lies in RadzenTreeItem.OnInitializedAsync. Here, ‘await Tree?.ExpandItem(this)’ is called first, and then the item is added to CurrentItems. The following scenario can occur:

Example of the tree:
- Parent
-- Child1
--- Child 1.1
--- Child 1.2
-- Child2
--- Child 2.1
--- Child 2.2

1) OnInitializedAsync is called for Parent and runs until ‘await Tree?.ExpandItem(this)’. In this example, execution pauses here for a while because this call takes a long time.
2) Meanwhile, OnInitializedAsync is called for Child1. ‘await Tree?.ExpandItem(this)’ is completed quickly in this example. Child1 is added to CurrentItems. It should actually be inserted after Parent, but Parent has not yet been added to the tree.
3) OnInitializedAsync is eventually continued for Parent, and Parent appears at the end of CurrentItems.

The incorrect order leads to an exception as soon as, for example, a node is collapsed. In RadzenTreeItem.Toggle, the call to ‘Tree.RemoveFromCurrentItems’ relies on the correct order of the items.

The proposed solution would be to first add the items to the tree in OnInitializedAsync and only then perform the await calls that can cause timing problems.
