### PR TITLE
Use IComponent as generic type constraint for DialogService methods

### DIFF
--- a/Radzen.Blazor/DialogService.cs
+++ b/Radzen.Blazor/DialogService.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using IComponent = Microsoft.AspNetCore.Components.IComponent;
 
 namespace Radzen
 {
@@ -144,7 +145,7 @@ namespace Radzen
         /// <param name="title">The text displayed in the title bar of the dialog.</param>
         /// <param name="parameters">The dialog parameters.</param>
         /// <param name="options">The dialog options.</param>
-        public virtual void Open<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, Dictionary<string, object?>? parameters = null, DialogOptions? options = null) where T : ComponentBase
+        public virtual void Open<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, Dictionary<string, object?>? parameters = null, DialogOptions? options = null) where T : IComponent
         {
             OpenDialog<T>(title, parameters, options);
         }
@@ -153,15 +154,15 @@ namespace Radzen
         /// Opens a dialog with the specified arguments.
         /// </summary>
         /// <param name="title">The text displayed in the title bar of the dialog.</param>
-        /// <param name="componentType">The type of the component to be displayed in the dialog. Must inherit from <see cref="ComponentBase"/>.</param>
+        /// <param name="componentType">The type of the component to be displayed in the dialog. Must inherit from <see cref="IComponent"/>.</param>
         /// <param name="parameters">The dialog parameters.</param>
         /// <param name="options">The dialog options.</param>
         [RequiresUnreferencedCode(TrimMessages.GenericMethodReflection)]
         public virtual void Open(string title, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type componentType, Dictionary<string, object?>? parameters = null, DialogOptions? options = null)
         {
-            if (!typeof(ComponentBase).IsAssignableFrom(componentType))
+            if (!typeof(IComponent).IsAssignableFrom(componentType))
             {
-                throw new ArgumentException("The component type must be a subclass of ComponentBase.", nameof(componentType));
+                throw new ArgumentException("The component type must be a subclass of IComponent.", nameof(componentType));
             }
 
             OpenDialog(title, componentType, parameters, options);
@@ -190,7 +191,7 @@ namespace Radzen
         /// <param name="parameters">The dialog parameters. Passed as property values of <typeparamref name="T" />.</param>
         /// <param name="options">The dialog options.</param>
         /// <returns>The value passed as argument to <see cref="Close" />.</returns>
-        public virtual Task<dynamic?> OpenAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, Dictionary<string, object?>? parameters = null, DialogOptions? options = null) where T : ComponentBase
+        public virtual Task<dynamic?> OpenAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, Dictionary<string, object?>? parameters = null, DialogOptions? options = null) where T : IComponent
         {
             var task = new TaskCompletionSource<dynamic?>();
             tasks.Add(task);
@@ -204,17 +205,17 @@ namespace Radzen
         /// Opens a dialog with the specified arguments dynamically.
         /// </summary>
         /// <param name="title">The text displayed in the title bar of the dialog.</param>
-        /// <param name="componentType">The type of the Blazor component to be displayed in a dialog. Must inherit from <see cref="ComponentBase"/>.</param>
+        /// <param name="componentType">The type of the Blazor component to be displayed in a dialog. Must inherit from <see cref="IComponent"/>.</param>
         /// <param name="parameters">The dialog parameters, passed as property values of the specified component.</param>
         /// <param name="options">The dialog options.</param>
         /// <returns>A task that represents the result passed as an argument to <see cref="Close"/>.</returns>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="componentType"/> does not inherit from <see cref="ComponentBase"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="componentType"/> does not inherit from <see cref="IComponent"/>.</exception>
         [RequiresUnreferencedCode(TrimMessages.GenericMethodReflection)]
         public virtual Task<dynamic?> OpenAsync(string title, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type componentType, Dictionary<string, object?>? parameters = null, DialogOptions? options = null)
         {
-            if (!typeof(ComponentBase).IsAssignableFrom(componentType))
+            if (!typeof(IComponent).IsAssignableFrom(componentType))
             {
-                throw new ArgumentException("The component type must be a subclass of ComponentBase.", nameof(componentType));
+                throw new ArgumentException("The component type must be a subclass of IComponent.", nameof(componentType));
             }
 
             var task = new TaskCompletionSource<dynamic?>();
@@ -235,7 +236,7 @@ namespace Radzen
         /// <param name="options">The side dialog options.</param>
         /// <returns>A task that completes when the dialog is closed or a new one opened</returns>
         public Task<dynamic?> OpenSideAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, Dictionary<string, object?>? parameters = null, SideDialogOptions? options = null)
-            where T : ComponentBase
+            where T : IComponent
         {
             CloseSideSilently();
             sideDialogResultTask = new TaskCompletionSource<dynamic?>();
@@ -254,16 +255,16 @@ namespace Radzen
         /// Opens a side dialog with the specified arguments dynamically.
         /// </summary>
         /// <param name="title">The text displayed in the title bar of the side dialog.</param>
-        /// <param name="componentType">The type of the Blazor component to be displayed in the side dialog. Must inherit from <see cref="ComponentBase"/>.</param>
+        /// <param name="componentType">The type of the Blazor component to be displayed in the side dialog. Must inherit from <see cref="IComponent"/>.</param>
         /// <param name="parameters">The dialog parameters, passed as property values of the specified component.</param>
         /// <param name="options">The side dialog options.</param>
         /// <returns>A task that represents the result passed as an argument to <see cref="CloseSide"/>.</returns>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="componentType"/> does not inherit from <see cref="ComponentBase"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="componentType"/> does not inherit from <see cref="IComponent"/>.</exception>
         public Task<dynamic?> OpenSideAsync(string title, Type componentType, Dictionary<string, object?>? parameters = null, SideDialogOptions? options = null)
         {
-            if (!typeof(ComponentBase).IsAssignableFrom(componentType))
+            if (!typeof(IComponent).IsAssignableFrom(componentType))
             {
-                throw new ArgumentException("The component type must be a subclass of ComponentBase.", nameof(componentType));
+                throw new ArgumentException("The component type must be a subclass of IComponent.", nameof(componentType));
             }
 
             CloseSideSilently();
@@ -290,7 +291,7 @@ namespace Radzen
         /// <param name="parameters">The dialog parameters. Passed as property values of <typeparamref name="T"/></param>
         /// <param name="options">The side dialog options.</param>
         public void OpenSide<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string title, Dictionary<string, object?>? parameters = null, SideDialogOptions? options = null)
-            where T : ComponentBase
+            where T : IComponent
         {
             CloseSideSilently();
 
@@ -308,15 +309,15 @@ namespace Radzen
         /// Opens a side dialog with the specified arguments dynamically.
         /// </summary>
         /// <param name="title">The text displayed in the title bar of the side dialog.</param>
-        /// <param name="componentType">The type of the Blazor component to be displayed in the side dialog. Must inherit from <see cref="ComponentBase"/>.</param>
+        /// <param name="componentType">The type of the Blazor component to be displayed in the side dialog. Must inherit from <see cref="IComponent"/>.</param>
         /// <param name="parameters">The dialog parameters, passed as property values of the specified component.</param>
         /// <param name="options">The side dialog options.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="componentType"/> does not inherit from <see cref="ComponentBase"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="componentType"/> does not inherit from <see cref="IComponent"/>.</exception>
         public void OpenSide(string title, Type componentType, Dictionary<string, object?>? parameters = null, SideDialogOptions? options = null)
         {
-            if (!typeof(ComponentBase).IsAssignableFrom(componentType))
+            if (!typeof(IComponent).IsAssignableFrom(componentType))
             {
-                throw new ArgumentException("The component type must be a subclass of ComponentBase.", nameof(componentType));
+                throw new ArgumentException("The component type must be a subclass of IComponent.", nameof(componentType));
             }
 
             CloseSideSilently();


### PR DESCRIPTION
`ComponentBase` implements `Microsoft.AspNetCore.Components.IComponent`. The Blazor rendering engine is designed to render classes implementing `IComponent` which allows us to create our own _ComponentBase_, if you will. The generic type constraints defined in `DialogService` methods should be restricted to types of `IComponent`.

This passes all tests, and I have verified that a custom component implementing `IComponent` will render correctly using these generic constraints. Let me know if any other validation is needed.

Aside: I have used this component library in professional Blazor projects for years and I love it. Thanks for all you guys do.