### PR TITLE
Marching ants effect on copy & cut

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/CopyOverlayTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CopyOverlayTests.cs
@@ -12,38 +12,37 @@ public class CopyOverlayTests : TestContext
     public void CopyOverlay_RendersNothing_When_Clipboard_Empty()
     {
         var sheet = new Worksheet(10, 10);
-        var spreadsheet = new RadzenSpreadsheet();
+        var clipboard = new SpreadsheetClipboard();
         var context = new CopyMockContext(sheet);
 
         var cut = RenderComponent<CopyOverlay>(parameters => parameters
             .Add(p => p.Worksheet, sheet)
-            .Add(p => p.Spreadsheet, spreadsheet)
-            .Add(p => p.Context, context));
+            .Add(p => p.Context, context)
+            .AddCascadingValue(clipboard));
 
         Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-overlay"));
     }
 
     [Fact]
-    public void CopyOverlay_RendersSvg_When_Clipboard_Has_Source()
+    public void CopyOverlay_RendersEdges_When_Clipboard_Has_Source()
     {
         var sheet = new Worksheet(10, 10);
         sheet.Selection.Select(RangeRef.Parse("B2:C3"));
         
-        var spreadsheet = new RadzenSpreadsheet();
-        spreadsheet.clipboard.Copy(sheet);
+        var clipboard = new SpreadsheetClipboard();
+        clipboard.Copy(sheet);
 
         var context = new CopyMockContext(sheet);
 
         var cut = RenderComponent<CopyOverlay>(parameters => parameters
             .Add(p => p.Worksheet, sheet)
-            .Add(p => p.Spreadsheet, spreadsheet)
-            .Add(p => p.Context, context));
+            .Add(p => p.Context, context)
+            .AddCascadingValue(clipboard));
 
-        var svgs = cut.FindAll(".rz-spreadsheet-copy-overlay");
-        Assert.Single(svgs);
+        var overlays = cut.FindAll(".rz-spreadsheet-copy-overlay");
+        Assert.Single(overlays);
 
-        var rect = cut.Find("rect");
-        Assert.NotNull(rect);
+        Assert.NotEmpty(cut.FindAll(".rz-copy-edge"));
     }
 
     [Fact]
@@ -53,17 +52,68 @@ public class CopyOverlayTests : TestContext
         var sheet2 = new Worksheet(10, 10);
         sheet1.Selection.Select(RangeRef.Parse("A1:B2"));
 
-        var spreadsheet = new RadzenSpreadsheet();
-        spreadsheet.clipboard.Copy(sheet1); // Copied on sheet1
+        var clipboard = new SpreadsheetClipboard();
+        clipboard.Copy(sheet1); // Copied on sheet1
 
         var context = new CopyMockContext(sheet2);
 
         var cut = RenderComponent<CopyOverlay>(parameters => parameters
             .Add(p => p.Worksheet, sheet2)
-            .Add(p => p.Spreadsheet, spreadsheet)
-            .Add(p => p.Context, context));
+            .Add(p => p.Context, context)
+            .AddCascadingValue(clipboard));
 
         Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-overlay")); // Not drawn on sheet2
+    }
+    [Fact]
+    public async void RendersEdges_WhenClipboardChanged_FiresAfterInitialRender()
+    {
+        var sheet = new Worksheet(10, 10);
+        var clipboard = new SpreadsheetClipboard();
+        var context = new CopyMockContext(sheet);
+
+        var cut = RenderComponent<CopyOverlay>(parameters => parameters
+            .Add(p => p.Worksheet, sheet)
+            .Add(p => p.Context, context)
+            .AddCascadingValue(clipboard));
+
+        Assert.Empty(cut.FindAll(".rz-copy-edge"));
+
+        sheet.Selection.Select(RangeRef.Parse("A1"));
+        await cut.InvokeAsync(() => clipboard.Copy(sheet));
+        Assert.NotEmpty(cut.FindAll(".rz-copy-edge"));
+    }
+
+    [Fact]
+    public void RendersFrozenClasses_AndTopEdgeOnly_OnSplitRange()
+    {
+        var sheet = new Worksheet(10, 10);
+        var clipboard = new SpreadsheetClipboard();
+        sheet.Selection.Select(RangeRef.Parse("A1"));
+        clipboard.Copy(sheet);
+
+        var frozenContext = new CopyMockContext(sheet);
+        frozenContext.SetOverrideRanges(new List<RangeInfo>
+        {
+            new RangeInfo
+            {
+                Range = RangeRef.Parse("A1"),
+                Top = true,
+                Right = true,
+                Bottom = false,
+                Left = true,
+                FrozenRow = true,
+                FrozenColumn = false
+            }
+        });
+
+        var cut = RenderComponent<CopyOverlay>(parameters => parameters
+            .Add(p => p.Worksheet, sheet)
+            .Add(p => p.Context, frozenContext)
+            .AddCascadingValue(clipboard));
+
+        Assert.NotNull(cut.Find(".rz-spreadsheet-frozen-row"));
+        Assert.NotEmpty(cut.FindAll(".rz-copy-edge-top"));
+        Assert.Empty(cut.FindAll(".rz-copy-edge-bottom"));
     }
 }
 
