### PR TITLE
As per Issue 2388 - Add another condition for overlapping appointments

### DIFF
--- a/Radzen.Blazor/Rendering/MonthView.razor
+++ b/Radzen.Blazor/Rendering/MonthView.razor
@@ -153,6 +153,12 @@
                         // Overlap, we cannot place the appointment in this band
                         continue;
                     }
+                    
+                    if(lastAppointmentInBand.Data.Start < slot.Start && lastAppointmentInBand.Data.End > slot.End)
+                    {
+                        // Overlap, we cannot place the appointment in this band
+                        continue;
+					}
 
                     // No overlap, we can add the appointment to this band if there is space for it. A band can contain appointments whose total duration is less than one week.
                     var bandDuration = band.Sum(a => a.Data.End.Subtract(days[a.DayIndex].Start).TotalDays);


### PR DESCRIPTION
As per [issue 2388](https://github.com/radzenhq/radzen-blazor/issues/2388)

This PR adds another condition for overlapping appointments that resolves the above issue.

This is the code from the example the Issuer created in GitHub that can now be pasted into a Radzen example -

```
@using System.Globalization

<RadzenScheduler @ref="_scheduler"
                 style="height: 768px;"
                 SlotRender="@OnSlotRender"
                 TItem="MyAppointment"
                 Data="_appointments"
                 AppointmentRender="args => AppointmentRender(args)"
                 LoadData="args => LoadDataAsync(args)"
                 StartProperty="@nameof(Appointment.Start)"
                 EndProperty="@nameof(Appointment.End)"
                 TextProperty="@nameof(Appointment.Text)">
    <RadzenMonthView Text=""/>
</RadzenScheduler>

@code
{
    private class MyAppointment
    {
        public DateTime Start { get; set; }
        public DateTime End { get; set; }
        public string Text { get; set; }
        public string Color { get; init; }
    }

    private RadzenScheduler<MyAppointment>? _scheduler;
    private readonly CultureInfo _culture = new("da-DK");
    private List<MyAppointment> _appointments = new List<MyAppointment>();

    void OnSlotRender(SchedulerSlotRenderEventArgs args)
    {
        // Highlight today in month view
        if (args.Start.Date == DateTime.Today)
        {
            args.Attributes["style"] = "background: var(--rz-scheduler-highlight-background-color, rgba(255,220,40,.2));";
        }
    }

    private void AppointmentRender(SchedulerAppointmentRenderEventArgs<MyAppointment> args)
    {
        args.Attributes["style"] = $"background: {args.Data.Color}";
    }

    private async Task LoadDataAsync(SchedulerLoadDataEventArgs args)
    {
        if (_scheduler != null)
        {
            _scheduler.DefaultCulture = _culture;
        }

        _appointments.Add(new MyAppointment
            {
                Start = new DateTime(2025,12,8),
                End = new DateTime(2025,12,8),
                Color = "Orange",
                Text = "8th of Dec",
            });

        _appointments.Add(new MyAppointment
            {
                Start = new DateTime(2025,12,9),
                End = new DateTime(2025,12,9),
                Color = "Purple",
                Text = "9th of Dec",
            });

        _appointments.Add(new MyAppointment
            {
                Start = new DateTime(2025,11,18),
                End = new DateTime(2025,12,9, 23, 59, 00),
                Color = "Red",
                Text = "18th of Nov to 9th of Dec",
            }); 
    }
}


```

Regards

Paul