### PR TITLE
When filtering a column of type List<DateTime?> the filter value is D…

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -365,7 +365,7 @@ namespace Radzen
             var constant = Expression.Constant(caseInsensitive ?
                 $"{filter.FilterValue}".ToLowerInvariant() :
                     isEnum && !isEnumerable && filter.FilterValue != null ? Enum.ToObject(Nullable.GetUnderlyingType(property.Type) ?? property.Type, filter.FilterValue) : filter.FilterValue,
-                    !isEnum && isEnumerable ? valueType : isEnumerableProperty ? valueType: property.Type);
+                    !isEnum && isEnumerable ? valueType : isEnumerableProperty ? collectionItemType ?? valueType : property.Type);
 
             if (caseInsensitive && !isEnumerable)
             {


### PR DESCRIPTION
When filtering a column of type List<DateTime?> the filter value is DateTime (on server side the filter value is DateTime or null, but never DateTime?).

The type of the constatnt expression must match with the collection item type. So if the collectionItemType is not empty use that parameter instead of valueType.