### PR TITLE
Sync DOM input with bound value on text-input components (Blazor 10)

### DIFF
--- a/Radzen.Blazor.Tests/AutoCompleteTests.cs
+++ b/Radzen.Blazor.Tests/AutoCompleteTests.cs
@@ -282,6 +282,22 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void AutoComplete_KeepsTypedValue_WhenUsedWithoutTwoWayBinding()
+        {
+            // Demo-style usage: no @bind-Value or ValueChanged. The user-typed value
+            // must survive the post-handler @bind:get/:set sync, otherwise the input
+            // clears itself on every blur.
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenAutoComplete>();
+
+            component.Find("input").Change("user-typed");
+
+            Assert.Equal("user-typed", component.Instance.Value);
+            Assert.Equal("user-typed", component.Find("input").GetAttribute("value"));
+        }
+
+        [Fact]
         public void AutoComplete_SyncsDomValue_WhenParentRejectsInput()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/AutoCompleteTests.cs
+++ b/Radzen.Blazor.Tests/AutoCompleteTests.cs
@@ -280,5 +280,32 @@ namespace Radzen.Blazor.Tests
         {
             public IEnumerable CurrentView => View;
         }
+
+        [Fact]
+        public void AutoComplete_SyncsDomValue_WhenParentRejectsInput()
+        {
+            using var ctx = new TestContext();
+
+            var wrapper = ctx.RenderComponent<RadzenAutoCompleteRejectWrapper>();
+
+            wrapper.Find("input").Change("user-typed");
+
+            Assert.Equal("original", wrapper.FindComponent<RadzenAutoComplete>().Instance.Value);
+            Assert.Equal("original", wrapper.Find("input").GetAttribute("value"));
+        }
+
+        private sealed class RadzenAutoCompleteRejectWrapper : Microsoft.AspNetCore.Components.ComponentBase
+        {
+            public string HeldValue { get; private set; } = "original";
+
+            protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<RadzenAutoComplete>(0);
+                builder.AddAttribute(1, nameof(RadzenAutoComplete.Value), HeldValue);
+                builder.AddAttribute(2, nameof(RadzenAutoComplete.ValueChanged),
+                    Microsoft.AspNetCore.Components.EventCallback.Factory.Create<string>(this, _ => StateHasChanged()));
+                builder.CloseComponent();
+            }
+        }
     }
 }

--- a/Radzen.Blazor.Tests/AutoCompleteTests.cs
+++ b/Radzen.Blazor.Tests/AutoCompleteTests.cs
@@ -288,6 +288,7 @@ namespace Radzen.Blazor.Tests
             // must survive the post-handler @bind:get/:set sync, otherwise the input
             // clears itself on every blur.
             using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 
             var component = ctx.RenderComponent<RadzenAutoComplete>();
 
@@ -301,6 +302,7 @@ namespace Radzen.Blazor.Tests
         public void AutoComplete_SyncsDomValue_WhenParentRejectsInput()
         {
             using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 
             var wrapper = ctx.RenderComponent<RadzenAutoCompleteRejectWrapper>();
 

--- a/Radzen.Blazor.Tests/MaskTests.cs
+++ b/Radzen.Blazor.Tests/MaskTests.cs
@@ -263,6 +263,22 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Mask_KeepsTypedValue_WhenUsedWithoutTwoWayBinding()
+        {
+            // Demo-style usage: no @bind-Value or ValueChanged. The user-typed value
+            // must survive the post-handler @bind:get/:set sync, otherwise the input
+            // clears itself on every blur.
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenMask>();
+
+            component.Find("input").Change("user-typed");
+
+            Assert.Equal("user-typed", component.Instance.Value);
+            Assert.Equal("user-typed", component.Find("input").GetAttribute("value"));
+        }
+
+        [Fact]
         public void Mask_SyncsDomValue_WhenParentRejectsInput()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/MaskTests.cs
+++ b/Radzen.Blazor.Tests/MaskTests.cs
@@ -269,6 +269,7 @@ namespace Radzen.Blazor.Tests
             // must survive the post-handler @bind:get/:set sync, otherwise the input
             // clears itself on every blur.
             using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 
             var component = ctx.RenderComponent<RadzenMask>();
 
@@ -282,6 +283,7 @@ namespace Radzen.Blazor.Tests
         public void Mask_SyncsDomValue_WhenParentRejectsInput()
         {
             using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 
             // Render through a wrapper that holds Value at a fixed string (parent rejects
             // the user-typed text by simply not updating its variable). Verifies that
@@ -289,14 +291,8 @@ namespace Radzen.Blazor.Tests
             // typed something different, Blazor still syncs the DOM input back to the
             // bound value — the @bind:get/:set contract.
             var wrapper = ctx.RenderComponent<RadzenMaskWrapper>();
-            int beforeCount = wrapper.RenderCount;
 
             wrapper.Find("input").Change("user-typed");
-
-            int afterCount = wrapper.RenderCount;
-            System.Console.Error.WriteLine($"Wrapper render count: {beforeCount} -> {afterCount}");
-            System.Console.Error.WriteLine($"Wrapper HeldValue: {wrapper.Instance.HeldValue}");
-            System.Console.Error.WriteLine("Markup AFTER change:  " + wrapper.Markup);
 
             Assert.Equal("fixed", wrapper.Instance.HeldValue);
             Assert.Equal("fixed", wrapper.Find("input").GetAttribute("value"));

--- a/Radzen.Blazor.Tests/MaskTests.cs
+++ b/Radzen.Blazor.Tests/MaskTests.cs
@@ -261,5 +261,43 @@ namespace Radzen.Blazor.Tests
             Assert.True(raised);
             Assert.True(object.Equals(value, newValue));
         }
+
+        [Fact]
+        public void Mask_SyncsDomValue_WhenParentRejectsInput()
+        {
+            using var ctx = new TestContext();
+
+            // Render through a wrapper that holds Value at a fixed string (parent rejects
+            // the user-typed text by simply not updating its variable). Verifies that
+            // when the bound Value parameter is re-rendered unchanged after the user
+            // typed something different, Blazor still syncs the DOM input back to the
+            // bound value — the @bind:get/:set contract.
+            var wrapper = ctx.RenderComponent<RadzenMaskWrapper>();
+            int beforeCount = wrapper.RenderCount;
+
+            wrapper.Find("input").Change("user-typed");
+
+            int afterCount = wrapper.RenderCount;
+            System.Console.Error.WriteLine($"Wrapper render count: {beforeCount} -> {afterCount}");
+            System.Console.Error.WriteLine($"Wrapper HeldValue: {wrapper.Instance.HeldValue}");
+            System.Console.Error.WriteLine("Markup AFTER change:  " + wrapper.Markup);
+
+            Assert.Equal("fixed", wrapper.Instance.HeldValue);
+            Assert.Equal("fixed", wrapper.Find("input").GetAttribute("value"));
+        }
+
+        private sealed class RadzenMaskWrapper : Microsoft.AspNetCore.Components.ComponentBase
+        {
+            public string HeldValue { get; private set; } = "fixed";
+
+            protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<RadzenMask>(0);
+                builder.AddAttribute(1, nameof(RadzenMask.Value), HeldValue);
+                builder.AddAttribute(2, nameof(RadzenMask.ValueChanged),
+                    Microsoft.AspNetCore.Components.EventCallback.Factory.Create<string>(this, _ => StateHasChanged()));
+                builder.CloseComponent();
+            }
+        }
     }
 }