@@ -71,6 +121,7 @@ public class CopyOverlayTests : TestContext
 public class CopyMockContext : IVirtualGridContext
 {
     private SheetView? view;
+    private IEnumerable<RangeInfo>? overrideRanges;
 
     public CopyMockContext(Worksheet? sheet = null)
     {
@@ -78,6 +129,11 @@ public class CopyMockContext : IVirtualGridContext
         {
             view = new SheetView(sheet);
         }
+    }
+
+    public void SetOverrideRanges(IEnumerable<RangeInfo> ranges)
+    {
+        overrideRanges = ranges;
     }
 
     public PixelRectangle GetRectangle(int row, int column)
@@ -90,8 +146,15 @@ public class CopyMockContext : IVirtualGridContext
         return new PixelRectangle(new PixelRange(left * 100, (right + 1) * 100), new PixelRange(top * 24, (bottom + 1) * 24));
     }
 
-    public IEnumerable<RangeInfo> GetRanges(RangeRef range) =>
-        view != null ? view.GetRanges(range) : [new RangeInfo { Range = range }];
+    public IEnumerable<RangeInfo> GetRanges(RangeRef range)
+    {
+        if (overrideRanges != null)
+        {
+            return overrideRanges;
+        }
+
+        return view != null ? view.GetRanges(range) : [new RangeInfo { Range = range, Top = true, Right = true, Bottom = true, Left = true }];
+    }
 
 #pragma warning disable CS0067
     public event Action? Scrolled;

--- a/Radzen.Blazor.Tests/Spreadsheet/CopyOverlayTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CopyOverlayTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Bunit;
+using Xunit;
+
+using Radzen.Documents.Spreadsheet;
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+public class CopyOverlayTests : TestContext
+{
+    [Fact]
+    public void CopyOverlay_RendersNothing_When_Clipboard_Empty()
+    {
+        var sheet = new Worksheet(10, 10);
+        var spreadsheet = new RadzenSpreadsheet();
+        var context = new CopyMockContext(sheet);
+
+        var cut = RenderComponent<CopyOverlay>(parameters => parameters
+            .Add(p => p.Worksheet, sheet)
+            .Add(p => p.Spreadsheet, spreadsheet)
+            .Add(p => p.Context, context));
+
+        Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-overlay"));
+    }
+
+    [Fact]
+    public void CopyOverlay_RendersSvg_When_Clipboard_Has_Source()
+    {
+        var sheet = new Worksheet(10, 10);
+        sheet.Selection.Select(RangeRef.Parse("B2:C3"));
+        
+        var spreadsheet = new RadzenSpreadsheet();
+        spreadsheet.clipboard.Copy(sheet);
+
+        var context = new CopyMockContext(sheet);
+
+        var cut = RenderComponent<CopyOverlay>(parameters => parameters
+            .Add(p => p.Worksheet, sheet)
+            .Add(p => p.Spreadsheet, spreadsheet)
+            .Add(p => p.Context, context));
+
+        var svgs = cut.FindAll(".rz-spreadsheet-copy-overlay");
+        Assert.Single(svgs);
+
+        var rect = cut.Find("rect");
+        Assert.NotNull(rect);
+    }
+
+    [Fact]
+    public void CopyOverlay_DoesNotRender_On_Different_Sheet()
+    {
+        var sheet1 = new Worksheet(10, 10);
+        var sheet2 = new Worksheet(10, 10);
+        sheet1.Selection.Select(RangeRef.Parse("A1:B2"));
+
+        var spreadsheet = new RadzenSpreadsheet();
+        spreadsheet.clipboard.Copy(sheet1); // Copied on sheet1
+
+        var context = new CopyMockContext(sheet2);
+
+        var cut = RenderComponent<CopyOverlay>(parameters => parameters
+            .Add(p => p.Worksheet, sheet2)
+            .Add(p => p.Spreadsheet, spreadsheet)
+            .Add(p => p.Context, context));
+
+        Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-overlay")); // Not drawn on sheet2
+    }
+}
+
+#nullable enable
+public class CopyMockContext : IVirtualGridContext
+{
+    private SheetView? view;
+
+    public CopyMockContext(Worksheet? sheet = null)
+    {
+        if (sheet != null)
+        {
+            view = new SheetView(sheet);
+        }
+    }
+
+    public PixelRectangle GetRectangle(int row, int column)
+    {
+        return new PixelRectangle(row * 24, column * 100, (row + 1) * 24, (column + 1) * 100);
+    }
+
+    public PixelRectangle GetRectangle(int top, int left, int bottom, int right)
+    {
+        return new PixelRectangle(new PixelRange(left * 100, (right + 1) * 100), new PixelRange(top * 24, (bottom + 1) * 24));
+    }
+
+    public IEnumerable<RangeInfo> GetRanges(RangeRef range) =>
+        view != null ? view.GetRanges(range) : [new RangeInfo { Range = range }];
+
+#pragma warning disable CS0067
+    public event Action? Scrolled;
+#pragma warning restore CS0067
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/CopyOverlayTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CopyOverlayTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Bunit;
 using Xunit;
 
@@ -42,7 +43,7 @@ public class CopyOverlayTests : TestContext
         var overlays = cut.FindAll(".rz-spreadsheet-copy-overlay");
         Assert.Single(overlays);
 
-        Assert.NotEmpty(cut.FindAll(".rz-copy-edge"));
+        Assert.NotEmpty(cut.FindAll(".rz-spreadsheet-copy-edge"));
     }
 
     [Fact]
@@ -53,7 +54,7 @@ public class CopyOverlayTests : TestContext
         sheet1.Selection.Select(RangeRef.Parse("A1:B2"));
 
         var clipboard = new SpreadsheetClipboard();
