### PR TITLE
Allow overriding Dropdown's GetItemOrValueFromProperty method

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -508,7 +508,7 @@ namespace Radzen
         /// <param name="item">The item.</param>
         /// <param name="property">The property.</param>
         /// <returns>System.Object.</returns>
-        public object? GetItemOrValueFromProperty(object? item, string property)
+        public virtual object? GetItemOrValueFromProperty(object? item, string property)
         {
             if (item != null)
             {


### PR DESCRIPTION
Changed the method signature to virtual, to allow overrding Enum translation with component activators (using the Display attribute's name instead of description for example)