### PR TITLE
Added ability to show group footers on every group level. Added a flag in the GroupDescriptor to control footer visibility.

### DIFF
--- a/Radzen.Blazor/Common.cs
+++ b/Radzen.Blazor/Common.cs
@@ -2623,6 +2623,12 @@ namespace Radzen
         public string FormatString { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to show the footer for the group.
+        /// </summary>
+        /// <value><c>true</c> if the footer should be shown; otherwise, <c>false</c>.</value>
+        public bool? ShowFooter { get; set; }
+
+        /// <summary>
         /// Gets the title of the group.
         /// </summary>
         /// <returns>System.String.</returns>

--- a/Radzen.Blazor/RadzenDataGridGroupFooterRow.razor
+++ b/Radzen.Blazor/RadzenDataGridGroupFooterRow.razor
@@ -15,7 +15,7 @@
 
             }
         }
-        @for (var j = 0; j < GetLevel() + (Grid.ShowGroupExpandColumn ? 0 : -1); j++)
+        @for (var j = 0; j < GetLevel() + (Grid.ShowGroupExpandColumn ? 0 : -1) + Grid.Groups.Count - GetLevel(); j++)
         {
             <td class="rz-col-icon">
                 <span class="rz-column-title"></span>
@@ -28,57 +28,57 @@
     </tr>
 }
 @code {
-        [Parameter]
-        public IList<RadzenDataGridColumn<TItem>> Columns { get; set; }
+    [Parameter]
+    public IList<RadzenDataGridColumn<TItem>> Columns { get; set; }
 
     GroupResult _groupResult;
-        [Parameter]
+    [Parameter]
     public GroupResult GroupResult
+    {
+        get
         {
-            get
+            return _groupResult;
+        }
+        set
+        {
+            if(_groupResult != value)
             {
-                return _groupResult;
-            }
-            set
-            {
-                if(_groupResult != value)
+                _groupResult = value;
+
+                var l = GetLevel();
+                var level = l > 0 ? l - 1 : l;
+
+                Group = new Group()
                 {
-                    _groupResult = value;
-
-                    var l = GetLevel();
-                    var level = l > 0 ? l - 1 : l;
-
-                    Group = new Group()
-                    {
-                        Level = level,
-                        GroupDescriptor = Grid.Groups[level],
-                        Data = _groupResult
-                    };
-                }
+                    Level = level,
+                    GroupDescriptor = Grid.Groups[level],
+                    Data = _groupResult
+                };
             }
         }
+    }
 
-        [Parameter]
-        public RadzenDataGrid<TItem> Grid { get; set; }
+    [Parameter]
+    public RadzenDataGrid<TItem> Grid { get; set; }
 
-        [Parameter]
-        public RadzenDataGridGroupRow<TItem> Parent { get; set; }
+    [Parameter]
+    public RadzenDataGridGroupRow<TItem> Parent { get; set; }
 
-        [Parameter]
-        public Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder Builder { get; set; }
+    [Parameter]
+    public Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder Builder { get; set; }
 
-        public Group Group { get; set; }
+    public Group Group { get; set; }
 
-        int GetLevel()
+    int GetLevel()
+    {
+        int i = 0;
+        var p = Parent;
+        while(p != null)
         {
-            int i = 0;
-            var p = Parent;
-            while(p != null)
-            {
-                p = p.Parent;
-                i++;
-            }
-
-            return i;
+            p = p.Parent;
+            i++;
         }
+
+        return i;
+    }
 }

--- a/Radzen.Blazor/RadzenDataGridGroupRow.razor
+++ b/Radzen.Blazor/RadzenDataGridGroupRow.razor
@@ -12,8 +12,8 @@
     }
 }
 <tr class="rz-group-row" @attributes="@rowArgs.Item2">
