### PR TITLE
Add FilterData to RadzenDataGridColumn for lookup-driven CheckBoxList filtering

### DIFF
--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Radzen.Blazor.Tests
@@ -3575,6 +3576,127 @@ namespace Radzen.Blazor.Tests
             component.Find("button.rz-grid-filter-icon").MouseDown();
 
             Assert.NotEmpty(component.FindAll("button.rz-apply-filter"));
+        }
+
+        private sealed class FilterLookupItem
+        {
+            public string Reference { get; set; } = string.Empty;
+            public int Code { get; set; }
+        }
+
+        [Fact]
+        public async Task DataGrid_FilterLookupData_FiltersByValueProperty()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = new[]
+            {
+                new FilterLookupItem { Reference = "A", Code = 1 },
+                new FilterLookupItem { Reference = "B", Code = 2 },
+                new FilterLookupItem { Reference = "C", Code = 3 },
+            };
+
+            var options = new[]
+            {
+                new { Id = 1, Name = "Urgent" },
+                new { Id = 2, Name = "Normal" },
+                new { Id = 3, Name = "Critical" },
+            };
+
+            var component = ctx.RenderComponent<RadzenDataGrid<FilterLookupItem>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<FilterLookupItem>>(p => p.Data, data);
+                parameterBuilder.Add<bool>(p => p.AllowFiltering, true);
+                parameterBuilder.Add<FilterMode>(p => p.FilterMode, FilterMode.CheckBoxList);
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<FilterLookupItem>));
+                    builder.AddAttribute(1, "Property", nameof(FilterLookupItem.Code));
+                    builder.AddAttribute(2, "FilterLookupData", options);
+                    builder.AddAttribute(3, "FilterLookupTextProperty", "Name");
+                    builder.AddAttribute(4, "FilterLookupValueProperty", "Id");
+                    builder.CloseComponent();
+                });
+            });
+
+            var grid = component.Instance;
+            var column = grid.ColumnsCollection.Single();
+
+            await component.InvokeAsync(() => column.SetFilterValue(new List<int> { 2, 3 }));
+            await component.InvokeAsync(() => grid.Reload());
+
+            var refs = grid.View.ToList().Select(x => x.Reference).OrderBy(x => x).ToArray();
+
+            Assert.Equal(new[] { "B", "C" }, refs);
+        }
+
+        [Fact]
+        public void DataGrid_CheckBoxList_WithoutFilterLookupData_RendersNativeFilter()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = new[]
+            {
+                new FilterLookupItem { Reference = "A", Code = 1 },
+                new FilterLookupItem { Reference = "B", Code = 2 },
+            };
+
+            var component = ctx.RenderComponent<RadzenDataGrid<FilterLookupItem>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<FilterLookupItem>>(p => p.Data, data);
+                parameterBuilder.Add<bool>(p => p.AllowFiltering, true);
+                parameterBuilder.Add<FilterMode>(p => p.FilterMode, FilterMode.CheckBoxList);
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<FilterLookupItem>));
+                    builder.AddAttribute(1, "Property", nameof(FilterLookupItem.Code));
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.Contains("rz-grid-filter-icon", component.Markup);
+        }
+
+        [Fact]
+        public void DataGrid_FilterLookupData_RendersOptionLabelsFromTextProperty()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = new[] { new FilterLookupItem { Reference = "A", Code = 1 } };
+            var options = new[]
+            {
+                new { Id = 1, Name = "Urgent" },
+                new { Id = 2, Name = "Normal" },
+                new { Id = 3, Name = "Critical" },
+            };
+
+            var component = ctx.RenderComponent<RadzenDataGrid<FilterLookupItem>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<FilterLookupItem>>(p => p.Data, data);
+                parameterBuilder.Add<bool>(p => p.AllowFiltering, true);
+                parameterBuilder.Add<FilterMode>(p => p.FilterMode, FilterMode.CheckBoxList);
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<FilterLookupItem>));
+                    builder.AddAttribute(1, "Property", nameof(FilterLookupItem.Code));
+                    builder.AddAttribute(2, "FilterLookupData", options);
+                    builder.AddAttribute(3, "FilterLookupTextProperty", "Name");
+                    builder.AddAttribute(4, "FilterLookupValueProperty", "Id");
+                    builder.CloseComponent();
+                });
+            });
+
+            component.Find("button.rz-grid-filter-icon").MouseDown();
+
+            var markup = component.Markup;
+            Assert.Contains("Urgent", markup);
+            Assert.Contains("Critical", markup);
         }
 
         private sealed class TrackingEnumerable<T> : IEnumerable<T>

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -438,6 +438,41 @@ namespace Radzen.Blazor
         public string FilterProperty { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the data source for the CheckBoxList filter's options. When set, the built-in
+        /// CheckBoxList filter shows these options — using <see cref="FilterLookupTextProperty"/> for the
+        /// label (display and in-dropdown search) and <see cref="FilterLookupValueProperty"/> for the
+        /// value — instead of deriving distinct values from the grid data. Selected values filter the
+        /// column's filter property, so the column's Property should be the underlying value (e.g. an id).
+        /// Applies to FilterMode.CheckBoxList. Mutually exclusive with the grid's LoadColumnFilterData
+        /// event per column: when FilterLookupData is set it supplies the options and LoadColumnFilterData
+        /// is not used for this column.
+        /// </summary>
+        [Parameter]
+        public IEnumerable? FilterLookupData { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property of <see cref="FilterLookupData"/> items used as the option label, shown
+        /// in the CheckBoxList filter and used for its search. Ignored when <see cref="FilterLookupData"/> is not set.
+        /// </summary>
+        [Parameter]
+        public string? FilterLookupTextProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property of <see cref="FilterLookupData"/> items used as the option value — the
+        /// value applied to the column filter when an option is selected. Ignored when
+        /// <see cref="FilterLookupData"/> is not set.
+        /// </summary>
+        [Parameter]
+        public string? FilterLookupValueProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the CheckBoxList filter's search box is shown when
+        /// <see cref="FilterLookupData"/> is set. Default is true. Ignored when FilterLookupData is not set.
+        /// </summary>
+        [Parameter]
+        public bool FilterLookupAllowFiltering { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the filter value.
         /// </summary>
         /// <value>The filter value.</value>

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -158,18 +158,26 @@
                                     @if (Column.FilterValueTemplate != null)
                                     {
                                         @Column.FilterValueTemplate(Column)
-                                    } 
+                                    }
                                     else
                                     {
                                         <RadzenProgressBarCircular Style="position:absolute;width:100%;" Visible="@isLoading" Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
                                         <RadzenListBox AllowVirtualization="@Column.AllowCheckBoxListVirtualization" AllowClear="true" Multiple="true" Style="height: 300px"
                                         TValue="IEnumerable" Value=@(hasPendingCheckBoxFilter ? pendingCheckBoxFilterValue as IEnumerable : Column.GetFilterValue() as IEnumerable) Change="@ListBoxChange"
-                                        Data=@filterValues Count=@filterValuesCount LoadData="@LoadFilterValues" 
-                                        AllowFiltering="@(!string.IsNullOrEmpty(Column.GetFilterProperty()))"
+                                        Data=@(Column.FilterLookupData ?? filterValues)
+                                        TextProperty="@(Column.FilterLookupData != null ? Column.FilterLookupTextProperty : null)"
+                                        ValueProperty="@(Column.FilterLookupData != null ? Column.FilterLookupValueProperty : null)"
+                                        Count="@(Column.FilterLookupData != null ? 0 : filterValuesCount)"
+                                        LoadData="@(Column.FilterLookupData != null ? default(EventCallback<Radzen.LoadDataArgs>) : EventCallback.Factory.Create<Radzen.LoadDataArgs>(this, LoadFilterValues))"
+                                        AllowFiltering="@(Column.FilterLookupData != null ? Column.FilterLookupAllowFiltering : !string.IsNullOrEmpty(Column.GetFilterProperty()))"
                                         Disabled="@(!Column.CanSetFilterValue())" FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                                         InputAttributes="@(new Dictionary<string,object>(){ { "aria-label", Column.Title + Grid.FilterValueAriaLabel  + Column.GetFilterValue() }})">
                                             <Template>
-                                                @if (context is Enum enumValue)
+                                                @if (Column.FilterLookupData != null)
+                                                {
+                                                    @PropertyAccess.GetItemOrValueFromProperty(context, Column.FilterLookupTextProperty)
+                                                }
+                                                else if (context is Enum enumValue)
                                                 {
                                                     @EnumExtensions.GetDisplayDescription(enumValue, Grid.EnumFilterTranslationFunc)
                                                 }

--- a/RadzenBlazorDemos/Pages/DataGridCheckBoxListLookupFilter.razor
+++ b/RadzenBlazorDemos/Pages/DataGridCheckBoxListLookupFilter.razor
@@ -1,0 +1,49 @@
+@using System.Collections
+
+<RadzenDataGrid AllowFiltering="true" FilterMode="FilterMode.CheckBoxList" AllowPaging="true" PageSize="5" Data="@orders" ColumnWidth="200px">
+    <Columns>
+        <RadzenDataGridColumn Property="@nameof(Order.Reference)" Title="Reference" />
+        <RadzenDataGridColumn Property="@nameof(Order.PriorityId)" Title="Priority"
+                              FilterLookupData="@priorities" FilterLookupTextProperty="Name" FilterLookupValueProperty="Id">
+            <Template Context="order">
+                @priorityNames[order.PriorityId]
+            </Template>
+        </RadzenDataGridColumn>
+    </Columns>
+</RadzenDataGrid>
+
+@code {
+    class Order
+    {
+        public string Reference { get; set; } = "";
+        public int PriorityId { get; set; }
+    }
+
+    record Priority(int Id, string Name);
+
+    // Ids are not in alphabetical order of their names, so filtering/searching by name in the
+    // dropdown is visibly different from the underlying id order.
+    readonly Priority[] priorities =
+    {
+        new(1, "Urgent"),
+        new(2, "Normal"),
+        new(3, "Critical")
+    };
+
+    readonly IReadOnlyDictionary<int, string> priorityNames;
+
+    public DataGridCheckBoxListLookupFilter()
+    {
+        priorityNames = priorities.ToDictionary(p => p.Id, p => p.Name);
+    }
+
+    readonly List<Order> orders = new()
+    {
+        new Order { Reference = "ORD-001", PriorityId = 1 },
+        new Order { Reference = "ORD-002", PriorityId = 2 },
+        new Order { Reference = "ORD-003", PriorityId = 3 },
+        new Order { Reference = "ORD-004", PriorityId = 2 },
+        new Order { Reference = "ORD-005", PriorityId = 1 },
+        new Order { Reference = "ORD-006", PriorityId = 3 }
+    };
+}

--- a/RadzenBlazorDemos/Pages/DataGridCheckBoxListLookupFilterPage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridCheckBoxListLookupFilterPage.razor
@@ -1,0 +1,14 @@
+@page "/datagrid-checkboxlist-lookup-filter"
+
+<RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
+    DataGrid <strong>CheckBoxList Filter with Lookup Data</strong>
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    Set FilterLookupData with FilterLookupTextProperty and FilterLookupValueProperty on a column to drive the CheckBoxList
+    filter from a lookup source. The Priority column stores an id but the filter shows, searches, and
+    filters by name, while still filtering on the underlying id.
+</RadzenText>
+
+<RadzenExample ComponentName="DataGrid" Example="DataGridCheckBoxListLookupFilter">
+    <DataGridCheckBoxListLookupFilter />
+</RadzenExample>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -612,6 +612,14 @@ namespace RadzenBlazorDemos
                         },
                         new Example
                         {
+                            Name = "CheckBoxList with Lookup",
+                            Path = "datagrid-checkboxlist-lookup-filter",
+                            Title = "Blazor DataGrid - CheckBoxList Filter with Lookup Data | Free UI Components by Radzen",
+                            Description = "Drive the CheckBoxList filter from a lookup data source: filter by id while showing and searching by name.",
+                            Tags = new [] { "checkboxlist", "lookup", "filter", "filtering", "datagrid", "table", "dataview" }
+                        },
+                        new Example
+                        {
                             Name = "CheckBoxList Auto-Apply",
                             Path = "datagrid-checkboxlist-auto-apply-filter",
                             Title = "Blazor DataGrid - CheckBoxList Filter Auto-Apply | Free UI Components by Radzen",


### PR DESCRIPTION
In my project I have a number of DataGrid columns whose values are ids (stages, divisions, categories, etc.) that I display via a lookup to a friendly name. I'd like the CheckBoxList filter to show, search, and order those options by name while still filtering on the underlying id.

Today the built-in CheckBoxList filter derives its options from the distinct values in the grid data and renders each option from its raw value (enum description / FormatString / ToString). There's no way to feed it a lookup so it can show a name for an id — so I'd been replacing the whole `FilterTemplate` with a hand-rolled `RadzenListBox`, which loses the native Clear/Apply/virtualization wiring.

This adds `FilterData` + `FilterTextProperty` + `FilterValueProperty` to `RadzenDataGridColumn`, mirroring `RadzenDropDown`'s `Data`/`TextProperty`/`ValueProperty`. When `FilterData` is set, the built-in CheckBoxList binds its `RadzenListBox` to it — displaying and searching by `FilterTextProperty`, selecting by `FilterValueProperty`. The column's `Property` stays the underlying id, so the existing CheckBoxList setup (`FilterPropertyType = IEnumerable<idType>`, operator `Contains`) still applies and selections filter as `id in (…)` — translating to both in-memory and OData/IQueryable sources.

- Entirely opt-in and non-breaking: when `FilterData` is null the existing distinct-values path is unchanged.
- Applies to `FilterMode.CheckBoxList`. Precedence is `FilterValueTemplate` > `FilterData` > native distinct values.
- Independent of the existing `LoadColumnFilterData` event (that drives the native path only); `FilterData` simply takes precedence per column.

Added tests (filter-by-value, option labels rendered from `FilterTextProperty`, and a regression that the native path is unchanged when `FilterData` is null) and a "CheckBoxList with Lookup" demo under DataGrid → Filtering.