### PR TITLE
fix(dialog): only apply a resized size when the user actually resized it

### DIFF
--- a/Radzen.Blazor/Rendering/DialogContainer.razor
+++ b/Radzen.Blazor/Rendering/DialogContainer.razor
@@ -126,13 +126,13 @@
     {
         shouldRender = false;
 
-        if(Dialog?.Options?.Resize != null && w != 0 && h != 0)
+        if (w != 0 && h != 0)
         {
-            Dialog.Options.Resize(new System.Drawing.Size(Convert.ToInt32(w), Convert.ToInt32(h)));
-        }
+            Dialog?.Options?.Resize?.Invoke(new System.Drawing.Size(Convert.ToInt32(w), Convert.ToInt32(h)));
 
-        width = $"width: {w}px;";
-        height = $"height: {h}px;";
+            width = $"width: {w}px;";
+            height = $"height: {h}px;";
+        }
 
         shouldRender = true;
     }

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -2756,6 +2756,53 @@ window.Radzen = {
                 dialog.offsetWidth = dialogElement.offsetWidth;
                 dialog.offsetHeight = dialogElement.offsetHeight;
 
+                var userResizing = false;
+
+                var pushSize = function () {
+                    if (!dialog) return;
+                    if (dialog.offsetWidth == dialogElement.offsetWidth &&
+                        dialog.offsetHeight == dialogElement.offsetHeight) return;
+
+                    dialog.offsetWidth = dialogElement.offsetWidth;
+                    dialog.offsetHeight = dialogElement.offsetHeight;
+
+                    dialog.invokeMethodAsync(
+                        'RadzenDialog.OnResize',
+                        dialogElement.offsetWidth,
+                        dialogElement.offsetHeight
+                    ).catch(function () { });
+                };
+
+                var stopTracking = function () {
+                    document.removeEventListener('pointermove', onPointerMove, true);
+                    document.removeEventListener('pointerup', onPointerUp, true);
+                    document.removeEventListener('pointercancel', onPointerUp, true);
+                };
+
+                var onPointerMove = function (e) {
+                    if (e.buttons === 1) {
+                        userResizing = true;
+                        return;
+                    }
+
+                    onPointerUp();
+                };
+
+                var onPointerUp = function () {
+                    stopTracking();
+                    if (!userResizing) return;
+                    userResizing = false;
+                    pushSize();
+                };
+
+                var onPointerDown = function (e) {
+                    if (e.button !== 0 || !e.isPrimary || e.target !== dialogElement) return;
+
+                    document.addEventListener('pointermove', onPointerMove, true);
+                    document.addEventListener('pointerup', onPointerUp, true);
+                    document.addEventListener('pointercancel', onPointerUp, true);
+                };
+
                 var dialogResize = function (e) {
                     if (!dialog) return;
 
@@ -2764,21 +2811,19 @@ window.Radzen = {
                         return;
                     }
 
-                    if (dialog.offsetWidth != e[0].target.offsetWidth || dialog.offsetHeight != e[0].target.offsetHeight) {
-
+                    if (!userResizing) {
                         dialog.offsetWidth = e[0].target.offsetWidth;
                         dialog.offsetHeight = e[0].target.offsetHeight;
-
-                        dialog.invokeMethodAsync(
-                            'RadzenDialog.OnResize',
-                            e[0].target.offsetWidth,
-                            e[0].target.offsetHeight
-                        ).catch(function () { });
+                        return;
                     }
+
+                    pushSize();
                 };
 
                 var resizeObserver = new ResizeObserver(dialogResize);
                 resizeObserver.observe(dialogElement);
+
+                dialogElement.addEventListener('pointerdown', onPointerDown);
 
                 var resizer = {
                     disposed: false,
@@ -2786,6 +2831,8 @@ window.Radzen = {
                         if (this.disposed) return;
                         this.disposed = true;
                         resizeObserver.disconnect();
+                        dialogElement.removeEventListener('pointerdown', onPointerDown);
+                        stopTracking();
                         var index = Radzen.dialogResizers.indexOf(this);
                         if (index != -1) {
                             Radzen.dialogResizers.splice(index, 1);


### PR DESCRIPTION
Opening a nested dialog permanently locked the size of the dialog underneath it, and so did anything else that changed a resizable dialog's box - content loading, validation messages appearing, a plain reflow.

openDialog wires a ResizeObserver to a resizable dialog and forwards every reported size to DialogContainer.OnResize, which writes it into the private width/height fields. DialogContainer.Style prefers those over Options.Width/Height and over anything CSS would do, so once the observer has fired even once the dialog is nailed to that size for good. A ResizeObserver cannot tell a user drag apart from any other layout change, so all of them were treated as a deliberate resize.

The symptom is specific to nested dialogs because OnResize does not call StateHasChanged: a latched size only reaches the DOM on the next render of the DialogContainer, and RadzenDialog.Open re-renders every container.

The browser's native "resize: both" handle hit-tests as the element that carries the resize property, never as one of its descendants, so the resize gesture starts with a primary-button pointerdown whose target is the dialog element itself.

Size changes are forwarded to .NET only while the gesture is in flight; other changes still update the JS-side baseline so the next real drag is detected. The final size is flushed on pointerup because the last ResizeObserver callback of a drag can be delivered after it. It's worth mentioning that many interops are triggered during the resize process, but this was a behavior that existed before the patch.

Additional: OnResize also no longer pins a 0x0 measurement - a hidden or not yet laid out dialog - which would collapse the dialog permanently. The callback already guarded against it; the style assignment did not.