### PR TITLE
Add custom CssPath to RadzenTheme and its using ThemeService

### DIFF
--- a/Radzen.Blazor.Tests/ThemeTests.cs
+++ b/Radzen.Blazor.Tests/ThemeTests.cs
@@ -1,0 +1,77 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class ThemeTests
+    {
+        [Fact]
+        public void Theme_Renders_Embedded_Default_CssPath()
+        {
+            const string path = "_content/Radzen.Blazor/css";
+
+            using var ctx = new TestContext();
+            ctx.Services.AddScoped<ThemeService>();
+            
+            var component = ctx.RenderComponent<RadzenTheme>(parameters =>
+            {
+                parameters.Add(p => p.Theme, "material");
+            });
+            
+            Assert.Contains(path, component.Markup);
+        }
+
+        [Fact]
+        public void Theme_Renders_Non_Embedded_Default_CssPath()
+        {
+            const string path = "\"css";
+            
+            using var ctx = new TestContext();
+            ctx.Services.AddScoped<ThemeService>();
+          
+            var component = ctx.RenderComponent<RadzenTheme>(parameters =>
+            {
+                parameters.Add(p => p.Theme, "awesome");
+            });
+            
+            Assert.Contains($"{path}/awesome-base.css", component.Markup);
+        }
+        
+        [Fact]
+        public void Theme_Renders_Non_Embedded_Custom_CssPath()
+        {
+            const string path = "_content/custom-assembly/css";
+            
+            using var ctx = new TestContext();
+            ctx.Services.AddScoped<ThemeService>();
+            
+            var component = ctx.RenderComponent<RadzenTheme>(parameters =>
+            {
+                parameters.Add(p => p.CssPath, path);
+                parameters.Add(p => p.Theme, "my-light");
+            });
+            
+            Assert.Contains(path, component.Markup);
+        }
+
+        [Fact]
+        public void Theme_Renders_Embedded_CssPath_For_Embedded_Themes()
+        {
+            const string path = "_content/Radzen.Blazor/css";
+            const string customPath = "_content/custom-assembly/css";
+            
+            using var ctx = new TestContext();
+            ctx.Services.AddScoped<ThemeService>();
+            
+            var component = ctx.RenderComponent<RadzenTheme>(parameters =>
+            {
+                parameters.Add(p => p.CssPath, customPath);
+                parameters.Add(p => p.Theme, "material");
+            });
+            
+            Assert.Contains(path, component.Markup);
+            Assert.DoesNotContain(customPath, component.Markup);
+        }
+    }
+}

--- a/Radzen.Blazor/RadzenTheme.razor.cs
+++ b/Radzen.Blazor/RadzenTheme.razor.cs
@@ -20,10 +20,16 @@ namespace Radzen.Blazor
         public string? Theme { get; set; }
 
         /// <summary>
-        /// When set to true the icon font will be preloadd.
+        /// When set to true the icon font will be preload.
         /// </summary>
         [Parameter]
         public bool PreloadIconFont { get; set; } = true;
+        
+        /// <summary>
+        /// Custom css path. If set, it overwrites the default path.
+        /// </summary>
+        [Parameter]
+        public string? CssPath { get; set; }
 
         /// <summary>
         /// Enables WCAG contrast requirements. If set to true additional CSS file will be loaded.
@@ -52,9 +58,9 @@ namespace Radzen.Blazor
         {
             persistentComponentState = ServiceProvider.GetService<PersistentComponentState>();
 
+            ThemeService.SetCssPath(CssPath);
             theme = ThemeService.Theme ?? GetCurrentTheme();
             wcag = ThemeService.Wcag ?? Wcag;
-
             if (theme != null)
             {
                 ThemeService.SetTheme(theme, true);

--- a/Radzen.Blazor/ThemeService.cs
+++ b/Radzen.Blazor/ThemeService.cs
@@ -404,6 +404,11 @@ namespace Radzen
         /// Specify if the theme should be right-to-left.
         /// </summary>
         public bool? RightToLeft { get; private set; }
+        
+        /// <summary>
+        /// Custom css path. If set, it overwrites the default path.
+        /// </summary>
+        public string? CssPath { get; private set; }
 
         /// <summary>
         /// Raised when the theme changes.
@@ -473,7 +478,11 @@ namespace Radzen
 
         internal string WcagHref => $"{Path}/{Theme}-wcag.css?v={Version}";
 
-        private string Path => Embedded ? $"_content/Radzen.Blazor/css" : "css";
+        private string Path => Embedded 
+            ? $"_content/Radzen.Blazor/css" 
+            : !string.IsNullOrEmpty(CssPath) 
+                ? CssPath 
+                : "css";
 
         internal bool Embedded => Theme switch
         {
@@ -516,6 +525,15 @@ namespace Radzen
                 RightToLeft = rightToLeft,
                 TriggerChange = true
             });
+        }
+
+        /// <summary>
+        /// Sets a specific css path to the theme service.
+        /// </summary>
+        /// <param name="cssPath">New css path to look for themes.</param>
+        public void SetCssPath(string? cssPath)
+        {
+            CssPath = cssPath;
         }
     }
 }


### PR DESCRIPTION
Adds a custom CssPath Property to the RadzenTheme to allow overwriting the default Path behavior.
It also sets the CssPath in the underlaying ThemeService. 

Closes #2354 