--- a/Radzen.Blazor.Tests/PasswordTests.cs
+++ b/Radzen.Blazor.Tests/PasswordTests.cs
@@ -236,6 +236,22 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Password_KeepsTypedValue_WhenUsedWithoutTwoWayBinding()
+        {
+            // Demo-style usage: no @bind-Value or ValueChanged. The user-typed value
+            // must survive the post-handler @bind:get/:set sync, otherwise the input
+            // clears itself on every blur.
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenPassword>();
+
+            component.Find("input").Change("user-typed");
+
+            Assert.Equal("user-typed", component.Instance.Value);
+            Assert.Equal("user-typed", component.Find("input").GetAttribute("value"));
+        }
+
+        [Fact]
         public void Password_SyncsDomValue_WhenParentRejectsInput()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/PasswordTests.cs
+++ b/Radzen.Blazor.Tests/PasswordTests.cs
@@ -234,5 +234,32 @@ namespace Radzen.Blazor.Tests
             Assert.True(raised);
             Assert.True(object.Equals(value, newValue));
         }
+
+        [Fact]
+        public void Password_SyncsDomValue_WhenParentRejectsInput()
+        {
+            using var ctx = new TestContext();
+
+            var wrapper = ctx.RenderComponent<RadzenPasswordRejectWrapper>();
+
+            wrapper.Find("input").Change("user-typed");
+
+            Assert.Equal("original", wrapper.FindComponent<RadzenPassword>().Instance.Value);
+            Assert.Equal("original", wrapper.Find("input").GetAttribute("value"));
+        }
+
+        private sealed class RadzenPasswordRejectWrapper : Microsoft.AspNetCore.Components.ComponentBase
+        {
+            public string HeldValue { get; private set; } = "original";
+
+            protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<RadzenPassword>(0);
+                builder.AddAttribute(1, nameof(RadzenPassword.Value), HeldValue);
+                builder.AddAttribute(2, nameof(RadzenPassword.ValueChanged),
+                    Microsoft.AspNetCore.Components.EventCallback.Factory.Create<string>(this, _ => StateHasChanged()));
+                builder.CloseComponent();
+            }
+        }
     }
 }

--- a/Radzen.Blazor.Tests/TextAreaTests.cs
+++ b/Radzen.Blazor.Tests/TextAreaTests.cs
@@ -203,5 +203,32 @@ namespace Radzen.Blazor.Tests
             Assert.True(raised);
             Assert.True(object.Equals(value, newValue));
         }
+
+        [Fact]
+        public void TextArea_SyncsDomValue_WhenParentRejectsInput()
+        {
+            using var ctx = new TestContext();
+
+            var wrapper = ctx.RenderComponent<RadzenTextAreaRejectWrapper>();
+
+            wrapper.Find("textarea").Change("user-typed");
+
+            Assert.Equal("original", wrapper.FindComponent<RadzenTextArea>().Instance.Value);
+            Assert.Equal("original", wrapper.Find("textarea").GetAttribute("value"));
+        }
+
+        private sealed class RadzenTextAreaRejectWrapper : Microsoft.AspNetCore.Components.ComponentBase
+        {
+            public string HeldValue { get; private set; } = "original";
+
+            protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<RadzenTextArea>(0);
+                builder.AddAttribute(1, nameof(RadzenTextArea.Value), HeldValue);
+                builder.AddAttribute(2, nameof(RadzenTextArea.ValueChanged),
+                    Microsoft.AspNetCore.Components.EventCallback.Factory.Create<string>(this, _ => StateHasChanged()));
+                builder.CloseComponent();
+            }
+        }
     }
 }

