### PR TITLE
Expose Responsive MaxWidth in RadzenSidebar

### DIFF
--- a/Radzen.Blazor/RadzenSidebar.razor
+++ b/Radzen.Blazor/RadzenSidebar.razor
@@ -4,7 +4,7 @@
 {
     @if (IsResponsive)
     {
-        <RadzenMediaQuery Query="(max-width: 768px)" Change=@OnChange />
+        <RadzenMediaQuery Query="@Query" Change=@OnChange />
     }
     <div @ref="@Element" style="@GetStyle()" @attributes="Attributes" class="@GetCssClass()"  id="@GetId()">
         @ChildContent

--- a/Radzen.Blazor/RadzenSidebar.razor.cs
+++ b/Radzen.Blazor/RadzenSidebar.razor.cs
@@ -36,6 +36,13 @@ namespace Radzen.Blazor
         [CascadingParameter]
         public RadzenLayout Layout { get; set; }
 
+        /// <summary>
+        /// Gets or sets the maximum width, in pixels, at which the component switches to a responsive layout.
+        /// </summary>
+        [Parameter]
+        public int ResponsiveMaxWidth { get; set; } = 768;
+        private string Query => $"(max-width: {ResponsiveMaxWidth}px)";
+
         /// <inheritdoc />
         protected override string GetComponentCssClass()
         {


### PR DESCRIPTION
I would like the RadzenSidebar to automatically retract when the page is viewed on an iPad, which has a viewport of 820px.  