### PR TITLE
ColorPicker: highlight selected color item

### DIFF
--- a/Radzen.Blazor/RadzenColorPicker.razor.cs
+++ b/Radzen.Blazor/RadzenColorPicker.razor.cs
@@ -96,6 +96,8 @@ namespace Radzen.Blazor
 
         Popup Popup { get; set; }
 
+        internal event EventHandler<string> SelectedColorChanged;
+
         string AlphaGradientStart
         {
             get
@@ -194,6 +196,8 @@ namespace Radzen.Blazor
 
         async Task TriggerChange()
         {
+            SelectedColorChanged.Invoke(this, Color);
+
             if (!ShowButton)
             {
                 await OnChanged();
@@ -407,6 +411,7 @@ namespace Radzen.Blazor
             if (value != Color)
             {
                 Color = value;
+                SelectedColorChanged?.Invoke(this, Color);
 
                 var hsv = RGB.Parse(Color).ToHSV();
                 SaturationHandleLeft = hsv.Saturation;

--- a/Radzen.Blazor/RadzenColorPickerItem.razor
+++ b/Radzen.Blazor/RadzenColorPickerItem.razor
@@ -1,4 +1,4 @@
 ﻿@using Radzen.Blazor.Rendering
 
-<div class="rz-colorpicker-item" style="background-color: @Background" @onmousedown:preventDefault @onclick=@OnClick
+<div class="rz-colorpicker-item @(isSelected ? "selected" : "")" style="background-color: @Background" @onmousedown:preventDefault @onclick=@OnClick
      tabindex="@(ColorPicker.Disabled ? -1 : 0)" @onkeypress="@(args => OnKeyPress(args, OnClick()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation></div>

--- a/Radzen.Blazor/RadzenColorPickerItem.razor.cs
+++ b/Radzen.Blazor/RadzenColorPickerItem.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Radzen.Blazor.Rendering;
+using System;
 using System.Threading.Tasks;
 
 namespace Radzen.Blazor
@@ -8,7 +9,7 @@ namespace Radzen.Blazor
     /// <summary>
     /// RadzenColorPickerItem component.
     /// </summary>
-    public partial class RadzenColorPickerItem
+    public partial class RadzenColorPickerItem : IDisposable
     {
         /// <summary>
         /// Gets or sets the value.
@@ -33,6 +34,37 @@ namespace Radzen.Blazor
         /// <value>The color picker.</value>
         [CascadingParameter]
         public RadzenColorPicker ColorPicker { get; set; }
+
+        private bool isSelected;
+
+        /// <inheritdoc/>
+        protected override Task OnInitializedAsync()
+        {
+            ColorPicker.SelectedColorChanged += ColorPickerColorChanged;
+            isSelected = ColorPicker.Value == Background;
+            return base.OnInitializedAsync();
+        }
+
+        /// <summary>
+        /// Detaches events from <see cref="ColorPicker" />.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            if (ColorPicker != null)
+            {
+                ColorPicker.SelectedColorChanged -= ColorPickerColorChanged;
+            }
+        }
+
+        private void ColorPickerColorChanged(object colorPicker, string newValue)
+        {
+            var shouldBeSelected = newValue == Background;
+            if (isSelected != shouldBeSelected)
+            {
+                isSelected = shouldBeSelected;
+                StateHasChanged();
+            }
+        }
 
         async Task OnClick()
         {

--- a/Radzen.Blazor/themes/_css-variables.scss
+++ b/Radzen.Blazor/themes/_css-variables.scss
@@ -268,6 +268,7 @@
   --rz-colorpicker-item-size: #{$colorpicker-item-size};
   --rz-colorpicker-item-border-radius: #{$colorpicker-item-border-radius};
   --rz-colorpicker-item-shadow: #{$colorpicker-item-shadow};
+  --rz-colorpicker-item-selected-transform: #{$colorpicker-item-selected-transform};
   --rz-colorpicker-handle-size: #{$colorpicker-handle-size};
   --rz-colorpicker-handle-border: #{$colorpicker-handle-border};
   --rz-colorpicker-handle-shadow: #{$colorpicker-handle-shadow};

--- a/Radzen.Blazor/themes/components/blazor/_colorpicker.scss
+++ b/Radzen.Blazor/themes/components/blazor/_colorpicker.scss
@@ -11,6 +11,7 @@ $colorpicker-items-gap: 0.5rem !default;
 $colorpicker-item-size: 1.25rem !default;
 $colorpicker-item-border-radius: var(--rz-border-radius) !default;
 $colorpicker-item-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset, rgba(0, 0, 0, 0.25) 0px 0px 4px inset !default;
+$colorpicker-item-selected-transform: scale(1.25) !default;
 $colorpicker-handle-size: 12px !default;
 $colorpicker-handle-border: 2px solid var(--rz-white) !default;
 $colorpicker-handle-shadow: var(--rz-white) 0px 0px 0px 1px, rgba(0, 0, 0, 0.3) 0px 0px 1px 1px inset, rgba(0, 0, 0, 0.4) 0px 0px 1px 2px !default;
@@ -286,6 +287,7 @@ button.rz-colorpicker-trigger {
   border-radius: var(--rz-colorpicker-item-border-radius);
   box-shadow: var(--rz-colorpicker-item-shadow);
   cursor: pointer;
+  transition: transform var(--rz-transition);
 
   &:focus {
     outline: var(--rz-outline-normal);
@@ -294,5 +296,9 @@ button.rz-colorpicker-trigger {
   &:focus-visible {
     outline: var(--rz-colorpicker-focus-outline);
     outline-offset: var(--rz-colorpicker-focus-outline-offset);
+  }
+
+  &.selected {
+    transform: var(--rz-colorpicker-item-selected-transform);
   }
 }


### PR DESCRIPTION
I've noticed that if you use a ColorPicker with only predefined colors and the OK button, it's impossible to tell which color has been selected.
With this change, the selected color is indicated by a 25% larger swatch. The indication is triggered not only by selecting a swatch directly, but also by other actions, such as entering a hex code.

<img width="400" height="563" alt="color picker focused vs selected" src="https://github.com/user-attachments/assets/9da6c3ad-a0d4-453c-9ca0-3599aed77633" />
