### PR TITLE
Fix RadzenLinearGaugeScaleRange not responding to gauge resize

### DIFF
--- a/Radzen.Blazor.Tests/LinearGaugeTests.cs
+++ b/Radzen.Blazor.Tests/LinearGaugeTests.cs
@@ -439,6 +439,31 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void LinearGauge_Range_UpdatesOnResize()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = ctx.RenderComponent<RadzenLinearGauge>(parameters =>
+                parameters.Add(p => p.Style, "width:300px;height:150px")
+                    .AddChildContent<RadzenLinearGaugeScale>(scale =>
+                        scale.AddChildContent<RadzenLinearGaugeScaleRange>(range =>
+                            range.Add(p => p.From, 0)
+                                .Add(p => p.To, 100)
+                                .Add(p => p.Fill, "blue"))));
+
+            component.InvokeAsync(() => component.Instance.Resize(300, 150));
+            var markupBefore = component.Markup;
+
+            component.InvokeAsync(() => component.Instance.Resize(600, 150));
+            var markupAfter = component.Markup;
+
+            // The range rect x/width attributes must change when the gauge is wider
+            Assert.NotEqual(markupBefore, markupAfter);
+            Assert.Contains("rz-linear-gauge-range", markupAfter);
+        }
+
+        [Fact]
         public void LinearGauge_Renders_RangeBorderRadius()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor/RadzenLinearGaugeScale.razor
+++ b/Radzen.Blazor/RadzenLinearGaugeScale.razor
@@ -48,6 +48,6 @@
         }
     }
 </g>
-<CascadingValue Value=@this IsFixed=true>
+<CascadingValue Value=@this>
     @ChildContent
 </CascadingValue>


### PR DESCRIPTION
RadzenLinearGaugeScale.razor wrapped its child content in <CascadingValue Value=@this IsFixed=true>. With IsFixed=true Blazor freezes the cascading parameter at initialization and does not re-pass it to child components on subsequent renders. As a result, when the gauge resizes and RadzenLinearGaugeScale re-renders, Blazor sees no changed parameters for RadzenLinearGaugeScaleRange (the Scale reference is the same fixed object; From/To/Fill etc. are unchanged) and skips its re-render entirely. The range band therefore keeps stale SVG coordinates and does not respond to any page resize.

Fix: remove IsFixed=true from the CascadingValue, matching the pattern already used by RadzenRadialGaugeScale.razor. The cascading value now participates in the normal render cycle so child ranges re-render and read the updated CurrentStart/CurrentEnd whenever the parent scale re-renders.

A regression test (LinearGauge_Range_UpdatesOnResize) is added to verify that the band coordinates change after a Resize() call.