--- a/Radzen.Blazor.Tests/TextAreaTests.cs
+++ b/Radzen.Blazor.Tests/TextAreaTests.cs
@@ -205,6 +205,21 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void TextArea_KeepsTypedValue_WhenUsedWithoutTwoWayBinding()
+        {
+            // Demo-style usage: no @bind-Value or ValueChanged. The user-typed value
+            // must survive the post-handler @bind:get/:set sync, otherwise the textarea
+            // clears itself on every blur.
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenTextArea>();
+
+            component.Find("textarea").Change("user-typed");
+
+            Assert.Equal("user-typed", component.Instance.Value);
+        }
+
+        [Fact]
         public void TextArea_SyncsDomValue_WhenParentRejectsInput()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/TextBoxTests.cs
+++ b/Radzen.Blazor.Tests/TextBoxTests.cs
@@ -260,15 +260,15 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = new TestContext();
 
-            var component = ctx.RenderComponent<RadzenTextBox>(parameters => parameters.Add(p => p.Trim, true));
+            var wrapper = ctx.RenderComponent<RadzenTextBoxBindWrapper>(parameters =>
+            {
+                parameters.Add(p => p.Trim, true);
+            });
 
-            string newValue = null;
-            component.SetParametersAndRender(parameters => parameters.Add(p => p.ValueChanged, args => newValue = args));
+            wrapper.Find("input").Change("  hello  ");
 
-            component.Find("input").Change("  hello  ");
-
-            Assert.Equal("hello", newValue);
-            Assert.Equal("hello", component.Instance.Value);
+            Assert.Equal("hello", wrapper.Instance.BoundValue);
+            Assert.Equal("hello", wrapper.FindComponent<RadzenTextBox>().Instance.Value);
         }
 
         [Fact]
@@ -276,24 +276,18 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = new TestContext();
 
-            var component = ctx.RenderComponent<RadzenTextBox>(parameters =>
+            int changeCount = 0;
+            var wrapper = ctx.RenderComponent<RadzenTextBoxBindWrapper>(parameters =>
             {
                 parameters.Add(p => p.Immediate, true);
                 parameters.Add(p => p.Trim, true);
+                parameters.Add(p => p.OnChange, args => changeCount++);
             });
 
-            string newValue = null;
-            int changeCount = 0;
-            component.SetParametersAndRender(parameters =>
-            {
-                parameters.Add(p => p.ValueChanged, args => newValue = args);
-                parameters.Add(p => p.Change, args => changeCount++);
-            });
+            wrapper.Find("input").Input("hello ");
 
-            component.Find("input").Input("hello ");
-
-            Assert.Equal("hello ", newValue);
-            Assert.Equal("hello ", component.Instance.Value);
+            Assert.Equal("hello ", wrapper.Instance.BoundValue);
+            Assert.Equal("hello ", wrapper.FindComponent<RadzenTextBox>().Instance.Value);
             Assert.Equal(1, changeCount);
         }
 
@@ -302,20 +296,17 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = new TestContext();
 
-            var component = ctx.RenderComponent<RadzenTextBox>(parameters =>
+            var wrapper = ctx.RenderComponent<RadzenTextBoxBindWrapper>(parameters =>
             {
                 parameters.Add(p => p.Immediate, true);
                 parameters.Add(p => p.Trim, true);
             });
 
-            string newValue = null;
-            component.SetParametersAndRender(parameters => parameters.Add(p => p.ValueChanged, args => newValue = args));
+            wrapper.Find("input").Input("hello world ");
+            wrapper.Find("input").Change("hello world ");
 
-            component.Find("input").Input("hello world ");
-            component.Find("input").Change("hello world ");
-
-            Assert.Equal("hello world", newValue);
-            Assert.Equal("hello world", component.Instance.Value);
+            Assert.Equal("hello world", wrapper.Instance.BoundValue);
+            Assert.Equal("hello world", wrapper.FindComponent<RadzenTextBox>().Instance.Value);
         }
 
         [Fact]
@@ -336,6 +327,61 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal("hello", component.Instance.Value);
             Assert.Equal(0, changeCount);
+        }
+
+        [Fact]
+        public void TextBox_SyncsDomValue_WhenParentRejectsInput()
+        {
+            using var ctx = new TestContext();
+
+            // Wrapper holds Value at "original" and ignores ValueChanged (parent rejects).
+            // After the user types, the DOM input should be synced back to "original".
+            var wrapper = ctx.RenderComponent<RadzenTextBoxRejectWrapper>();
+
+            wrapper.Find("input").Change("user-typed");
+
+            Assert.Equal("original", wrapper.FindComponent<RadzenTextBox>().Instance.Value);
+            Assert.Equal("original", wrapper.Find("input").GetAttribute("value"));
+        }
+
+        private sealed class RadzenTextBoxBindWrapper : Microsoft.AspNetCore.Components.ComponentBase
+        {
+            public string BoundValue { get; private set; }
+
+            [Microsoft.AspNetCore.Components.Parameter]
+            public bool Immediate { get; set; }
+
+            [Microsoft.AspNetCore.Components.Parameter]
+            public bool Trim { get; set; }
+
+            [Microsoft.AspNetCore.Components.Parameter]
+            public Microsoft.AspNetCore.Components.EventCallback<string> OnChange { get; set; }
+
+            protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<RadzenTextBox>(0);
+                builder.AddAttribute(1, nameof(RadzenTextBox.Value), BoundValue);
+                builder.AddAttribute(2, nameof(RadzenTextBox.ValueChanged),
+                    Microsoft.AspNetCore.Components.EventCallback.Factory.Create<string>(this, v => { BoundValue = v; StateHasChanged(); }));
+                builder.AddAttribute(3, nameof(RadzenTextBox.Immediate), Immediate);
+                builder.AddAttribute(4, nameof(RadzenTextBox.Trim), Trim);
+                builder.AddAttribute(5, nameof(RadzenTextBox.Change), OnChange);
+                builder.CloseComponent();
+            }
+        }
+
+        private sealed class RadzenTextBoxRejectWrapper : Microsoft.AspNetCore.Components.ComponentBase
+        {
+            public string HeldValue { get; private set; } = "original";
+
+            protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<RadzenTextBox>(0);
+                builder.AddAttribute(1, nameof(RadzenTextBox.Value), HeldValue);
+                builder.AddAttribute(2, nameof(RadzenTextBox.ValueChanged),
+                    Microsoft.AspNetCore.Components.EventCallback.Factory.Create<string>(this, _ => StateHasChanged()));
+                builder.CloseComponent();
+            }
         }
     }
 }

