### PR TITLE
Enable pasting into unlocked cells in protected sheets

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
@@ -58,4 +58,36 @@ public class SpreadsheetClipboardTests
 
         Assert.Equal("=B2", target.Cells[1, 1].Formula);
     }
+    
+    [Fact]
+    public void Paste_Respects_CellLocking_InProtectedSheet()
+    {
+        var sheet = new Worksheet(5, 5);
+    
+        sheet.Cells[0, 0].Format = new Format { Locked = true };
+        sheet.Cells[0, 1].Format = new Format { Locked = false };
+        sheet.Protection.IsProtected = true;
+
+        var clipboard = new SpreadsheetClipboard();
+    
+        clipboard.Paste(sheet, RangeRef.Parse("A1"), "BlockedValue\tAllowedValue");
+
+        Assert.Null(sheet.Cells[0, 0].Value);
+    
+        Assert.Equal("AllowedValue", sheet.Cells[0, 1].Value); 
+    }
+    [Fact]
+    public void Paste_Works_When_Protection_Is_Disabled()
+    {
+        var sheet = new Worksheet(5, 5);
+
+        sheet.Cells[0, 0].Format = new Format { Locked = true };
+        sheet.Protection.IsProtected = false;
+
+        var clipboard = new SpreadsheetClipboard();
+
+        clipboard.Paste(sheet, RangeRef.Parse("A1"), "AllowedValue");
+
+        Assert.Equal("AllowedValue", sheet.Cells[0, 0].Value);
+    }
 }

--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
@@ -59,7 +59,6 @@ public class SpreadsheetClipboardTests
 
         Assert.Equal("=B2", target.Cells[1, 1].Formula);
     }
-    
     [Fact]
     public void PasteCommand_Succeeds_When_All_Target_Cells_Unlocked_In_Protected_Sheet()
     {
@@ -122,7 +121,6 @@ public class SpreadsheetClipboardTests
         Assert.Equal("Data1", sheet.Cells[0, 0].Value);
         Assert.Equal("Data2", sheet.Cells[0, 1].Value);
     }
-    
     [Fact]
     public async Task CutSelectionAsync_PreventsLockedCells_OnProtectedSheet()
     {

--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
@@ -60,34 +60,65 @@ public class SpreadsheetClipboardTests
     }
     
     [Fact]
-    public void Paste_Respects_CellLocking_InProtectedSheet()
+    public void PasteCommand_Succeeds_When_All_Target_Cells_Unlocked_In_Protected_Sheet()
     {
-        var sheet = new Worksheet(5, 5);
-    
-        sheet.Cells[0, 0].Format = new Format { Locked = true };
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Test", 5, 5);
+        var view = new WorkbookView(workbook).GetView(sheet);
+
+        sheet.Cells[0, 0].Format = new Format { Locked = false };
         sheet.Cells[0, 1].Format = new Format { Locked = false };
         sheet.Protection.IsProtected = true;
 
         var clipboard = new SpreadsheetClipboard();
-    
-        clipboard.Paste(sheet, RangeRef.Parse("A1"), "BlockedValue\tAllowedValue");
+        var command = new PasteCommand(clipboard, sheet, RangeRef.Parse("A1"), "Data1\tData2");
 
-        Assert.Null(sheet.Cells[0, 0].Value);
-    
-        Assert.Equal("AllowedValue", sheet.Cells[0, 1].Value); 
+        var result = view.Commands.Execute(command);
+
+        Assert.True(result);
+        Assert.Equal("Data1", sheet.Cells[0, 0].Value);
+        Assert.Equal("Data2", sheet.Cells[0, 1].Value);
     }
+
     [Fact]
-    public void Paste_Works_When_Protection_Is_Disabled()
+    public void PasteCommand_Fails_Entirely_If_Any_Target_Cell_Locked_In_Protected_Sheet()
     {
-        var sheet = new Worksheet(5, 5);
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Test", 5, 5);
+        var view = new WorkbookView(workbook).GetView(sheet);
+
+        sheet.Cells[0, 0].Format = new Format { Locked = false };
+        sheet.Cells[0, 1].Format = new Format { Locked = true };
+        sheet.Protection.IsProtected = true;
+
+        var clipboard = new SpreadsheetClipboard();
+        var command = new PasteCommand(clipboard, sheet, RangeRef.Parse("A1"), "Data1\tData2");
+
+        var result = view.Commands.Execute(command);
+
+        Assert.False(result);
+        Assert.Null(sheet.Cells[0, 0].Value);
+        Assert.Null(sheet.Cells[0, 1].Value);
+    }
+
+    [Fact]
+    public void PasteCommand_Works_When_Protection_Is_Disabled()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Test", 5, 5);
+        var view = new WorkbookView(workbook).GetView(sheet);
 
         sheet.Cells[0, 0].Format = new Format { Locked = true };