-        clipboard.Copy(sheet1); // Copied on sheet1
+        clipboard.Copy(sheet1);
 
         var context = new CopyMockContext(sheet2);
 
@@ -62,10 +63,10 @@ public class CopyOverlayTests : TestContext
             .Add(p => p.Context, context)
             .AddCascadingValue(clipboard));
 
-        Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-overlay")); // Not drawn on sheet2
+        Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-overlay"));
     }
     [Fact]
-    public async void RendersEdges_WhenClipboardChanged_FiresAfterInitialRender()
+    public async Task RendersEdges_WhenClipboardChanged_FiresAfterInitialRender()
     {
         var sheet = new Worksheet(10, 10);
         var clipboard = new SpreadsheetClipboard();
@@ -76,11 +77,11 @@ public class CopyOverlayTests : TestContext
             .Add(p => p.Context, context)
             .AddCascadingValue(clipboard));
 
-        Assert.Empty(cut.FindAll(".rz-copy-edge"));
+        Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-edge"));
 
         sheet.Selection.Select(RangeRef.Parse("A1"));
         await cut.InvokeAsync(() => clipboard.Copy(sheet));
-        Assert.NotEmpty(cut.FindAll(".rz-copy-edge"));
+        Assert.NotEmpty(cut.FindAll(".rz-spreadsheet-copy-edge"));
     }
 
     [Fact]
@@ -112,8 +113,8 @@ public class CopyOverlayTests : TestContext
             .AddCascadingValue(clipboard));
 
         Assert.NotNull(cut.Find(".rz-spreadsheet-frozen-row"));
-        Assert.NotEmpty(cut.FindAll(".rz-copy-edge-top"));
-        Assert.Empty(cut.FindAll(".rz-copy-edge-bottom"));
+        Assert.NotEmpty(cut.FindAll(".rz-spreadsheet-copy-edge-top"));
+        Assert.Empty(cut.FindAll(".rz-spreadsheet-copy-edge-bottom"));
     }
 }
 

--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
@@ -142,4 +142,65 @@ public class SpreadsheetClipboardTests
         Assert.Equal("CanCut", sheet.Cells[0, 0].Value);
         Assert.Equal("CannotCut", sheet.Cells[1, 0].Value);
     }
+    [Fact]
+    public void GetSource_ReturnsRange_OnlyForSourceSheet()
+    {
+        var sheet1 = new Worksheet(10, 10);
+        var sheet2 = new Worksheet(10, 10);
+        sheet1.Selection.Select(RangeRef.Parse("A1:B2"));
+        
+        var clipboard = new SpreadsheetClipboard();
+        clipboard.Copy(sheet1);
+        
+        Assert.Equal(RangeRef.Parse("A1:B2"), clipboard.GetSource(sheet1));
+        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet2)); // Isn't drawn on a different sheet
+    }
+
+    [Fact]
+    public void GetSource_SurvivesCopyPaste_ButClearsOnExternalPaste()
+    {
+        var sheet = new Worksheet(10, 10);
+        sheet.Cells[0, 0].Value = "Data";
+        sheet.Selection.Select(RangeRef.Parse("A1"));
+        
+        var clipboard = new SpreadsheetClipboard();
+        clipboard.Copy(sheet);
+        
+        // Internal Paste (matches CSV, simulating a normal app paste)
+        clipboard.TryPaste(sheet, RangeRef.Parse("B1"), "Data");
+        Assert.Equal(RangeRef.Parse("A1"), clipboard.GetSource(sheet)); // Survives copy-paste
+        
+        // External Paste (doesn't match CSV, simulating paste from another app)
+        clipboard.TryPaste(sheet, RangeRef.Parse("C1"), "ExternalData");
+        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet)); // Clears on external paste
+    }
+
+    [Fact]
+    public void GetSource_ClearsOnCutPaste()
+    {
+        var sheet = new Worksheet(10, 10);
+        sheet.Cells[0, 0].Value = "Data";
+        sheet.Selection.Select(RangeRef.Parse("A1"));
+        
+        var clipboard = new SpreadsheetClipboard();
+        clipboard.Cut(sheet);
+        
+        Assert.Equal(RangeRef.Parse("A1"), clipboard.GetSource(sheet));
+        
+        clipboard.Paste(sheet, RangeRef.Parse("B1"));
+        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet)); // Clears after cut-paste completes
+    }
+
+    [Fact]
+    public void Clear_RemovesSource()
+    {
+        var sheet = new Worksheet(10, 10);
+        sheet.Selection.Select(RangeRef.Parse("A1"));
+        
+        var clipboard = new SpreadsheetClipboard();
+        clipboard.Copy(sheet);
+        
+        clipboard.Clear(); // Simulates the Escape key or structural edits
+        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet));
+    }
 }

--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetClipboardTests.cs
@@ -153,7 +153,7 @@ public class SpreadsheetClipboardTests
         clipboard.Copy(sheet1);
         
         Assert.Equal(RangeRef.Parse("A1:B2"), clipboard.GetSource(sheet1));
-        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet2)); // Isn't drawn on a different sheet
+        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet2));
     }
 
     [Fact]
@@ -166,13 +166,11 @@ public class SpreadsheetClipboardTests
         var clipboard = new SpreadsheetClipboard();
         clipboard.Copy(sheet);
         
