### PR TITLE
Allow to use a RenderFragment as title for the RadzenChat component

### DIFF
--- a/Radzen.Blazor.Tests/ChatTests.cs
+++ b/Radzen.Blazor.Tests/ChatTests.cs
@@ -28,6 +28,27 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void RadzenChat_ShouldRenderWithTitleContent()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            var component = ctx.RenderComponent<RadzenChat>(parameters => parameters
+                .Add(p => p.TitleContent, builder =>
+                {
+                    builder.OpenComponent<RadzenBadge>(0);
+                    builder.AddAttribute(1, nameof(RadzenBadge.Text), "Chat Badge");
+                    builder.CloseComponent();
+                })
+                .Add(p => p.CurrentUserId, "user1")
+                .Add(p => p.Users, new List<ChatUser>())
+                .Add(p => p.Messages, new List<ChatMessage>())
+                .Add(p => p.EmptyMessage, "No messages yet!")
+            );
+
+            Assert.Contains("Chat Badge", component.Markup);
+        }
+
+        [Fact]
         public void RadzenChat_ShouldShowEmptyMessageWhenNoMessages()
         {
             using var ctx = new TestContext();
@@ -40,6 +61,7 @@ namespace Radzen.Blazor.Tests
                 .Add(p => p.EmptyMessage, "No messages yet!")
             );
 
+            Assert.Contains("Test Chat", component.Markup);
             Assert.Contains("No messages yet!", component.Markup);
         }
 

