### PR TITLE
RadzenDropdown: correctly close popup on item selection, ignoring OpenOnFocus #1295

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -364,8 +364,7 @@ namespace Radzen.Blazor
             {
                 if (!Multiple && !isFromKey)
                 {
-                    isOpen = false;
-                    await JSRuntime.InvokeVoidAsync("Radzen.closePopup", PopupID, Reference, nameof(OnClose));
+                    await ClosePopup("Enter");
                 }
 
                 if (ClearSearchAfterSelection)


### PR DESCRIPTION
The PR fixes #1295, and uses the ClosePopup function to handle the focus it gets, and not reopen the popup on selection.

can be tested by giving the dropdown in `DropDownFiltering.razor` a `OpenOnFocus=true`, and overwriting the `OnAfterRender` with the following : 

```
protected override async Task OnAfterRenderAsync(bool firstRender)
{
    if (firstRender)
    {
        await radzenDropDown.FocusAsync();
    }
}
```

then selecting an item in the dropdown