### PR TITLE
Fix sytax error in Radzen.Blazor.js

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -38,7 +38,7 @@ window.Radzen = {
             }
         };
     },
-    downloadFile = function (fileName, data, mimeType) {
+    downloadFile: function (fileName, data, mimeType) {
         const blob = new Blob([data], { type: mimeType });
         const url = URL.createObjectURL(blob);
 


### PR DESCRIPTION
Fix syntax error causing unhandled exception ('Radzen' was undefined)