### PR TITLE
Add CanClose callback to prevent dialog dismissal

### DIFF
--- a/Radzen.Blazor.Tests/DialogServiceTests.cs
+++ b/Radzen.Blazor.Tests/DialogServiceTests.cs
@@ -409,5 +409,108 @@ namespace Radzen.Blazor.Tests
 				Assert.Equal("rz-dialog-wrapper wrapper-class", resultingOptions.WrapperCssClass);
 			}
 		}
+
+		public class CanCloseTests
+		{
+			[Fact(DisplayName = "TryCloseAsync closes when CanClose is null")]
+			public async Task TryCloseAsync_Closes_WhenCanCloseIsNull()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var openTask = dialogService.OpenAsync<DialogServiceTests>("Test");
+
+				// Act
+				var closed = await dialogService.TryCloseAsync();
+
+				// Assert
+				Assert.True(closed);
+				Assert.True(openTask.IsCompleted);
+			}
+
+			[Fact(DisplayName = "TryCloseAsync closes when CanClose returns true")]
+			public async Task TryCloseAsync_Closes_WhenCanCloseReturnsTrue()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var options = new DialogOptions { CanClose = () => Task.FromResult(true) };
+				var openTask = dialogService.OpenAsync<DialogServiceTests>("Test", options: options);
+
+				// Act
+				var closed = await dialogService.TryCloseAsync();
+
+				// Assert
+				Assert.True(closed);
+				Assert.True(openTask.IsCompleted);
+			}
+
+			[Fact(DisplayName = "TryCloseAsync blocks when CanClose returns false")]
+			public async Task TryCloseAsync_Blocks_WhenCanCloseReturnsFalse()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var options = new DialogOptions { CanClose = () => Task.FromResult(false) };
+				var openTask = dialogService.OpenAsync<DialogServiceTests>("Test", options: options);
+
+				// Act
+				var closed = await dialogService.TryCloseAsync();
+
+				// Assert
+				Assert.False(closed);
+				Assert.False(openTask.IsCompleted);
+			}
+
+			[Fact(DisplayName = "Programmatic Close bypasses CanClose")]
+			public async Task Close_Bypasses_CanClose()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var options = new DialogOptions { CanClose = () => Task.FromResult(false) };
+				var openTask = dialogService.OpenAsync<DialogServiceTests>("Test", options: options);
+
+				// Act
+				dialogService.Close();
+
+				// Assert
+				Assert.True(openTask.IsCompleted);
+			}
+
+			[Fact(DisplayName = "TryCloseSideAsync respects CanClose on SideDialogOptions")]
+			public async Task TryCloseSideAsync_Respects_CanClose()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var sideOptions = new SideDialogOptions { CanClose = () => Task.FromResult(false) };
+
+				SideDialogOptions resultingOptions = null;
+				dialogService.OnSideOpen += (_, _, opts) => resultingOptions = opts;
+
+				dialogService.OpenSide<DialogServiceTests>("Test", options: sideOptions);
+
+				// Act
+				var closed = await dialogService.TryCloseSideAsync();
+
+				// Assert
+				Assert.False(closed);
+			}
+
+			[Fact(DisplayName = "TryCloseSideAsync closes when CanClose returns true")]
+			public async Task TryCloseSideAsync_Closes_WhenCanCloseReturnsTrue()
+			{
+				// Arrange
+				var dialogService = new DialogService(null, null);
+				var sideOptions = new SideDialogOptions { CanClose = () => Task.FromResult(true) };
+				bool sideClosed = false;
+				dialogService.OnSideClose += (_) => sideClosed = true;
+
+				dialogService.OpenSide<DialogServiceTests>("Test", options: sideOptions);
+
+				// Act
+				var closed = await dialogService.TryCloseSideAsync();
+
+				// Assert
+				Assert.True(closed);
+				Assert.True(sideClosed);
+			}
+		}
 	}
 }

--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -513,7 +513,7 @@ namespace Radzen
                 return false;
             }
 
-            await CloseSideAsync(result);
+            CloseSide(result);
             return true;
         }
 

--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -164,6 +165,7 @@ namespace Radzen
         /// </summary>
         protected List<TaskCompletionSource<dynamic>> tasks = new List<TaskCompletionSource<dynamic>>();
         private TaskCompletionSource<dynamic>? sideDialogResultTask;
+        private SideDialogOptions? currentSideDialogOptions;
 
         /// <summary>
         /// Opens a dialog with the specified arguments.
@@ -233,6 +235,7 @@ namespace Radzen
             }
 
             options.Title = title;
