### PR TITLE
Fix DropDown selected base values with derived data

### DIFF
--- a/Radzen.Blazor.Tests/DropDownTests.cs
+++ b/Radzen.Blazor.Tests/DropDownTests.cs
@@ -796,6 +796,37 @@ namespace Radzen.Blazor.Tests
             Assert.Contains("rz-dropdown-clear-icon", component.Markup);
         }
 
+        class BaseDataItem
+        {
+            public string Text { get; set; }
+        }
+
+        class DerivedDataItem : BaseDataItem
+        {
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public void DropDown_Renders_SelectedBaseValue_WhenDataItemsAreDerived()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var data = new[] { new DerivedDataItem { Text = "Item 1", Id = 1 } };
+            var value = new BaseDataItem { Text = "Item 1" };
+
+            var component = ctx.RenderComponent<RadzenDropDown<BaseDataItem>>(parameters =>
+            {
+                parameters.Add(p => p.Data, data);
+                parameters.Add(p => p.TextProperty, nameof(BaseDataItem.Text));
+                parameters.Add(p => p.Value, value);
+            });
+
+            var dropdown = component.Find("div.rz-dropdown");
+
+            Assert.Equal("Item 1", dropdown.GetAttribute("aria-label"));
+        }
+
         [Fact]
         public void DropDown_DoesNotRender_AllowClear_WhenNotAllowed()
         {

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -470,16 +470,19 @@ namespace Radzen
                 if (!string.IsNullOrEmpty(ValueProperty))
                 {
                     valuePropertyGetter = GetGetter(ValueProperty, type);
+                    valuePropertyGetterType = type;
                 }
 
                 if (!string.IsNullOrEmpty(TextProperty))
                 {
                     textPropertyGetter = GetGetter(TextProperty, type);
+                    textPropertyGetterType = type;
                 }
 
                 if (!string.IsNullOrEmpty(DisabledProperty))
                 {
                     disabledPropertyGetter = GetGetter(DisabledProperty, type);
+                    disabledPropertyGetterType = type;
                 }
 
                 if (selectedItems.Count == 0)
@@ -507,8 +510,18 @@ namespace Radzen
         }
 
         internal Func<object, object?>? valuePropertyGetter;
+        internal Type? valuePropertyGetterType;
+
         internal Func<object, object?>? textPropertyGetter;
+        internal Type? textPropertyGetterType;
+
         internal Func<object, object?>? disabledPropertyGetter;
+        internal Type? disabledPropertyGetterType;
+
+        private object? GetItemOrValueFromPropertyUsingGetter(object item, string property, Func<object, object?>? getter, Type? getterType)
+        {
+            return getter != null && getterType?.IsInstanceOfType(item) == true ? getter(item) : PropertyAccess.GetItemOrValueFromProperty(item, property);
+        }
 
         /// <summary>
         /// Gets the item or value from property.
@@ -528,15 +541,15 @@ namespace Radzen
 
                 if (property == TextProperty)
                 {
-                    return textPropertyGetter != null ? textPropertyGetter(item) : PropertyAccess.GetItemOrValueFromProperty(item, property);
+                    return GetItemOrValueFromPropertyUsingGetter(item, property, textPropertyGetter, textPropertyGetterType);
                 }
                 else if (property == ValueProperty)
                 {
-                    return valuePropertyGetter != null ? valuePropertyGetter(item) : PropertyAccess.GetItemOrValueFromProperty(item, property);
+                    return GetItemOrValueFromPropertyUsingGetter(item, property, valuePropertyGetter, valuePropertyGetterType);
                 }
                 else if (property == DisabledProperty)
                 {
-                    return disabledPropertyGetter != null ? disabledPropertyGetter(item) : PropertyAccess.GetItemOrValueFromProperty(item, property);
+                    return GetItemOrValueFromPropertyUsingGetter(item, property, disabledPropertyGetter, disabledPropertyGetterType);
                 }
             }
 


### PR DESCRIPTION
Fixes #2543

Summary:
- Track the runtime type used to compile dropdown property getters.
- Fall back to reflection property access when the selected item is not assignable to the getter type.
- Add a regression test for selected base values with derived data items.

Tests:
- dotnet test Radzen.Blazor.Tests\Radzen.Blazor.Tests.csproj --filter FullyQualifiedName~DropDown_Renders_SelectedBaseValue_WhenDataItemsAreDerived --no-restore