### PR TITLE
RadzenPivotDataGrid AddPivotAggregate exposed

### DIFF
--- a/Radzen.Blazor/RadzenPivotDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenPivotDataGrid.razor.cs
@@ -735,8 +735,12 @@ namespace Radzen.Blazor
                 StateHasChanged();
             }
         }
-
-        internal void AddPivotAggregate(RadzenPivotAggregate<TItem> aggregate)
+        
+        /// <summary>
+        /// Adds a pivot aggregate to the pivot grid if it does not already exist.
+        /// </summary>
+        /// <param name="aggregate">The pivot aggregate to add.</param>
+        public void AddPivotAggregate(RadzenPivotAggregate<TItem> aggregate)
         {
             if (!allPivotAggregates.Contains(aggregate))
             {


### PR DESCRIPTION
`AddPivotAggregate` needs to be exposed to be able to initialize a `RadzenPivotDataGrid` in C# instead of Razor. This was probably meant to be part of https://github.com/radzenhq/radzen-blazor/commit/135a0bbe5c83a7d477f328ad130259af2b0a5101 where `AddPivotRow` and `AddPivotColumn` were exposed. 