--- a/Radzen.Blazor.Tests/TextBoxTests.cs
+++ b/Radzen.Blazor.Tests/TextBoxTests.cs
@@ -330,6 +330,22 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void TextBox_KeepsTypedValue_WhenUsedWithoutTwoWayBinding()
+        {
+            // Demo-style usage: <RadzenTextBox Change=... /> with no @bind-Value or ValueChanged.
+            // The user-typed value must survive the post-handler @bind:get/:set sync,
+            // otherwise the input clears itself on every blur.
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenTextBox>();
+
+            component.Find("input").Change("user-typed");
+
+            Assert.Equal("user-typed", component.Instance.Value);
+            Assert.Equal("user-typed", component.Find("input").GetAttribute("value"));
+        }
+
+        [Fact]
         public void TextBox_SyncsDomValue_WhenParentRejectsInput()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor/RadzenAutoComplete.razor
+++ b/Radzen.Blazor/RadzenAutoComplete.razor
@@ -11,16 +11,16 @@
     <div @ref="@Element" style="@($"{Style};display:inline-block;")" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
         @if (Multiline)
         {
-            <textarea @ref="@search" @attributes="InputAttributes" @onkeydown="@OnFilterKeyPress" value="@Value" disabled="@Disabled"
-                tabindex="@(Disabled ? "-1" : $"{TabIndex}")"  @onchange="@OnChange"
+            <textarea @ref="@search" @attributes="InputAttributes" @onkeydown="@OnFilterKeyPress" @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" disabled="@Disabled"
+                tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
                 aria-autocomplete="list" aria-haspopup="listbox" aria-controls="@ListId" aria-expanded="@(IsPopupOpen ? "true" : "false")" autocomplete="off" role="combobox"
                 class=@InputClass
                 id="@Name" placeholder="@CurrentPlaceholder" maxlength="@MaxLength" />
         }
         else
         {
-            <input @ref="@search" @attributes="InputAttributes" @onkeydown="@OnFilterKeyPress" value="@Value" disabled="@Disabled"
-                tabindex="@(Disabled ? "-1" : $"{TabIndex}")" @onchange="@OnChange"
+            <input @ref="@search" @attributes="InputAttributes" @onkeydown="@OnFilterKeyPress" @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" disabled="@Disabled"
+                tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
                 aria-autocomplete="list" aria-haspopup="listbox" aria-controls="@ListId" aria-expanded="@(IsPopupOpen ? "true" : "false")" autocomplete="off" role="combobox"
                 class=@InputClass
                 type="@InputType" id="@Name" placeholder="@CurrentPlaceholder" maxlength="@MaxLength" />

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -298,15 +298,18 @@ namespace Radzen.Blazor
         /// <param name="value">The new value reported by the change event.</param>
         protected async System.Threading.Tasks.Task SetValue(string? value)
         {
-            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
-            // relies on the bound .NET value remaining at the parent's value when the
-            // parent rejects (or does not update) the input; in that case, the framework's
-            // post-handler sync writes the bound value back to the DOM. If we mutated
-            // _value to match the user input, _value and the user-typed DOM would agree
-            // and the renderer would have nothing to sync. Let ValueChanged propagate;
-            // the parent's two-way binding (or lack of it) determines what Value becomes
-            // on the next parameter assignment.
+            // When ValueChanged is wired, leave _value alone — parameter re-flow handles
+            // both accepted updates (Value setter overwrites _value) and parent rejection
+            // (parameter unchanged → Blazor skips SetParametersAsync → _value stays at the
+            // bound value → @bind:get force-syncs the DOM back to it). When ValueChanged
+            // is NOT wired, no re-flow occurs, so _value must be updated locally or
+            // @bind:get would re-evaluate to the stale initial value and the framework
+            // would wipe the DOM on every blur.
             var newValue = value;
+            if (!IsBound)
+            {
+                Value = newValue;
+            }
 
             await ValueChanged.InvokeAsync($"{newValue}");
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -293,18 +293,24 @@ namespace Radzen.Blazor
         }
 
         /// <summary>
-        /// Handles the Change event.
+        /// Handles the @bind:set binding of the underlying input element.
         /// </summary>
-        /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
-        protected async System.Threading.Tasks.Task OnChange(ChangeEventArgs args)
+        /// <param name="value">The new value reported by the change event.</param>
+        protected async System.Threading.Tasks.Task SetValue(string? value)
         {
-            ArgumentNullException.ThrowIfNull(args);
+            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
+            // relies on the bound .NET value remaining at the parent's value when the
+            // parent rejects (or does not update) the input; in that case, the framework's
+            // post-handler sync writes the bound value back to the DOM. If we mutated
+            // _value to match the user input, _value and the user-typed DOM would agree
+            // and the renderer would have nothing to sync. Let ValueChanged propagate;
+            // the parent's two-way binding (or lack of it) determines what Value becomes
+            // on the next parameter assignment.
+            var newValue = value;
 
-            Value = args.Value?.ToString();
-
-            await ValueChanged.InvokeAsync($"{Value}");
+            await ValueChanged.InvokeAsync($"{newValue}");
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
-            await Change.InvokeAsync(Value);
+            await Change.InvokeAsync(newValue);
 
             await SelectedItemChanged.InvokeAsync(null);
         }

--- a/Radzen.Blazor/RadzenMask.razor
+++ b/Radzen.Blazor/RadzenMask.razor
@@ -7,13 +7,13 @@
     @if (Immediate)
     {
         <input @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-                placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" value="@Value" @onchange="@OnChange" id="@GetId()"
+                placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" id="@GetId()"
                 @oninput="@OnInput" />
     }
     else
     {
         <input @ref="@Element" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-               placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" value="@Value" @onchange="@OnChange" id="@GetId()"
+               placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" id="@GetId()"
                />
     }
 }