-        // Internal Paste (matches CSV, simulating a normal app paste)
         clipboard.TryPaste(sheet, RangeRef.Parse("B1"), "Data");
-        Assert.Equal(RangeRef.Parse("A1"), clipboard.GetSource(sheet)); // Survives copy-paste
+        Assert.Equal(RangeRef.Parse("A1"), clipboard.GetSource(sheet));
         
-        // External Paste (doesn't match CSV, simulating paste from another app)
         clipboard.TryPaste(sheet, RangeRef.Parse("C1"), "ExternalData");
-        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet)); // Clears on external paste
+        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet));
     }
 
     [Fact]
@@ -188,7 +186,7 @@ public class SpreadsheetClipboardTests
         Assert.Equal(RangeRef.Parse("A1"), clipboard.GetSource(sheet));
         
         clipboard.Paste(sheet, RangeRef.Parse("B1"));
-        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet)); // Clears after cut-paste completes
+        Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet));
     }
 
     [Fact]
@@ -200,7 +198,7 @@ public class SpreadsheetClipboardTests
         var clipboard = new SpreadsheetClipboard();
         clipboard.Copy(sheet);
         
-        clipboard.Clear(); // Simulates the Escape key or structural edits
+        clipboard.Clear();
         Assert.Equal(RangeRef.Invalid, clipboard.GetSource(sheet));
     }
 }

--- a/Radzen.Blazor/RadzenSpreadsheet.razor
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor
@@ -154,7 +154,9 @@
             </Template>
             <ChildContent>
                 <SelectionOverlay Worksheet=@Worksheet Context=@context />
-                <CopyOverlay Worksheet=@Worksheet Context=@context Spreadsheet=@this />
+                <CascadingValue Value=@clipboard IsFixed="true">
+                    <CopyOverlay Worksheet=@Worksheet Context=@context/>
+                </CascadingValue>
                 <AutofillOverlay Worksheet=@Worksheet Context=@context />
                 <ImageOverlay Worksheet=@Worksheet Context=@context />
                 <ChartOverlay Worksheet=@Worksheet Context=@context />

--- a/Radzen.Blazor/RadzenSpreadsheet.razor
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor
@@ -154,6 +154,7 @@
             </Template>
             <ChildContent>
                 <SelectionOverlay Worksheet=@Worksheet Context=@context />
+                <CopyOverlay Worksheet=@Worksheet Context=@context Spreadsheet=@this />
                 <AutofillOverlay Worksheet=@Worksheet Context=@context />
                 <ImageOverlay Worksheet=@Worksheet Context=@context />
                 <ChartOverlay Worksheet=@Worksheet Context=@context />

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -431,9 +431,21 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
             accessibility?.AnnounceAction(message);
         }
 
+        if (executed && IsStructuralCommand(command))
+        {
+            clipboard.Clear();
+        }
+        
         return executed;
     }
 
+    private bool IsStructuralCommand(ICommand command) => command is
+        InsertRowCommand or InsertColumnCommand or 
+        DeleteRowsCommand or DeleteColumnsCommand or 
+        SortCommand or MultiKeySortCommand or 
+        FilterCommand or TableFilterCommand or 
+        SheetAutoFilterCommand or RemoveFilterCommand;
+    
     /// <inheritdoc/>
     public void Undo()
     {
@@ -443,6 +455,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         }
 
         ActiveView?.Commands.Undo();
+        clipboard.Clear();
     }
 
     /// <inheritdoc/>
@@ -454,6 +467,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         }
 
         ActiveView?.Commands.Redo();
+        clipboard.Clear();
     }
 
     /// <inheritdoc/>
@@ -1531,7 +1545,8 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         {
             Editor?.Cancel();
         }
-
+        clipboard.Clear();
+        
         return Task.CompletedTask;
     }
 
@@ -1547,7 +1562,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
     // Approximate page size (rows) for PageUp/PageDown - a screenful without coupling to the viewport.
     private const int PageRows = 20;
 
-    private readonly SpreadsheetClipboard clipboard = new();
+    internal readonly SpreadsheetClipboard clipboard = new();
 
     /// <inheritdoc/>
     protected override void OnInitialized()
@@ -1558,7 +1573,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         workbook = Workbook;
         StampCulture(workbook);
         Bind("Enter", _ => CycleSelectionAsync(1, 0));
-        Bind("Escape", _ => CancelEditAsync());
+        Bind("Escape", _ => CancelEditAsync(),global:true);
         Bind("Tab", _ => CycleSelectionAsync(0, 1));
         Bind("ArrowUp", _ => MoveSelectionAsync(-1, 0));
         Bind("ArrowDown", _ => MoveSelectionAsync(1, 0));

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -431,20 +431,16 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
             accessibility?.AnnounceAction(message);
         }
 
-        if (executed && IsStructuralCommand(command))
+        if (executed && command is not (PasteCommand
+                or ResizeColumnCommand or ResizeRowCommand
+                or MoveAnchoredCommand<SheetImage> or MoveAnchoredCommand<SheetChart>
+                or ResizeAnchoredCommand<SheetImage> or ResizeAnchoredCommand<SheetChart>))
         {
             clipboard.Clear();
         }
         
         return executed;
     }
-
-    private bool IsStructuralCommand(ICommand command) => command is
-        InsertRowCommand or InsertColumnCommand or 
-        DeleteRowsCommand or DeleteColumnsCommand or 
-        SortCommand or MultiKeySortCommand or 
-        FilterCommand or TableFilterCommand or 
-        SheetAutoFilterCommand or RemoveFilterCommand;
     
     /// <inheritdoc/>
     public void Undo()