+            currentSideDialogOptions = options;
             OnSideOpen?.Invoke(typeof(T), parameters ?? new Dictionary<string, object?>(), options);
             return sideDialogResultTask.Task;
         }
@@ -262,6 +265,7 @@ namespace Radzen
             }
 
             options.Title = title;
+            currentSideDialogOptions = options;
             OnSideOpen?.Invoke(componentType, parameters ?? new Dictionary<string, object?>(), options);
 
             return sideDialogResultTask.Task;
@@ -286,6 +290,7 @@ namespace Radzen
             }
 
             options.Title = title;
+            currentSideDialogOptions = options;
             OnSideOpen?.Invoke(typeof(T), parameters ?? new Dictionary<string, object?>(), options);
         }
 
@@ -312,6 +317,7 @@ namespace Radzen
             }
 
             options.Title = title;
+            currentSideDialogOptions = options;
             OnSideOpen?.Invoke(componentType, parameters ?? new Dictionary<string, object?>(), options);
         }
 
@@ -322,6 +328,7 @@ namespace Radzen
             {
                 sideDialogResultTask.TrySetResult(null!);
             }
+            currentSideDialogOptions = null;
         }
 
         /// <summary>
@@ -335,6 +342,7 @@ namespace Radzen
                 sideDialogResultTask.TrySetResult(result);
             }
 
+            currentSideDialogOptions = null;
             OnSideClose?.Invoke(result);
         }
 
@@ -430,15 +438,15 @@ namespace Radzen
         /// <summary>
         /// The dialogs
         /// </summary>
-        protected List<object> dialogs = new List<object>();
+        protected List<DialogOptions> dialogs = new List<DialogOptions>();
 
         internal void OpenDialog<T>(string? title, Dictionary<string, object?>? parameters, DialogOptions? options)
         {
-            dialogs.Add(new object());
-
             // Validate and set default values for the dialog options
             options ??= new();
             parameters ??= new Dictionary<string, object?>();
+
+            dialogs.Add(options);
             options.Width = !String.IsNullOrEmpty(options.Width) ? options.Width : "600px";
             options.Left = !String.IsNullOrEmpty(options.Left) ? options.Left : "";
             options.Top = !String.IsNullOrEmpty(options.Top) ? options.Top : "";
@@ -473,6 +481,51 @@ namespace Radzen
                 tasks.Remove(task);
                 task.SetResult(result);
             }
+        }
+
+        /// <summary>
+        /// Attempts to close the last opened dialog. Invokes <see cref="DialogOptionsBase.CanClose"/> if set.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <returns><c>true</c> if the dialog was closed; <c>false</c> if closing was prevented by <see cref="DialogOptionsBase.CanClose"/>.</returns>
+        public virtual async Task<bool> TryCloseAsync(dynamic? result = null)
+        {
+            var dialogOptions = dialogs.LastOrDefault();
+
+            if (dialogOptions?.CanClose is { } canClose && !await canClose())
+            {
+                return false;
+            }
+
+            Close(result);
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to close the side dialog. Invokes <see cref="DialogOptionsBase.CanClose"/> if set.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <returns><c>true</c> if the side dialog was closed; <c>false</c> if closing was prevented by <see cref="DialogOptionsBase.CanClose"/>.</returns>
+        public virtual async Task<bool> TryCloseSideAsync(dynamic? result = null)
+        {
+            if (currentSideDialogOptions?.CanClose is { } canClose && !await canClose())
+            {
+                return false;
+            }
+
+            await CloseSideAsync(result);
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to close the last opened dialog. Called from JavaScript ESC handler.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <returns><c>true</c> if the dialog was closed; <c>false</c> if closing was prevented.</returns>
+        [JSInvokable("DialogService.TryClose")]
+        public virtual async Task<bool> TryCloseFromJs(dynamic? result = null)
+        {
+            return await TryCloseAsync(result);
         }
 
         /// <inheritdoc />
@@ -896,6 +949,27 @@ namespace Radzen
                 {
                     closeTabIndex = value;
                     OnPropertyChanged(nameof(CloseTabIndex));
+                }
+            }
+        }
+
+        private Func<Task<bool>>? canClose;
+
+        /// <summary>
+        /// Gets or sets a callback invoked when the user attempts to close the dialog
+        /// (via X button, overlay click, or ESC key). Return <c>false</c> to prevent closing.
+        /// Not invoked when <see cref="DialogService.Close"/> is called programmatically.
+        /// </summary>
+        [JsonIgnore]
+        public Func<Task<bool>>? CanClose
+        {
+            get => canClose;
+            set
+            {
+                if (canClose != value)
+                {
+                    canClose = value;
+                    OnPropertyChanged(nameof(CanClose));
                 }
             }
         }