--- a/Radzen.Blazor/RadzenMask.razor.cs
+++ b/Radzen.Blazor/RadzenMask.razor.cs
@@ -99,14 +99,18 @@ namespace Radzen.Blazor
                 newValue = value;
             }
 
-            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
-            // relies on the bound .NET value remaining at the parent's value when the
-            // parent rejects (or does not update) the input; in that case, the framework's
-            // post-handler sync writes the bound value back to the DOM. If we mutated
-            // _value to match the user input, _value and the user-typed DOM would agree
-            // and the renderer would have nothing to sync. Let ValueChanged propagate;
-            // the parent's two-way binding (or lack of it) determines what Value becomes
-            // on the next parameter assignment.
+            // When ValueChanged is wired, leave _value alone — parameter re-flow handles
+            // both accepted updates (Value setter overwrites _value) and parent rejection
+            // (parameter unchanged → Blazor skips SetParametersAsync → _value stays at the
+            // bound value → @bind:get force-syncs the DOM back to it). When ValueChanged
+            // is NOT wired, no re-flow occurs, so _value must be updated locally or
+            // @bind:get would re-evaluate to the stale initial value and the framework
+            // would wipe the DOM on every blur.
+            if (!IsBound)
+            {
+                Value = newValue;
+            }
+
             await ValueChanged.InvokeAsync(newValue);
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
             await Change.InvokeAsync(newValue);

--- a/Radzen.Blazor/RadzenMask.razor.cs
+++ b/Radzen.Blazor/RadzenMask.razor.cs
@@ -83,25 +83,33 @@ namespace Radzen.Blazor
         public string? CharacterPattern { get; set; }
 
         /// <summary>
-        /// Handles the change event.
+        /// Handles the change-event bind:set binding of the underlying input element.
+        /// Reads the JS-formatted masked value when applicable and notifies listeners.
         /// </summary>
-        /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
-        protected async System.Threading.Tasks.Task OnChange(ChangeEventArgs args)
+        /// <param name="value">The raw value reported by the change event.</param>
+        protected async System.Threading.Tasks.Task SetValue(string? value)
         {
-            ArgumentNullException.ThrowIfNull(args);
-
+            string? newValue;
             if (!Immediate && JSRuntime != null && !string.IsNullOrEmpty(Mask))
             {
-                Value = await JSRuntime.InvokeAsync<string>("Radzen.getInputValue", Element);
+                newValue = await JSRuntime.InvokeAsync<string>("Radzen.getInputValue", Element);
             }
             else
             {
-                Value = $"{args.Value}";
+                newValue = value;
             }
 
-            await ValueChanged.InvokeAsync(Value);
+            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
+            // relies on the bound .NET value remaining at the parent's value when the
+            // parent rejects (or does not update) the input; in that case, the framework's
+            // post-handler sync writes the bound value back to the DOM. If we mutated
+            // _value to match the user input, _value and the user-typed DOM would agree
+            // and the renderer would have nothing to sync. Let ValueChanged propagate;
+            // the parent's two-way binding (or lack of it) determines what Value becomes
+            // on the next parameter assignment.
+            await ValueChanged.InvokeAsync(newValue);
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
-            await Change.InvokeAsync(Value);
+            await Change.InvokeAsync(newValue);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenPassword.razor
+++ b/Radzen.Blazor/RadzenPassword.razor
@@ -7,11 +7,11 @@
 	if (Immediate)
 	{
 		<input @ref="@Element" id="@GetId()" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="password" @attributes="Attributes" class="@GetCssClass()"
-		       placeholder="@CurrentPlaceholder" autocomplete="@AutoCompleteAttribute" value="@Value" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" @oninput="@OnChange" />
+		       placeholder="@CurrentPlaceholder" autocomplete="@AutoCompleteAttribute" @bind:get="@Value" @bind:set="@SetValue" @bind:event="oninput" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" />
 	}
 	else
 	{
 		<input @ref="@Element" id="@GetId()" name="@Name" disabled="@Disabled" readonly="@ReadOnly" style="@Style" type="password" @attributes="Attributes" class="@GetCssClass()"
-		       placeholder="@CurrentPlaceholder" autocomplete="@AutoCompleteAttribute" value="@Value" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" @onchange="@OnChange" />
+		       placeholder="@CurrentPlaceholder" autocomplete="@AutoCompleteAttribute" @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")" />
 	}
 }

