### PR TITLE
[RadzenDropDown]  SearchText parameter was not working correctly when used together with LoadData

### DIFF
--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -1061,6 +1061,7 @@ namespace Radzen
             if (JSRuntime != null)
             {
                 searchText = await JSRuntime.InvokeAsync<string>("Radzen.getInputValue", search) ?? string.Empty;
+                await InvokeAsync(() => SearchTextChanged.InvokeAsync(SearchText));
             }
 
             if (!LoadData.HasDelegate)
@@ -1108,7 +1109,6 @@ namespace Radzen
                 await JSRuntime.InvokeVoidAsync("Radzen.updateActiveDescendant", list, null, -1);
                 await JSRuntime.InvokeAsync<string>("Radzen.repositionPopup", Element, PopupID);
             }
-            await InvokeAsync(() => SearchTextChanged.InvokeAsync(SearchText));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes issue in DropDownBase where SearchText parameter was not set correctly when LoadData parameter is used. 

Issue can be noted in [playground example](https://blazor.radzen.com/playground/92504eb8-5db1-45ce-bb4f-2292d4e2f7f6)