### PR TITLE
Fix color of clear and close buttons

### DIFF
--- a/Radzen.Blazor/themes/components/blazor/_dropdown.scss
+++ b/Radzen.Blazor/themes/components/blazor/_dropdown.scss
@@ -104,6 +104,7 @@ $multiselect-checkbox-margin-inline: 0 0.5rem !default;
   display: flex;
   align-items: center;
   font-size: var(--rz-dropdown-trigger-icon-height);
+  color: inherit;
   opacity: 0.4;
   background: none;
   border: none;

--- a/Radzen.Blazor/themes/components/blazor/_notification.scss
+++ b/Radzen.Blazor/themes/components/blazor/_notification.scss
@@ -134,6 +134,7 @@ $notification-info-icon-color: $notification-info-color !default;
 
 .rz-notification-close {
   cursor: pointer;
+  color: inherit;
   opacity: 0.75;
   background: none;
   border: none;


### PR DESCRIPTION
The commit https://github.com/radzenhq/radzen-blazor/commit/28e9090d45617a17ac1ebaa0049c92f2c16cca1b changed many elements to `button`, accidentally breaking text colors of some. It's is especially visible in the dark mode:
<img width="511" height="62" alt="a dropdown component with a barely visible clear button" src="https://github.com/user-attachments/assets/6751ab43-a77b-4dd6-8052-3bf9572d415e" />
<img width="400" height="100" alt="a notification with a close button that doesn't have sufficient contrast" src="https://github.com/user-attachments/assets/aaf6c861-8ef1-4838-9291-f233481d33be" />
This pull request makes them inherit the parent text color. I believe that it worked this way before the aforementioned commit:
<img width="511" height="62" alt="a dropdown component with a fixed clear button" src="https://github.com/user-attachments/assets/2c8638dd-22c2-4ae2-851b-9d43d51fdbed" />
<img width="400" height="100" alt="a notification with a close button that matches the text color" src="https://github.com/user-attachments/assets/3bb3dde9-e2c2-4df6-9205-37e6fe5fb0b4" />
