### PR TITLE
RadzenDataGrid throws an exception when a filter value is loaded for a sub property

### DIFF
--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -3436,16 +3436,36 @@ namespace Radzen.Blazor
 
             // Fix nested property settings load issue
             // GetFilterValue reads settings as list only if the filterProperty type is IEnumerable and the settings value is JsonElement array.
-            if ( columnSettings.FilterValue is JsonElement jsonElement && jsonElement.ValueKind != JsonValueKind.Array
-                && !typeof(string).IsAssignableFrom(gridColumn.FilterPropertyType) && (typeof(IEnumerable<>).IsAssignableFrom(gridColumn.FilterPropertyType) || typeof(IEnumerable).IsAssignableFrom(gridColumn.FilterPropertyType)))
+            if (columnSettings.FilterValue is JsonElement { ValueKind: not JsonValueKind.Array }
+                && !typeof(string).IsAssignableFrom(gridColumn.FilterPropertyType)
+                && typeof(IEnumerable).IsAssignableFrom(gridColumn.FilterPropertyType))
             {
                 filterPropertyType = PropertyAccess.GetElementType(gridColumn.FilterPropertyType);
             }
-
-            if (!AreObjectsEqual(isFirst ? gridColumn.GetFilterValue() : gridColumn.GetSecondFilterValue(),
-                GetFilterValue(isFirst ? columnSettings.FilterValue : columnSettings.SecondFilterValue, filterPropertyType)))
+            else if (columnSettings.FilterValue is JsonElement { ValueKind: JsonValueKind.Array }
+                && !typeof(string).IsAssignableFrom(gridColumn.FilterPropertyType)
+                && typeof(IEnumerable).IsAssignableFrom(gridColumn.FilterPropertyType)
+                && gridColumn.FilterProperty != gridColumn.Property)
             {
-                gridColumn.SetFilterValue(GetFilterValue(isFirst ? columnSettings.FilterValue : columnSettings.SecondFilterValue, filterPropertyType), isFirst);
+                var subPropertyFilterType = PropertyAccess
+                    .GetElementType(gridColumn.FilterPropertyType)
+                    .GetProperty(gridColumn.GetFilterProperty())!
+                    .PropertyType;
+
+                filterPropertyType = typeof(IEnumerable<>).MakeGenericType(subPropertyFilterType);
+            }
+
+            var columnFilterValue = isFirst
+                ? gridColumn.GetFilterValue()
+                : gridColumn.GetSecondFilterValue();
+
+            var columnSettingsFilterValue = isFirst
+                ? GetFilterValue(columnSettings.FilterValue, filterPropertyType)
+                : GetFilterValue(columnSettings.SecondFilterValue, filterPropertyType);
+
+            if (!AreObjectsEqual(columnFilterValue, columnSettingsFilterValue))
+            {
+                gridColumn.SetFilterValue(columnSettingsFilterValue, isFirst);
                 return true;
             }
 


### PR DESCRIPTION
Hi,
I have encountered this issue with `RadzenDataGrid` while storing and retrieving the settings from the browser data storage. The issue arise only when the settings are serialized an then de-serialized from JSON.

## Example to reproduce the error
```CSharp
<ErrorBoundary @ref=_errorBoundary>
    <ChildContent>
        <TestDataGrid @ref=_dataGrid Data=_users AllowFiltering=true LoadSettings=OnLoadSettings SettingsChanged="OnSettingsChanged">
            <Columns>
                <RadzenDataGridColumn Title="Name" Property="Name" FilterMode="FilterMode.CheckBoxList" />
                <RadzenDataGridColumn Title="Roles" Property="Roles" FilterProperty="Id" Type=@typeof(IEnumerable<Role>) FilterMode="FilterMode.CheckBoxList">
                    <Template>
                        @string.Join(", ", context.Roles.Select(x => x.Description))
                    </Template>
                </RadzenDataGridColumn>
            </Columns>
        </TestDataGrid>
    </ChildContent>
    <ErrorContent>
        <RadzenText Text=@context.Message Style="color: red" />
        <RadzenButton Text="Recover" Click="OnRecoverClick" />
    </ErrorContent>
</ErrorBoundary>

<RadzenFieldset Text="Logs">
    @foreach (var log in _logs)
    {
        <RadzenText Text="@log" TextStyle="TextStyle.Body2" />
    }
</RadzenFieldset>

@using System.Text.Json
@using System.Collections
@code {
    record User(string Name, IEnumerable<Role> Roles);
    record Role(int Id, string Description);

    User[] _users = [
        new("Jhon", [new(0, "Admin")]),
        new("James", [
            new(0, "Admin"),
            new(1, "Guest")
        ]),
        new("Jhon", [new(1, "Guest")])
    ];

    static string? _settingsJson;
    RadzenDataGrid<User>? _dataGrid;
    ErrorBoundary? _errorBoundary;
    Stack<string> _logs = [];

    private void OnSettingsChanged(DataGridSettings args)
    {
        _settingsJson = JsonSerializer.Serialize(args, new JsonSerializerOptions()
        {
            WriteIndented = true
        });
        _logs.Push(_settingsJson);
        _logs.Push("Settings Changed");
    }

    private void OnLoadSettings(DataGridLoadSettingsEventArgs args)
    {
        if (_settingsJson is null) return;

        args.Settings = JsonSerializer.Deserialize<DataGridSettings>(_settingsJson);
        _logs.Push("Settings Loaded");
    }

    private void OnRecoverClick(MouseEventArgs args)
    {
        _settingsJson = null;
        _errorBoundary?.Recover();
        _logs.Push("Restored");
    }
}

```
## Source of the problem
The exception is raised in this piece of code:

https://github.com/radzenhq/radzen-blazor/blob/3dea0a5f67cb0c50fcdeee83dbac61daa486520b/Radzen.Blazor/RadzenDataGrid.razor.cs#L3696-L3710

The first iteration detect a sub property, generate a List<Role> (for my example), and tries to populate it by calling GetFilterValue again on the elements of the array. This nested call will not find any match for the Role type and will end up returning a string that is not compatible with the List<Role>.

## Fix
The fix that I have implemented detects if the grid column has a sub property filter, then adjusts the type that is passed to `GetFilterValue` to be an `IEnumerable` of the type of the sub property key. This then get correctly used by `QueryExtensions` to generate the expression to filter the data.