### PR TITLE
Hides DropDown clear button in ReadOnly mode

### DIFF
--- a/Radzen.Blazor/RadzenDropDown.razor
+++ b/Radzen.Blazor/RadzenDropDown.razor
@@ -173,10 +173,13 @@
                             <span class="notranslate rz-multiselect-filter-icon rzi rzi-search"></span>
                         </div>
                     }
-                    <button type="button" tabindex="-1" id="@(GetId() + "clear")" class="rz-multiselect-close" aria-label="@ClearAriaLabel"
-                            @onclick="@ClearAll" @onclick:stopPropagation="true">
-                        <span class="notranslate rzi rzi-times"></span>
-                    </button>
+                    @if (AllowClear && !ReadOnly && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
+                    {
+                        <button type="button" tabindex="-1" id="@(GetId() + "clear")" class="rz-multiselect-close" aria-label="@ClearAriaLabel"
+                                @onclick="@ClearAll" @onclick:stopPropagation="true">
+                            <span class="notranslate rzi rzi-times"></span>
+                        </button>
+                    }
                 </div>
                 }
             }
@@ -201,7 +204,7 @@
                 @FooterTemplate
             }
         </div>
-        @if (AllowClear && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
+        @if (AllowClear && !ReadOnly && (!Multiple && HasValue || Multiple && selectedItems.Count > 0))
         {
             <button type="button" tabindex="-1" class="notranslate rz-dropdown-clear-icon rzi rzi-times" aria-label="@ClearAriaLabel"
                     @onclick="@ClearAll" @onclick:stopPropagation="true"></button>


### PR DESCRIPTION
Fixes an issue where the clear button in the RadzenDropDown component was visible and functional even when the component was in `ReadOnly` mode. This allowed users to bypass the read-only state and clear selected values.

Now, the clear button is conditionally rendered, ensuring it only appears when `AllowClear` is true, the component is *not* `ReadOnly`, and there are selected items. This change prevents unintended modifications to the dropdown's value when it is configured as read-only.

Note : Since the ClearAll method is defined in DropDownBase, and DropDownBase cannot access the ReadOnly property in RadzenDropDown, the ReadOnly check is performed in RadzenDropDown.razor.