### PR TITLE
Fix CSP inline event handler violations in RadzenProfileMenu

### DIFF
--- a/Radzen.Blazor/RadzenProfileMenu.razor
+++ b/Radzen.Blazor/RadzenProfileMenu.razor
@@ -6,10 +6,10 @@
         role="menu" aria-label="@ToggleAriaLabel" tabindex="0"
         @onkeydown="@OnKeyPress" @onkeydown:preventDefault=preventKeyPress @onkeydown:stopPropagation="stopKeydownPropagation">
         <li class="rz-navigation-item">
-            <div class="rz-navigation-item-wrapper" role="button" tabindex="0" aria-haspopup="menu"
+            <div @ref="@toggleRef" class="rz-navigation-item-wrapper" role="button" tabindex="0" aria-haspopup="menu"
                  aria-label="@ToggleAriaLabel"
                  aria-expanded="@((!Collapsed).ToString().ToLowerInvariant())" aria-controls="@($"{GetId()}-menu")"
-                 onclick="Radzen.toggleMenuItem(this)" @onkeydown="OnToggleKeyDown">
+                 @onclick="OnToggleClick" @onkeydown="OnToggleKeyDown">
                 <div class="rz-navigation-item-link">
                     <div class="item-text" @onkeydown:stopPropagation="stopGuardKeydownPropagation" @onkeydown="OnGuardKeyDown">
                         @if (Template != null)

--- a/Radzen.Blazor/RadzenProfileMenu.razor.cs
+++ b/Radzen.Blazor/RadzenProfileMenu.razor.cs
@@ -59,6 +59,15 @@ namespace Radzen.Blazor
 
         string contentStyle = "display:none;position:absolute;z-index:1;";
 
+        ElementReference toggleRef;
+        async Task OnToggleClick()
+        {
+            if (JSRuntime != null)
+            {
+                await JSRuntime.InvokeVoidAsync("Radzen.toggleMenuItem", toggleRef);
+            }
+        }
+
         /// <summary>
         /// Toggles the menu open/close state.
         /// </summary>


### PR DESCRIPTION
  ### Summary                                                                                                                                                                                                                         
                                                                                                                                                                                                                                      
  `RadzenProfileMenu` renders an inline `onclick="Radzen.toggleMenuItem(this)"` attribute on the toggle element. This violates Content Security Policy (CSP) when `unsafe-inline` is not allowed for scripts, causing the profile menu
   dropdown to silently fail to open.                                                                                                                                                                                                 
                                                                                                                                                                                                                                    
  ### Changes

  - Replaced the inline `onclick` handler with a Blazor `@onclick` event binding (`OnToggleClick`)
  - Added an `ElementReference` (`toggleRef`) to pass the DOM element to `Radzen.toggleMenuItem` via JS interop (`IJSRuntime.InvokeVoidAsync`)
  - No changes to behavior or public API — the fix is internal to the component

  ### Before / After

  | Before | After |
  |---|---|
  | `onclick="Radzen.toggleMenuItem(this)"` | `@onclick="OnToggleClick"` → JS interop call |
  | Blocked by CSP `script-src` without `unsafe-inline` | Works with strict CSP policies |