### PR TITLE
Fixed an issue in MonthView where clicking on an appointment would, f…

### DIFF
--- a/Radzen.Blazor/Rendering/MonthView.razor
+++ b/Radzen.Blazor/Rendering/MonthView.razor
@@ -326,7 +326,12 @@
         if (Scheduler != null)
         {
             await Scheduler.SelectAppointment(data);
-            await contentView.FocusAsync();
+
+            try
+            {
+                await contentView.FocusAsync();
+            }
+            catch (JSException) {}
         }
     }
 


### PR DESCRIPTION
## Problem

A `JSException` could occur when calling `contentView.FocusAsync()` after selecting an appointment.

This happened when the component was disposed, the user navigated to another page, or the referenced DOM element was removed before the asynchronous operation completed. In these scenarios, Blazor would throw the following exception:

```text
Unable to focus an invalid element.
```

## Root Cause

`FocusAsync()` requires a valid `ElementReference` that is still present in the DOM.

Since `SelectAppointment()` is asynchronous, the component state may change before the focus operation is executed. If the target element no longer exists when `FocusAsync()` runs, Blazor throws a `JSException`.

## Fix

Added exception handling around the `FocusAsync()` call to safely ignore cases where the target element is no longer available.

```csharp
async Task OnAppointmentClick(AppointmentData data)
{
    if (Scheduler != null)
    {
        await Scheduler.SelectAppointment(data);

        try
        {
            await contentView.FocusAsync();
        }
        catch (JSException)
        {
        }
    }
}
```

## Result

- Prevents unnecessary exceptions during navigation or component disposal.
- Handles DOM lifecycle race conditions gracefully.
- Preserves the intended focus behavior when the element is available.
- Avoids user-facing errors for a non-critical UI interaction.