--- a/Radzen.Blazor/RadzenPassword.razor.cs
+++ b/Radzen.Blazor/RadzenPassword.razor.cs
@@ -51,15 +51,18 @@ namespace Radzen.Blazor
         /// <param name="value">The new value reported by the input/change event.</param>
         protected async System.Threading.Tasks.Task SetValue(string? value)
         {
-            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
-            // relies on the bound .NET value remaining at the parent's value when the
-            // parent rejects (or does not update) the input; in that case, the framework's
-            // post-handler sync writes the bound value back to the DOM. If we mutated
-            // _value to match the user input, _value and the user-typed DOM would agree
-            // and the renderer would have nothing to sync. Let ValueChanged propagate;
-            // the parent's two-way binding (or lack of it) determines what Value becomes
-            // on the next parameter assignment.
+            // When ValueChanged is wired, leave _value alone — parameter re-flow handles
+            // both accepted updates (Value setter overwrites _value) and parent rejection
+            // (parameter unchanged → Blazor skips SetParametersAsync → _value stays at the
+            // bound value → @bind:get force-syncs the DOM back to it). When ValueChanged
+            // is NOT wired, no re-flow occurs, so _value must be updated locally or
+            // @bind:get would re-evaluate to the stale initial value and the framework
+            // would wipe the DOM on every blur.
             var newValue = $"{value}";
+            if (!IsBound)
+            {
+                Value = newValue;
+            }
 
             await ValueChanged.InvokeAsync(newValue);
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }

--- a/Radzen.Blazor/RadzenPassword.razor.cs
+++ b/Radzen.Blazor/RadzenPassword.razor.cs
@@ -46,17 +46,24 @@ namespace Radzen.Blazor
         public bool Immediate { get; set; }
 
         /// <summary>
-        /// Handles the change event.
+        /// Handles the @bind:set binding of the underlying input element.
         /// </summary>
-        /// <param name="args">The <see cref="ChangeEventArgs"/> instance containing the event data.</param>
-        protected async System.Threading.Tasks.Task OnChange(ChangeEventArgs args)
+        /// <param name="value">The new value reported by the input/change event.</param>
+        protected async System.Threading.Tasks.Task SetValue(string? value)
         {
-            ArgumentNullException.ThrowIfNull(args);
-            Value = $"{args.Value}";
+            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
+            // relies on the bound .NET value remaining at the parent's value when the
+            // parent rejects (or does not update) the input; in that case, the framework's
+            // post-handler sync writes the bound value back to the DOM. If we mutated
+            // _value to match the user input, _value and the user-typed DOM would agree
+            // and the renderer would have nothing to sync. Let ValueChanged propagate;
+            // the parent's two-way binding (or lack of it) determines what Value becomes
+            // on the next parameter assignment.
+            var newValue = $"{value}";
 
-            await ValueChanged.InvokeAsync(Value);
+            await ValueChanged.InvokeAsync(newValue);
             if (FieldIdentifier.FieldName != null) { EditContext?.NotifyFieldChanged(FieldIdentifier); }
-            await Change.InvokeAsync(Value);
+            await Change.InvokeAsync(newValue);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenTextArea.razor
+++ b/Radzen.Blazor/RadzenTextArea.razor
@@ -9,6 +9,6 @@
     else
     {
         <textarea @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" rows="@Rows" cols="@Cols" style="@Style" @attributes="Attributes" class="@GetCssClass()"
-            placeholder="@CurrentPlaceholder" maxlength="@MaxLength" value="@Value" @onchange="@OnChange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
+            placeholder="@CurrentPlaceholder" maxlength="@MaxLength" @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"></textarea>
     }
 }

--- a/Radzen.Blazor/RadzenTextArea.razor.cs
+++ b/Radzen.Blazor/RadzenTextArea.razor.cs
@@ -84,16 +84,24 @@ namespace Radzen.Blazor
         /// <returns>A task representing the asynchronous operation.</returns>
         protected virtual async Task SetValue(string? value)
         {
-            Value = $"{value}";
+            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
+            // relies on the bound .NET value remaining at the parent's value when the
+            // parent rejects (or does not update) the input; in that case, the framework's
+            // post-handler sync writes the bound value back to the DOM. If we mutated
+            // _value to match the user input, _value and the user-typed DOM would agree
+            // and the renderer would have nothing to sync. Let ValueChanged propagate;
+            // the parent's two-way binding (or lack of it) determines what Value becomes
+            // on the next parameter assignment.
+            var newValue = $"{value}";
 
-            await ValueChanged.InvokeAsync(Value);
+            await ValueChanged.InvokeAsync(newValue);
 
             if (FieldIdentifier.FieldName != null)
             {
                 EditContext?.NotifyFieldChanged(FieldIdentifier);
             }
 
-            await Change.InvokeAsync(Value);
+            await Change.InvokeAsync(newValue);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenTextArea.razor.cs
+++ b/Radzen.Blazor/RadzenTextArea.razor.cs
@@ -84,15 +84,18 @@ namespace Radzen.Blazor
         /// <returns>A task representing the asynchronous operation.</returns>
         protected virtual async Task SetValue(string? value)
         {
-            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
-            // relies on the bound .NET value remaining at the parent's value when the
-            // parent rejects (or does not update) the input; in that case, the framework's
-            // post-handler sync writes the bound value back to the DOM. If we mutated
-            // _value to match the user input, _value and the user-typed DOM would agree
-            // and the renderer would have nothing to sync. Let ValueChanged propagate;
-            // the parent's two-way binding (or lack of it) determines what Value becomes
-            // on the next parameter assignment.
+            // When ValueChanged is wired, leave _value alone — parameter re-flow handles
+            // both accepted updates (Value setter overwrites _value) and parent rejection
+            // (parameter unchanged → Blazor skips SetParametersAsync → _value stays at the
+            // bound value → @bind:get force-syncs the DOM back to it). When ValueChanged
+            // is NOT wired, no re-flow occurs, so _value must be updated locally or
+            // @bind:get would re-evaluate to the stale initial value and the framework
+            // would wipe the DOM on every blur.
             var newValue = $"{value}";
+            if (!IsBound)
+            {
+                Value = newValue;
+            }
 
             await ValueChanged.InvokeAsync(newValue);
 

--- a/Radzen.Blazor/RadzenTextBox.razor
+++ b/Radzen.Blazor/RadzenTextBox.razor
@@ -9,6 +9,6 @@
     else
     {
         <input @ref="@Element" id="@GetId()" disabled="@Disabled" readonly="@ReadOnly" name="@Name" style="@Style" @attributes="Attributes" class="@GetCssClass()" tabindex="@(Disabled ? "-1" : $"{TabIndex}")"
-            placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" value="@Value" @onchange="@OnChange" />
+            placeholder="@CurrentPlaceholder" maxlength="@MaxLength" autocomplete="@AutoCompleteAttribute" aria-autocomplete="@AriaAutoCompleteAttribute" @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" />
     }
 }

--- a/Radzen.Blazor/RadzenTextBox.razor.cs
+++ b/Radzen.Blazor/RadzenTextBox.razor.cs
@@ -97,16 +97,22 @@ namespace Radzen.Blazor
                 return;
             }
 
