### PR TITLE
Fix does not contains (and NotIn) filtering on collection.

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -478,10 +478,12 @@ namespace Radzen
                 _ => null
             };
 
-            if (collectionItemType != null && primaryExpression != null &&
-                !(filter.FilterOperator == FilterOperator.In || filter.FilterOperator == FilterOperator.NotIn))
+            if (collectionItemType != null && primaryExpression != null 
+                                           && filter.FilterOperator is FilterOperator.Contains or FilterOperator.DoesNotContain)
             {
-                primaryExpression = Expression.Call(typeof(Enumerable), nameof(Enumerable.Any), new Type[] { collectionItemType },
+                var methodName = filter.FilterOperator == FilterOperator.Contains ? nameof(Enumerable.Any) : nameof(Enumerable.All);
+
+                primaryExpression = Expression.Call(typeof(Enumerable), methodName, new Type[] { collectionItemType },
                     GetNestedPropertyExpression(parameter, filter.Property), Expression.Lambda(primaryExpression, collectionItemTypeParameter));
             }
 


### PR DESCRIPTION
On the demo page, the Awards and WorkStatus DoesNotContain filtering shows invalid data. (Eg: does not countains Award3, Award4)
https://blazor.radzen.com/datagrid-filtervalue-template?theme=material3