### PR TITLE
Fix IsNull/IsEmpty filter operators broken by case-insensitive mode

### DIFF
--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -752,7 +752,11 @@ namespace Radzen
 
             var constant = Expression.Constant(constantValue, constantType);
 
-            if (caseInsensitive && !isEnumerable)
+            if (caseInsensitive && !isEnumerable
+                && filter.FilterOperator != FilterOperator.IsNull
+                && filter.FilterOperator != FilterOperator.IsNotNull
+                && filter.FilterOperator != FilterOperator.IsEmpty
+                && filter.FilterOperator != FilterOperator.IsNotEmpty)
             {
                 property = Expression.Call(notNullCheck(property), typeof(string).GetMethod("ToLower", Type.EmptyTypes)!);
             }


### PR DESCRIPTION
When `FilterCaseSensitivity.CaseInsensitive` is enabled, the `notNullCheck(property).ToLower()` wrapping is applied to all filter operators, including `IsNull`/`IsNotNull`/`IsEmpty`/`IsNotEmpty`. The `notNullCheck` coalesces null strings to `""`, which:
- Breaks `IsNull` — null becomes `""`, never matches `null`
- Breaks `IsEmpty` — null becomes `""`, falsely matches as empty

Fix: skip the `ToLower()` wrapping for these four operators.

Fixes `QueryableExtension.cs:755`.