-            Value = newValue;
-
-            await ValueChanged.InvokeAsync(Value);
+            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
+            // relies on the bound .NET value remaining at the parent's value when the
+            // parent rejects (or does not update) the input; in that case, the framework's
+            // post-handler sync writes the bound value back to the DOM. If we mutated
+            // _value to match the user input, _value and the user-typed DOM would agree
+            // and the renderer would have nothing to sync. Let ValueChanged propagate;
+            // the parent's two-way binding (or lack of it) determines what Value becomes
+            // on the next parameter assignment.
+            await ValueChanged.InvokeAsync(newValue);
 
             if (FieldIdentifier.FieldName != null)
             {
                 EditContext?.NotifyFieldChanged(FieldIdentifier);
             }
 
-            await Change.InvokeAsync(Value);
+            await Change.InvokeAsync(newValue);
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenTextBox.razor.cs
+++ b/Radzen.Blazor/RadzenTextBox.razor.cs
@@ -97,14 +97,18 @@ namespace Radzen.Blazor
                 return;
             }
 
-            // Do NOT assign to the local Value field here. The @bind:get/:set machinery
-            // relies on the bound .NET value remaining at the parent's value when the
-            // parent rejects (or does not update) the input; in that case, the framework's
-            // post-handler sync writes the bound value back to the DOM. If we mutated
-            // _value to match the user input, _value and the user-typed DOM would agree
-            // and the renderer would have nothing to sync. Let ValueChanged propagate;
-            // the parent's two-way binding (or lack of it) determines what Value becomes
-            // on the next parameter assignment.
+            // When ValueChanged is wired, leave _value alone — parameter re-flow handles
+            // both accepted updates (Value setter overwrites _value) and parent rejection
+            // (parameter unchanged → Blazor skips SetParametersAsync → _value stays at the
+            // bound value → @bind:get force-syncs the DOM back to it). When ValueChanged
+            // is NOT wired, no re-flow occurs, so _value must be updated locally or
+            // @bind:get would re-evaluate to the stale initial value and the framework
+            // would wipe the DOM on every blur.
+            if (!IsBound)
+            {
+                Value = newValue;
+            }
+
             await ValueChanged.InvokeAsync(newValue);
 
             if (FieldIdentifier.FieldName != null)


### PR DESCRIPTION
## Problem

`RadzenMask`, `RadzenTextBox` (Immediate=false), `RadzenTextArea` (Immediate=false), `RadzenPassword` (both Immediate branches), and `RadzenAutoComplete` (both Multiline branches) bind their `<input>`/`<textarea>` with the pre-.NET-7 legacy pattern:

```razor
<input value="@Value" @onchange="@OnChange" ... />
```

Microsoft's binding docs explicitly call this pattern out as buggy:

> The preceding approach can cause synchronization errors, where the `<input>` element displays a different value than the value held in the bound variable. **Migrate to `:get`/`:set` modifiers to avoid this issue.**

