### PR TITLE
Fix RadzenSteps next/previous buttons not reflecting disabled state

### DIFF
--- a/Radzen.Blazor.Tests/StepsTests.cs
+++ b/Radzen.Blazor.Tests/StepsTests.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Xunit;
 
 namespace Radzen.Blazor.Tests
@@ -64,6 +65,88 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains("Continue", component.Markup);
             Assert.Contains("Back", component.Markup);
+        }
+
+        [Fact]
+        public void Steps_NextButton_DisabledWhenNextStepIsDisabled()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenSteps>(parameters =>
+            {
+                parameters.Add(p => p.ShowStepsButtons, true);
+                parameters.Add(p => p.SelectedIndex, 0);
+                parameters.Add<RenderFragment>(p => p.Steps, builder =>
+                {
+                    builder.OpenComponent<RadzenStepsItem>(0);
+                    builder.AddAttribute(1, "Text", "Step 1");
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenStepsItem>(2);
+                    builder.AddAttribute(3, "Text", "Step 2");
+                    builder.AddAttribute(4, "Disabled", true);
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenStepsItem>(5);
+                    builder.AddAttribute(6, "Text", "Step 3");
+                    builder.CloseComponent();
+                });
+            });
+
+            var nextButton = component.Find("button.rz-steps-next");
+            Assert.Contains("rz-state-disabled", nextButton.GetAttribute("class"));
+            Assert.NotNull(nextButton.GetAttribute("disabled"));
+        }
+
+        [Fact]
+        public void Steps_PrevButton_DisabledWhenPrevStepIsDisabled()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenSteps>(parameters =>
+            {
+                parameters.Add(p => p.ShowStepsButtons, true);
+                parameters.Add(p => p.SelectedIndex, 2);
+                parameters.Add<RenderFragment>(p => p.Steps, builder =>
+                {
+                    builder.OpenComponent<RadzenStepsItem>(0);
+                    builder.AddAttribute(1, "Text", "Step 1");
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenStepsItem>(2);
+                    builder.AddAttribute(3, "Text", "Step 2");
+                    builder.AddAttribute(4, "Disabled", true);
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenStepsItem>(5);
+                    builder.AddAttribute(6, "Text", "Step 3");
+                    builder.CloseComponent();
+                });
+            });
+
+            var prevButton = component.Find("button.rz-steps-prev");
+            Assert.Contains("rz-state-disabled", prevButton.GetAttribute("class"));
+            Assert.NotNull(prevButton.GetAttribute("disabled"));
+        }
+
+        [Fact]
+        public void Steps_NextButton_NotDisabledWhenNextStepIsEnabled()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenSteps>(parameters =>
+            {
+                parameters.Add(p => p.ShowStepsButtons, true);
+                parameters.Add(p => p.SelectedIndex, 0);
+                parameters.Add<RenderFragment>(p => p.Steps, builder =>
+                {
+                    builder.OpenComponent<RadzenStepsItem>(0);
+                    builder.AddAttribute(1, "Text", "Step 1");
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenStepsItem>(2);
+                    builder.AddAttribute(3, "Text", "Step 2");
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenStepsItem>(4);
+                    builder.AddAttribute(5, "Text", "Step 3");
+                    builder.CloseComponent();
+                });
+            });
+
+            var nextButton = component.Find("button.rz-steps-next");
+            Assert.DoesNotContain("rz-state-disabled", nextButton.GetAttribute("class"));
         }
     }
 }

--- a/Radzen.Blazor/RadzenSteps.razor
+++ b/Radzen.Blazor/RadzenSteps.razor
@@ -63,13 +63,13 @@
     {
     <div class="rz-steps-buttons">
         <button type="button" id="@(GetId() + "prev")" title="@PreviousTitle" aria-label="@PreviousAriaLabel"
-           class='@($"rz-steps-prev {(IsFirstVisibleStep() ?  "rz-state-disabled" : "")}")'
-           disabled="@(IsFirstVisibleStep())" aria-disabled="@(IsFirstVisibleStep())"
+           class='@($"rz-steps-prev {(IsFirstVisibleStep() || IsPrevStepDisabled() ?  "rz-state-disabled" : "")}")'
+           disabled="@(IsFirstVisibleStep() || IsPrevStepDisabled())" aria-disabled="@(IsFirstVisibleStep() || IsPrevStepDisabled())"
            @onkeypress="@(args => OnKeyPress(args, PrevStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@PrevStep"><span class="notranslate rzi"></span>@PreviousText</button>
         <button type="button" id="@(GetId() + "next")" title="@NextTitle" aria-label="@NextAriaLabel"
-           class='@($"rz-steps-next {(IsLastVisibleStep() ?  "rz-state-disabled" : "")}")' 
-           disabled="@(IsLastVisibleStep())" aria-disabled="@(IsLastVisibleStep())"
+           class='@($"rz-steps-next {(IsLastVisibleStep() || IsNextStepDisabled() ?  "rz-state-disabled" : "")}")'
+           disabled="@(IsLastVisibleStep() || IsNextStepDisabled())" aria-disabled="@(IsLastVisibleStep() || IsNextStepDisabled())"
            @onkeypress="@(args => OnKeyPress(args, NextStep()))" @onkeypress:preventDefault=preventKeyPress @onkeypress:stopPropagation
            @onclick="@NextStep">@NextText<span class="notranslate rzi"></span></button>
     </div>

--- a/Radzen.Blazor/RadzenSteps.razor.cs
+++ b/Radzen.Blazor/RadzenSteps.razor.cs
@@ -95,6 +95,40 @@ namespace Radzen.Blazor
             return false;
         }
 
+        bool IsNextStepDisabled()
+        {
+            var nextIndex = SelectedIndex + 1;
+            while (nextIndex < steps.Count)
+            {
+                if (!steps[nextIndex].Visible)
+                {
+                    nextIndex++;
+                    continue;
+                }
+
+                break;
+            }
+
+            return nextIndex < steps.Count && steps[nextIndex].Disabled;
+        }
+
+        bool IsPrevStepDisabled()
+        {
+            var prevIndex = SelectedIndex - 1;
+            while (prevIndex >= 0 && prevIndex < steps.Count)
+            {
+                if (!steps[prevIndex].Visible)
+                {
+                    prevIndex--;
+                    continue;
+                }
+
+                break;
+            }
+
+            return prevIndex >= 0 && prevIndex < steps.Count && steps[prevIndex].Disabled;
+        }
+
         /// <summary>
         /// Programmatically navigates to the next visible step in the sequence.
         /// If already at the last step, this method does nothing. Respects CanChange validation.


### PR DESCRIPTION
## Summary
- Next/Previous navigation buttons now reflect the disabled state of the target step
- Added `IsNextStepDisabled()` and `IsPrevStepDisabled()` helper methods that mirror the existing visible-step-skipping logic from `NextStep()`/`PrevStep()`
- Buttons receive `rz-state-disabled` class, `disabled`, and `aria-disabled` attributes when the adjacent visible step is disabled

Fixes #2418

## Test plan
- [x] Added 3 new unit tests verifying disabled state propagation to nav buttons
- [x] All 1634 existing tests pass with no regressions