@@ -455,7 +451,6 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         }
 
         ActiveView?.Commands.Undo();
-        clipboard.Clear();
     }
 
     /// <inheritdoc/>
@@ -467,7 +462,6 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         }
 
         ActiveView?.Commands.Redo();
-        clipboard.Clear();
     }
 
     /// <inheritdoc/>
@@ -1544,6 +1538,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         if (Editor?.Mode != EditMode.None)
         {
             Editor?.Cancel();
+            return Task.CompletedTask;
         }
         clipboard.Clear();
         
@@ -1573,7 +1568,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         workbook = Workbook;
         StampCulture(workbook);
         Bind("Enter", _ => CycleSelectionAsync(1, 0));
-        Bind("Escape", _ => CancelEditAsync(),global:true);
+        Bind("Escape", _ => CancelEditAsync(), global: true);
         Bind("Tab", _ => CycleSelectionAsync(0, 1));
         Bind("ArrowUp", _ => MoveSelectionAsync(-1, 0));
         Bind("ArrowDown", _ => MoveSelectionAsync(1, 0));
@@ -1849,10 +1844,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
         }
         if (IsFeatureAllowed(SpreadsheetFeature.Clipboard))
         {
-            if (IsFeatureAllowed(SpreadsheetFeature.Clipboard))
-        {
             menuItems.Add(new() { Text = Localize(nameof(RadzenStrings.Spreadsheet_Copy)), Value = "copy", Icon = "content_copy" });
-        }
         }
         if (canCutPaste)
         {

--- a/Radzen.Blazor/RadzenSpreadsheet.razor.cs
+++ b/Radzen.Blazor/RadzenSpreadsheet.razor.cs
@@ -1557,7 +1557,7 @@ public partial class RadzenSpreadsheet : RadzenComponent, IAsyncDisposable, ISpr
     // Approximate page size (rows) for PageUp/PageDown - a screenful without coupling to the viewport.
     private const int PageRows = 20;
 
-    internal readonly SpreadsheetClipboard clipboard = new();
+    private readonly SpreadsheetClipboard clipboard = new();
 
     /// <inheritdoc/>
     protected override void OnInitialized()

--- a/Radzen.Blazor/Spreadsheet/CopyOverlay.razor
+++ b/Radzen.Blazor/Spreadsheet/CopyOverlay.razor
@@ -1,22 +1,20 @@
 @using Radzen.Documents.Spreadsheet
 
-@{
-    var sourceRange = Spreadsheet.clipboard.GetSource(Worksheet);
-}
-
-@if (sourceRange != RangeRef.Invalid)
+@if (Clipboard?.GetSource(Worksheet) is { } sourceRange && sourceRange != RangeRef.Invalid)
 {
     @foreach (var rangeInfo in Context.GetRanges(sourceRange))
     {
-        var rect = Context.GetRectangle(
-            rangeInfo.Range.Start.Row, 
-            rangeInfo.Range.Start.Column, 
-            rangeInfo.Range.End.Row, 
-            rangeInfo.Range.End.Column
-        );
+        var rect = Context.GetRectangle(rangeInfo.Range.Start.Row, rangeInfo.Range.Start.Column, rangeInfo.Range.End.Row, rangeInfo.Range.End.Column);
+        var cssClass = "rz-spreadsheet-copy-overlay";
         
-        <svg class="rz-spreadsheet-copy-overlay" style="@rect.ToStyle()">
-            <rect width="100%" height="100%" />
-        </svg>
+        if (rangeInfo.FrozenRow) cssClass += " rz-spreadsheet-frozen-row";
+        if (rangeInfo.FrozenColumn) cssClass += " rz-spreadsheet-frozen-column";
+
+        <div class="@cssClass" style="@rect.ToStyle()">
+            @if (rangeInfo.Top) { <div class="rz-copy-edge rz-copy-edge-top"></div> }
+            @if (rangeInfo.Bottom) { <div class="rz-copy-edge rz-copy-edge-bottom"></div> }
+            @if (rangeInfo.Left) { <div class="rz-copy-edge rz-copy-edge-left"></div> }
+            @if (rangeInfo.Right) { <div class="rz-copy-edge rz-copy-edge-right"></div> }
+        </div>
     }
 }

--- a/Radzen.Blazor/Spreadsheet/CopyOverlay.razor
+++ b/Radzen.Blazor/Spreadsheet/CopyOverlay.razor
@@ -1,0 +1,22 @@
+@using Radzen.Documents.Spreadsheet
+
+@{
+    var sourceRange = Spreadsheet.clipboard.GetSource(Worksheet);
+}
+
+@if (sourceRange != RangeRef.Invalid)
+{
+    @foreach (var rangeInfo in Context.GetRanges(sourceRange))
+    {
+        var rect = Context.GetRectangle(
+            rangeInfo.Range.Start.Row, 
+            rangeInfo.Range.Start.Column, 
+            rangeInfo.Range.End.Row, 
+            rangeInfo.Range.End.Column
+        );
+        
+        <svg class="rz-spreadsheet-copy-overlay" style="@rect.ToStyle()">
+            <rect width="100%" height="100%" />
+        </svg>
+    }
+}

--- a/Radzen.Blazor/Spreadsheet/CopyOverlay.razor
+++ b/Radzen.Blazor/Spreadsheet/CopyOverlay.razor
@@ -11,10 +11,10 @@
         if (rangeInfo.FrozenColumn) cssClass += " rz-spreadsheet-frozen-column";
 
         <div class="@cssClass" style="@rect.ToStyle()">
-            @if (rangeInfo.Top) { <div class="rz-copy-edge rz-copy-edge-top"></div> }
-            @if (rangeInfo.Bottom) { <div class="rz-copy-edge rz-copy-edge-bottom"></div> }
-            @if (rangeInfo.Left) { <div class="rz-copy-edge rz-copy-edge-left"></div> }
-            @if (rangeInfo.Right) { <div class="rz-copy-edge rz-copy-edge-right"></div> }
+            @if (rangeInfo.Top) { <div class="rz-spreadsheet-copy-edge rz-spreadsheet-copy-edge-top"></div> }
+            @if (rangeInfo.Bottom) { <div class="rz-spreadsheet-copy-edge rz-spreadsheet-copy-edge-bottom"></div> }
+            @if (rangeInfo.Left) { <div class="rz-spreadsheet-copy-edge rz-spreadsheet-copy-edge-left"></div> }
+            @if (rangeInfo.Right) { <div class="rz-spreadsheet-copy-edge rz-spreadsheet-copy-edge-right"></div> }
         </div>
     }
 }

