### PR TITLE
Introduce SortComparer to RadzenDataGridColumn, for custom IComparer sort support

### DIFF
--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -3593,6 +3593,108 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal(new[] { "A", "B", "C" }, order);
         }
+
+        [Fact]
+        public void DataGrid_SortComparer_ComposesWithSecondaryColumn()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            // Two rows share Code=2 (Normal); secondary sort by Reference breaks the tie.
+            var data = new[]
+            {
+                new SortComparerItem { Reference = "B2", Code = 2 },
+                new SortComparerItem { Reference = "A", Code = 1 },
+                new SortComparerItem { Reference = "B1", Code = 2 },
+            };
+
+            var component = ctx.RenderComponent<RadzenDataGrid<SortComparerItem>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<SortComparerItem>>(p => p.Data, data);
+                parameterBuilder.Add<bool>(p => p.AllowSorting, true);
+                parameterBuilder.Add<bool>(p => p.AllowMultiColumnSorting, true);
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<SortComparerItem>));
+                    builder.AddAttribute(1, "Property", nameof(SortComparerItem.Code));
+                    builder.AddAttribute(2, "SortComparer", PriorityNameComparer());
+                    builder.AddAttribute(3, "SortOrder", SortOrder.Ascending);
+                    builder.CloseComponent();
+
+                    builder.OpenComponent(4, typeof(RadzenDataGridColumn<SortComparerItem>));
+                    builder.AddAttribute(5, "Property", nameof(SortComparerItem.Reference));
+                    builder.AddAttribute(6, "SortOrder", SortOrder.Ascending);
+                    builder.CloseComponent();
+                });
+            });
+
+            var order = component.Instance.View.ToList().Select(x => x.Reference).ToArray();
+
+            // Primary by mapped name asc: Normal (Code 2) before Urgent (Code 1).
+            // Secondary by Reference asc breaks the Normal tie: B1 before B2.
+            Assert.Equal(new[] { "B1", "B2", "A" }, order);
+        }
+
+        [Fact]
+        public void DataGrid_WithoutSortComparer_OrdersByRawValue()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = new[]
+            {
+                new SortComparerItem { Reference = "A", Code = 3 },
+                new SortComparerItem { Reference = "B", Code = 1 },
+                new SortComparerItem { Reference = "C", Code = 2 },
+            };
+
+            var component = ctx.RenderComponent<RadzenDataGrid<SortComparerItem>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<SortComparerItem>>(p => p.Data, data);
+                parameterBuilder.Add<bool>(p => p.AllowSorting, true);
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<SortComparerItem>));
+                    builder.AddAttribute(1, "Property", nameof(SortComparerItem.Reference));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent(2, typeof(RadzenDataGridColumn<SortComparerItem>));
+                    builder.AddAttribute(3, "Property", nameof(SortComparerItem.Code));
+                    builder.AddAttribute(4, "SortOrder", SortOrder.Ascending);
+                    builder.CloseComponent();
+                });
+            });
+
+            var order = component.Instance.View.ToList().Select(x => x.Reference).ToArray();
+
+            // No comparer: default ordering by raw Code value 1,2,3 -> B, C, A
+            Assert.Equal(new[] { "B", "C", "A" }, order);
+        }
+
+        [Fact]
+        public void DataGrid_SortComparer_HandlesValuesMissingFromMap()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            // Code 99 is not in the comparer's map; the comparer treats it as empty string (sorts first asc).
+            var data = new[]
+            {
+                new SortComparerItem { Reference = "A", Code = 1 },
+                new SortComparerItem { Reference = "X", Code = 99 },
+                new SortComparerItem { Reference = "C", Code = 3 },
+            };
+
+            var component = RenderSortComparerGrid(ctx, data, SortOrder.Ascending);
+
+            var order = component.Instance.View.ToList().Select(x => x.Reference).ToArray();
+
+            // "" (X) first, then Critical (C), then Urgent (A)
+            Assert.Equal(new[] { "X", "C", "A" }, order);
+        }
     }
 
     public class SortComparerItem

--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -3,6 +3,7 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -3518,5 +3519,85 @@ namespace Radzen.Blazor.Tests
                 public void Reset() => _inner.Reset();
             }
         }