-     @if (Grid.ShowGroupExpandColumn)
-     {
+    @if (Grid.ShowGroupExpandColumn)
+    {
         @if (Group.GroupDescriptor != null)
         {
             @for (var i = 0; i < GetLevel(); i++)
@@ -86,7 +86,7 @@
     GroupResult _groupResult;
     [Parameter]
     public GroupResult GroupResult
-    { 
+    {
         get
         {
             return _groupResult;
@@ -99,11 +99,11 @@
 
                 var level = GetLevel();
                 Group = new Group()
-                    {
-                        Level = level,
-                        GroupDescriptor = Grid.Groups?.ElementAtOrDefault(level),
-                        Data = _groupResult
-                    };
+                {
+                    Level = level,
+                    GroupDescriptor = Grid.Groups?.ElementAtOrDefault(level),
+                    Data = _groupResult
+                };
             }
         }
     }
@@ -113,92 +113,103 @@
     {
         get
         {
-             var columnsOfGrid = Columns
-                   .Where(c => c.GetVisible())
-                   .ToList();
+            var columnsOfGrid = Columns
+                  .Where(c => c.GetVisible())
+                  .ToList();
             return columnsOfGrid.Sum(c => CountVisibleLeafColumns<TItem>(c));
-            }
         }
+    }
 
-        [Parameter]
-        public RadzenDataGrid<TItem> Grid { get; set; }
+    [Parameter]
+    public RadzenDataGrid<TItem> Grid { get; set; }
 
-        [Parameter]
-        public RadzenDataGridGroupRow<TItem> Parent { get; set; }
+    [Parameter]
+    public RadzenDataGridGroupRow<TItem> Parent { get; set; }
 
-        [Parameter]
-        public Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder Builder { get; set; }
+    [Parameter]
+    public Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder Builder { get; set; }
 
-        RenderFragment DrawDataRows(bool groupFootersOnly = false)
+    RenderFragment DrawDataRows(bool groupFootersOnly = false)
+    {
+        return new RenderFragment(builder =>
         {
-            return new RenderFragment(builder =>
+            if(GroupResult.Subgroups != null)
             {
-                if(GroupResult.Subgroups != null)
+                foreach(var g in GroupResult.Subgroups)
                 {
-                    foreach(var g in GroupResult.Subgroups)
+                    builder.OpenComponent(0, typeof(RadzenDataGridGroupRow<TItem>));
+                    builder.AddAttribute(1, "Columns", Columns);
+                    builder.AddAttribute(3, "Grid", Grid);
+                    builder.AddAttribute(3, "Parent", this);
+                    builder.AddAttribute(5, "GroupResult", g);
+                    builder.AddAttribute(6, "Builder", builder);
+                    builder.CloseComponent();
+                }
+
+                if (Group.GroupDescriptor.ShowFooter.GetValueOrDefault() && Columns.Where(c => c.GroupFooterTemplate != null).Any())
+                {
+                    builder.OpenComponent(7, typeof(RadzenDataGridGroupFooterRow<TItem>));
+                    builder.AddAttribute(8, "Columns", Columns);
+                    builder.AddAttribute(9, "Grid", Grid);
+                    builder.AddAttribute(10, "GroupResult", GroupResult);
+                    builder.AddAttribute(11, "Builder", builder);
+                    builder.AddAttribute(12, "Parent", this);
+                    builder.CloseComponent();
+                }
+            }
+            else
+            {
+                if(!groupFootersOnly)
+                {
+                    int i = 0;
+                    foreach(var item in GroupResult.Items)
                     {
-                        builder.OpenComponent(0, typeof(RadzenDataGridGroupRow<TItem>));
+                        builder.OpenComponent(0, typeof(RadzenDataGridRow<TItem>));
                         builder.AddAttribute(1, "Columns", Columns);
+                        builder.AddAttribute(2, "Index", i);
                         builder.AddAttribute(3, "Grid", Grid);
-                        builder.AddAttribute(3, "Parent", this);
-                        builder.AddAttribute(5, "GroupResult", g);
-                        builder.AddAttribute(6, "Builder", builder);
-                        builder.CloseComponent();
-                    }
-                }
-                else
-                {
-                    if(!groupFootersOnly)
-                    {
-                        int i = 0;
-                        foreach(var item in GroupResult.Items)
+                        builder.AddAttribute(4, "TItem", typeof(TItem));
+                        builder.AddAttribute(5, "Item", item);
+                        builder.AddAttribute(6, "InEditMode", Grid.IsRowInEditMode((TItem)item));
+
+                        if (Grid.editContexts.ContainsKey((TItem)item))
                         {
-                            builder.OpenComponent(0, typeof(RadzenDataGridRow<TItem>));
-                            builder.AddAttribute(1, "Columns", Columns);
-                            builder.AddAttribute(2, "Index", i);
-                            builder.AddAttribute(3, "Grid", Grid);
-                            builder.AddAttribute(4, "TItem", typeof(TItem));
-                            builder.AddAttribute(5, "Item", item);
-                            builder.AddAttribute(6, "InEditMode", Grid.IsRowInEditMode((TItem)item));
-
-                            if (Grid.editContexts.ContainsKey((TItem)item))
-                            {
-                                builder.AddAttribute(7, nameof(RadzenDataGridRow<TItem>.EditContext), Grid.editContexts[(TItem)item]);
-                            }
-
-                            builder.CloseComponent();
-                            i++;
+                            builder.AddAttribute(7, nameof(RadzenDataGridRow<TItem>.EditContext), Grid.editContexts[(TItem)item]);
                         }
-                    }
 
-                    if (Columns.Where(c => c.GroupFooterTemplate != null).Any())
-                    {
-                        builder.OpenComponent(7, typeof(RadzenDataGridGroupFooterRow<TItem>));
-                        builder.AddAttribute(8, "Columns", Columns);
-                        builder.AddAttribute(9, "Grid", Grid);
-                        builder.AddAttribute(10, "GroupResult", GroupResult);
-                        builder.AddAttribute(11, "Builder", builder);
-                        builder.AddAttribute(12, "Parent", this);
                         builder.CloseComponent();
+                        i++;
                     }
                 }
-            });
-        }
 
-        public Group Group { get; set; }
-
-        int GetLevel()
-        {
-            int i = 0;
-            var p = Parent;
-            while(p != null)
-            {
-                p = p.Parent;
-                i++;
+                if (Group.GroupDescriptor.ShowFooter.GetValueOrDefault(true) && Columns.Where(c => c.GroupFooterTemplate != null).Any())
+                {
+                    builder.OpenComponent(7, typeof(RadzenDataGridGroupFooterRow<TItem>));
+                    builder.AddAttribute(8, "Columns", Columns);
+                    builder.AddAttribute(9, "Grid", Grid);
+                    builder.AddAttribute(10, "GroupResult", GroupResult);
+                    builder.AddAttribute(11, "Builder", builder);
+                    builder.AddAttribute(12, "Parent", this);
+                    builder.CloseComponent();
+                }
             }
+        });
+    }
 
-            return i;
+    public Group Group { get; set; }
+
+    int GetLevel()
+    {
+        int i = 0;
+        var p = Parent;
+        while(p != null)
+        {
+            p = p.Parent;
+            i++;
         }
+
+        return i;
+    }
 
     private int CountVisibleLeafColumns<T>(RadzenDataGridColumn<TItem> column)
     {


### PR DESCRIPTION
Currently RadzenDataGrid renders group footers on for the inner most group. It is also possible to have a grand total for all data in the grid. In the example below, data is grouped by Country and then by City. Average age is aggregated in the footer via GroupFooterTemplate and in the grand total via FooterTemplate. This display the average age by city and in total, but there is no way to see it aggregated by country.
<img width="1586" height="590" alt="image" src="https://github.com/user-attachments/assets/7c571d00-b6db-4288-85e0-0cd74fae579b" />

The goal of this pull request is to address this issue without changing current DataGrid behavior. The result of the new grouping setup looks like the example below, with the aggregates per country also displayed.

<img width="1589" height="663" alt="image" src="https://github.com/user-attachments/assets/b60e1a71-41b7-4ad7-98c2-be20e1a58881" />

This behavior is configured by the ShowFooter property of the GroupDescriptor, if it's not specified. only group footers for the inner most group will be displayed, as it was before. 

For the example above the following groups were applied:
`args.Grid.Groups.Add(new GroupDescriptor() { Property = "Country", SortOrder = SortOrder.Descending, ShowFooter = true });
args.Grid.Groups.Add(new GroupDescriptor() { Property = "City", SortOrder = SortOrder.Descending });` 

With this new capability, it will be also possible to render group footers only for the country group, but not for the city.
`            args.Grid.Groups.Add(new GroupDescriptor() { Property = "Country", SortOrder = SortOrder.Descending, ShowFooter = true });
            args.Grid.Groups.Add(new GroupDescriptor() { Property = "City", SortOrder = SortOrder.Descending, ShowFooter = false });`

<img width="1591" height="561" alt="image" src="https://github.com/user-attachments/assets/a73e77cb-ad18-4d96-ac67-40007246ceb0" />

ShowFooter property nullable property and is null by default. It is interpreted as true, for the inner-most group and false for all others. 
  