--- a/Radzen.Blazor/Spreadsheet/CopyOverlay.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/CopyOverlay.razor.cs
@@ -24,34 +24,23 @@ public partial class CopyOverlay : IDisposable
     /// <summary>
     /// Gets or sets the parent spreadsheet component.
     /// </summary>
-    [Parameter]
-    public RadzenSpreadsheet Spreadsheet { get; set; } = default!;
-
-    private readonly EventBinding<SpreadsheetClipboard> clipboardBinding;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CopyOverlay"/> class.
-    /// </summary>
-    public CopyOverlay()
+    [CascadingParameter]
+    internal SpreadsheetClipboard Clipboard { get; set; } = default!;
+    /// <inheritdoc/>
+    protected override void OnInitialized()
     {
-        clipboardBinding = new EventBinding<SpreadsheetClipboard>(
-            c => c.Changed += OnClipboardChanged,
-            c => c.Changed -= OnClipboardChanged);
+        if (Clipboard != null)
+        {
+            Clipboard.Changed += StateHasChanged;
+        }
     }
 
     /// <inheritdoc/>
-    protected override void OnParametersSet()
+    public void Dispose()
     {
-        clipboardBinding.Bind(Spreadsheet.clipboard);
-    }
-
-    private void OnClipboardChanged(object? sender, EventArgs e)
-    {
-        InvokeAsync(StateHasChanged);
-    }
-
-    void IDisposable.Dispose()
-    {
-        clipboardBinding.Dispose();
+        if (Clipboard != null)
+        {
+            Clipboard.Changed -= StateHasChanged;
+        }
     }
 }

