### PR TITLE
Add RTL support to RadzenSpreadsheet

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/CellSelectionTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CellSelectionTests.cs
@@ -91,7 +91,7 @@ public class CellSelectionTests : TestContext
 
         // Assert
         var element = cut.Find(".rz-spreadsheet-selection-cell");
-        Assert.Equal("transform: translate(0px, 0px); width: 100px; height: 24px", element.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 0px; inset-block-start: 0px; width: 100px; height: 24px;", element.GetAttribute("style"));
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class CellSelectionTests : TestContext
         Assert.NotNull(frozen);
         
         // First element (frozen)
-        Assert.Equal("transform: translate(0px, 0px); width: 100px; height: 24px", frozen.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 0px; inset-block-start: 0px; width: 100px; height: 24px;", frozen.GetAttribute("style"));
         Assert.Contains("rz-spreadsheet-selection-cell-top", frozen.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-left", frozen.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-right", frozen.ClassName);
@@ -130,7 +130,7 @@ public class CellSelectionTests : TestContext
         Assert.NotNull(unfrozen);
         
         // Second element (non-frozen)
-        Assert.Equal("transform: translate(0px, 24px); width: 100px; height: 48px", unfrozen.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 0px; inset-block-start: 24px; width: 100px; height: 48px;", unfrozen.GetAttribute("style"));
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-top", unfrozen.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-left", unfrozen.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-right", unfrozen.ClassName);
@@ -163,7 +163,7 @@ public class CellSelectionTests : TestContext
         
         // First element (frozen)
         Assert.Contains("rz-spreadsheet-frozen-column", frozen.ClassName);
-        Assert.Equal("transform: translate(0px, 0px); width: 100px; height: 24px", frozen.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 0px; inset-block-start: 0px; width: 100px; height: 24px;", frozen.GetAttribute("style"));
         Assert.Contains("rz-spreadsheet-selection-cell-top", frozen.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-left", frozen.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-bottom", frozen.ClassName);
@@ -173,7 +173,7 @@ public class CellSelectionTests : TestContext
 
         Assert.NotNull(unfrozen);
         // Second element (non-frozen)
-        Assert.Equal("transform: translate(100px, 0px); width: 200px; height: 24px", unfrozen.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 100px; inset-block-start: 0px; width: 200px; height: 24px;", unfrozen.GetAttribute("style"));
         Assert.Contains("rz-spreadsheet-selection-cell-top", unfrozen.ClassName);
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-left", unfrozen.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-bottom", unfrozen.ClassName);
@@ -206,7 +206,7 @@ public class CellSelectionTests : TestContext
         Assert.NotNull(both);
         Assert.Contains("rz-spreadsheet-frozen-row", both.ClassName);
         Assert.Contains("rz-spreadsheet-frozen-column", both.ClassName);
-        Assert.Equal("transform: translate(0px, 0px); width: 100px; height: 24px", both.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 0px; inset-block-start: 0px; width: 100px; height: 24px;", both.GetAttribute("style"));
         Assert.Contains("rz-spreadsheet-selection-cell-top", both.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-left", both.ClassName);
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-bottom", both.ClassName);
@@ -217,7 +217,7 @@ public class CellSelectionTests : TestContext
         Assert.NotNull(frozenColumn);
         Assert.DoesNotContain("rz-spreadsheet-frozen-row", frozenColumn.ClassName);
         Assert.Contains("rz-spreadsheet-frozen-column", frozenColumn.ClassName);
-        Assert.Equal("transform: translate(0px, 24px); width: 100px; height: 48px", frozenColumn.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 0px; inset-block-start: 24px; width: 100px; height: 48px;", frozenColumn.GetAttribute("style"));
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-top", frozenColumn.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-left", frozenColumn.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-bottom", frozenColumn.ClassName);
@@ -228,7 +228,7 @@ public class CellSelectionTests : TestContext
         Assert.NotNull(frozenRow);
         Assert.Contains("rz-spreadsheet-frozen-row", frozenRow.ClassName);
         Assert.DoesNotContain("rz-spreadsheet-frozen-column", frozenRow.ClassName);
-        Assert.Equal("transform: translate(100px, 0px); width: 200px; height: 24px", frozenRow.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 100px; inset-block-start: 0px; width: 200px; height: 24px;", frozenRow.GetAttribute("style"));
         Assert.Contains("rz-spreadsheet-selection-cell-top", frozenRow.ClassName);
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-left", frozenRow.ClassName);
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-bottom", frozenRow.ClassName);
@@ -239,7 +239,7 @@ public class CellSelectionTests : TestContext
         Assert.NotNull(neither);
         Assert.DoesNotContain("rz-spreadsheet-frozen-row", neither.ClassName);
         Assert.DoesNotContain("rz-spreadsheet-frozen-column", neither.ClassName);
-        Assert.Equal("transform: translate(100px, 24px); width: 200px; height: 48px", neither.GetAttribute("style"));
+        Assert.Equal("inset-inline-start: 100px; inset-block-start: 24px; width: 200px; height: 48px;", neither.GetAttribute("style"));
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-top", neither.ClassName);
         Assert.DoesNotContain("rz-spreadsheet-selection-cell-left", neither.ClassName);
         Assert.Contains("rz-spreadsheet-selection-cell-bottom", neither.ClassName);

--- a/Radzen.Blazor.Tests/Spreadsheet/RangeSelectionItemTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/RangeSelectionItemTests.cs
@@ -36,8 +36,8 @@ public class RangeSelectionItemTests : TestContext
         // The style should include mask properties that account for the merged cell
         var style = element.GetAttribute("style");
         Assert.NotNull(style);
-        Assert.Contains("mask-size", style);
-        Assert.Contains("mask-position", style);
+        Assert.Contains("--rz-spreadsheet-mask-w", style);
+        Assert.Contains("--rz-spreadsheet-mask-x", style);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class RangeSelectionItemTests : TestContext
         
         var style = element.GetAttribute("style");
         Assert.NotNull(style);
-        Assert.Contains("transform", style);
+        Assert.Contains("inset-inline-start", style);
         Assert.Contains("width", style);
         Assert.Contains("height", style);
     }
@@ -105,8 +105,8 @@ public class RangeSelectionItemTests : TestContext
         
         var frozenStyle = frozenElement.GetAttribute("style");
         Assert.NotNull(frozenStyle);
-        Assert.Contains("mask-size", frozenStyle);
-        Assert.Contains("mask-position", frozenStyle);
+        Assert.Contains("--rz-spreadsheet-mask-w", frozenStyle);
+        Assert.Contains("--rz-spreadsheet-mask-x", frozenStyle);
 
         // Test the non-frozen part (B1:B1)
         var nonFrozenRange = ranges.First(r => !r.FrozenColumn);
@@ -128,7 +128,7 @@ public class RangeSelectionItemTests : TestContext
         
         var nonFrozenStyle = nonFrozenElement.GetAttribute("style");
         Assert.NotNull(nonFrozenStyle);
-        Assert.Contains("mask-size", nonFrozenStyle);
-        Assert.Contains("mask-position", nonFrozenStyle);
+        Assert.Contains("--rz-spreadsheet-mask-w", nonFrozenStyle);
+        Assert.Contains("--rz-spreadsheet-mask-x", nonFrozenStyle);
     }
 } 

--- a/Radzen.Blazor/Spreadsheet/AutofillOverlay.razor
+++ b/Radzen.Blazor/Spreadsheet/AutofillOverlay.razor
@@ -8,7 +8,7 @@
         {
             var rect = Context.GetRectangle(range.Range.Start.Row, range.Range.Start.Column, range.Range.End.Row, range.Range.End.Column);
             <div class=@HandleClass(range.FrozenRow, range.FrozenColumn)
-                 style=@($"transform: translate({(rect.Left + rect.Width - 4).ToPx()}, {(rect.Top + rect.Height - 4).ToPx()});") ></div>
+                 style=@($"inset-inline-start: {(rect.Left + rect.Width - 4).ToPx()}; inset-block-start: {(rect.Top + rect.Height - 4).ToPx()};") ></div>
         }
     }
 

--- a/Radzen.Blazor/Spreadsheet/CellView.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/CellView.razor.cs
@@ -373,13 +373,13 @@ public partial class CellView : CellBase, IDisposable
             }
             if (isLeftCol)
             {
-                sb.Append("border-left:1px solid ");
+                sb.Append("border-inline-start:1px solid ");
                 sb.Append(preset.BorderColor);
                 sb.Append(';');
             }
             if (isRightCol)
             {
-                sb.Append("border-right:1px solid ");
+                sb.Append("border-inline-end:1px solid ");
                 sb.Append(preset.BorderColor);
                 sb.Append(';');
             }

--- a/Radzen.Blazor/Spreadsheet/ColumnHeader.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/ColumnHeader.razor.cs
@@ -38,5 +38,5 @@ public partial class ColumnHeader : HeaderBase
                                      .Add("rz-spreadsheet-header-selected", Selected)
                                      .ToString();
 
-    private string ResizeHandleStyle => $"left: {Rect.Right.ToPx()}; top: {Rect.Top.ToPx()}; height: {Rect.Height.ToPx()};";
+    private string ResizeHandleStyle => $"inset-inline-start: {Rect.Right.ToPx()}; inset-block-start: {Rect.Top.ToPx()}; height: {Rect.Height.ToPx()};";
 }

--- a/Radzen.Blazor/Spreadsheet/DrawingOverlayBase.cs
+++ b/Radzen.Blazor/Spreadsheet/DrawingOverlayBase.cs
@@ -231,7 +231,7 @@ public abstract class DrawingOverlayBase<TDrawing> : ComponentBase, IDisposable 
     private string GetZoneStyle(RangeInfo zone)
     {
         var rect = Context.GetRectangle(zone.Range.Start.Row, zone.Range.Start.Column, zone.Range.End.Row, zone.Range.End.Column);
-        return $"transform: translate({rect.Left.ToPx()}, {rect.Top.ToPx()}); width: {rect.Width.ToPx()}; height: {rect.Height.ToPx()};";
+        return rect.ToStyle();
     }
 
     private string GetContainerStyle(TDrawing drawing, RangeRef range, RangeInfo zone)
@@ -239,7 +239,7 @@ public abstract class DrawingOverlayBase<TDrawing> : ComponentBase, IDisposable 
         var (width, height) = GetDimensions(drawing, range);
         var (offsetX, offsetY) = GetZoneOffset(drawing, zone);
 
-        return $"position: absolute; left: {offsetX.ToPx()}; top: {offsetY.ToPx()}; width: {width.ToPx()}; height: {height.ToPx()};";
+        return $"position: absolute; inset-inline-start: {offsetX.ToPx()}; inset-block-start: {offsetY.ToPx()}; width: {width.ToPx()}; height: {height.ToPx()};";
     }
 
     private string GetClass(bool frozenRow, bool frozenColumn)
@@ -282,7 +282,7 @@ public abstract class DrawingOverlayBase<TDrawing> : ComponentBase, IDisposable 
             case "w":  x = offsetX - half; y = offsetY + height / 2 - half; break;
         }
 
