### PR TITLE
Handle Appointment JSDisconnectedException in DisposeAsync

### DIFF
--- a/Radzen.Blazor/Rendering/Appointment.razor
+++ b/Radzen.Blazor/Rendering/Appointment.razor
@@ -152,11 +152,21 @@
 
     public async ValueTask DisposeAsync()
     {
-        if (jsRef != null)
+        try
         {
-            await jsRef.InvokeVoidAsync("dispose");
-            await jsRef.DisposeAsync();
+            if (jsRef != null)
+            {
+                await jsRef.InvokeVoidAsync("dispose");
+                await jsRef.DisposeAsync();
+            }
         }
-        dotnetRef?.Dispose();
+        catch (JSDisconnectedException)
+        {
+        }
+        finally
+        {
+            dotnetRef?.Dispose();
+        }
+
     }
 }


### PR DESCRIPTION
Prevent multiple JSDisconnectedException errors when closing the browser tab. Previously, one exception was thrown per appointment during disposal.
The change catches and ignores those expected disconnection errors when disposing.