### PR TITLE
RadzenDropDown/Grid: Modify bound collection in-place

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -1401,17 +1401,21 @@ namespace Radzen
             public ReferenceGenericCollectionAssignment(T originalCollection)
             {
                 this.originalCollection = originalCollection;
-                // Pre-calculate if we can handle this type and get method info
-                if (typeof(T).IsGenericType && !typeof(T).IsArray)
+                // Pre-calculate if we can handle this instance and get method info
+                if (originalCollection != null)
                 {
-                    var elementType = typeof(T).GetGenericArguments()[0];
-                    var genericCollectionType = typeof(ICollection<>).MakeGenericType(elementType);
-
-                    if (genericCollectionType.IsAssignableFrom(typeof(T)))
+                    var actualType = originalCollection.GetType();
+                    if (actualType.IsGenericType && !actualType.IsArray)
                     {
-                        clearMethod = typeof(T).GetMethod("Clear");
-                        addMethod = typeof(T).GetMethod("Add");
-                        canHandle = clearMethod != null && addMethod != null;
+                        var elementType = actualType.GetGenericArguments()[0];
+                        var genericCollectionType = typeof(ICollection<>).MakeGenericType(elementType);
+
+                        if (genericCollectionType.IsAssignableFrom(actualType))
+                        {
+                            clearMethod = actualType.GetMethod("Clear");
+                            addMethod = actualType.GetMethod("Add");
+                            canHandle = clearMethod != null && addMethod != null;
+                        }
                     }
                 }
             }

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -1187,7 +1187,14 @@ namespace Radzen
             {
                 if (ValueChanged.HasDelegate)
                 {
-                    await collectionAssignment.MakeAssignment((IEnumerable)internalValue, ValueChanged);
+                    if (Multiple)
+                    {
+                        await collectionAssignment.MakeAssignment((IEnumerable)internalValue, ValueChanged);
+                    }
+                    else
+                    {
+                        await ValueChanged.InvokeAsync((T)internalValue);
+                    }
                 }
 
                 if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
@@ -1304,7 +1311,6 @@ namespace Radzen
                         {
                             selectedItems = values.Cast<object>().ToHashSet(ItemComparer);
                         }
-
                     }
                 }
             }

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -1350,13 +1350,13 @@ namespace Radzen
         
         private class DefaultCollectionAssignment
         {
-            public virtual async Task MakeAssignment(IEnumerable selectedItems, EventCallback<T> ValueChanged)
+            public virtual async Task MakeAssignment(IEnumerable selectedItems, EventCallback<T> valueChanged)
             {
                 if (typeof(IList).IsAssignableFrom(typeof(T)))
                 {
                     if (object.Equals(selectedItems, null))
                     {
-                        await ValueChanged.InvokeAsync(default(T));
+                        await valueChanged.InvokeAsync(default(T));
                     }
                     else
                     {
@@ -1365,14 +1365,14 @@ namespace Radzen
                         {
                             list.Add(i);
                         }
-                        await ValueChanged.InvokeAsync((T)(object)list);
+                        await valueChanged.InvokeAsync((T)(object)list);
                     }
                 }
                 else if (typeof(T).IsGenericType && typeof(ICollection<>).MakeGenericType(typeof(T).GetGenericArguments()[0]).IsAssignableFrom(typeof(T)))
                 {
                     if (object.Equals(selectedItems, null))
                     {
-                        await ValueChanged.InvokeAsync(default(T));
+                        await valueChanged.InvokeAsync(default(T));
                     }
                     else
                     {
@@ -1382,12 +1382,12 @@ namespace Radzen
                             {
                                 list.Add(i);
                             }
-                            await ValueChanged.InvokeAsync((T)(object)list);
+                            await valueChanged.InvokeAsync((T)(object)list);
                     }
                 }
                 else
                 {
-                    await ValueChanged.InvokeAsync(object.Equals(selectedItems, null) ? default(T) : (T)selectedItems);
+                    await valueChanged.InvokeAsync(object.Equals(selectedItems, null) ? default(T) : (T)selectedItems);
                 }
             }
 
@@ -1428,12 +1428,12 @@ namespace Radzen
                 }
             }
 
-            public override async Task MakeAssignment(IEnumerable selectedItems, EventCallback<T> ValueChanged)
+            public override async Task MakeAssignment(IEnumerable selectedItems, EventCallback<T> valueChanged)
             {
                 if (!canHandle)
                 {
                     // Fallback to default behavior when we can't handle the type
-                    await base.MakeAssignment(selectedItems, ValueChanged);
+                    await base.MakeAssignment(selectedItems, valueChanged);
                     return;
                 }
 
@@ -1450,7 +1450,7 @@ namespace Radzen
                         removeMethod.Invoke(originalCollection, [i]);
                 }
 