-        return $"position: absolute; left: {x.ToPx()}; top: {y.ToPx()};";
+        return $"position: absolute; inset-inline-start: {x.ToPx()}; inset-block-start: {y.ToPx()};";
     }
 
     /// <inheritdoc/>

--- a/Radzen.Blazor/Spreadsheet/FrameItemBase.cs
+++ b/Radzen.Blazor/Spreadsheet/FrameItemBase.cs
@@ -76,7 +76,7 @@ public abstract partial class FrameItemBase : ComponentBase
         get
         {
             var rect = Context.GetRectangle(Range.Start.Row, Range.Start.Column, Range.End.Row, Range.End.Column);
-            return $"transform: translate({rect.Left.ToPx()}, {rect.Top.ToPx()}); width: {rect.Width.ToPx()}; height: {rect.Height.ToPx()}";
+            return rect.ToStyle();
         }
     }
 }

--- a/Radzen.Blazor/Spreadsheet/InputPrompt.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/InputPrompt.razor.cs
@@ -108,7 +108,7 @@ public partial class InputPrompt : IDisposable
         var rect = Context.GetRectangle(cell.Row, cell.Column);
         var left = rect.Left + 4;
         var top = rect.Top + rect.Height + 2;
-        style = $"transform: translate({left.ToPx()}, {top.ToPx()});";
+        style = $"inset-inline-start: {left.ToPx()}; inset-block-start: {top.ToPx()};";
 
         className = ClassList.Create("rz-spreadsheet-input-prompt")
             .Add("rz-spreadsheet-frozen-column", Worksheet is not null && cell.Column < Worksheet.Columns.Frozen)

