### PR TITLE
Allow Specifying the interactive SortOrder Sequence on Data Grids

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -278,6 +278,12 @@ namespace Radzen.Blazor
         [Parameter]
         public SortOrder? SortOrder { get; set; }
 
+        /// <summary>
+        /// Gets or sets the sequence of the <see cref="Radzen.SortOrder"/>s to use when sorting the column interactively.
+        /// </summary>
+        [Parameter]
+        public SortOrder?[] SortOrderSequence { get; set; } = [Radzen.SortOrder.Ascending, Radzen.SortOrder.Descending, null];
+
         bool visible = true;
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="RadzenDataGridColumn{TItem}"/> is visible.

--- a/Radzen.Blazor/RadzenPivotDataGrid.razor
+++ b/Radzen.Blazor/RadzenPivotDataGrid.razor
@@ -198,7 +198,7 @@
                                 <tr class="rz-pivot-header-row">
                                 <th class="rz-pivot-column-header @(isSortable ? "rz-sortable-column" : "")" style="width:100%;margin-top:5px;">
                                     <div class="rz-pivot-header-content-wrapper">
-                                        <div @onclick="@(args => OnColumnSort(args, column))"
+                                        <div @onclick="@(args => OnAggregateSort(args, column))"
                                                 @onkeydown="@(isSortable ? OnSortKeyPressed : (Func<KeyboardEventArgs, Task>)null)"
                                                 class="rz-pivot-header-content @(isSortable ? "rz-sortable" : "")"
                                                 tabindex="@(isSortable ? "0" : null)"

--- a/Radzen.Blazor/RadzenPivotField.razor.cs
+++ b/Radzen.Blazor/RadzenPivotField.razor.cs
@@ -31,6 +31,12 @@ namespace Radzen.Blazor
         public SortOrder? SortOrder { get; set; }
 
         /// <summary>
+        /// Gets or sets the sequence of the <see cref="Radzen.SortOrder"/>s to use when sorting the column interactively.
+        /// </summary>
+        [Parameter]
+        public SortOrder?[] SortOrderSequence { get; set; } = [Radzen.SortOrder.Ascending, Radzen.SortOrder.Descending, null];
+
+        /// <summary>
         /// Gets or sets a value indicating whether this column is sortable.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
With this PR it will be possible to specify the Sequence of SortOrders to use on DataGrid columns or PivotGrid fields for interactive sorting.

The sequence is used to determine the next sort order when a user interactively sorts a column e.g. by clicking the column. This does not prevent the column to have a SortOrder that is not in the sequence, e.g. via programmatic sorting.

Resolves #2236 