+        sheet.Cells[0, 1].Format = new Format { Locked = true };
         sheet.Protection.IsProtected = false;
 
         var clipboard = new SpreadsheetClipboard();
+        var command = new PasteCommand(clipboard, sheet, RangeRef.Parse("A1"), "Data1\tData2");
 
-        clipboard.Paste(sheet, RangeRef.Parse("A1"), "AllowedValue");
+        var result = view.Commands.Execute(command);
 
-        Assert.Equal("AllowedValue", sheet.Cells[0, 0].Value);
+        Assert.True(result);
+        Assert.Equal("Data1", sheet.Cells[0, 0].Value);
+        Assert.Equal("Data2", sheet.Cells[0, 1].Value);
     }
 }

--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
@@ -59,6 +59,7 @@ public class SpreadsheetClipboardTests
 
         Assert.Equal("=B2", target.Cells[1, 1].Formula);
     }
+
     [Fact]
     public void PasteCommand_Succeeds_When_All_Target_Cells_Unlocked_In_Protected_Sheet()
     {
@@ -121,6 +122,7 @@ public class SpreadsheetClipboardTests
         Assert.Equal("Data1", sheet.Cells[0, 0].Value);
         Assert.Equal("Data2", sheet.Cells[0, 1].Value);
     }
+
     [Fact]
     public async Task CutSelectionAsync_PreventsLockedCells_OnProtectedSheet()
     {

--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 using Radzen.Documents.Spreadsheet;
@@ -120,5 +121,25 @@ public class SpreadsheetClipboardTests
         Assert.True(result);
         Assert.Equal("Data1", sheet.Cells[0, 0].Value);
         Assert.Equal("Data2", sheet.Cells[0, 1].Value);
+    }
+    
+    [Fact]
+    public async Task CutSelectionAsync_PreventsLockedCells_OnProtectedSheet()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Test", 5, 5);
+        var spreadsheet = new RadzenSpreadsheet { Workbook = workbook };
+
+        sheet.Cells[0, 0].SetValue("CanCut");
+        sheet.Cells[0, 0].Format = new Format { Locked = false };
+        sheet.Cells[1, 0].SetValue("CannotCut");
+        sheet.Cells[1, 0].Format = new Format { Locked = true };
+        sheet.Protection.IsProtected = true;
+
+        sheet.Selection.Select(new RangeRef(new CellRef(0, 0), new CellRef(1, 0)));
+        await spreadsheet.CutSelectionAsync();
+
+        Assert.Equal("CanCut", sheet.Cells[0, 0].Value);
+        Assert.Equal("CannotCut", sheet.Cells[1, 0].Value);
     }
 }

--- a/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
@@ -552,33 +552,26 @@ public partial class Worksheet
         return result.ToString();
     }
 
-    internal void InsertDelimitedString(CellRef address, string value, string cellDelimiter = "\t")
-    {
-        ArgumentNullException.ThrowIfNull(value);
-        ArgumentNullException.ThrowIfNull(cellDelimiter);
-        var rows = value.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
-
-        var rowCount = Math.Min(rows.Length, RowCount - address.Row);
-
-        for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
-        {
-            var cells = rows[rowIndex].Split([cellDelimiter], StringSplitOptions.None);
-            var columnCount = Math.Min(cells.Length, ColumnCount - address.Column);
-
-            for (var columnIndex = 0; columnIndex < columnCount; columnIndex++)
-            {
-                var cell = Cells[address.Row + rowIndex, address.Column + columnIndex];
-            
-                if (Protection.IsProtected && (cell.Format.Locked is true))
-                {
-                    continue;
-                }
-
-                cell.SetValue(cells[columnIndex]);
-            }
-        }
-    }
-
+   internal void InsertDelimitedString(CellRef address, string value, string cellDelimiter = "\t")
+   {
+       ArgumentNullException.ThrowIfNull(value);
+       ArgumentNullException.ThrowIfNull(cellDelimiter);
+       var rows = value.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+   
+       var rowCount = Math.Min(rows.Length, RowCount - address.Row);
+   
+       for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
+       {
+           var cells = rows[rowIndex].Split([cellDelimiter], StringSplitOptions.None);
+           var columnCount = Math.Min(cells.Length, ColumnCount - address.Column);
+   
+           for (var columnIndex = 0; columnIndex < columnCount; columnIndex++)
+           {
+               var cell = Cells[address.Row + rowIndex, address.Column + columnIndex];
+               cell.SetValue(cells[columnIndex]);
+           }
+       }
+   }
     /// <summary>
     /// Deletes the specified column and shifts cells left. Updates formulas and decreases column count.
     /// </summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