--- a/Radzen.Blazor/Spreadsheet/PixelTypes.cs
+++ b/Radzen.Blazor/Spreadsheet/PixelTypes.cs
@@ -104,15 +104,25 @@ public readonly struct PixelRectangle(PixelRange x, PixelRange y)
     public void AppendStyle(StringBuilder sb)
     {
         ArgumentNullException.ThrowIfNull(sb);
-        sb.Append("transform: translate(");
+        sb.Append("inset-inline-start: ");
         sb.Append(Left.ToPx());
-        sb.Append(',');
+        sb.Append("; inset-block-start: ");
         sb.Append(Top.ToPx());
-        sb.Append("); width: ");
+        sb.Append("; width: ");
         sb.Append(Width.ToPx());
         sb.Append("; height: ");
         sb.Append(Height.ToPx());
         sb.Append(';');
+    }
+
+    /// <summary>
+    /// Returns the rectangle's position and dimensions as a CSS style string.
+    /// </summary>
+    public string ToStyle()
+    {
+        var sb = StringBuilderCache.Acquire();
+        AppendStyle(sb);
+        return StringBuilderCache.GetStringAndRelease(sb);
     }
 }
 

--- a/Radzen.Blazor/Spreadsheet/RangePicker.razor
+++ b/Radzen.Blazor/Spreadsheet/RangePicker.razor
@@ -3,7 +3,7 @@
 @using Radzen.Blazor
 
 <div class="rz-range-picker" style=@Style>
