### PR TITLE
Radzen Examples Split View

### DIFF
--- a/RadzenBlazorDemos/Shared/RadzenExample.razor
+++ b/RadzenBlazorDemos/Shared/RadzenExample.razor
@@ -45,6 +45,18 @@
                     <CodeViewer ComponentName="@ComponentName" @bind-Value="@source" ComponentSource="@Source" PageName="@ExampleUrl" Compiled="OnCompiled" />
                 </div>
             </RadzenTabsItem>
+            <RadzenTabsItem Text="Split View" Title="Split view between example and source code">
+                <RadzenSplitter>
+                    <RadzenSplitterPane Size="50%">
+                        @(dynamicContent ?? ChildContent)
+                    </RadzenSplitterPane>
+                    <RadzenSplitterPane>
+                        <div class="source-tab-item rz-pb-2">
+                            <CodeViewer ComponentName="@ComponentName" @bind-Value="@source" ComponentSource="@Source" PageName="@ExampleUrl" Compiled="OnCompiled" />
+                        </div>
+                    </RadzenSplitterPane>
+                </RadzenSplitter>
+            </RadzenTabsItem>
             @foreach (var p in AdditionalSourceCodePages)
             {
             <RadzenTabsItem Text="@Path.GetFileName(p)" Icon="code">
@@ -133,7 +145,8 @@
             builder.CloseComponent();
         };
 
-        selectedIndex = 0;
+		// If split view was selected, stay in split view after recompilation
+        selectedIndex = selectedIndex & 2;
     }
 
     public void Dispose()


### PR DESCRIPTION
Hi guys

Something that's niggled me a little when using the example site. I do like to scroll through the code of an example while being able to refer to the rendered output. Not too easy when switching tabs. Also, you may scroll to some code, and then want to view how that affects the output. When switching back, you lose your position in the code window.

This PR adds a split view to the `RadzenExample` component. Not only can you review the code while viewing the output, but if you make a change and run your code, the output is updated and your code position remains.

I find it a much more pleasant experience.

What do you think?

BTW, if you do like the idea, there are some CSS issues that I did not know how to deal with. You will notice that the top of the `CodeViewer` component is trimmed. Not sure why placing it in a `RadzenSplitterPane` should do that.

Also, I assume that the `CodeViewer` or the `Monaco` component must have a fixed height, and cannot be dynamic?

Regards

Paul
