### PR TITLE
enhance tailwind compatibility

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_input.scss
+++ b/Radzen.Blazor/themes/components/blazor/_input.scss
@@ -66,13 +66,15 @@ $input-transition: var(--rz-transition-all), width 0, height 0 !default;
   }
 }
 
-input {
-  color: var(--rz-input-value-color);
-  font-size: var(--rz-input-font-size);
+@layer radzen {
+  input {
+    color: var(--rz-input-value-color);
+    font-size: var(--rz-input-font-size);
 
-  &::placeholder {
-    color: var(--rz-input-placeholder-color);
-  }
+    &::placeholder {
+      color: var(--rz-input-placeholder-color);
+    }
+  }  
 }
 
 %input-base {


### PR DESCRIPTION
## Problem:

Using a Tailwind CSS utility class to set the text color on a native `<input>` HTML element doesn't work in a Radzen project.

```html
<input class="text-fuchsia-700 text-7xl" /> <!---it doesn't work-->
```

## Root cause:

Radzen's stylesheet sets the style of the standard HTML input in an intrusive way:

```css
input {
  color: ...
}
```

Meanwhile, the Tailwind CSS utility sets the color in a more gentle way:

```css
@layer utilities {
   .text-fuchsia-700 {
     color:...
   }
}
```

The Tailwind CSS rule is more specific but cannot take precedence because it's defined inside a CSS layer. Tailwind follows the best practices of a modern CSS framework, using a CSS layer instead of `!important` everywhere.

## Correction

Modifying a native style of an HTML tag directly without any specificity (such as `@layer` or `.rz-` class) is generally not recommended, Instead, these rules are now placed within a `radzen` CSS @layer. This ensures Radzen's styles are applied but allows other CSS frameworks, such as Tailwind, to properly override or extend them when needed, making the rule less intrusive and more compatible.