-    <RadzenTextBox @ref=textBox Value=@Value Change=@OnTextChanged InputSize=@InputSize Style="width: 100%; padding-right: 2rem;" />
+    <RadzenTextBox @ref=textBox Value=@Value Change=@OnTextChanged InputSize=@InputSize Style="width: 100%; padding-inline-end: 2rem;" />
     <button type="button" class="rz-range-picker-collapse" @onclick=@OnPickClick title=@Title>
         <i class="notranslate rzi">grid_on</i>
     </button>

--- a/Radzen.Blazor/Spreadsheet/RangeSelectionItem.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/RangeSelectionItem.razor.cs
@@ -95,7 +95,7 @@ public partial class RangeSelectionItem
             var offsetX = intersectionRect.Left - rect.Left;
             var offsetY = intersectionRect.Top - rect.Top;
 
-            return $@"transform: translate({rect.Left.ToPx()}, {rect.Top.ToPx()}); width: {rect.Width.ToPx()}; height: {rect.Height.ToPx()}; mask-size: 100% 100%, {intersectionRect.Width.ToPx()} {intersectionRect.Height.ToPx()}; mask-position: 0 0, {offsetX.ToPx()} {offsetY.ToPx()};";
+            return rect.ToStyle() + $" --rz-spreadsheet-mask-x: {offsetX.ToPx()}; --rz-spreadsheet-mask-y: {offsetY.ToPx()}; --rz-spreadsheet-mask-w: {intersectionRect.Width.ToPx()}; --rz-spreadsheet-mask-h: {intersectionRect.Height.ToPx()};";
         }
     }
 }

--- a/Radzen.Blazor/Spreadsheet/RowHeader.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/RowHeader.razor.cs
@@ -39,5 +39,5 @@ public partial class RowHeader : HeaderBase
                                      .Add("rz-spreadsheet-header-selected", Selected)
                                      .ToString();
 
-    private string ResizeHandleStyle => $"top: {Rect.Bottom.ToPx()}; left: {Rect.Left.ToPx()}; width: {Rect.Width.ToPx()};";
+    private string ResizeHandleStyle => $"inset-block-start: {Rect.Bottom.ToPx()}; inset-inline-start: {Rect.Left.ToPx()}; width: {Rect.Width.ToPx()};";
 }

--- a/Radzen.Blazor/Spreadsheet/ValidationError.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/ValidationError.razor.cs
@@ -97,7 +97,7 @@ public partial class ValidationError : IDisposable
         var rect = Context.GetRectangle(cell.Row, cell.Column);
         var left = rect.Left + 4;
         var top = rect.Top + rect.Height + 2;
-        style = $"transform: translate({left.ToPx()}, {top.ToPx()});";
+        style = $"inset-inline-start: {left.ToPx()}; inset-block-start: {top.ToPx()};";
 
         className = ClassList.Create("rz-spreadsheet-validation-error")
             .Add("rz-spreadsheet-frozen-column", Worksheet is not null && cell.Column < Worksheet.Columns.Frozen)