--- a/Radzen.Blazor/RadzenDialog.razor
+++ b/Radzen.Blazor/RadzenDialog.razor
@@ -66,7 +66,7 @@
                 </div>
                 @if (sideOptions?.ShowClose == true)
                 {
-                    <button id="@($"rz-dialog-side-{sideOptions?.GetHashCode() ?? 0}-cl")" type="button" aria-label="@CloseSideDialogAriaLabel" class="rz-dialog-side-titlebar-close" @onclick="@(_ => Service!.CloseSide())" tabindex="@(sideOptions?.CloseTabIndex ?? 0)">
+                    <button id="@($"rz-dialog-side-{sideOptions?.GetHashCode() ?? 0}-cl")" type="button" aria-label="@CloseSideDialogAriaLabel" class="rz-dialog-side-titlebar-close" @onclick="@(async _ => await Service!.TryCloseSideAsync())" tabindex="@(sideOptions?.CloseTabIndex ?? 0)">
                         <span class="notranslate rzi rzi-times"></span>
                     </button>
                 }
@@ -80,7 +80,7 @@
     {
         @if (sideOptions.CloseDialogOnOverlayClick)
         {
-            <div @onclick="@Service!.CloseSide" class="rz-dialog-mask" aria-hidden="true" tabindex="-1"></div>
+            <div @onclick="@(async () => await Service!.TryCloseSideAsync())" class="rz-dialog-mask" aria-hidden="true" tabindex="-1"></div>
         }
         else
         {

--- a/Radzen.Blazor/RadzenDialog.razor
+++ b/Radzen.Blazor/RadzenDialog.razor
@@ -66,7 +66,7 @@
                 </div>
                 @if (sideOptions?.ShowClose == true)
                 {
-                    <button id="@($"rz-dialog-side-{sideOptions?.GetHashCode() ?? 0}-cl")" type="button" aria-label="@CloseSideDialogAriaLabel" class="rz-dialog-side-titlebar-close" @onclick="@(async _ => await Service!.TryCloseSideAsync())" tabindex="@(sideOptions?.CloseTabIndex ?? 0)">
+                    <button id="@($"rz-dialog-side-{sideOptions?.GetHashCode() ?? 0}-cl")" type="button" aria-label="@CloseSideDialogAriaLabel" class="rz-dialog-side-titlebar-close" @onclick="CloseSide" tabindex="@(sideOptions?.CloseTabIndex ?? 0)">
                         <span class="notranslate rzi rzi-times"></span>
                     </button>
                 }
@@ -80,7 +80,8 @@
     {
         @if (sideOptions.CloseDialogOnOverlayClick)
         {
-            <div @onclick="@(async () => await Service!.TryCloseSideAsync())" class="rz-dialog-mask" aria-hidden="true" tabindex="-1"></div>
+            <div @onclick="CloseSide" class="rz-dialog-mask"
+                 aria-hidden="true" tabindex="-1"></div>
         }
         else
         {
@@ -234,6 +235,14 @@
         });
         isSideDialogOpen = true;
         StateHasChanged();
+    }
+
+    private async Task CloseSide()
+    {
+        if (Service is not null)
+        {
+            await Service!.TryCloseSideAsync();
+        }
     }
 
     private bool sideDialogClosing = false;

--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -77,13 +77,13 @@
 </div>
 
 @code {
-    void OnKeyPress(KeyboardEventArgs args)
+    async Task OnKeyPress(KeyboardEventArgs args)
     {
         var key = args.Code != null ? args.Code : args.Key;
 
         if (key == "Space" || key == "Enter")
         {
-            Close();
+            await Close();
         }
     }
 
@@ -179,9 +179,12 @@
 
     object? reference;
 
-    void Close()
+    async Task Close()
     {
-        Service?.Close();
+        if (Service != null)
+        {
+            await Service.TryCloseAsync();
+        }
     }
 
     string Class => ClassList.Create("rz-dialog rz-open")

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -2450,16 +2450,18 @@ window.Radzen = {
           var lastDialog = dialogs[dialogs.length - 1];
 
           if (lastDialog && lastDialog.options && lastDialog.options.closeDialogOnEsc) {
-              try { Radzen.dialogService.invokeMethodAsync('DialogService.Close', null); } catch { }
-
-              if (dialogs.length <= 1) {
-                  document.removeEventListener('keydown', Radzen.closePopupOrDialog);
-                  delete Radzen.dialogService;
-                  var layout = document.querySelector('.rz-layout');
-                  if (layout) {
-                      layout.removeEventListener('keydown', Radzen.disableKeydown);
-                  }
-              }
+              try {
+                  Radzen.dialogService.invokeMethodAsync('DialogService.TryClose', null).then(function(closed) {
+                      if (closed && dialogs.length <= 1) {
+                          document.removeEventListener('keydown', Radzen.closePopupOrDialog);
+                          delete Radzen.dialogService;
+                          var layout = document.querySelector('.rz-layout');
+                          if (layout) {
+                              layout.removeEventListener('keydown', Radzen.disableKeydown);
+                          }
+                      }
+                  });
+              } catch (e) { }
           }
       }
   },

--- a/RadzenBlazorDemos/Pages/DialogCanClose.razor
+++ b/RadzenBlazorDemos/Pages/DialogCanClose.razor
@@ -1,0 +1,62 @@
+@inject DialogService DialogService
+
+<div class="rz-p-12 rz-text-align-center">
+    <RadzenStack Orientation="Orientation.Horizontal" Gap="1rem" JustifyContent="JustifyContent.Center" Wrap="FlexWrap.Wrap">
+        <RadzenButton Text="Dialog with CanClose" ButtonStyle="ButtonStyle.Secondary" Click=@OpenDialog />
+        <RadzenButton Text="Side dialog with CanClose" ButtonStyle="ButtonStyle.Light" Click=@OpenSideDialog />
+    </RadzenStack>
+</div>
+
+@code {
+    async Task OpenDialog()
+    {
+        bool hasUnsavedChanges = false;
+
+        await DialogService.OpenAsync("Unsaved Changes Guard", ds =>
+    @<div>
+        <RadzenStack Gap="1rem">
+            <RadzenText TextStyle="TextStyle.Body1">Try closing this dialog with the X button, ESC key, or overlay click while the checkbox is checked.</RadzenText>
+            <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
+                <RadzenCheckBox @bind-Value="hasUnsavedChanges" Name="UnsavedChanges" />
+                <RadzenLabel Text="Has unsaved changes" Component="UnsavedChanges" />
+            </RadzenStack>
+            <RadzenButton Text="Save and Close" Click="() => ds.Close(true)" Style="width: 100%" />
+        </RadzenStack>
+    </div>, new DialogOptions()
+            {
+                CloseDialogOnOverlayClick = true,
+                CanClose = async () =>
+                {
+                    if (!hasUnsavedChanges)
+                        return true;
+
+                    return await DialogService.Confirm("You have unsaved changes. Discard?", "Confirm",
+                        new ConfirmOptions() { OkButtonText = "Discard", CancelButtonText = "Cancel" }) == true;
+                }
+            });
+    }
+
+    async Task OpenSideDialog()
+    {
+        bool hasUnsavedChanges = false;
+
+        await DialogService.OpenSideAsync<DialogCanCloseContent>("Edit Panel",
+            new Dictionary<string, object>
+            {
+                { nameof(DialogCanCloseContent.HasUnsavedChangesChanged), EventCallback.Factory.Create<bool>(this, (value) => hasUnsavedChanges = value) }
+            },
+            new SideDialogOptions()
+            {
+                CloseDialogOnOverlayClick = true,
+                ShowMask = true,
+                CanClose = async () =>
+                {
+                    if (!hasUnsavedChanges)
+                        return true;
+
+                    return await DialogService.Confirm("You have unsaved changes. Discard?", "Confirm",
+                        new ConfirmOptions() { OkButtonText = "Discard", CancelButtonText = "Cancel" }) == true;
+                }
+            });
+    }
+}

--- a/RadzenBlazorDemos/Pages/DialogCanCloseContent.razor
+++ b/RadzenBlazorDemos/Pages/DialogCanCloseContent.razor
@@ -1,0 +1,23 @@
+@inject DialogService DialogService
+
+<RadzenStack Gap="1rem">
+    <RadzenText TextStyle="TextStyle.Body1">Try closing this side dialog while the checkbox is checked.</RadzenText>
+    <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
+        <RadzenCheckBox Value="hasUnsavedChanges" ValueChanged="@OnChanged" Name="SideUnsavedChanges" TValue="bool" />
+        <RadzenLabel Text="Has unsaved changes" Component="SideUnsavedChanges" />
+    </RadzenStack>
+    <RadzenButton Text="Save and Close" Click="@(() => DialogService.CloseSide(true))" Style="width: 100%" />
+</RadzenStack>
+
+@code {
+    bool hasUnsavedChanges;
+
+    [Parameter]
+    public EventCallback<bool> HasUnsavedChangesChanged { get; set; }
+
+    async Task OnChanged(bool value)
+    {
+        hasUnsavedChanges = value;
+        await HasUnsavedChangesChanged.InvokeAsync(value);
+    }
+}

--- a/RadzenBlazorDemos/Pages/DialogPage.razor
+++ b/RadzenBlazorDemos/Pages/DialogPage.razor
@@ -59,6 +59,16 @@
     <DialogAlert />
 </RadzenExample>
 
+<RadzenText Anchor="dialog#prevent-close" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    Prevent dialog from closing
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Use the <code>CanClose</code> callback to prevent a dialog from closing when the user clicks the X button, overlay, or presses ESC. Return <code>false</code> to block the close. Programmatic <code>Close()</code> calls always succeed.
+</RadzenText>
+<RadzenExample ComponentName="Dialog" Example="DialogCanClose" AdditionalSourceCodePages=@(new List<string>() { "/demos/Pages/DialogCanCloseContent.razor" })>
+    <DialogCanClose />
+</RadzenExample>
+
 <RadzenText Anchor="dialog#close-dialog-by-clicking-outside" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
     Close Dialog by clicking outside
 </RadzenText>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -1429,7 +1429,7 @@ namespace RadzenBlazorDemos
                 },
                 new Example
                 {
-                    Toc = [ new () { Text = "Open page as a dialog", Anchor = "#open-page-as-dialog" }, new () { Text = "Inline Dialog", Anchor = "#inline-dialog" }, new () { Text = "Busy Dialog", Anchor = "#busy-dialog" }, new () { Text = "Confirm Dialog", Anchor = "#confirm-dialog" }, new () { Text = "Alert Dialog", Anchor = "#alert-dialog" }, new () { Text = "Close Dialog by clicking outside", Anchor = "#close-dialog-by-clicking-outside" }, new () { Text = "Side Dialog", Anchor = "#side-dialog" }, new () { Text = "Dialog with custom CSS classes", Anchor = "#custom-css-classes" }, new () { Text = "Update dialog properties", Anchor = "#cascading-value" } ],
+                    Toc = [ new () { Text = "Open page as a dialog", Anchor = "#open-page-as-dialog" }, new () { Text = "Inline Dialog", Anchor = "#inline-dialog" }, new () { Text = "Busy Dialog", Anchor = "#busy-dialog" }, new () { Text = "Confirm Dialog", Anchor = "#confirm-dialog" }, new () { Text = "Alert Dialog", Anchor = "#alert-dialog" }, new () { Text = "Prevent dialog from closing", Anchor = "#prevent-close" }, new () { Text = "Close Dialog by clicking outside", Anchor = "#close-dialog-by-clicking-outside" }, new () { Text = "Side Dialog", Anchor = "#side-dialog" }, new () { Text = "Dialog with custom CSS classes", Anchor = "#custom-css-classes" }, new () { Text = "Update dialog properties", Anchor = "#cascading-value" } ],
                     Name = "Dialog",
                     Description = "Demonstration and configuration of the Blazor RadzenDialog component.",
                     Path = "dialog",


### PR DESCRIPTION
## Summary

- Adds `CanClose` (`Func<Task<bool>>?`) property to `DialogOptionsBase`, available on both `DialogOptions` and `SideDialogOptions`
- When set, invoked on user-initiated close actions (X button, overlay click, ESC key). Return `false` to prevent closing
- Programmatic `Close(result)` always succeeds — never checks `CanClose`

Closes #2476

## Changes

- **`DialogService.cs`** — `CanClose` property on `DialogOptionsBase`, `TryCloseAsync()` / `TryCloseSideAsync()` methods, `[JSInvokable("DialogService.TryClose")]` endpoint, `dialogs` list changed from `List<object>` to `List<DialogOptions>`
- **`DialogContainer.razor`** — X button and overlay route through `TryCloseAsync`
- **`RadzenDialog.razor`** — Side dialog X button and overlay route through `TryCloseSideAsync`
- **`Radzen.Blazor.js`** — ESC handler calls `DialogService.TryClose` and conditionally cleans up based on result
- **`DialogServiceTests.cs`** — 6 tests covering null/true/false `CanClose`, programmatic bypass, and side dialog behavior
- **Demo pages** — `DialogCanClose.razor` with regular and side dialog examples