-                await ValueChanged.InvokeAsync(originalCollection);
+                await valueChanged.InvokeAsync(originalCollection);
             }
 
             public override T GetCleared()

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -394,7 +394,7 @@ namespace Radzen
             await SearchTextChanged.InvokeAsync(searchText);
             await JSRuntime.InvokeAsync<string>("Radzen.setInputValue", search, "");
 
-            internalValue = default(T);
+            internalValue = collectionAssignment.GetCleared();
             selectedItem = null;
 
             selectedItems.Clear();
@@ -1405,6 +1405,11 @@ namespace Radzen
                     await ValueChanged.InvokeAsync(object.Equals(selectedItems, null) ? default(T) : (T)selectedItems);
                 }
             }
+
+            public virtual T GetCleared()
+            {
+                return default(T);
+            }
         }
 
         private class ReferenceGenericCollectionAssignment : DefaultCollectionAssignment
@@ -1448,6 +1453,16 @@ namespace Radzen
                 }
 
                 await ValueChanged.InvokeAsync(originalCollection);
+            }
+
+            public override T GetCleared()
+            {
+                if (canHandle)
+                {
+                    clearMethod.Invoke(originalCollection, null);
+                    return originalCollection;
+                }
+                return base.GetCleared();
             }
         }
     }

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -328,28 +328,7 @@ namespace Radzen
                 internalValue = selectedItems.AsQueryable().Cast(type);
             }
 
-            if (typeof(IList).IsAssignableFrom(typeof(T)))
-            {
-                var list = (IList)Activator.CreateInstance(typeof(T));
-                foreach (var i in (IEnumerable)internalValue)
-                {
-                    list.Add(i);
-                }
-                await ValueChanged.InvokeAsync((T)(object)list);
-            }
-            else if (typeof(T).IsGenericType && typeof(ICollection<>).MakeGenericType(typeof(T).GetGenericArguments()[0]).IsAssignableFrom(typeof(T)))
-            {
-                var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(typeof(T).GetGenericArguments()[0]));
-                foreach (var i in (IEnumerable)internalValue)
-                {
-                    list.Add(i);
-                }
-                await ValueChanged.InvokeAsync((T)(object)list);
-            }
-            else
-            {
-                await ValueChanged.InvokeAsync((T)internalValue);
-            }
+            await collectionAssignment.MakeAssignment((IEnumerable)internalValue, ValueChanged);
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
             await Change.InvokeAsync(internalValue);
 


### PR DESCRIPTION
I have hit another scenario where binding a collection to `RadzenDropDown` or `RadenDropDownGrid` is problematic.

I am using a custom collection that does not have a public default constructor.  `RadzenDropDown` uses `Activator.CreateInstance` to generate new collections on changes to the dropdown selection.  This makes the control unusable for this binding scenario.

I've posted another example in issue #1401 , where Clear nulls instead of Clears the bound collection.  There are other subtle issues that can occur when the bound collection is wholesale replaced (i.e. change tracking).  
In these cases I had to build component wrappers around the `RadzenDropDown` which are less than ideal.

In any case, I decided this latest limitation was a good time to try and resolve / support this scenario in a non-breaking way.

I've located the point in the code where these collections are replaced, and abstracted the existing behavior to a class, that can be swapped out with an implementation that preserves the bound collection, modifying it in place.

So as not to pollute the Parameter space, the opt-in flag is a protected field on `DropDownBase`, such that this behavior can be adjusted via subclassing.  I wasn't sure the appetite for this behavior, so did not want to take a broader approach until the maintainers have evaluated its utility and safety.

## Benefits ##
- A bound collection is modified in place, easing situations where
  - reference equality is important
  - it is not as feasible to rely on `Activator.CreateInstance` allocation, i.e. custom collection ctors
  - it is important to receive accurate notifications from collections implementing `INotifyCollectionChanged`
- Is entirely opt-in, the default behavior is maintained.  ~~I did make a small refactor to simplify some type gymnastics that seemed unnecessary, that can be easily reverted if warranted~~ (I reverted this to reduce risk)
- Performs well for large collections via use of HashSets internally

The diff looks large, but only due to moving existing code into a class.  Reviewers are encouraged to review commit by commit.

@SimonLissack