--- a/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
+++ b/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
@@ -45,6 +45,8 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 
 .rz-virtual-grid-content {
     position: absolute;
+    inset-inline-start: 0;
+    inset-block-start: 0;
     z-index: 1;
     overflow: hidden;
 }
@@ -88,7 +90,8 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 
 .rz-spreadsheet-cell {
     position: absolute;
-    border-right: var(--rz-spreadsheet-cell-border);
+    isolation: isolate;
+    border-inline-end: var(--rz-spreadsheet-cell-border);
     border-bottom: var(--rz-spreadsheet-cell-border);
     cursor: cell;
     font-size: 0.75rem;
@@ -113,7 +116,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-selection-cell-right {
-    border-right: 2px solid var(--rz-primary);
+    border-inline-end: 2px solid var(--rz-primary);
 }
 
 .rz-spreadsheet-selection-cell-bottom {
@@ -121,7 +124,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-selection-cell-left {
-    border-left: 2px solid var(--rz-primary);
+    border-inline-start: 2px solid var(--rz-primary);
 }
 
 .rz-spreadsheet-selection-range {
@@ -137,7 +140,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-selection-range-right {
-    border-right: 2px solid var(--rz-primary);
+    border-inline-end: 2px solid var(--rz-primary);
 }
 
 .rz-spreadsheet-selection-range-bottom {
@@ -145,7 +148,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-selection-range-left {
-    border-left: 2px solid var(--rz-primary);
+    border-inline-start: 2px solid var(--rz-primary);
 }
 
 .rz-spreadsheet-selection-range-mask {
@@ -154,6 +157,14 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
                 linear-gradient(white, white);
     mask-composite: exclude;
     mask-repeat: no-repeat;
+    mask-size: 100% 100%, var(--rz-spreadsheet-mask-w) var(--rz-spreadsheet-mask-h);
+    mask-position: 0 0, var(--rz-spreadsheet-mask-x) var(--rz-spreadsheet-mask-y);
+}
+
+[dir="rtl"] .rz-spreadsheet-selection-range-mask {
+    // mask-position % resolves against (container - image), so mirror with the 4-value
+    // edge-offset form instead: the hole's inline-end edge sits --mask-x from the right.
+    mask-position: 0 0, right var(--rz-spreadsheet-mask-x) top var(--rz-spreadsheet-mask-y);
 }
 
 .rz-spreadsheet-autofill-handle {
@@ -181,7 +192,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-autofill-range-right {
-    border-right: 2px dashed var(--rz-primary);
+    border-inline-end: 2px dashed var(--rz-primary);
 }
 
 .rz-spreadsheet-autofill-range-bottom {
@@ -189,7 +200,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-autofill-range-left {
-    border-left: 2px dashed var(--rz-primary);
+    border-inline-start: 2px dashed var(--rz-primary);
 }
 
 .rz-spreadsheet-autofill-handle.rz-spreadsheet-frozen-row,
@@ -215,7 +226,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
     position: absolute;
     box-sizing: border-box;
     background: var(--rz-spreadsheet-header-background-color);
-    border-right: var(--rz-spreadsheet-cell-border);
+    border-inline-end: var(--rz-spreadsheet-cell-border);
     border-bottom: var(--rz-spreadsheet-cell-border);
     font-weight: 500;
     font-size: 0.75rem;
@@ -459,11 +470,11 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-table-frame-left {
-    border-left: 1px solid var(--rz-text-color);
+    border-inline-start: 1px solid var(--rz-text-color);
 }
 
 .rz-spreadsheet-table-frame-right {
-    border-right: 1px solid var(--rz-text-color);
+    border-inline-end: 1px solid var(--rz-text-color);
 }
 
 .rz-spreadsheet-table-frame-bottom {
@@ -505,7 +516,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 .rz-spreadsheet-cell-chevron {
     position: absolute;
     top: 2px;
-    right: 2px;
+    inset-inline-end: 2px;
     border-radius: 0;
     padding: 0 !important;
 }
@@ -581,18 +592,19 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
     &::after {
         content: '';
         position: absolute;
-        top: 0;
-        right: 0;
+        inset-block-start: 0;
+        inset-inline-end: 0;
         width: 0;
         height: 0;
-        border-style: solid;
-        border-width: 0 6px 6px 0;
-        border-color: transparent var(--rz-danger) transparent transparent;
+        // Logical border longhands flip the danger triangle to the inline-end corner
+        // in both directions, so no [dir=rtl] override is needed.
+        border-block-end: 6px solid transparent;
+        border-inline-end: 6px solid var(--rz-danger);
     }
 }
 
 .rz-spreadsheet-cell-number {
-    text-align: right;
+    text-align: end;
 }
 
 .rz-spreadsheet-cell-error {
@@ -600,7 +612,7 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 }
 
 .rz-spreadsheet-cell-editor-number {
-    text-align: right;
+    text-align: end;
 }
 
 
@@ -670,6 +682,13 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 .rz-spreadsheet-resize-s { cursor: ns-resize; }
 .rz-spreadsheet-resize-sw { cursor: nesw-resize; }
 .rz-spreadsheet-resize-w { cursor: ew-resize; }
+
+[dir="rtl"] {
+    .rz-spreadsheet-resize-nw { cursor: nesw-resize; }
+    .rz-spreadsheet-resize-ne { cursor: nwse-resize; }
+    .rz-spreadsheet-resize-se { cursor: nesw-resize; }
+    .rz-spreadsheet-resize-sw { cursor: nwse-resize; }
+}
 
 .rz-spreadsheet-chart {
     position: absolute;

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -5784,6 +5784,7 @@ class Spreadsheet {
     this.element = element;
     this.dotNetRef = dotNetRef;
     this.shortcuts = shortcuts;
+    this.rtl = Radzen.isRTL(element);
     this.element.addEventListener('keydown', this.onKeyDown);
     this.element.addEventListener('pointerdown', this.onPointerDown);
     this.element.addEventListener('dblclick', this.onDoubleClick);
@@ -5827,6 +5828,8 @@ class Spreadsheet {
 
   onPointerDown = async (e) => {
     if (e.button != 0) return;
+
+    this.rtl = Radzen.isRTL(this.element);
 
     if (e.target.matches('.rz-spreadsheet-autofill-handle')) {
       addEventListener('pointermove', this.onAutofillPointerMove);
@@ -6002,9 +6005,9 @@ class Spreadsheet {
       type: e.type,
       button: e.button,
       buttons: e.buttons,
-      clientX: e.clientX,
+      clientX: this.rtl ? -e.clientX : e.clientX,
       clientY: e.clientY,
-      offsetX: e.offsetX,
+      offsetX: this.rtl ? (e.target?.offsetWidth ?? 0) - e.offsetX : e.offsetX,
       offsetY: e.offsetY,
       pageX: e.pageX,
       pageY: e.pageY,
@@ -6241,9 +6244,13 @@ Radzen.createVirtualItemContainer = (scrollable, content, ref) => {
     e.preventDefault();
   });
 
+  var rtl = Radzen.isRTL(scrollable);
+
   scrollable.addEventListener('scroll', function () {
     var scrollTop = scrollable.scrollTop;
-    var scrollLeft = scrollable.scrollLeft;
+    // In RTL the native scrollLeft is 0 at the right and negative toward the left;
+    // report a non-negative logical scroll so the C# layout math stays direction-agnostic.
+    var scrollLeft = rtl ? -scrollable.scrollLeft : scrollable.scrollLeft;
 
     ref.invokeMethodAsync('OnScroll', scrollLeft, scrollTop);
   });
@@ -6260,7 +6267,7 @@ Radzen.createVirtualItemContainer = (scrollable, content, ref) => {
   return { width, height, scrollHeight, scrollWidth };
 };
 Radzen.scrollElementTo = (scrollable, left, top) => {
-  scrollable.scrollTo({ top: top, left: left });
+  scrollable.scrollTo({ top: top, left: Radzen.isRTL(scrollable) ? -left : left });
 };
 Radzen.createFormField = function(el) {
   if (!el || typeof el.addEventListener !== 'function') return null;


### PR DESCRIPTION
Adds right-to-left (RTL) support to `RadzenSpreadsheet`. When the component is on a `dir="rtl"` page the grid now mirrors fully: column A on the right, columns flow leftward, row headers and the vertical scrollbar on the left. 