### PR TITLE
Make `ClearFilters` in `RadzenDataGridColumn` virtual

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -1209,7 +1209,7 @@ namespace Radzen.Blazor
         /// <summary>
         /// Sets to default column filter values and operators.
         /// </summary>
-        public void ClearFilters()
+        public virtual void ClearFilters()
         {
             var fo = FilterOperator == FilterOperator.Custom
                 ? FilterOperator.Custom


### PR DESCRIPTION
**Description:**
Currently, the `ClearFilters` method in `RadzenDataGridColumn` is not virtual, which prevents developers from overriding it in custom column implementations.

**Why this change is needed:**
When using `FilterValueTemplate` and `SecondFilterValueTemplate`, the built-in *Clear* button cannot reset the values inside these templates, since it has no access to them. To handle this properly, I need to override `ClearFilters` so I can reset the template’s filter values whenever the method is invoked.

**Proposed solution:**
Mark `ClearFilters` as `virtual`, allowing developers to extend its behavior by overriding it in their derived components.

**Impact:**
This change is backward-compatible and does not affect existing functionality. It only provides more flexibility for advanced use cases where filter values are rendered via templates.