### PR TITLE
Cleanup RadzenStack's style compiling to not generate an extra semicolon

### DIFF
--- a/Radzen.Blazor/RadzenStack.razor.cs
+++ b/Radzen.Blazor/RadzenStack.razor.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using System;
 using System.Linq;
-using System.Text;
 
 namespace Radzen.Blazor
 {
@@ -94,18 +93,18 @@ namespace Radzen.Blazor
 
             if (Wrap == FlexWrap.Wrap)
             {
-                wrap = ";flex-wrap:wrap;";
+                wrap = "flex-wrap:wrap;";
             }
             else if (Wrap == FlexWrap.NoWrap)
             {
-                wrap = ";flex-wrap:nowrap;";
-            } 
+                wrap = "flex-wrap:nowrap;";
+            }
             else if (Wrap == FlexWrap.WrapReverse)
             {
-                wrap = ";flex-wrap:wrap-reverse;";
+                wrap = "flex-wrap:wrap-reverse;";
             }
 
-            return $"{Style}{(!string.IsNullOrEmpty(Style) && !Style.EndsWith(";") ? ";" : "")}{(!string.IsNullOrEmpty(Gap) ? "--rz-gap:" + Gap + (Gap.All(c => Char.IsDigit(c)) ? "px;" : "") : "")}{wrap}";
+            return $"{Style}{(!string.IsNullOrEmpty(Style) && !Style.EndsWith(";") ? ";" : "")}{(!string.IsNullOrEmpty(Gap) ? "--rz-gap:" + Gap + (Gap.All(c => Char.IsDigit(c)) ? "px;" : ";") : "")}{wrap}";
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
is caused if gap is not filled in, which makes it add wrap, which has a `;` before and after the flex-wrap while it doesn't need it before it