### PR TITLE
Textbox/TextArea : add debounce parameter to make Immediate easier on the UI Thread

### DIFF
--- a/Radzen.Blazor/RadzenTextArea.razor
+++ b/Radzen.Blazor/RadzenTextArea.razor
@@ -5,12 +5,12 @@
 {
     if (Immediate)
     {
-    <textarea @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" rows="@Rows" cols="@Cols" style="@Style" @attributes="Attributes" class="@GetCssClass()"
-        placeholder="@CurrentPlaceholder" maxlength="@MaxLength" value="@Value" @oninput="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
+        <textarea @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" rows="@Rows" cols="@Cols" style="@Style" @attributes="Attributes" class="@GetCssClass()"
+                  placeholder="@CurrentPlaceholder" maxlength="@MaxLength" value="@CurrentValue" @oninput="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
     }
     else
     {
-    <textarea @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" rows="@Rows" cols="@Cols" style="@Style" @attributes="Attributes" class="@GetCssClass()"
-        placeholder="@CurrentPlaceholder" maxlength="@MaxLength" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
+        <textarea @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" rows="@Rows" cols="@Cols" style="@Style" @attributes="Attributes" class="@GetCssClass()"
+                  placeholder="@CurrentPlaceholder" maxlength="@MaxLength" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
     }
 }

--- a/Radzen.Blazor/RadzenTextArea.razor.cs
+++ b/Radzen.Blazor/RadzenTextArea.razor.cs
@@ -67,12 +67,48 @@ namespace Radzen.Blazor
         public bool Immediate { get; set; }
 
         /// <summary>
+        /// Gets or sets the debounce delay in milliseconds when Immediate is true.
+        /// This controls how long to wait after the user stops typing before triggering the value update.
+        /// Only applies when Immediate is true. Set to 0 to disable debouncing.
+        /// </summary>
+        /// <value>The debounce delay in milliseconds. Default is 0, aka disabled</value>
+        [Parameter]
+        public int DebounceDelay { get; set; } = 0;
+
+        /// <summary>
+        /// Gets the current input value, which may be the intermediate value while typing or the bound Value.
+        /// </summary>
+        protected string CurrentValue => _currentValueBuffer ?? Value;
+        private string _currentValueBuffer;
+
+        /// <summary>
         /// Handles the <see cref="E:Change" /> event.
         /// </summary>
         /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
         protected async Task OnChange(ChangeEventArgs args)
         {
-            Value = $"{args.Value}";
+            var newValue = $"{args.Value}";
+            _currentValueBuffer = newValue;
+            await DebounceValueUpdate(newValue);
+        }
+
+        private Task DebounceValueUpdate(string value)
+        {
+            //if immediate is not set, or there is no debounce delay, update value immediately
+            if (!Immediate || DebounceDelay <= 0)
+                return SetValue(value);
+
+            Debounce(() => InvokeAsync(() => SetValue(value)), DebounceDelay);
+
+            //return empty task so the event is handled. the task above will execute the update later
+            return Task.CompletedTask;
+        }
+
+
+        private async Task SetValue(string newValue)
+        {
+            _currentValueBuffer = null;
+            Value = newValue;
 
             await ValueChanged.InvokeAsync(Value);
 

--- a/Radzen.Blazor/RadzenTextBox.razor
+++ b/Radzen.Blazor/RadzenTextBox.razor
@@ -4,7 +4,7 @@
     if (Immediate)
     {
     <input @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-        placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" value="@Value" @oninput="@OnChange" />
+        placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" value="@CurrentValue" @oninput="@OnChange" />
     }
     else
     {


### PR DESCRIPTION
We noticed that when using immediate if you would type faster than it takes to process the input & re-render it will start acting weird. some text is removed, input shows up delayed, drops some letters being typed etc etc.

Sadly this only happens if the UI is very busy/has a lot of controls etc etc so its very hard to reproduce -_-
I used the existing debounce classes to delay the processing of the input, but only if the delay is given which is 0 by default so it behaves as before.