### PR TITLE
Add support for datepicker callbacks, fire callback on close.

### DIFF
--- a/Radzen.Blazor/RadzenDatePicker.razor
+++ b/Radzen.Blazor/RadzenDatePicker.razor
@@ -27,7 +27,7 @@
             }
         }
 
-        <Popup id="@PopupID" Lazy=@(PopupRenderMode == PopupRenderMode.OnDemand) @ref=@popup style=@PopupStyle class="@($"{(Inline ? "rz-datepicker-inline-container " : "rz-datepicker-popup-container ")}")">
+        <Popup id="@PopupID" Lazy=@(PopupRenderMode == PopupRenderMode.OnDemand) @ref=@popup style=@PopupStyle Close=@OnClose class="@($"{(Inline ? "rz-datepicker-inline-container " : "rz-datepicker-popup-container ")}")">
                 <div class="rz-calendar" @onkeydown="@OnPopupKeyDown">
                     @if (!TimeOnly)
                     {

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -203,7 +203,7 @@ namespace Radzen.Blazor
                 Close();
             }
 
-            if(Min.HasValue && CurrentDate < Min.Value || Max.HasValue && CurrentDate > Max.Value)
+            if (Min.HasValue && CurrentDate < Min.Value || Max.HasValue && CurrentDate > Max.Value)
             {
                 return;
             }
@@ -466,7 +466,7 @@ namespace Radzen.Blazor
                         }
                         else if (value is TimeOnly timeOnly)
                         {
-                            DateTimeValue = new DateTime(1,1,0001, timeOnly.Hour, timeOnly.Minute, timeOnly.Second, timeOnly.Millisecond, Kind);
+                            DateTimeValue = new DateTime(1, 1, 0001, timeOnly.Hour, timeOnly.Minute, timeOnly.Second, timeOnly.Millisecond, Kind);
                         }
 #endif
                         else
@@ -997,6 +997,14 @@ namespace Radzen.Blazor
                 }
             }
         }
+        /// <summary>
+        /// Called when popup is closed.
+        /// </summary>
+        [JSInvokable]
+        public async Task OnClose()
+        {
+            await OnChange();
+        }
 
         async Task OnChange()
         {
@@ -1139,7 +1147,7 @@ namespace Radzen.Blazor
 
             if (Visible && !Disabled && !ReadOnly && !Inline && PopupRenderMode == PopupRenderMode.Initial)
             {
-                await JSRuntime.InvokeVoidAsync("Radzen.createDatePicker", Element, PopupID);
+                await JSRuntime.InvokeVoidAsync("Radzen.createDatePicker", Element, PopupID, Reference, nameof(OnClose));
             }
         }
 
@@ -1273,7 +1281,7 @@ namespace Radzen.Blazor
         async Task OnPopupKeyDown(KeyboardEventArgs args)
         {
             var key = args.Code != null ? args.Code : args.Key;
-            if(key == "Escape")
+            if (key == "Escape")
             {
                 preventKeyPress = false;
 
@@ -1362,7 +1370,7 @@ namespace Radzen.Blazor
                 catch
                 { }
             }
-            
+
         }
     }
 }

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -1041,11 +1041,11 @@ window.Radzen = {
           input.onclick = null;
       }
   },
-  createDatePicker(el, popupId) {
+  createDatePicker(el, popupId, instance, callback) {
       if(!el) return;
       var handler = function (e, condition) {
           if (condition) {
-              Radzen.togglePopup(e.currentTarget.parentNode, popupId, false, null, null, true, false);
+              Radzen.togglePopup(e.currentTarget.parentNode, popupId, false, instance, callback, true, false);
           }
       };
 


### PR DESCRIPTION
This addresses https://github.com/radzenhq/radzen-blazor/issues/2257

Should allow the Close function in a datepicker to fire appropriately when clicking away from the datepicker instead of using the OK button.  This will provide a means to keep the time synced with the model without needing the OK button.