### PR TITLE
Set the width of theY-axis in pixels on a graph

### DIFF
--- a/Radzen.Blazor.Tests/AxisBaseWidthTests.cs
+++ b/Radzen.Blazor.Tests/AxisBaseWidthTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class AxisBaseWidthTests
+    {
+        // Minimal concrete AxisBase implementation for testing
+        private class TestAxis : AxisBase
+        {
+            internal override double Size => 0;
+        }
+
+        private static MethodInfo GetShouldRefreshChartMethod()
+        {
+            var method = typeof(AxisBase).GetMethod(
+                "ShouldRefreshChart",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (method == null) throw new InvalidOperationException("Could not find ShouldRefreshChart method.");
+            return method;
+        }
+
+        [Fact]
+        public void ShouldRefreshChart_IsTrue_When_WidthParameterChanges_FromNullToValue()
+        {
+            var axis = new TestAxis();
+            axis.Width = null;
+
+            var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+            {
+                ["Width"] = 42
+            });
+
+            var method = GetShouldRefreshChartMethod();
+            var result = (bool)method.Invoke(axis, new object[] { parameters })!;
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldRefreshChart_IsFalse_When_WidthParameterNotProvided()
+        {
+            var axis = new TestAxis();
+            axis.Width = 10;
+
+            var parameters = ParameterView.Empty;
+
+            var method = GetShouldRefreshChartMethod();
+            var result = (bool)method.Invoke(axis, new object[] { parameters })!;
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ShouldRefreshChart_IsFalse_When_WidthParameterProvidedWithSameValue()
+        {
+            var axis = new TestAxis();
+            axis.Width = 25;
+
+            var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+            {
+                ["Width"] = 25
+            });
+
+            var method = GetShouldRefreshChartMethod();
+            var result = (bool)method.Invoke(axis, new object[] { parameters })!;
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ShouldRefreshChart_IsTrue_When_WidthParameterProvidedWithDifferentValue()
+        {
+            var axis = new TestAxis();
+            axis.Width = 25;
+
+            var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+            {
+                ["Width"] = 100
+            });
+
+            var method = GetShouldRefreshChartMethod();
+            var result = (bool)method.Invoke(axis, new object[] { parameters })!;
+
+            Assert.True(result);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/AxisMeasurerTests.cs
+++ b/Radzen.Blazor.Tests/AxisMeasurerTests.cs
@@ -1,0 +1,69 @@
+using Radzen.Blazor.Rendering;
+using System;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class AxisMeasurerTests
+    {
+        private class TestAxis : AxisBase
+        {
+            internal override double Size => 0;
+        }
+
+        private class TestScale : ScaleBase
+        {
+            private readonly (double Start, double End, double Step) _ticks;
+            private readonly bool _isLog;
+            private readonly Func<double, string> _formatter;
+
+            public TestScale((double Start, double End, double Step) ticks, bool isLog = false, Func<double, string>? formatter = null)
+            {
+                _ticks = ticks;
+                _isLog = isLog;
+                _formatter = formatter ?? (v => v.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
+                // Provide valid Input/Output for some Scale implementations if needed
+                Input.Start = ticks.Start;
+                Input.End = ticks.End;
+                Output.Start = 0;
+                Output.End = 100;
+            }
+
+            public override object Value(double value) => value;
+
+            public override string FormatTick(string format, object value)
+            {
+                if (value is double d) return _formatter(d);
+                return value?.ToString() ?? string.Empty;
+            }
+
+            public override (double Start, double End, double Step) Ticks(int distance) => _ticks;
+
+            public override double Scale(double value, bool padding = false) => value;
+
+            public override bool IsLogarithmic => _isLog;
+        }
+
+        [Fact]
+        public void YAxis_Returns_AxisWidth_When_Provided_And_Valid()
+        {
+            var scale = new TestScale((0, 0, 1));
+            var axis = new TestAxis { Width = 50 };
+            var title = new RadzenAxisTitle { Text = null };
+
+            var result = AxisMeasurer.YAxis(scale, axis, title);
+
+            Assert.Equal(50d, result);
+        }
+
+        [Fact]
+        public void YAxis_Throws_When_Width_Less_Than_Minimum()
+        {
+            var scale = new TestScale((0, 0, 1));
+            var axis = new TestAxis { Width = 10 };
+            var title = new RadzenAxisTitle { Text = null };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => AxisMeasurer.YAxis(scale, axis, title));
+        }
+    }
+}

--- a/Radzen.Blazor/AxisBase.cs
+++ b/Radzen.Blazor/AxisBase.cs
@@ -84,6 +84,7 @@ namespace Radzen.Blazor
 
         /// <summary>
         /// Gets or sets the width of the axis in pixels. If not set, the width is calculated automatically based on the axis content.
+        /// The parameter only has effect for vertically rendered value axes. It is ignored on the category axis in normal charts and on value axes in inverted (bar) charts
         /// </summary>
         [Parameter]
         public int? Width { get; set; }
@@ -171,7 +172,8 @@ namespace Radzen.Blazor
                    DidParameterChange(parameters, nameof(CrossesAt), CrossesAt) ||
                    DidParameterChange(parameters, nameof(Logarithmic), Logarithmic) ||
                    DidParameterChange(parameters, nameof(LogarithmicBase), LogarithmicBase) ||
-                   DidParameterChange(parameters, nameof(Step), Step);
+                   DidParameterChange(parameters, nameof(Step), Step) ||
+                   DidParameterChange(parameters, nameof(Width), Width);
         }
 
         internal string Format(ScaleBase scale, double idx)

--- a/Radzen.Blazor/AxisBase.cs
+++ b/Radzen.Blazor/AxisBase.cs
@@ -1,6 +1,6 @@
+using Microsoft.AspNetCore.Components;
 using System;
 using System.Globalization;
-using Microsoft.AspNetCore.Components;
 
 namespace Radzen.Blazor
 {
@@ -83,6 +83,12 @@ namespace Radzen.Blazor
         public int TickDistance { get; set; } = 100;
 
         /// <summary>
+        /// Gets or sets the width of the axis in pixels. If not set, the width is calculated automatically based on the axis content.
+        /// </summary>
+        [Parameter]
+        public int? Width { get; set; }
+
+        /// <summary>
         /// Specifies the minimum value of the axis.
         /// </summary>
         /// <value>The minimum.</value>
@@ -141,7 +147,7 @@ namespace Radzen.Blazor
         [Parameter]
         public object? CrossesAt { get; set; }
 
-    /// <summary>
+        /// <summary>
         /// Specifies the label rotation angle in degrees. Set to <c>null</c> by default which means no rotation is applied. Has higher precedence than <see cref="LabelAutoRotation"/>.
         /// </summary>
         [Parameter]

--- a/Radzen.Blazor/RadzenValueAxis.razor
+++ b/Radzen.Blazor/RadzenValueAxis.razor
@@ -3,7 +3,7 @@
 
 @inherits AxisBase
 <CascadingValue Value="@this">
-  @ChildContent
+    @ChildContent
 </CascadingValue>
 @code {
     [Parameter]
@@ -21,7 +21,7 @@
         }
         else
         {
-            return AxisMeasurer.YAxis(chart.ValueScale, chart.ValueAxis, Title);
+            return AxisMeasurer.YAxis(chart.ValueScale, this, Title);
         }
     }
 

--- a/Radzen.Blazor/RadzenValueAxis.razor
+++ b/Radzen.Blazor/RadzenValueAxis.razor
@@ -3,7 +3,7 @@
 
 @inherits AxisBase
 <CascadingValue Value="@this">
-    @ChildContent
+  @ChildContent
 </CascadingValue>
 @code {
     [Parameter]

--- a/Radzen.Blazor/Rendering/AxisMeasurer.cs
+++ b/Radzen.Blazor/Rendering/AxisMeasurer.cs
@@ -1,6 +1,4 @@
-using Microsoft.AspNetCore.Components;
 using System;
-using System.ComponentModel;
 
 namespace Radzen.Blazor.Rendering
 {
@@ -21,6 +19,12 @@ namespace Radzen.Blazor.Rendering
             ArgumentNullException.ThrowIfNull(scale);
             ArgumentNullException.ThrowIfNull(axis);
             ArgumentNullException.ThrowIfNull(title);
+
+            //We can use the axis width if it is set, otherwise we need to calculate the width based on the ticks and title
+            if (axis.Width.HasValue)
+            {
+                return axis.Width.Value;
+            }
 
             var ticks = scale.Ticks(axis.TickDistance);
 

--- a/Radzen.Blazor/Rendering/AxisMeasurer.cs
+++ b/Radzen.Blazor/Rendering/AxisMeasurer.cs
@@ -20,9 +20,9 @@ namespace Radzen.Blazor.Rendering
             ArgumentNullException.ThrowIfNull(axis);
             ArgumentNullException.ThrowIfNull(title);
 
-            //We can use the axis width if it is set, otherwise we need to calculate the width based on the ticks and title
             if (axis.Width.HasValue)
             {
+                ArgumentOutOfRangeException.ThrowIfLessThan(axis.Width.Value, 24);
                 return axis.Width.Value;
             }
 

--- a/RadzenBlazorDemos/Pages/MultipleAxesChartConfig.razor
+++ b/RadzenBlazorDemos/Pages/MultipleAxesChartConfig.razor
@@ -13,7 +13,7 @@
                     <RadzenAxisTitle Text="Revenue ($)" />
                     <RadzenGridLines Visible="true" />
                 </RadzenValueAxis>
-                <RadzenValueAxis Name="orders">
+                <RadzenValueAxis Width="50" Name="orders">
                     <RadzenAxisTitle Text="Order Count" />
                 </RadzenValueAxis>
                 <RadzenLegend Position="LegendPosition.Bottom" />


### PR DESCRIPTION
Sets the width of the axis in pixels. If not specified, the width is calculated automatically. Setting a fixed width can help reduce unnecessary spacing when using multiple Y-axes.