### PR TITLE
Fix TextProperty documentation in RadzenScheduler

### DIFF
--- a/Radzen.Blazor/RadzenScheduler.razor.cs
+++ b/Radzen.Blazor/RadzenScheduler.razor.cs
@@ -156,7 +156,7 @@ namespace Radzen.Blazor
         /// <summary>
         /// Specifies the property of <typeparamref name="TItem" /> which will set <see cref="AppointmentData.Text" />.
         /// </summary>
-        /// <value>The name of the property. Must be a <c>DateTime</c> property.</value>
+        /// <value>The name of the property. Must be a <c>string</c> property.</value>
         [Parameter]
         public string? TextProperty { get; set; }
 


### PR DESCRIPTION
Should be string, not DateTime