### PR TITLE
Set default MinWidth to 80px to prevent columns from disappearin…

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -455,7 +455,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The min-width.</value>
         [Parameter]
-        public string MinWidth { get; set; } = 80px;
+        public string MinWidth { get; set; } = "80px";
 
 
         /// <summary>


### PR DESCRIPTION
## issue
When resizing columns to minimum width, they could shrink to zero and 
become completely hidden with no way to restore them. 

## fix 
Setting a default MinWidth of 80px ensures columns remain visible and interactive while 
still allowing user customization.
