### PR TITLE
Legend Mouse Hover for Pie and Donut Charts

### DIFF
--- a/Radzen.Blazor/RadzenPieSeries.razor.cs
+++ b/Radzen.Blazor/RadzenPieSeries.razor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Radzen.Blazor
 {
@@ -186,6 +187,8 @@ namespace Radzen.Blazor
                     builder.AddAttribute(5, nameof(LegendItem.Color), PickColor(Items.IndexOf(data), Fills));
                     builder.AddAttribute(6, nameof(LegendItem.Click), EventCallback.Factory.Create(this, () => OnLegendClick(data!)));
                     builder.AddAttribute(7, nameof(LegendItem.Clickable), clickable);
+                    builder.AddAttribute(8, nameof(LegendItem.MouseOver), EventCallback.Factory.Create(this, () => OnLegendMouseOver(data!)));
+                    builder.AddAttribute(9, nameof(LegendItem.MouseOut), EventCallback.Factory.Create(this, () => OnLegendMouseOut()));
                     builder.CloseComponent();
                 }
                 ;
@@ -207,6 +210,21 @@ namespace Radzen.Blazor
                 await chart.LegendClick.InvokeAsync(args);
             }
         }
+
+        internal object? MouseOverLegendData { get; set; }
+        private async Task OnLegendMouseOver(object data)
+        {
+            // When the mouse is over a legend item, we want to show the tooltip for the corresponding segment.
+            // To do that, we store the data of the legend item in a property that can be accessed in the DataAt method.
+            MouseOverLegendData = data;
+        }
+        private async Task OnLegendMouseOut()
+        {
+            // When the mouse leaves a legend item, we want to hide the tooltip.
+            // To do that, we clear the MouseOverLegendData property.
+            MouseOverLegendData = null;
+        }
+
         /// <inheritdoc />
         public override bool Contains(double x, double y, double tolerance)
         {
@@ -223,6 +241,13 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         public override (object, Point) DataAt(double x, double y)
         {
+            // If the mouse is over a legend item, we want to show the tooltip for the corresponding segment.
+            // To do that, we check if MouseOverLegendData is not null and return it as the data for the tooltip.
+            if (MouseOverLegendData != null)
+            {
+                return (MouseOverLegendData!, new Point() { X = x, Y = y });
+            }
+
             if (!Contains(x, y, 0))
             {
                 return (default!, new Point());

--- a/Radzen.Blazor/Rendering/LegendItem.razor
+++ b/Radzen.Blazor/Rendering/LegendItem.razor
@@ -1,6 +1,6 @@
 @using Radzen.Blazor
 
-<span class="rz-legend-item" style="@Style" @onclick="@OnClick" role="button" aria-disabled="@(!Clickable).ToString().ToLowerInvariant()" tabindex="@(Clickable ? "0" : "-1")" @onkeypress="@OnKeyPress" @onkeypress:preventDefault=@preventKeyPress @onkeypress:stopPropagation>
+<span class="rz-legend-item" style="@Style" @onmouseover="@OnMouseOver" @onmouseout="@OnMouseOut" @onclick="@OnClick" role="button" aria-disabled="@(!Clickable).ToString().ToLowerInvariant()" tabindex="@(Clickable ? "0" : "-1")" @onkeypress="@OnKeyPress" @onkeypress:preventDefault=@preventKeyPress @onkeypress:stopPropagation>
     <svg width="@((MarkerSize * 2).ToInvariantString())" height="@((MarkerSize * 2).ToInvariantString())">
         <g class="rz-series-@Index @Class">
             <Marker X="@MarkerSize" Y="@MarkerSize" Type="@(MarkerType == MarkerType.None ? MarkerType.Square : MarkerType)" Fill="@Color" Size="@MarkerSize" />
@@ -32,6 +32,12 @@
     public EventCallback Click { get; set; }
 
     [Parameter]
+    public EventCallback MouseOver { get; set; }
+
+    [Parameter]
+    public EventCallback MouseOut { get; set; }
+
+    [Parameter]
     public bool Clickable { get; set; } = true;
 
     [Parameter]
@@ -45,6 +51,16 @@
         {
             await Click.InvokeAsync();
         }
+    }
+
+    async Task OnMouseOver()
+    {
+        await MouseOver.InvokeAsync();
+    }
+
+    async Task OnMouseOut()
+    {
+        await MouseOut.InvokeAsync();
     }
 
     async Task OnKeyPress(KeyboardEventArgs args)


### PR DESCRIPTION
As per [forum request](https://forum.radzen.com/t/radzenchart-tooltips/21411) this PR implements Pie and Donut tooltips for legend items activated by `mouseover` and `mouseout` events.

Regards

Paul