+
+        static IComparer PriorityNameComparer()
+        {
+            var names = new Dictionary<int, string> { [1] = "Urgent", [2] = "Normal", [3] = "Critical" };
+            return Comparer<object>.Create((a, b) =>
+                string.Compare(
+                    names.TryGetValue(Convert.ToInt32(a), out var an) ? an : string.Empty,
+                    names.TryGetValue(Convert.ToInt32(b), out var bn) ? bn : string.Empty,
+                    StringComparison.Ordinal));
+        }
+
+        static IRenderedComponent<RadzenDataGrid<SortComparerItem>> RenderSortComparerGrid(
+            TestContext ctx, SortComparerItem[] data, SortOrder order)
+        {
+            return ctx.RenderComponent<RadzenDataGrid<SortComparerItem>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<SortComparerItem>>(p => p.Data, data);
+                parameterBuilder.Add<bool>(p => p.AllowSorting, true);
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<SortComparerItem>));
+                    builder.AddAttribute(1, "Property", nameof(SortComparerItem.Reference));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent(2, typeof(RadzenDataGridColumn<SortComparerItem>));
+                    builder.AddAttribute(3, "Property", nameof(SortComparerItem.Code));
+                    builder.AddAttribute(4, "SortComparer", PriorityNameComparer());
+                    builder.AddAttribute(5, "SortOrder", order);
+                    builder.CloseComponent();
+                });
+            });
+        }
+
+        [Fact]
+        public void DataGrid_SortComparer_OrdersByMappedName_Ascending()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = new[]
+            {
+                new SortComparerItem { Reference = "A", Code = 1 },
+                new SortComparerItem { Reference = "B", Code = 2 },
+                new SortComparerItem { Reference = "C", Code = 3 },
+            };
+
+            var component = RenderSortComparerGrid(ctx, data, SortOrder.Ascending);
+
+            var order = component.Instance.View.ToList().Select(x => x.Reference).ToArray();
+
+            Assert.Equal(new[] { "C", "B", "A" }, order);
+        }
+
+        [Fact]
+        public void DataGrid_SortComparer_OrdersByMappedName_Descending()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = new[]
+            {
+                new SortComparerItem { Reference = "A", Code = 1 },
+                new SortComparerItem { Reference = "B", Code = 2 },
+                new SortComparerItem { Reference = "C", Code = 3 },
+            };
+
+            var component = RenderSortComparerGrid(ctx, data, SortOrder.Descending);
+
+            var order = component.Instance.View.ToList().Select(x => x.Reference).ToArray();
+
+            Assert.Equal(new[] { "A", "B", "C" }, order);
+        }
+    }
+
+    public class SortComparerItem
+    {
+        public string Reference { get; set; } = string.Empty;
+        public int Code { get; set; }
     }
 }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2060,7 +2060,11 @@ namespace Radzen.Blazor
 
                     if (!string.IsNullOrEmpty(orderBy))
                     {
-                        if (typeof(TItem) == typeof(object))
+                        if (HasSortComparer())
+                        {
+                            view = OrderByComparers(view);
+                        }
+                        else if (typeof(TItem) == typeof(object))
                         {
                             var firstItem = view.FirstOrDefault();
                             if (firstItem != null)
@@ -2103,6 +2107,42 @@ namespace Radzen.Blazor
                 return QueryOnlyVisibleColumns ? view
                     .Select(allColumns.Where(c => c.GetVisible() && !string.IsNullOrEmpty(c.Property)).Select(c => c.Property)) : view;
             }
+        }
+
+        RadzenDataGridColumn<TItem>? SortColumn(SortDescriptor descriptor) =>
+            allColumns.FirstOrDefault(c => c.GetSortProperty() == descriptor.Property);
+
+        bool HasSortComparer() => sorts.Any(d => SortColumn(d)?.SortComparer != null);
+
+        static IComparer<object?> ToObjectComparer(IComparer? comparer) =>
+            comparer == null ? Comparer<object?>.Default : Comparer<object?>.Create((a, b) => comparer.Compare(a, b));
+
+        IQueryable<TItem> OrderByComparers(IQueryable<TItem> source)
+        {
+            IOrderedEnumerable<TItem>? ordered = null;
+
+            foreach (var descriptor in sorts)
+            {
+                var column = SortColumn(descriptor);
+                var comparer = ToObjectComparer(column?.SortComparer);
+                Func<TItem, object?> keySelector = item => column != null ? column.GetSortValue(item) : null;
+                var ascending = descriptor.SortOrder != SortOrder.Descending;
+
+                if (ordered == null)
+                {
+                    ordered = ascending
+                        ? source.OrderBy(keySelector, comparer)
+                        : source.OrderByDescending(keySelector, comparer);
+                }
+                else
+                {
+                    ordered = ascending
+                        ? ordered.ThenBy(keySelector, comparer)
+                        : ordered.ThenByDescending(keySelector, comparer);
+                }
+            }
+
+            return (ordered ?? source.AsEnumerable()).AsQueryable();
         }
 
         internal bool IsVirtualizationAllowed()

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -431,6 +431,9 @@ namespace Radzen.Blazor
         /// It does not apply to server-paged data (LoadData or OData), which sorts on the server,
         /// or to self-referencing (tree) data. Binding a queryable provider (such as Entity
         /// Framework) directly to Data together with a comparer evaluates the comparer in memory.