@@ -552,26 +552,27 @@ public partial class Worksheet
         return result.ToString();
     }
 
-   internal void InsertDelimitedString(CellRef address, string value, string cellDelimiter = "\t")
-   {
-       ArgumentNullException.ThrowIfNull(value);
-       ArgumentNullException.ThrowIfNull(cellDelimiter);
-       var rows = value.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
-   
-       var rowCount = Math.Min(rows.Length, RowCount - address.Row);
-   
-       for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
-       {
-           var cells = rows[rowIndex].Split([cellDelimiter], StringSplitOptions.None);
-           var columnCount = Math.Min(cells.Length, ColumnCount - address.Column);
-   
-           for (var columnIndex = 0; columnIndex < columnCount; columnIndex++)
-           {
-               var cell = Cells[address.Row + rowIndex, address.Column + columnIndex];
-               cell.SetValue(cells[columnIndex]);
-           }
-       }
-   }
+    internal void InsertDelimitedString(CellRef address, string value, string cellDelimiter = "\t")
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(cellDelimiter);
+        var rows = value.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+
+        var rowCount = Math.Min(rows.Length, RowCount - address.Row);
+
+        for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
+        {
+            var cells = rows[rowIndex].Split([cellDelimiter], StringSplitOptions.None);
+            var columnCount = Math.Min(cells.Length, ColumnCount - address.Column);
+
+            for (var columnIndex = 0; columnIndex < columnCount; columnIndex++)
+            {
+                var cell = Cells[address.Row + rowIndex, address.Column + columnIndex];
+                cell.SetValue(cells[columnIndex]);
+            }
+        }
+    }
+
     /// <summary>
     /// Deletes the specified column and shifts cells left. Updates formulas and decreases column count.
     /// </summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
@@ -1095,6 +1095,7 @@ public partial class Worksheet
             };
         }
     }
+
     /// <summary>
     /// Checks if all cells in the specified range are editable.
     /// </summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
@@ -568,6 +568,12 @@ public partial class Worksheet
             for (var columnIndex = 0; columnIndex < columnCount; columnIndex++)
             {
                 var cell = Cells[address.Row + rowIndex, address.Column + columnIndex];
+            
+                if (Protection.IsProtected && (cell.Format.Locked is true))
+                {
+                    continue;
+                }
+
                 cell.SetValue(cells[columnIndex]);
             }
         }

--- a/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
@@ -1095,5 +1095,29 @@ public partial class Worksheet
             };
         }
     }
