### PR TITLE
Fix grid settings handling for sub properties column

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -22,7 +22,7 @@ namespace Radzen
         /// <summary>
         /// Projects each element of a sequence into a collection of property values.
         /// </summary>
-        internal static IQueryable Select(this IQueryable source, string propertyName)
+        public static IQueryable Select(this IQueryable source, string propertyName)
         {
             var parameter = Expression.Parameter(source.ElementType, "x");
 

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3429,7 +3429,7 @@ namespace Radzen.Blazor
         /// <param name="gridColumn">Grid colum to set.</param>
         /// <param name="columnSettings">Setting of the column.</param>
         /// <param name="isFirst">Handle first or second filter value.</param>
-        /// <returns></returns>
+        /// <returns>Returns true if state should update.</returns>
         public virtual bool SetColumnFilterValueFromSettings(RadzenDataGridColumn<TItem> gridColumn, DataGridColumnSettings columnSettings, bool isFirst)
         {
             var filterPropertyType = gridColumn.FilterPropertyType;
@@ -3521,8 +3521,9 @@ namespace Radzen.Blazor
                             }
 
                             // Filtering
-                            SetColumnFilterValueFromSettings(gridColumn, column, true);
-                            
+                            if( SetColumnFilterValueFromSettings(gridColumn, column, true))
+                                shouldUpdateState = true;
+
                             if (gridColumn.GetFilterOperator() != column.FilterOperator)
                             {
                                 gridColumn.SetFilterOperator(column.FilterOperator);
@@ -3530,7 +3531,8 @@ namespace Radzen.Blazor
                             }
 
                             // 2nd filter value
-                            SetColumnFilterValueFromSettings(gridColumn, column, false);
+                            if( SetColumnFilterValueFromSettings(gridColumn, column, false))
+                                shouldUpdateState = true;
 
                             if (gridColumn.GetSecondFilterOperator() != column.SecondFilterOperator)
                             {

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -200,6 +200,11 @@ namespace Radzen.Blazor
                 {
                     SetFilterOperator(FilterOperator.Contains);
                 }
+
+                if (!string.IsNullOrEmpty(Property) && !string.IsNullOrEmpty(FilterProperty))
+                    UniqueID ??= $"{Property}.{FilterProperty}"; // To be sure the column uniqueID is unique even when filtering on sub property.
+                else
+                    UniqueID ??= Property ?? FilterProperty;
             }
         }
         

--- a/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
+++ b/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
@@ -16,7 +16,7 @@
 <RadzenButton Click="@(args => Settings = null)" Text="Clear saved settings" Style="margin-bottom: 16px" />
 <RadzenButton Click="@(args => NavigationManager.NavigateTo("/datagrid-save-settings-loaddata", true))" Text="Reload" Style="margin-bottom: 16px" />
 <RadzenDataGrid @ref=grid @bind-Settings="@Settings" LoadSettings="@LoadSettings" AllowFiltering="true" AllowColumnPicking="true" AllowGrouping="true" AllowPaging="true" 
-                AllowSorting="true" AllowMultiColumnSorting="true" ShowMultiColumnSortingIndex="true" FilterMode="FilterMode.SimpleWithMenu"
+                AllowSorting="true" AllowMultiColumnSorting="true" ShowMultiColumnSortingIndex="true"
                 AllowColumnResize="true" AllowColumnReorder="true" ColumnWidth="200px"
                 FilterPopupRenderMode="PopupRenderMode.OnDemand" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                 Data="@employees" IsLoading=@isLoading Count="@count" LoadData=@LoadData

--- a/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
+++ b/RadzenBlazorDemos/Pages/DataGridSaveSettingsLoadData.razor
@@ -16,7 +16,7 @@
 <RadzenButton Click="@(args => Settings = null)" Text="Clear saved settings" Style="margin-bottom: 16px" />
 <RadzenButton Click="@(args => NavigationManager.NavigateTo("/datagrid-save-settings-loaddata", true))" Text="Reload" Style="margin-bottom: 16px" />
 <RadzenDataGrid @ref=grid @bind-Settings="@Settings" LoadSettings="@LoadSettings" AllowFiltering="true" AllowColumnPicking="true" AllowGrouping="true" AllowPaging="true" 
-                AllowSorting="true" AllowMultiColumnSorting="true" ShowMultiColumnSortingIndex="true"
+                AllowSorting="true" AllowMultiColumnSorting="true" ShowMultiColumnSortingIndex="true" FilterMode="FilterMode.SimpleWithMenu"
                 AllowColumnResize="true" AllowColumnReorder="true" ColumnWidth="200px"
                 FilterPopupRenderMode="PopupRenderMode.OnDemand" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                 Data="@employees" IsLoading=@isLoading Count="@count" LoadData=@LoadData
@@ -33,6 +33,17 @@
         <RadzenDataGridColumn Property="@nameof(Employee.HireDate)" Title="Hire Date" FormatString="{0:d}" />
         <RadzenDataGridColumn Property="@nameof(Employee.City)" Title="City" />
         <RadzenDataGridColumn Property="@nameof(Employee.Country)" Title="Country" />
+
+        <RadzenDataGridColumn Property="Orders" FilterProperty="ShipCity" Title="Order ship city" Type="typeof(ICollection<Order>)" Sortable="false">
+            <Template>
+                @(string.Join(',', context.Orders.Select(od => od.ShipCity)))
+            </Template>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn Property="Orders" FilterProperty="ShipPostalCode" Title="Order ShipPostalCode" Type="typeof(ICollection<Order>)" Sortable="false">
+            <Template>
+                @(string.Join(',', context.Orders.Select(od => od.ShipPostalCode)))
+            </Template>
+        </RadzenDataGridColumn>
     </Columns>
 </RadzenDataGrid>
 
@@ -55,7 +66,7 @@
 
         await Task.Yield();
 
-        var query = dbContext.Employees.AsQueryable();
+        var query = dbContext.Employees.Include("Orders").AsQueryable();
 
         if (!string.IsNullOrEmpty(args.Filter))
         {


### PR DESCRIPTION
- Fix loading grid settings when multiple column has the same Property (e.g, using sub-property filtering)
- Fix loaded settings type handling to handle an IEnumerable column where the filter value is not ValueKind.Array.
- The loaded filter value type handling was moved to a virtual method to make it possible to extend with custom logic.
- Added default value for Unique ID is not set.
- Set `QueryableExtension.Select` method to public. Need for generic template generation on sub propertie filter columns.
- Add example.