--- a/Radzen.Blazor/Spreadsheet/CopyOverlay.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/CopyOverlay.razor.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.AspNetCore.Components;
+using Radzen.Documents.Spreadsheet;
+
+namespace Radzen.Blazor.Spreadsheet;
+
+/// <summary>
+/// Renders an overlay for the copied selection in a spreadsheet.
+/// </summary>
+public partial class CopyOverlay : IDisposable
+{
+    /// <summary>
+    /// Gets or sets the sheet that contains the copy overlay.
+    /// </summary>
+    [Parameter]
+    public Worksheet Worksheet { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the context for the virtual grid that contains the copy overlay.
+    /// </summary>
+    [Parameter]
+    public IVirtualGridContext Context { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the parent spreadsheet component.
+    /// </summary>
+    [Parameter]
+    public RadzenSpreadsheet Spreadsheet { get; set; } = default!;
+
+    private readonly EventBinding<SpreadsheetClipboard> clipboardBinding;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CopyOverlay"/> class.
+    /// </summary>
+    public CopyOverlay()
+    {
+        clipboardBinding = new EventBinding<SpreadsheetClipboard>(
+            c => c.Changed += OnClipboardChanged,
+            c => c.Changed -= OnClipboardChanged);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnParametersSet()
+    {
+        clipboardBinding.Bind(Spreadsheet.clipboard);
+    }
+
+    private void OnClipboardChanged(object? sender, EventArgs e)
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    void IDisposable.Dispose()
+    {
+        clipboardBinding.Dispose();
+    }
+}

--- a/Radzen.Blazor/Spreadsheet/CopyOverlay.razor.cs
+++ b/Radzen.Blazor/Spreadsheet/CopyOverlay.razor.cs
@@ -21,11 +21,9 @@ public partial class CopyOverlay : IDisposable
     [Parameter]
     public IVirtualGridContext Context { get; set; } = default!;
 
-    /// <summary>
-    /// Gets or sets the parent spreadsheet component.
-    /// </summary>
     [CascadingParameter]
     internal SpreadsheetClipboard Clipboard { get; set; } = default!;
+
     /// <inheritdoc/>
     protected override void OnInitialized()
     {

--- a/Radzen.Blazor/Spreadsheet/SpreadsheetClipboard.cs
+++ b/Radzen.Blazor/Spreadsheet/SpreadsheetClipboard.cs
@@ -18,6 +18,7 @@ class SpreadsheetClipboard
     private Worksheet? sheet;
     private ClipboardOperation operation;
     private string? csv;
+    public event EventHandler? Changed;
 
     public void Copy(Worksheet sheet)
     {
@@ -25,6 +26,7 @@ class SpreadsheetClipboard
         range = sheet.Selection.Range;
         operation = ClipboardOperation.Copy;
         csv = sheet.GetDelimitedString(range.Value);
+        Changed?.Invoke(this, EventArgs.Empty);
     }
 
     public void Cut(Worksheet sheet)
@@ -33,6 +35,7 @@ class SpreadsheetClipboard
         range = sheet.Selection.Range;
         operation = ClipboardOperation.Move;
         csv = sheet.GetDelimitedString(range.Value);
+        Changed?.Invoke(this, EventArgs.Empty);
     }
 
     public void Paste(Worksheet targetSheet, RangeRef destination)
@@ -142,13 +145,26 @@ class SpreadsheetClipboard
         source = RangeRef.Invalid;
         return false;
     }
-
+    
+    public RangeRef GetSource(Worksheet targetSheet) =>
+        range.HasValue && ReferenceEquals(sheet, targetSheet) ? range.Value : RangeRef.Invalid;
+    
+    public void Clear()
+    {
+        ClearInternal();
+    }
+    
     private void ClearInternal()
     {
+        var rangeHadValue = range.HasValue;
         range = null;
         sheet = null;
         csv = null;
         operation = ClipboardOperation.Copy;
+        if (rangeHadValue)
+        {
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     private static void Clear(Worksheet sourceSheet, RangeRef source)

--- a/Radzen.Blazor/Spreadsheet/SpreadsheetClipboard.cs
+++ b/Radzen.Blazor/Spreadsheet/SpreadsheetClipboard.cs
@@ -18,7 +18,7 @@ class SpreadsheetClipboard
     private Worksheet? sheet;
     private ClipboardOperation operation;
     private string? csv;
-    public event EventHandler? Changed;
+    public event Action? Changed;
 
     public void Copy(Worksheet sheet)
     {
@@ -26,7 +26,7 @@ class SpreadsheetClipboard
         range = sheet.Selection.Range;
         operation = ClipboardOperation.Copy;
         csv = sheet.GetDelimitedString(range.Value);
-        Changed?.Invoke(this, EventArgs.Empty);
+        Changed?.Invoke();
     }
 
     public void Cut(Worksheet sheet)
@@ -35,7 +35,7 @@ class SpreadsheetClipboard
         range = sheet.Selection.Range;
         operation = ClipboardOperation.Move;
         csv = sheet.GetDelimitedString(range.Value);
-        Changed?.Invoke(this, EventArgs.Empty);
+        Changed?.Invoke();
     }
 
     public void Paste(Worksheet targetSheet, RangeRef destination)
@@ -66,8 +66,8 @@ class SpreadsheetClipboard
 
             if (operation == ClipboardOperation.Move)
             {
-                Clear(sheet, source);
-                ClearInternal();
+                ClearRange(sheet, source);
+                Clear();
             }
         }
     }
@@ -81,7 +81,7 @@ class SpreadsheetClipboard
         }
 
         // clear internal clipboard when external data is pasted
-        ClearInternal();
+        Clear();
         return false;
     }
 
@@ -151,11 +151,6 @@ class SpreadsheetClipboard
     
     public void Clear()
     {
-        ClearInternal();
-    }
-    
-    private void ClearInternal()
-    {
         var rangeHadValue = range.HasValue;
         range = null;
         sheet = null;
@@ -163,11 +158,11 @@ class SpreadsheetClipboard
         operation = ClipboardOperation.Copy;
         if (rangeHadValue)
         {
-            Changed?.Invoke(this, EventArgs.Empty);
+            Changed?.Invoke();
         }
     }
 
-    private static void Clear(Worksheet sourceSheet, RangeRef source)
+    private static void ClearRange(Worksheet sourceSheet, RangeRef source)
     {
         for (var sr = source.Start.Row; sr <= source.End.Row; sr++)
         {

--- a/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
+++ b/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
@@ -858,3 +858,29 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
         background-color: var(--rz-base-background-color);
     }
 }
+
+.rz-spreadsheet-copy-overlay {
+    position: absolute;
+    pointer-events: none;
+    z-index: 3;
+    transform: translateZ(0);
+
+    rect {
+        fill: none;
+        stroke: var(--rz-secondary);
+        stroke-width: 2px;
+        stroke-dasharray: 4, 4;
+        animation: rz-spreadsheet-marching-ants 1s linear infinite;
+        will-change: stroke-dashoffset;
+
+        @media (prefers-reduced-motion: reduce) {
+            animation: none;
+        }
+    }
+}
+
+@keyframes rz-spreadsheet-marching-ants {
+    to {
+        stroke-dashoffset: -16;
+    }
+}