--- a/Radzen.Blazor/RadzenChat.razor
+++ b/Radzen.Blazor/RadzenChat.razor
@@ -8,14 +8,20 @@
 {
     <div @ref="@Element" @attributes="Attributes" class="@GetCssClass()" style="@Style" id="@GetId()" >
         <!-- Chat Header -->
-        @if (!string.IsNullOrWhiteSpace(Title) || ShowClearButton || ShowUsers)
+        @if (TitleContent != null || !string.IsNullOrWhiteSpace(Title) || ShowClearButton || ShowUsers)
         {       
             <RadzenStack class="rz-chat-header" Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween" Gap="0.5rem">
                 <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
-                    @if (!string.IsNullOrWhiteSpace(Title))
+                    <span class="rz-chat-header-title">
+                    @if (TitleContent != null)
                     {
-                        <span class="rz-chat-header-title">@Title</span>
+                        @TitleContent
                     }
+                    else if (!string.IsNullOrWhiteSpace(Title))
+                    {
+                        @Title
+                    }
+                    </span>
                     @if (ShowUsers && Users.Any())
                     {
                         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.25rem" class="rz-chat-users">
@@ -24,7 +30,7 @@
                                 <RadzenStack class="rz-chat-participant-avatar" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.Center" Gap="0" title="@participant.Name">
                                     @if (!string.IsNullOrEmpty(participant.AvatarUrl))
                                     {
-                                        <img src="@participant.AvatarUrl" alt="@participant.Name" class="rz-chat-participant-image" />
+                                        <img src="@participant.AvatarUrl" alt="@participant.Name" class="rz-chat-participant-image"/>
                                     }
                                     else
                                     {

--- a/Radzen.Blazor/RadzenChat.razor.cs
+++ b/Radzen.Blazor/RadzenChat.razor.cs
@@ -218,10 +218,16 @@ namespace Radzen.Blazor
         public string? MultipleUsersTypingFormat { get; set; } = "{0} and {1} others are typing...";
 
         /// <summary>
-        /// Gets or sets the title displayed in the chat header.
+        /// Gets or sets the title displayed in the chat header. <see cref="TitleContent" /> has preference over this property.
         /// </summary>
         [Parameter]
         public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom title content rendered in the chat header.
+        /// </summary>
+        [Parameter]
+        public RenderFragment? TitleContent { get; set; }
 
         /// <summary>
         /// Gets or sets the placeholder text for the input field.

--- a/RadzenBlazorDemos/Pages/ChatPage.razor
+++ b/RadzenBlazorDemos/Pages/ChatPage.razor
@@ -67,3 +67,13 @@
 <RadzenExample ComponentName="Chat" Example="ChatCompact">
     <ChatCompact />
 </RadzenExample>
+
+<RadzenText Anchor="chat#title" TextStyle="TextStyle.DisplayH5" TagName="TagName.H2" class="rt-pt-12">
+    RenderFragment as Title
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Use a RenderFragment to display more complex content in the title of the chat component.
+</RadzenText>
+<RadzenExample ComponentName="Chat" Example="ChatTitle">
+    <ChatTitle />
+</RadzenExample>

--- a/RadzenBlazorDemos/Pages/ChatTitle.razor
+++ b/RadzenBlazorDemos/Pages/ChatTitle.razor
@@ -1,0 +1,98 @@
+@using Radzen
+@using Radzen.Blazor
+@inherits ComponentBase
+
+<RadzenStack class="rz-p-0 rz-p-md-12">
+    <RadzenCard class="rz-p-4" Variant="Variant.Outlined">
+        <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+            <RadzenLabel Text="Title Content RenderFragment" />
+        </RadzenStack>
+    </RadzenCard>
+    <RadzenChat @ref="basicChat"
+                CurrentUserId="user1"
+                Users="@users"
+                Messages="@messages"
+                MessagesChanged="@OnMessagesChanged"
+                Placeholder="Type your message..."
+                Style="height: 500px;"
+                ShowTypingIndicator="true"
+                MessageAdded="@OnMessageAdded"
+                MessageSent="@OnMessageSent"
+                ChatCleared="@OnChatCleared"
+                TypingChanged="@OnTypingChanged">
+        <TitleContent>
+            <RadzenBadge>Chat Title Bade</RadzenBadge>
+        </TitleContent>
+    </RadzenChat>
+</RadzenStack>
+
+<EventConsole @ref="console" Style="min-height: 230px;" />
+
+@code {
+    RadzenChat basicChat;
+    EventConsole console;
+    
+    private List<ChatUser> users = new();
+    private List<ChatMessage> messages = new();
+
+    protected override void OnInitialized()
+    {
+        // Initialize users
+        users.AddRange(new[]
+        {
+            new ChatUser { Id = "user1", Name = "John Doe", Color = "#1976d2" },
+            new ChatUser { Id = "user2", Name = "Jane Smith", Color = "#388e3c" },
+            new ChatUser { Id = "user3", Name = "Bob Johnson", Color = "#f57c00" }
+        });
+
+        // Add some sample messages
+        messages.AddRange(new[]
+        {
+            new ChatMessage { Content = "Welcome to the team chat! 👋", UserId = "user1", Timestamp = DateTime.Now.AddMinutes(-30) },
+            new ChatMessage { Content = "Thanks John! Looking forward to working together.", UserId = "user2", Timestamp = DateTime.Now.AddMinutes(-29) },
+            new ChatMessage { Content = "Same here! Let's make this project amazing! 🚀", UserId = "user3", Timestamp = DateTime.Now.AddMinutes(-28) }
+        });
+    }
+
+    void OnMessageAdded(ChatMessage message)
+    {
+        var participant = users.FirstOrDefault(p => p.Id == message.UserId);
+        var participantName = participant?.Name ?? "Unknown";
+        console.Log($"Message added: {participantName} - {message.Content.Substring(0, Math.Min(50, message.Content.Length))}...", 
+                   message.UserId == "user1" ? AlertStyle.Info : AlertStyle.Success);
+    }
+
+    void OnMessageSent(ChatMessage message)
+    {
+        console.Log($"Message sent: {message.Content}", AlertStyle.Info);
+    }
+
+    void OnMessagesChanged(IEnumerable<ChatMessage> newMessages)
+    {
+        messages = newMessages.ToList();
+        StateHasChanged();
+    }
+
+    void OnChatCleared()
+    {
+        console.Log("Chat cleared", AlertStyle.Warning);
+    }
+
+    async Task SimulateJaneTyping()
+    {
+        if (basicChat == null)
+        {
+            return;
+        }
+
+        await basicChat.SetUserTyping("user2", true);
+        await Task.Delay(1500);
+        await basicChat.SetUserTyping("user2", false);
+    }
+
+    void OnTypingChanged(ChatTypingEventArgs args)
+    {
+        // In a real app you would broadcast this via SignalR to other clients.
+        console.Log($"TypingChanged: {args.UserId} => {args.IsTyping}", AlertStyle.Info);
+    }
+}


### PR DESCRIPTION
Created an optional parameter `TitleContent` for the `RadzenChat` component, that overrides the `Title` parameter if set.

This is a `RenderFragment` to be used for more complex content in the Titlebar.

Added Unit Tests and an additional Sample on the Chat Page.