### PR TITLE
Fix filtering in RadzenAutoComplete if Data is simple list of strings

### DIFF
--- a/Radzen.Blazor.Tests/AutoCompleteTests.cs
+++ b/Radzen.Blazor.Tests/AutoCompleteTests.cs
@@ -1,6 +1,9 @@
-﻿using Bunit;
+﻿using System.Collections;
+using Bunit;
 using Xunit;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Radzen.Blazor.Tests
 {
@@ -134,6 +137,31 @@ namespace Radzen.Blazor.Tests
             Assert.Equal("given-name", AutoCompleteType.FirstName.GetAutoCompleteValue());
             Assert.Equal("additional-name", AutoCompleteType.MiddleName.GetAutoCompleteValue());
             Assert.Equal("family-name", AutoCompleteType.LastName.GetAutoCompleteValue());
+        }
+
+        [Fact]
+        public void AutoComplete_Filters_StringList()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            var data = new List<string> { "Apple", "Banana", "Cherry" };
+
+            var component = ctx.RenderComponent<AutoCompleteWithAccessibleView>(parameters =>
+            {
+                parameters
+                    .Add(p => p.Data, data)
+                    .Add(p => p.SearchText, "Ban")
+                    .Add(p => p.OpenOnFocus, true);
+            });
+            
+            Assert.Contains("Banana", component.Instance.CurrentView.OfType<string>());
+            Assert.DoesNotContain("Apple", component.Instance.CurrentView.OfType<string>());
+            Assert.DoesNotContain("Cherry", component.Instance.CurrentView.OfType<string>());
+        }
+        
+        private sealed class AutoCompleteWithAccessibleView : RadzenAutoComplete
+        {
+            public IEnumerable CurrentView => View;
         }
     }
 }

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -254,7 +254,7 @@ namespace Radzen.Blazor
             {
                 if (Query != null)
                 {
-                    return TextProperty != null ? Query.Where(TextProperty, searchText ?? string.Empty, FilterOperator, FilterCaseSensitivity) : Query;
+                    return Query.Where(TextProperty ?? string.Empty, searchText ?? string.Empty, FilterOperator, FilterCaseSensitivity);
                 }
 
                 return null;


### PR DESCRIPTION
This PR should fix the filtering of data in RadzenAutoComplete if the data is a simple list of strings (issue #2421).