### PR TITLE
feat: keyboard key that triggers opening the popup

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -132,13 +132,22 @@ namespace Radzen.Blazor
             return args;
         }
 
+        /// <summary>
+        /// Gets or sets the keyboard key that triggers opening the popup when <see cref="OpenOnFocus"/> is enabled.
+        /// Default is <c>"Enter"</c>.
+        /// </summary>
+        /// <value>The keyboard key used to open the popup.</value>
+        [Parameter]
+        public string OpenPopupKey { get; set; } = "Enter";
+
         private async Task OnFocus()
         {
             if (OpenOnFocus)
             {
-                await OpenPopup("Enter", false);
+                await OpenPopup(OpenPopupKey, false);
             }
         }
+
         internal override async Task ClosePopup(string key)
         {
             bool of = false;

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -128,11 +128,19 @@ namespace Radzen.Blazor
         [Parameter]
         public bool OpenOnFocus { get; set; }
 
+        /// <summary>
+        /// Gets or sets the keyboard key that triggers opening the popup when <see cref="OpenOnFocus"/> is enabled.
+        /// Default is <c>"Enter"</c>.
+        /// </summary>
+        /// <value>The keyboard key used to open the popup.</value>
+        [Parameter]
+        public string OpenPopupKey { get; set; } = "Enter";
+
         private async Task OnFocus()
         {
             if (OpenOnFocus)
             {
-                await OpenPopup("Enter", false);
+                await OpenPopup(OpenPopupKey, false);
             }
         }
 


### PR DESCRIPTION
**Description:**
Currently, the key used to open the popup inside Radzen components is hard-coded as `"Enter"`, which prevents developers from customizing this behavior based on their UI/UX requirements.

**Why this change is needed:**
Some applications require different keyboard shortcuts depending on accessibility rules, localization, platform conventions, or specific workflow needs. Because the key value is fixed in the component code, developers have no way to configure or override the trigger key for opening the popup when `OpenOnFocus` is enabled. This limitation reduces flexibility, especially when building reusable or domain-specific components.

**Proposed solution:**
Introduce a new component parameter:

```csharp
/// <summary>
/// Gets or sets the keyboard key that triggers opening the popup when <see cref="OpenOnFocus"/> is enabled.
/// Default is <c>"Enter"</c>.
/// </summary>
/// <value>The keyboard key used to open the popup.</value>
[Parameter]
public string OpenPopupKey { get; set; } = "Enter";
```

Then replace the hard-coded `"Enter"` value with this parameter:

```csharp
private async Task OnFocus()
{
    if (OpenOnFocus)
    {
        await OpenPopup(OpenPopupKey, false);
    }
}
```

This keeps current behavior intact while allowing developers to set any desired key, e.g. `"Space"`, `"F4"`, or localized/custom key names.

**Impact:**
This change is fully backward-compatible because the default value remains `"Enter"`. Existing applications will continue to work without modification. At the same time, developers gain the ability to customize the popup activation key for advanced scenarios, improving accessibility, flexibility, and component reusability.
