### PR TITLE
Add Support for Immediate changes in TextArea

### DIFF
--- a/Radzen.Blazor/RadzenTextArea.razor
+++ b/Radzen.Blazor/RadzenTextArea.razor
@@ -4,5 +4,5 @@
 @if (Visible)
 {
     <textarea @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" rows="@Rows" cols="@Cols" style="@Style" @attributes="Attributes" class="@GetCssClass()"
-              placeholder="@CurrentPlaceholder" maxlength="@MaxLength" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
+              placeholder="@CurrentPlaceholder" maxlength="@MaxLength" value="@Value" @oninput="@OnInput" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
 }

--- a/Radzen.Blazor/RadzenTextArea.razor.cs
+++ b/Radzen.Blazor/RadzenTextArea.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
 
 namespace Radzen.Blazor
 {
@@ -60,15 +61,45 @@ namespace Radzen.Blazor
         public int Cols { get; set; } = 20;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the component should update the value immediately when the user types. Set to <c>false</c> by default.
+        /// </summary>
+        [Parameter]
+        public bool Immediate { get; set; }
+
+        /// <summary>
         /// Handles the <see cref="E:Change" /> event.
         /// </summary>
         /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
-        protected async System.Threading.Tasks.Task OnChange(ChangeEventArgs args)
+        protected Task OnChange(ChangeEventArgs args)
         {
-            Value = $"{args.Value}";
+            if (Immediate)
+                return Task.CompletedTask;
+
+            return OnValueChanged(args.Value?.ToString());
+        }
+
+        /// <summary>
+        /// Handles the <see cref="E:Input" /> event.
+        /// </summary>
+        /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
+        protected Task OnInput(ChangeEventArgs args)
+        {
+            if (!Immediate)
+                return Task.CompletedTask;
+
+            return OnValueChanged(args.Value?.ToString());
+        }
+
+        protected async Task OnValueChanged(string value)
+        {
+            Value = value;
 
             await ValueChanged.InvokeAsync(Value);
-            if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
+            if (FieldIdentifier.FieldName != null)
+            {
+                EditContext?.NotifyFieldChanged(FieldIdentifier);
+            }
+
             await Change.InvokeAsync(Value);
         }
 

--- a/RadzenBlazorDemos/Pages/TextAreaConfig.razor
+++ b/RadzenBlazorDemos/Pages/TextAreaConfig.razor
@@ -31,10 +31,16 @@
         </RadzenCard>
     </RadzenColumn>
     <RadzenColumn Size="12" SizeMD="4">
-        <RadzenCard>
-            <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Auto-resize TextArea</RadzenText>
-            <RadzenTextArea oninput="event.target.style.height = Math.max(event.target.clientHeight, event.target.scrollHeight) + 'px';" Change=@(args => OnChange(args, "Auto-resize")) Style="width: 100%" aria-label="Auto-resize" />
-        </RadzenCard>
+	    <RadzenCard>
+		    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Auto-resize TextArea</RadzenText>
+		    <RadzenTextArea oninput="event.target.style.height = Math.max(event.target.clientHeight, event.target.scrollHeight) + 'px';" Change=@(args => OnChange(args, "Auto-resize")) Style="width: 100%" aria-label="Auto-resize" />
+	    </RadzenCard>
+    </RadzenColumn>
+    <RadzenColumn Size="12" SizeMD="4">
+	    <RadzenCard>
+		    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.H3">Change on every input</RadzenText>
+            <RadzenTextArea Immediate="true" Change=@(args => OnChange(args, "TextBox with change on every input")) @bind-Value=@value aria-label="TextArea with change on every input" />
+	    </RadzenCard>
     </RadzenColumn>
 </RadzenRow>
 


### PR DESCRIPTION
after the implementation of immediate on the textfield was useful for us, as we implemented a textbox that processes input and checks for shortcuts (like '!uc008' replaces it with a big long text).

however, we would like to do the same with the text area, which this implements and can be tested in the demo page