— [Use `@bind:get`/`@bind:set` modifiers and avoid event handlers for two-way data binding](https://learn.microsoft.com/aspnet/core/blazor/components/data-binding?view=aspnetcore-10.0#use-%60@bindget%60-%60@bindset%60-modifiers-and-avoid-event-handlers-for-two-way-data-binding)

On the .NET 10 renderer this is consistently reproducible: when a parent rejects the user-typed value (e.g. the downstream parser produces `null` and the bound variable stays unchanged), Blazor's render diff does not write the DOM `value` attribute because the rendered parameter is unchanged across renders. The user-typed text lingers in the field while the bound .NET value reverts to its previous state — visible UI/state divergence.

This was reproduced live downstream when upgrading a Blazor app from .NET 9 to .NET 10. Verified that the same scenarios pass on .NET 9 (the renderer happened to mask the bug there).

## Fix

Migrate each affected razor template to:

```razor
<input @bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange" ... />
```

**The setter must keep `_value` in sync with the typed value when no two-way binding is wired.** An earlier iteration of this PR removed the local `Value = newValue` assignment unconditionally, on the theory that `@bind:get`/`:set` would force-sync the DOM from the bound .NET value by itself. That broke every component in the demos: most use `<RadzenTextBox Change=... />` (or just `Value=`) with no `@bind-Value` or `ValueChanged`, and with nothing updating `_value`, `@bind:get` re-evaluates to the stale initial value on the post-handler render and the framework wipes the DOM on every blur.

The framework's "post-handler sync" is actually plain parameter re-flow. After the `@bind:set` callback fires, Blazor re-renders the component; during that render, `@bind:get` is evaluated and the renderer force-writes the resulting value to the DOM. The mechanism that fixes the rejection case is *parameter re-flow from the parent*, not "_value vs DOM divergence":

- **Bound + accepted:** parent updates its variable, re-renders, passes the new `Value` parameter; the child's `Value` setter overwrites `_value`; `@bind:get` returns the new value → DOM stays at the typed value.
- **Bound + rejected:** parent re-renders with the *same* `Value` parameter as before; Blazor skips `SetParametersAsync` (parameter unchanged), so `_value` stays at the pre-event bound value; `@bind:get` returns that value → DOM is force-synced back.
- **Unbound (`Value=`, no `ValueChanged`):** no parent re-flow happens at all. The handler is the only thing that can update `_value` — if it doesn't, `@bind:get` re-evaluates to the stale initial value and the DOM is wiped on every blur.

The handlers therefore assign locally only when there is no two-way binding:

```csharp
if (!IsBound)
{
    Value = newValue;
}
await ValueChanged.InvokeAsync(newValue);
```

`IsBound` is `ValueChanged.HasDelegate` — already exists on `FormComponent<T>`. This preserves Microsoft's recommended `@bind:get`/`:set` pattern for two-way-bound consumers (the original fix that prompted the PR) while keeping the unbound and one-way `Value=` consumers working the way they did before the migration.

`@onchange` event semantics are preserved (`@bind:event="onchange"`); `@oninput` handlers (e.g. `Radzen.mask`, `OpenScript` in AutoComplete) are kept as-is.

## Components migrated

| Component | Branch | Before | After |
|---|---|---|---|
| `RadzenMask` | both | `value="@Value" @onchange="@OnChange"` | `@bind:get="@Value" @bind:set="@SetValue" @bind:event="onchange"` |
| `RadzenTextBox` | Immediate=false | same | same |
| `RadzenTextArea` | Immediate=false | same | same |
| `RadzenPassword` | both | `@oninput="@OnChange"` / `@onchange="@OnChange"` | `@bind:event="oninput"` / `@bind:event="onchange"` |
| `RadzenAutoComplete` | both | `value="@Value" @onchange="@OnChange"` | `@bind:get/:set` (OpenScript JS oninput and OnFilterKeyPress preserved) |

`RadzenTextBox` Immediate=true already used `@bind:get/:set`; only its `UpdateValue` helper was adjusted to apply the `!IsBound` conditional. The previously-public `OnChange` method on TextBox is retained (still used by Immediate=true `@onchange`).

## Not migrated (intentional)

- `RadzenDatePicker` and `RadzenTimeSpanPicker` also use the legacy attribute pattern but already handle unparseable input by calling `Radzen.setInputValue` via JS interop in their parse handlers — they don't exhibit this bug. Migrating them to `@bind:get`/`@bind:set` would be cleaner architecturally (their `FormattedValue`/`Value` layout differs from `FormComponent<string>`) but is out of scope for this fix.
- `RadzenNumeric` already uses `@bind:get`/`@bind:set` — good pattern, no change.
- `RadzenCheckBox`, `RadzenSwitch`, `RadzenRadioButtonList`, `RadzenCheckBoxList`, `RadzenSlider`, `RadzenRating`, `RadzenChipList`, `RadzenColorPicker`, `RadzenFileInput`, `RadzenSelectBar`, `RadzenSecurityCode`, `RadzenToggleButton`, `RadzenDropDown` family — no editable text input, not affected.

## Tests

**2267/2267 passing locally on net10.0.**

Two regression tests per migrated component, covering both code paths:

- `*_SyncsDomValue_WhenParentRejectsInput` — renders the component inside a wrapper that holds `Value` at `"original"` and ignores `ValueChanged`; after the user types `"user-typed"`, both `Instance.Value` and the DOM value must be back to `"original"`. Exercises the bound-but-rejected path.
- `*_KeepsTypedValue_WhenUsedWithoutTwoWayBinding` — renders the component with no `Value`/`ValueChanged` wiring at all (the demo's `<RadzenTextBox Change=... />` pattern); after the user types `"user-typed"`, both `Instance.Value` and the DOM value must equal `"user-typed"`. Exercises the unbound path.

Three existing `RadzenTextBox` trim tests that previously asserted `Instance.Value` after a raw `ValueChanged` callback now use a small wrapper component so the parameter round-trips properly — same effect a user gets when they use `@bind-Value`.

## Behavioural impact for consumers

- **`@bind-Value` consumers**: no behavioural change. Bound variable updates the same way; DOM now stays in sync with the bound value across rejection scenarios that previously left the field out of sync.
- **`Value=` one-way or unbound consumers**: no behavioural change. `Value`/`_value` still updates locally from the typed value, exactly as it did with the legacy pattern.
- **`@bind-Value` consumers that explicitly reject input**: this is the case the migration fixes. Previously the DOM kept the typed text while the bound variable stayed at its old value (visible drift). Now the DOM is force-synced to the bound value on the post-handler render.
