### PR TITLE
Add CloseOnClickOutside parameter to Popup

### DIFF
--- a/Radzen.Blazor/Rendering/Popup.razor
+++ b/Radzen.Blazor/Rendering/Popup.razor
@@ -9,6 +9,8 @@
 </div>
 
 @code {
+    #nullable disable
+
     bool open;
     ElementReference target;
 
@@ -41,7 +43,20 @@
         if (open)
         {
             await Open.InvokeAsync(null);
-            await JSRuntime.InvokeVoidAsync("Radzen.openPopup", target, GetId(), CloseOnClickOutside, null, null, null, Reference, nameof(OnClose), true, AutoFocusFirstElement, disableSmartPosition);
+            await JSRuntime.InvokeVoidAsync(
+                "Radzen.openPopup",
+                target,
+                GetId(),
+                false,
+                null,
+                null,
+                null,
+                Reference,
+                nameof(OnClose),
+                CloseOnClickOutside,      // <-- mapped to closeOnDocumentClick
+                AutoFocusFirstElement,
+                disableSmartPosition
+            );
         }
         else
         {


### PR DESCRIPTION
Add a parameter called CloseOnClickOutside Popup, default is true. This maintains the current behavior. If set false, the Popup will remain open with the user click outside of it.