### PR TITLE
Fix/radzen enum display name

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Radzen
@@ -523,8 +524,20 @@ namespace Radzen
                 var enumValue = item as Enum;
                 if (enumValue != null)
                 {
-                    return Radzen.Blazor.EnumExtensions.GetDisplayDescription(enumValue);
+                    var field = enumValue.GetType().GetField(enumValue.ToString());
+                    if (field != null)
+                    {
+                        var displayAttr = field.GetCustomAttribute<System.ComponentModel.DataAnnotations.DisplayAttribute>();
+                        if (displayAttr != null)
+                            return displayAttr.Name ?? displayAttr.GetDescription() ?? enumValue.ToString();
+
+                        var descAttr = field.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>();
+                        if (descAttr != null)
+                            return descAttr.Description;
+                    }
+                    return enumValue.ToString();
                 }
+
 
                 if (property == TextProperty)
                 {

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -538,7 +538,6 @@ namespace Radzen
                     return enumValue.ToString();
                 }
 
-
                 if (property == TextProperty)
                 {
                     return textPropertyGetter != null ? textPropertyGetter(item) : PropertyAccess.GetItemOrValueFromProperty(item, property);


### PR DESCRIPTION
This PR fixes enum binding in Radzen DropDown and adds improved support for enum display values.

### Changes

* Fixed enum binding so the DropDown correctly displays enum values
* Added support for `Display(Name)` as the preferred display value
* Added fallback support for `Display(Description)` to avoid breaking existing implementations

`Display(Name)` is considered the correct approach. Support for `Display(Description)` is maintained only for backward compatibility, as some existing implementations may rely on it.

Additionally, the example in Radzen documentation currently does not work as expected:
https://blazor.radzen.com/dropdown-custom-objects
Section: **DropDown data binding to enum**

This PR fixes that behavior and also adds the new functionality.

### Example

Not recommended:

```csharp
[Display(Description = "Almond Green")]
AlmondGreen,
```

Recommended:

```csharp
[Display(Name = "Almond Green")]
AlmondGreen,
```

With this change, the reading priority is:
- [Display(Name = "...")]
- [Display(Description = "...")] (if supported by your version)
- [Description("...")] from System.ComponentModel
- enumValue.ToString() as fallback

This ensures proper display behavior and aligns with the recommended usage.