+    /// <summary>
+    /// Checks if all cells in the specified range are editable.
+    /// </summary>
+    /// <param name="range">The range of cells to validate.</param>
+    /// <returns><c>true</c> if the entire range can be modified; otherwise, <c>false</c>.</returns>
+    public bool IsRangeEditable(RangeRef range)
+    {
+        if (!Protection.IsProtected)
+        {
+            return true;
+        }
 
+        for (int r = range.Start.Row; r <= range.End.Row; r++)
+        {
+            for (int c = range.Start.Column; c <= range.End.Column; c++)
+            {
+                if (!IsCellEditable(new CellRef(r, c)))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
 }

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -369,24 +369,14 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        if (ReadOnly)
+        if (ReadOnly || (command.Feature is SpreadsheetFeature feature && !IsFeatureAllowed(feature)))
         {
             return false;
         }
 
-        if (command.Feature is SpreadsheetFeature feature && !IsFeatureAllowed(feature))
-        {
-            return false;
-        }
-
-        //check if the command is blocked by sheet protection
         if (command is IProtectedCommand pc && Worksheet?.Protection.IsActionBlocked(pc.RequiredAction) == true)
         {
-            //allow only if it is a PasteCommand and the target cell is explicitly unlocked
-            bool isPaste = command is PasteCommand;
-            bool isEditable = Worksheet != null && Worksheet.IsCellEditable(Worksheet.Selection.Cell);
-
-            if (!isPaste || !isEditable)
+            if (command is not PasteCommand)
             {
                 return false;
             }

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -369,13 +369,20 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        if (ReadOnly || (command.Feature is SpreadsheetFeature feature && !IsFeatureAllowed(feature)))
+        if (ReadOnly)
+        {
+            return false;
+        }
+
+        if (command.Feature is SpreadsheetFeature feature && !IsFeatureAllowed(feature))
         {
             return false;
         }
 
         if (command is IProtectedCommand pc && Worksheet?.Protection.IsActionBlocked(pc.RequiredAction) == true)
         {
+            // PasteCommand is a special case: it bypasses the sheet-level EditCell block
+            // because it validates locking at the cell level during DoExecute().
             if (command is not PasteCommand)
             {
                 return false;
@@ -1711,6 +1718,22 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
 
         if (Worksheet is not null)
         {
+            
+            if (Worksheet.Protection.IsProtected)
+            {
+                var range = Worksheet.Selection.Range; 
+                for (int r = range.Start.Row; r <= range.End.Row; r++)
+                {
+                    for (int c = range.Start.Column; c <= range.End.Column; c++)
+                    {
+                        if (!Worksheet.IsCellEditable(new CellRef(r, c)))
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+            
             var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
             clipboard.Copy(Worksheet);
 
@@ -1721,7 +1744,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         }
     }
 
-    private async Task CutSelectionAsync()
+    internal async Task CutSelectionAsync()
     {
         if (!IsFeatureAllowed(SpreadsheetFeature.Clipboard) || !IsFeatureAllowed(SpreadsheetFeature.Editing))
         {
@@ -1730,6 +1753,22 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
 
         if (Worksheet is not null)
         {
+            // reject the cut if the range contains any locked cells on a protected sheet
+            if (Worksheet.Protection.IsProtected)
+            {
+                var range = Worksheet.Selection.Range; 
+                for (int r = range.Start.Row; r <= range.End.Row; r++)
+                {
+                    for (int c = range.Start.Column; c <= range.End.Column; c++)
+                    {
+                        if (!Worksheet.IsCellEditable(new CellRef(r, c)))
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+            
             var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
             clipboard.Cut(Worksheet);
 

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -379,9 +379,17 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
             return false;
         }
 
-        if (command is Spreadsheet.IProtectedCommand pc && Worksheet?.Protection.IsActionBlocked(pc.RequiredAction) == true)
+        //check if the command is blocked by sheet protection
+        if (command is IProtectedCommand pc && Worksheet?.Protection.IsActionBlocked(pc.RequiredAction) == true)
         {
-            return false;
+            //allow only if it is a PasteCommand and the target cell is explicitly unlocked
+            bool isPaste = command is PasteCommand;
+            bool isEditable = Worksheet != null && Worksheet.IsCellEditable(Worksheet.Selection.Cell);
+
+            if (!isPaste || !isEditable)
+            {
+                return false;
+            }
         }
 
         if (CommandExecuting.HasDelegate)

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -1718,7 +1718,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
 
         if (Worksheet is not null)
         {
-          var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
+            var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
             clipboard.Copy(Worksheet);
 
             if (jsRef is not null)
@@ -1738,10 +1738,11 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         if (Worksheet is not null)
         {
             // reject the cut if the range contains any locked cells on a protected sheet
-            if (Worksheet.Protection.IsProtected && !Worksheet.IsRangeEditable(Worksheet.Selection.Range))
+            if (!Worksheet.IsRangeEditable(Worksheet.Selection.Range))
             {
                 return;
             }
+
             var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
             clipboard.Cut(Worksheet);
 

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -1718,23 +1718,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
 
         if (Worksheet is not null)
         {
-            
-            if (Worksheet.Protection.IsProtected)
-            {
-                var range = Worksheet.Selection.Range; 
-                for (int r = range.Start.Row; r <= range.End.Row; r++)
-                {
-                    for (int c = range.Start.Column; c <= range.End.Column; c++)
-                    {
-                        if (!Worksheet.IsCellEditable(new CellRef(r, c)))
-                        {
-                            return;
-                        }
-                    }
-                }
-            }
-            
-            var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
+          var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
             clipboard.Copy(Worksheet);
 
             if (jsRef is not null)
@@ -1754,21 +1738,10 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         if (Worksheet is not null)
         {
             // reject the cut if the range contains any locked cells on a protected sheet
-            if (Worksheet.Protection.IsProtected)
+            if (Worksheet.Protection.IsProtected && !Worksheet.IsRangeEditable(Worksheet.Selection.Range))
             {
-                var range = Worksheet.Selection.Range; 
-                for (int r = range.Start.Row; r <= range.End.Row; r++)
-                {
-                    for (int c = range.Start.Column; c <= range.End.Column; c++)
-                    {
-                        if (!Worksheet.IsCellEditable(new CellRef(r, c)))
-                        {
-                            return;
-                        }
-                    }
-                }
+                return;
             }
-            
             var text = Worksheet.GetDelimitedString(Worksheet.Selection.Range);
             clipboard.Cut(Worksheet);
 

--- a/Radzen.Blazor/Spreadsheet/PasteCommand.cs
+++ b/Radzen.Blazor/Spreadsheet/PasteCommand.cs
@@ -48,10 +48,12 @@ class PasteCommand : RangeSnapshotCommandBase
         {
             return false;
         }
-        if (sheet.Protection.IsProtected && !sheet.IsRangeEditable(destinationRange))
+
+        if (!sheet.IsRangeEditable(destinationRange))
         {
             return false;
         }
+
         CaptureRange(destinationRange.GetCells());
 
         if (clipboard.TryGetMoveSource(sheet, out var moveSource))

--- a/Radzen.Blazor/Spreadsheet/PasteCommand.cs
+++ b/Radzen.Blazor/Spreadsheet/PasteCommand.cs
@@ -48,21 +48,10 @@ class PasteCommand : RangeSnapshotCommandBase
         {
             return false;
         }
-        
-        if (sheet.Protection.IsProtected)
+        if (sheet.Protection.IsProtected && !sheet.IsRangeEditable(destinationRange))
         {
-            for (int r = destinationRange.Start.Row; r <= destinationRange.End.Row; r++)
-            {
-                for (int c = destinationRange.Start.Column; c <= destinationRange.End.Column; c++)
-                {
-                    if (!sheet.IsCellEditable(new CellRef(r, c)))
-                    {
-                        return false;
-                    }
-                }
-            }
+            return false;
         }
-        
         CaptureRange(destinationRange.GetCells());
 
         if (clipboard.TryGetMoveSource(sheet, out var moveSource))

--- a/Radzen.Blazor/Spreadsheet/PasteCommand.cs
+++ b/Radzen.Blazor/Spreadsheet/PasteCommand.cs
@@ -48,7 +48,21 @@ class PasteCommand : RangeSnapshotCommandBase
         {
             return false;
         }
-
+        
+        if (sheet.Protection.IsProtected)
+        {
+            for (int r = destinationRange.Start.Row; r <= destinationRange.End.Row; r++)
+            {
+                for (int c = destinationRange.Start.Column; c <= destinationRange.End.Column; c++)
+                {
+                    if (!sheet.IsCellEditable(new CellRef(r, c)))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        
         CaptureRange(destinationRange.GetCells());
 
         if (clipboard.TryGetMoveSource(sheet, out var moveSource))


### PR DESCRIPTION
Issue: 
Currently, when sheet.Protection.IsProtected is set to true, the RadzenSpreadsheet component globally disables clipboard pasting. This happens even for cells where Format.Locked is explicitly set to false.

Example:
Try pasting into column E: [https://blazor.radzen.com/spreadsheet-protection](https://blazor.radzen.com/spreadsheet-protection)

Changes:
1. RadzenSpreadsheet.cs: Updated ExecuteAsync to allow the PasteCommand if the target cell is editable, even when the sheet is protected.
2. Worksheet.cs: Updated InsertDelimitedString to verify the Locked property of each cell before writing data.

Tests:
1. Paste_Respects_CellLocking_InProtectedSheet: Verifies that within a protected sheet, locked cells are ignored while unlocked cells are correctly updated during a multi-cell paste.
2. Paste_Works_When_Protection_Is_Disabled: Ensures that existing paste behavior remains unchanged and fully functional when protection is not enabled.

All existing and new unit tests have passed.
