### PR TITLE
only use the designated fragment when pasting html into a RadzenHtmlEditor

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -2011,7 +2011,19 @@ window.Radzen = {
       } else if (paste) {
         e.preventDefault();
         var data = e.clipboardData.getData('text/html') || e.clipboardData.getData('text/plain');
-        data = Radzen.extractHTMLFragment(data);
+        
+        const startMarker = "<!--StartFragment-->";
+        const endMarker = "<!--EndFragment-->";
+
+        const startIndex = data.indexOf(startMarker);
+        const endIndex = data.indexOf(endMarker);
+
+        // check if the pasted data contains fragment markers
+        if (startIndex != -1 || endIndex != -1 || endIndex > startIndex) {
+            // only paste the fragment
+            data = data.substring(startIndex + startMarker.length, endIndex).trim();
+        }
+
         instance.invokeMethodAsync('OnPaste', data)
           .then(function (html) {
             document.execCommand("insertHTML", false, html);
@@ -2580,20 +2592,5 @@ window.Radzen = {
     unregisterScrollListener: function (element) {
       document.removeEventListener('scroll', element.scrollHandler, true);
       window.removeEventListener('resize', element.scrollHandler, true);
-    },
-    extractHTMLFragment: function (html) {
-        const startMarker = "<!--StartFragment-->";
-        const endMarker = "<!--EndFragment-->";
-
-        const startIndex = html.indexOf(startMarker);
-        const endIndex = html.indexOf(endMarker);
-
-        if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
-            // no fragment found
-            return html;
-        }
-
-        // get the fragment
-        return html.substring(startIndex + startMarker.length, endIndex).trim();
     }
 };


### PR DESCRIPTION
Fixes #2280

Pasting copies html code sometimes generates a lot of unnessary markup, especially when using word on a mac. The actually marked characters get surrounded by <!--StartFragment--> and <!--EndFragment--> comments. The proposed change only pastes the string within these comments.