--- a/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
+++ b/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
@@ -862,25 +862,46 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
 .rz-spreadsheet-copy-overlay {
     position: absolute;
     pointer-events: none;
-    z-index: 3;
-    transform: translateZ(0);
+    z-index: 1;
 
-    rect {
-        fill: none;
-        stroke: var(--rz-secondary);
-        stroke-width: 2px;
-        stroke-dasharray: 4, 4;
-        animation: rz-spreadsheet-marching-ants 1s linear infinite;
-        will-change: stroke-dashoffset;
+    &.rz-spreadsheet-frozen-row, &.rz-spreadsheet-frozen-column {
+        z-index: 3;
+    }
 
-        @media (prefers-reduced-motion: reduce) {
-            animation: none;
-        }
+    &.rz-spreadsheet-frozen-row.rz-spreadsheet-frozen-column {
+        z-index: 4;
+    }
+
+    .rz-copy-edge {
+        position: absolute;
+        will-change: background-position;
+    }
+
+    .rz-copy-edge-top, .rz-copy-edge-bottom {
+        height: 2px;
+        left: 0;
+        right: 0;
+        background: repeating-linear-gradient(to right, var(--rz-secondary) 0, var(--rz-secondary) 4px, transparent 4px, transparent 8px);
+    }
+
+    .rz-copy-edge-left, .rz-copy-edge-right {
+        width: 2px;
+        top: 0;
+        bottom: 0;
+        background: repeating-linear-gradient(to bottom, var(--rz-secondary) 0, var(--rz-secondary) 4px, transparent 4px, transparent 8px);
+    }
+
+    .rz-copy-edge-top { top: -1px; animation: rz-marching-x 1s linear infinite; }
+    .rz-copy-edge-bottom { bottom: -1px; animation: rz-marching-x-reverse 1s linear infinite; }
+    .rz-copy-edge-left { left: -1px; animation: rz-marching-y-reverse 1s linear infinite; }
+    .rz-copy-edge-right { right: -1px; animation: rz-marching-y 1s linear infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+        .rz-copy-edge { animation: none !important; }
     }
 }
 
-@keyframes rz-spreadsheet-marching-ants {
-    to {
-        stroke-dashoffset: -16;
-    }
-}
+@keyframes rz-marching-x { to { background-position: 8px 0; } }
+@keyframes rz-marching-x-reverse { to { background-position: -8px 0; } }
+@keyframes rz-marching-y { to { background-position: 0 8px; } }
+@keyframes rz-marching-y-reverse { to { background-position: 0 -8px; } }

--- a/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
+++ b/Radzen.Blazor/themes/components/blazor/_spreadsheet.scss
@@ -872,36 +872,36 @@ $spreadsheet-splitter-background-color: var(--rz-base-200) !default;
         z-index: 4;
     }
 
-    .rz-copy-edge {
+    .rz-spreadsheet-copy-edge {
         position: absolute;
         will-change: background-position;
     }
 
-    .rz-copy-edge-top, .rz-copy-edge-bottom {
+    .rz-spreadsheet-copy-edge-top, .rz-spreadsheet-copy-edge-bottom {
         height: 2px;
         left: 0;
         right: 0;
         background: repeating-linear-gradient(to right, var(--rz-secondary) 0, var(--rz-secondary) 4px, transparent 4px, transparent 8px);
     }
 
-    .rz-copy-edge-left, .rz-copy-edge-right {
+    .rz-spreadsheet-copy-edge-left, .rz-spreadsheet-copy-edge-right {
         width: 2px;
         top: 0;
         bottom: 0;
         background: repeating-linear-gradient(to bottom, var(--rz-secondary) 0, var(--rz-secondary) 4px, transparent 4px, transparent 8px);
     }
 
-    .rz-copy-edge-top { top: -1px; animation: rz-marching-x 1s linear infinite; }
-    .rz-copy-edge-bottom { bottom: -1px; animation: rz-marching-x-reverse 1s linear infinite; }
-    .rz-copy-edge-left { left: -1px; animation: rz-marching-y-reverse 1s linear infinite; }
-    .rz-copy-edge-right { right: -1px; animation: rz-marching-y 1s linear infinite; }
+    .rz-spreadsheet-copy-edge-top { top: -1px; animation: rz-spreadsheet-marching-x 1s linear infinite; }
+    .rz-spreadsheet-copy-edge-bottom { bottom: -1px; animation: rz-spreadsheet-marching-x-reverse 1s linear infinite; }
+    .rz-spreadsheet-copy-edge-left { left: -1px; animation: rz-spreadsheet-marching-y-reverse 1s linear infinite; }
+    .rz-spreadsheet-copy-edge-right { right: -1px; animation: rz-spreadsheet-marching-y 1s linear infinite; }
 
     @media (prefers-reduced-motion: reduce) {
-        .rz-copy-edge { animation: none !important; }
+        .rz-spreadsheet-copy-edge { animation: none !important; }
     }
 }
 
-@keyframes rz-marching-x { to { background-position: 8px 0; } }
-@keyframes rz-marching-x-reverse { to { background-position: -8px 0; } }
-@keyframes rz-marching-y { to { background-position: 0 8px; } }
-@keyframes rz-marching-y-reverse { to { background-position: 0 -8px; } }
+@keyframes rz-spreadsheet-marching-x { to { background-position: 8px 0; } }
+@keyframes rz-spreadsheet-marching-x-reverse { to { background-position: -8px 0; } }
+@keyframes rz-spreadsheet-marching-y { to { background-position: 0 8px; } }
+@keyframes rz-spreadsheet-marching-y-reverse { to { background-position: 0 -8px; } }


### PR DESCRIPTION
I implemented excel's marching ants

Copy Behavior: When a range is copied, the marching ants persist even after pasting, allowing users to paste multiple times.
Cut Behavior: When a range is cut, the marching ants automatically clear immediately after a paste operation. The clipboard is not cleared


Also i noticed that Excel clears the clipboard on ESC key pressed. I can implement this in another pr if it is something we want