+        /// Note that when a column with a SortComparer takes part in a multi-column sort, the whole
+        /// sort is performed in memory — every column's sort key is evaluated in memory, not just
+        /// this column's.
         /// </summary>
         [Parameter]
         public IComparer? SortComparer { get; set; }

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -425,11 +425,12 @@ namespace Radzen.Blazor
 
         /// <summary>
         /// Gets or sets a custom comparer used to order this column when the DataGrid sorts an
-        /// in-memory data source. When set, the grid orders rows by this column's sort value using
-        /// the supplied comparer instead of the default member-path ordering — for example, sorting
-        /// id values by their mapped display text. Ignored for server-side data sources
-        /// (LoadData, OData, or a remote IQueryable provider), which fall back to property-path sorting.
-        /// Custom comparers are also not applied to self-referencing (tree) data.
+        /// in-memory data source. When set, the grid orders rows by this column's sort value
+        /// (the value at the sort property) using the supplied comparer instead of the default
+        /// member-path ordering — for example, sorting id values by their mapped display text.
+        /// It does not apply to server-paged data (LoadData or OData), which sorts on the server,
+        /// or to self-referencing (tree) data. Binding a queryable provider (such as Entity
+        /// Framework) directly to Data together with a comparer evaluates the comparer in memory.
         /// </summary>
         [Parameter]
         public IComparer? SortComparer { get; set; }

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -424,6 +424,16 @@ namespace Radzen.Blazor
         public string SortProperty { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets a custom comparer used to order this column when the DataGrid sorts an
+        /// in-memory data source. When set, the grid orders rows by this column's sort value using
+        /// the supplied comparer instead of the default member-path ordering — for example, sorting
+        /// id values by their mapped display text. Ignored for server-side data sources
+        /// (LoadData, OData, or a remote IQueryable provider), which fall back to property-path sorting.
+        /// </summary>
+        [Parameter]
+        public IComparer? SortComparer { get; set; }
+
+        /// <summary>
         /// Gets or sets the group property name.
         /// </summary>
         /// <value>The group property name.</value>
@@ -867,6 +877,15 @@ namespace Radzen.Blazor
             {
                 return Property;
             }
+        }
+
+        /// <summary>
+        /// Gets the value used to sort this column for the given item (the value at the sort property).
+        /// </summary>
+        internal object? GetSortValue(TItem item)
+        {
+            var sortProperty = GetSortProperty();
+            return string.IsNullOrEmpty(sortProperty) ? null : PropertyAccess.GetValue(item, sortProperty);
         }
 
         internal void SetSortOrder(SortOrder? order)

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -429,6 +429,7 @@ namespace Radzen.Blazor
         /// the supplied comparer instead of the default member-path ordering — for example, sorting
         /// id values by their mapped display text. Ignored for server-side data sources
         /// (LoadData, OData, or a remote IQueryable provider), which fall back to property-path sorting.
+        /// Custom comparers are also not applied to self-referencing (tree) data.
         /// </summary>
         [Parameter]
         public IComparer? SortComparer { get; set; }

--- a/RadzenBlazorDemos/Pages/DataGridSortComparer.razor
+++ b/RadzenBlazorDemos/Pages/DataGridSortComparer.razor
@@ -1,0 +1,42 @@
+@using System.Collections
+
+<RadzenDataGrid AllowSorting="true" AllowPaging="true" PageSize="5" Data="@orders" ColumnWidth="200px">
+    <Columns>
+        <RadzenDataGridColumn Property="@nameof(Order.Reference)" Title="Reference" />
+        <RadzenDataGridColumn Property="@nameof(Order.PriorityId)" Title="Priority" SortComparer="@priorityComparer">
+            <Template Context="order">
+                @priorities[order.PriorityId]
+            </Template>
+        </RadzenDataGridColumn>
+    </Columns>
+</RadzenDataGrid>
+
+@code {
+    class Order
+    {
+        public string Reference { get; set; } = string.Empty;
+        public int PriorityId { get; set; }
+    }
+
+    // Ids are not in alphabetical order of their names, so sorting by the comparer (which orders by
+    // the mapped name) is visibly different from sorting by the raw PriorityId.
+    static readonly IReadOnlyDictionary<int, string> priorities = new Dictionary<int, string>
+    {
+        [1] = "Urgent",
+        [2] = "Normal",
+        [3] = "Critical"
+    };
+
+    readonly IComparer priorityComparer = Comparer<object>.Create((a, b) =>
+        string.Compare(priorities[(int)a], priorities[(int)b], StringComparison.OrdinalIgnoreCase));
+
+    readonly List<Order> orders = new()
+    {
+        new Order { Reference = "ORD-001", PriorityId = 1 },
+        new Order { Reference = "ORD-002", PriorityId = 2 },
+        new Order { Reference = "ORD-003", PriorityId = 3 },
+        new Order { Reference = "ORD-004", PriorityId = 2 },
+        new Order { Reference = "ORD-005", PriorityId = 1 },
+        new Order { Reference = "ORD-006", PriorityId = 3 }
+    };
+}

