### PR TITLE
Topmost visible section instead of closest above center

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -2574,37 +2574,37 @@ window.Radzen = {
 
       this.unregisterScrollListener(element);
       element.scrollHandler = () => {
-        const center = (container.tagName === 'HTML' ? 0 : container.getBoundingClientRect().top) + container.clientHeight / 2;
-
-        let min = Number.MAX_SAFE_INTEGER;
-        let match;
-
-        for (let i = 0; i < elements.length; i++) {
-          const element = elements[i];
-          if (!element) continue;
-
-          const rect = element.getBoundingClientRect();
-          const diff = Math.abs(rect.top - center);
-
-          if (!match && rect.top < center) {
-            match = selectors[i];
-            min = diff;
-            continue;
-          }
-
-          if (match && rect.top >= center) continue;
-
-          if (diff < min) {
-            match = selectors[i];
-            min = diff;
-          }
-        }
-
-        if (match !== currentSelector) {
-          currentSelector = match;
-          this.navigateTo(currentSelector, false);
-          ref.invokeMethodAsync('ScrollIntoView', currentSelector);
-        }
+        const contTop = container.tagName === 'HTML' ? 0 : container.getBoundingClientRect().top;
+	    const center = contTop + container.clientHeight / 2; 
+	  
+	    let min = Number.MAX_SAFE_INTEGER; 
+	    let match; 
+	  
+	    for (let i = 0; i < elements.length; i++) { 
+	      const element = elements[i]; 
+	      if (!element) continue; 
+	  
+	      const rect = element.getBoundingClientRect(); 
+	  
+	      if (!match && rect.top < center) { 
+	        match = selectors[i]; 
+		    min = rect.top; 
+		    continue; 
+	      } 
+	  
+	      if (match && rect.top >= center) continue; 
+	   
+	      if (match && (min < contTop || rect.top < min && rect.top >= contTop)) { 
+		    match = selectors[i]; 
+		    min = rect.top; 
+	      } 
+	    } 
+	  
+	    if (match !== currentSelector) { 
+	      currentSelector = match; 
+	      this.navigateTo(currentSelector, false); 
+	      ref.invokeMethodAsync('ScrollIntoView', currentSelector); 
+	    } 
       };
 
       document.addEventListener('scroll', element.scrollHandler, true);


### PR DESCRIPTION
Referencing https://github.com/radzenhq/radzen-blazor/issues/2328, take the top most visible section as url reference instead of the clostest element.top to and above center line of app container