### PR TITLE
set filter datetimes according to specified DateTimeKind

### DIFF
--- a/Radzen.Blazor/RadzenDataFilterProperty.cs
+++ b/Radzen.Blazor/RadzenDataFilterProperty.cs
@@ -150,12 +150,6 @@ namespace Radzen.Blazor
         [Parameter]
         public Type Type { get; set; }
 
-        /// <summary>
-        /// Gets or sets the kind of DateTime bind to control
-        /// </summary>
-        [Parameter]
-        public DateTimeKind Kind { get; set; } = DateTimeKind.Unspecified;
-
         Func<TItem, object> propertyValueGetter;
 
         internal object GetHeader()
@@ -250,7 +244,7 @@ namespace Radzen.Blazor
         {
             if ((FilterPropertyType == typeof(DateTimeOffset) || FilterPropertyType == typeof(DateTimeOffset?)) && value != null && value is DateTime?)
             {
-                DateTimeOffset? offset = DateTime.SpecifyKind((DateTime)value, Kind);
+                DateTimeOffset? offset = DateTime.SpecifyKind((DateTime)value, ((DateTime?)value).Value.Kind);
                 value = offset;
             }
 

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -620,12 +620,6 @@ namespace Radzen.Blazor
         public Type Type { get; set; }
 
         /// <summary>
-        /// Gets or sets the kind of DateTime bind to control
-        /// </summary>
-        [Parameter]
-        public DateTimeKind Kind { get; set; } = DateTimeKind.Unspecified;
-
-        /// <summary>
         /// Gets or sets the IFormatProvider used for FormatString.
         /// </summary>
         /// <value>The IFormatProvider.</value>
@@ -1123,7 +1117,7 @@ namespace Radzen.Blazor
         {
             if ((FilterPropertyType == typeof(DateTimeOffset) || FilterPropertyType == typeof(DateTimeOffset?)) && value != null && value is DateTime?)
             {
-                DateTimeOffset? offset = DateTime.SpecifyKind((DateTime)value, Kind);
+                DateTimeOffset? offset = DateTime.SpecifyKind((DateTime)value, ((DateTime?)value).Value.Kind);
                 value = offset;
             }
 

--- a/Radzen.Blazor/RadzenPivotField.razor.cs
+++ b/Radzen.Blazor/RadzenPivotField.razor.cs
@@ -351,7 +351,7 @@ namespace Radzen.Blazor
         {
             if ((FilterPropertyType == typeof(DateTimeOffset) || FilterPropertyType == typeof(DateTimeOffset?)) && value != null && value is DateTime?)
             {
-                DateTimeOffset? offset = DateTime.SpecifyKind((DateTime)value, Kind);
+                DateTimeOffset? offset = DateTime.SpecifyKind((DateTime)value, ((DateTime?)value).Value.Kind);
                 value = offset;
             }
 
@@ -418,12 +418,6 @@ namespace Radzen.Blazor
         /// <value>The data type.</value>
         [Parameter]
         public Type Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets the kind of DateTime bind to control
-        /// </summary>
-        [Parameter]
-        public DateTimeKind Kind { get; set; } = DateTimeKind.Unspecified;
 
         /// <summary>
         /// Disposes the component and removes it from the parent pivot grid.


### PR DESCRIPTION
This pull request ensures that DateTime/DateTimeOffset values used for RadzenDataGrid column filters are set according to the specified DateTimeKind before being sent to LoadData

https://github.com/radzenhq/radzen-blazor/issues/2316