--- a/RadzenBlazorDemos/Pages/DataGridSortComparer.razor
+++ b/RadzenBlazorDemos/Pages/DataGridSortComparer.razor
@@ -28,7 +28,10 @@
     };
 
     readonly IComparer priorityComparer = Comparer<object>.Create((a, b) =>
-        string.Compare(priorities[(int)a], priorities[(int)b], StringComparison.OrdinalIgnoreCase));
+        string.Compare(PriorityName(a), PriorityName(b), StringComparison.OrdinalIgnoreCase));
+
+    static string PriorityName(object value) =>
+        priorities.TryGetValue((int)value, out var name) ? name : string.Empty;
 
     readonly List<Order> orders = new()
     {

--- a/RadzenBlazorDemos/Pages/DataGridSortComparerPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridSortComparerPage.razor
@@ -1,0 +1,13 @@
+@page "/datagrid-sort-comparer"
+
+<RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
+    DataGrid <strong>Custom Sort Comparer</strong>
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    Set the SortComparer column property to order in-memory data with a custom comparer. Here the
+    Priority column stores an id but sorts by its mapped name. Custom comparers apply to in-memory data only.
+</RadzenText>
+
+<RadzenExample ComponentName="DataGrid" Example="DataGridSortComparer">
+    <DataGridSortComparer />
+</RadzenExample>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -772,6 +772,14 @@ namespace RadzenBlazorDemos
                             Title = "Blazor DataGrid - Sort API | Free UI Components by Radzen",
                             Description = "Set the initial sort order of your RadzenDataGrid via the SortOrder column property.",
                             Tags = new [] { "api", "sort", "datagrid", "table", "dataview" }
+                        },
+                        new Example
+                        {
+                            Name = "Custom Sort Comparer",
+                            Path = "datagrid-sort-comparer",
+                            Title = "Blazor DataGrid - Custom Sort Comparer | Free UI Components by Radzen",
+                            Description = "Sort a column with a custom IComparer, for example ordering id values by their mapped display name.",
+                            Tags = new [] { "comparer", "custom", "sort", "datagrid", "table", "dataview" }
                         }
                     }
                 },


### PR DESCRIPTION
In my project I have a number of DataGrid columns whose values are ids (stages, divisions, categories, etc.) that I display via a lookup to a friendly name. I'd like those columns to sort by the displayed name rather than the underlying id.

Today the DataGrid's client-side sort orders by a member path only — the order expression is built from the column's sort property — so a column bound to an id sorts in id order, with no way to supply a custom comparison. `FilterTemplate`/`FilterProperty` already let you customize filtering, but there isn't an equivalent for sorting.

This adds a `SortComparer` parameter to `RadzenDataGridColumn`. When set, the grid orders that column's in-memory data with the supplied `IComparer` instead of the default member-path ordering — e.g. comparing id values by their mapped display text. It composes with multi-column sorting (OrderBy/ThenBy) and honors ascending/descending.

- Entirely opt-in and non-breaking: when `SortComparer` is null the existing sort path is untouched.
- Applies to in-memory data. Server-paged data (LoadData/OData) sorts on the server and is unaffected; self-referencing (tree) data is also excluded. Both are noted in the XML docs.
- The comparer receives the column's sort-property values, so it's easy to back with a small lookup/dictionary (or any custom ordering — natural sort, a fixed enum order, etc.).

I considered instead wrapping the value in an `IComparable` type, but that pushes the wrapper through display/filtering/equality; a per-column comparer keeps the row value (the id) clean and isolates the sort concern to the one column.

Added tests (single and multi-column, ascending/descending, the default no-comparer path, and unmapped values) and a "Custom Sort Comparer" demo under DataGrid → Sorting.