### PR TITLE
Add buffer support to progress bars

### DIFF
--- a/Radzen.Blazor.Tests/ProgressBarCircularTests.cs
+++ b/Radzen.Blazor.Tests/ProgressBarCircularTests.cs
@@ -18,11 +18,15 @@ namespace Radzen.Blazor.Tests
         public void ProgressBarCircular_Renders_SvgCirclesWithCorrectRadius()
         {
             using var ctx = new TestContext();
-            var component = ctx.RenderComponent<RadzenProgressBarCircular>();
+            var component = ctx.RenderComponent<RadzenProgressBarCircular>(p =>
+            {
+                p.Add(x => x.BufferValue, 75);
+            });
 
-            // SVG contains viewBox, background circle, and value circle with correct radius
+            // SVG contains viewBox, background circle, and value, buffer circles with correct radius
             Assert.Contains(@"viewBox=""-19 -19 38 38""", component.Markup);
             Assert.Contains(@"class=""rz-progressbar-circular-background"" r=""15.91549""", component.Markup);
+            Assert.Contains(@"class=""rz-progressbar-circular-buffer-value"" r=""15.91549""", component.Markup);
             Assert.Contains(@"class=""rz-progressbar-circular-value"" r=""15.91549""", component.Markup);
         }
 
@@ -65,6 +69,56 @@ namespace Radzen.Blazor.Tests
 
             // At 100%, dashoffset = (1 - 1) * 100 = 0
             Assert.Contains(@"stroke-dashoffset=""0""", component.Markup);
+        }
+
+        [Fact]
+        public void ProgressBarCircular_BufferValue_Renders_CorrectDashoffset()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenProgressBarCircular>(p =>
+            {
+                p.Add(x => x.Value, 40);
+                p.Add(x => x.BufferValue, 75);
+            });
+
+            var bufferCircle = component.Find(".rz-progressbar-circular-buffer-value");
+            var valueCircle = component.Find(".rz-progressbar-circular-value");
+
+            Assert.Equal("25", bufferCircle.GetAttribute("stroke-dashoffset"));
+            Assert.Equal("60", valueCircle.GetAttribute("stroke-dashoffset"));
+        }
+
+        [Fact]
+        public void ProgressBarCircular_DoesNotRenderBuffer_WhenBufferValueIsNotSet()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBarCircular>(parameters =>
+            {
+                parameters.Add(p => p.Value, -10);
+                parameters.Add(p => p.Min, -100);
+                parameters.Add(p => p.Max, 100);
+            });
+
+            Assert.Empty(component.FindAll(".rz-progressbar-circular-buffer-value"));
+        }
+
+        [Fact]
+        public void ProgressBarCircular_RendersBuffer_WhenBufferIsZero()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBarCircular>(parameters =>
+            {
+                parameters.Add(p => p.Value, -20);
+                parameters.Add(p => p.BufferValue, 0);
+                parameters.Add(p => p.Min, -100);
+                parameters.Add(p => p.Max, 100);
+            });
+
+            var bufferCircle = component.Find(".rz-progressbar-circular-buffer-value");
+
+            Assert.Equal("50", bufferCircle.GetAttribute("stroke-dashoffset"));
         }
 
         [Fact]

--- a/Radzen.Blazor.Tests/ProgressBarTests.cs
+++ b/Radzen.Blazor.Tests/ProgressBarTests.cs
@@ -72,7 +72,7 @@ namespace Radzen.Blazor.Tests
 
             component.SetParametersAndRender(parameters => parameters.Add(p => p.Style, value));
 
-            Assert.Contains(@$"style=""--rz-progressbar-value: 0%;{value}""", component.Markup);
+            Assert.Contains(@$"style=""--rz-progressbar-value: 0%;--rz-progressbar-buffer-value: 0%;{value}""", component.Markup);
         }
 
         [Fact]
@@ -113,12 +113,13 @@ namespace Radzen.Blazor.Tests
             var value = 4.5;
             var max = 500;
 
-            component.SetParametersAndRender(parameters => { 
+            component.SetParametersAndRender(parameters =>
+            {
                 parameters.Add<double>(p => p.Value, value);
                 parameters.Add<double>(p => p.Max, max);
             });
 
-            Assert.Contains(@$"style=""--rz-progressbar-value: {Math.Min(value / max * 100, 100).ToInvariantString()}%;""", component.Markup);
+            Assert.Contains(@$"style=""--rz-progressbar-value: {Math.Min(value / max * 100, 100).ToInvariantString()}%;--rz-progressbar-buffer-value: 0%;""", component.Markup);
         }
 
         [Fact]
@@ -128,7 +129,7 @@ namespace Radzen.Blazor.Tests
 
             var component = ctx.RenderComponent<RadzenProgressBar>();
 
-            component.SetParametersAndRender(parameters=>parameters.Add(p=>p.ProgressBarStyle, ProgressBarStyle.Success));
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.ProgressBarStyle, ProgressBarStyle.Success));
             Assert.Contains(@$"rz-progressbar-success", component.Markup);
 
             component.SetParametersAndRender(parameters => parameters.Add(p => p.ProgressBarStyle, ProgressBarStyle.Info));
@@ -182,5 +183,123 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains("Custom: 75%", component.Markup);
         }
+
+        [Fact]
+        public void ProgressBar_Renders_BufferValueParameter()
+        {
+            using var ctx = new TestContext();
+            var bufferValue = 70;
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.BufferValue, bufferValue);
+            });
+
+            Assert.Contains(@$"--rz-progressbar-buffer-value: {bufferValue}%;", component.Markup);
+            Assert.Contains(@"class=""rz-progressbar-buffer-value""", component.Markup);
+        }
+
+        [Fact]
+        public void ProgressBar_Renders_WidthFromBufferValueAndMaxParameters()
+        {
+            using var ctx = new TestContext();
+
+            var bufferValue = 250d;
+            var max = 500d;
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.BufferValue, bufferValue);
+                parameters.Add(p => p.Max, max);
+            });
+
+            Assert.Contains(@$"--rz-progressbar-buffer-value: {Math.Min(bufferValue / max * 100, 100).ToInvariantString()}%;", component.Markup);
+        }
+
+        [Fact]
+        public void ProgressBar_Renders_BufferValueWithCustomRange()
+        {
+            using var ctx = new TestContext();
+
+            var bufferValue = 300d;
+            var min = 100d;
+            var max = 500d;
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.BufferValue, bufferValue);
+                parameters.Add(p => p.Min, min);
+                parameters.Add(p => p.Max, max);
+            });
+
+            var normalizedBufferValue = Math.Min(Math.Max((bufferValue - min) / (max - min), 0), 1) * 100;
+
+            Assert.Contains(@$"--rz-progressbar-buffer-value: {normalizedBufferValue.ToInvariantString()}%;", component.Markup);
+        }
+
+        [Fact]
+        public void ProgressBar_Clamps_BufferValueAboveMax()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.BufferValue, 150);
+                parameters.Add(p => p.Max, 100);
+            });
+
+            Assert.Contains(@"--rz-progressbar-buffer-value: 100%;", component.Markup);
+        }
+
+        [Fact]
+        public void ProgressBar_Clamps_BufferValueBelowMin()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.BufferValue, -50);
+                parameters.Add(p => p.Min, 0);
+                parameters.Add(p => p.Max, 100);
+            });
+
+            Assert.Contains(@"--rz-progressbar-buffer-value: 0%;", component.Markup);
+        }
+
+        [Fact]
+        public void ProgressBar_DoesNotRender_BufferInIndeterminateMode()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.BufferValue, 70);
+                parameters.Add(p => p.Mode, ProgressBarMode.Indeterminate);
+            });
+
+            Assert.DoesNotContain(@"class=""rz-progressbar-buffer-value""", component.Markup);
+        }
+
+        [Fact]
+        public void ProgressBar_Renders_BufferBehindValue()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.Value, 30);
+                parameters.Add(p => p.BufferValue, 70);
+            });
+
+            Assert.Contains(@"--rz-progressbar-value: 30%;", component.Markup);
+            Assert.Contains(@"--rz-progressbar-buffer-value: 70%;", component.Markup);
+
+            var bufferIndex = component.Markup.IndexOf(@"class=""rz-progressbar-buffer-value""", StringComparison.Ordinal);
+            var valueIndex = component.Markup.IndexOf(@"class=""rz-progressbar-value""", StringComparison.Ordinal);
+
+            Assert.True(bufferIndex >= 0);
+            Assert.True(valueIndex > bufferIndex);
+        }
+
     }
 }

--- a/Radzen.Blazor.Tests/ProgressBarTests.cs
+++ b/Radzen.Blazor.Tests/ProgressBarTests.cs
@@ -281,6 +281,20 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void ProgressBar_DoesNotRenderBuffer_WhenBufferValueIsNotSet()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.Value, -10);
+                parameters.Add(p => p.Min, -100);
+                parameters.Add(p => p.Max, 100);
+            });
+            Assert.DoesNotContain(@"class=""rz-progressbar-buffer-value""", component.Markup);
+        }
+
+        [Fact]
         public void ProgressBar_Renders_BufferBehindValue()
         {
             using var ctx = new TestContext();
@@ -301,5 +315,20 @@ namespace Radzen.Blazor.Tests
             Assert.True(valueIndex > bufferIndex);
         }
 
+        [Fact]
+        public void ProgressBar_RendersBuffer_WhenBufferIsZero()
+        {
+            using var ctx = new TestContext();
+
+            var component = ctx.RenderComponent<RadzenProgressBar>(parameters =>
+            {
+                parameters.Add(p => p.Value, -20);
+                parameters.Add(p => p.BufferValue, 0);
+                parameters.Add(p => p.Min, -100);
+                parameters.Add(p => p.Max, 100);
+            });
+
+            Assert.Contains(@"--rz-progressbar-buffer-value: 50%;", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenProgressBar.razor
+++ b/Radzen.Blazor/RadzenProgressBar.razor
@@ -3,8 +3,16 @@
 @using Radzen.Blazor.Rendering;
 @if (Visible)
 {
-    <div @ref="@Element" style="@($"--rz-progressbar-value: {(NormalizedValue * 100).ToInvariantString()}%;{Style}")" aria-valuemax="@Max" aria-valuemin="@Min" role="progressbar" @attributes="Attributes" class="@GetCssClass()"
+    <div @ref="@Element" 
+         style="@($"--rz-progressbar-value: {(NormalizedValue * 100).ToInvariantString()}%;--rz-progressbar-buffer-value: {(NormalizedBufferValue * 100).ToInvariantString()}%;{Style}")"
+         aria-valuemax="@Max" aria-valuemin="@Min" role="progressbar" @attributes="Attributes" class="@GetCssClass()"
          aria-valuenow="@(Mode == ProgressBarMode.Indeterminate ? null : (double?)Value)" aria-label="@AriaLabel" id="@GetId()">
+
+        @if (Mode == ProgressBarMode.Determinate)
+        {
+            <div class="rz-progressbar-buffer-value" aria-hidden="true"></div>
+        }
+
         <div class="rz-progressbar-value"></div>
         @if (ShowValue)
         {

--- a/Radzen.Blazor/RadzenProgressBar.razor
+++ b/Radzen.Blazor/RadzenProgressBar.razor
@@ -8,7 +8,7 @@
          aria-valuemax="@Max" aria-valuemin="@Min" role="progressbar" @attributes="Attributes" class="@GetCssClass()"
          aria-valuenow="@(Mode == ProgressBarMode.Indeterminate ? null : (double?)Value)" aria-label="@AriaLabel" id="@GetId()">
 
-        @if (Mode == ProgressBarMode.Determinate)
+        @if (Mode == ProgressBarMode.Determinate && HasBufferValue)
         {
             <div class="rz-progressbar-buffer-value" aria-hidden="true"></div>
         }

--- a/Radzen.Blazor/RadzenProgressBar.razor.cs
+++ b/Radzen.Blazor/RadzenProgressBar.razor.cs
@@ -74,6 +74,15 @@ namespace Radzen.Blazor
         public double Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the buffered progress value.
+        /// The buffer is displayed behind the current progress value in determinate mode.
+        /// Should be between <see cref="Min"/> and <see cref="Max"/>. Values outside this range are clamped.
+        /// </summary>
+        /// <value>The buffered progress value. The default is 0.</value>
+        [Parameter]
+        public double BufferValue { get; set; }
+
+        /// <summary>
         /// Gets or sets the minimum value of the progress range.
         /// Use non-zero values for custom progress scales (e.g., 0-1000 for byte counts).
         /// </summary>
@@ -105,6 +114,14 @@ namespace Radzen.Blazor
         public Action<double>? ValueChanged { get; set; }
 
         /// <summary>
+        /// Gets or sets a callback invoked when the buffer value changes.
+        /// Note: This is an Action, not EventCallback. For data binding, the BufferValue property is typically bound directly.
+        /// </summary>
+        /// <value>The buffer value changed callback.</value>
+        [Parameter]
+        public Action<double>? BufferValueChanged { get; set; }
+
+        /// <summary>
         /// Gets or sets the semantic color style of the progress bar.
         /// Determines the progress bar color: Primary, Success, Info, Warning, Danger, etc.
         /// </summary>
@@ -123,6 +140,26 @@ namespace Radzen.Blazor
         /// <summary>
         /// Progress in range from 0 to 1.
         /// </summary>
-        protected double NormalizedValue => Math.Min(Math.Max((Value - Min) / (Max - Min), 0), 1);
+        protected double NormalizedValue => Normalize(Value);
+
+        /// <summary>
+        /// Buffered progress normalized to the range 0–1.
+        /// </summary>
+        protected double NormalizedBufferValue => Normalize(BufferValue);
+
+        /// <summary>
+        /// Normalizes a given value to a range between 0 and 1 based on the <see cref="Min"/> and <see cref="Max"/> properties.
+        /// </summary>
+        /// <param name="value">Value to normalize.</param>
+        /// <returns>The normalized value.</returns>
+        private double Normalize(double value)
+        {
+            if (double.IsNaN(value) || double.IsNaN(Min) || double.IsNaN(Max) || Max <= Min)
+            {
+                return 0;
+            }
+
+            return Math.Min(Math.Max((value - Min) / (Max - Min), 0), 1);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenProgressBar.razor.cs
+++ b/Radzen.Blazor/RadzenProgressBar.razor.cs
@@ -76,11 +76,13 @@ namespace Radzen.Blazor
         /// <summary>
         /// Gets or sets the buffered progress value.
         /// The buffer is displayed behind the current progress value in determinate mode.
-        /// Should be between <see cref="Min"/> and <see cref="Max"/>. Values outside this range are clamped.
+        /// Set to <c>null</c> to hide the buffer.
+        /// Values outside the range defined by <see cref="Min"/> and <see cref="Max"/>
+        /// are clamped.
         /// </summary>
-        /// <value>The buffered progress value. The default is 0.</value>
+        /// <value>The buffered progress value. The default is <c>null</c>.</value>
         [Parameter]
-        public double BufferValue { get; set; }
+        public double? BufferValue { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum value of the progress range.
@@ -119,7 +121,7 @@ namespace Radzen.Blazor
         /// </summary>
         /// <value>The buffer value changed callback.</value>
         [Parameter]
-        public Action<double>? BufferValueChanged { get; set; }
+        public Action<double?>? BufferValueChanged { get; set; }
 
         /// <summary>
         /// Gets or sets the semantic color style of the progress bar.
@@ -138,6 +140,11 @@ namespace Radzen.Blazor
         public string? AriaLabel { get; set; }
 
         /// <summary>
+        /// Gets whether a buffered progress value has been supplied.
+        /// </summary>
+        protected bool HasBufferValue => BufferValue.HasValue;
+
+        /// <summary>
         /// Progress in range from 0 to 1.
         /// </summary>
         protected double NormalizedValue => Normalize(Value);
@@ -145,7 +152,7 @@ namespace Radzen.Blazor
         /// <summary>
         /// Buffered progress normalized to the range 0–1.
         /// </summary>
-        protected double NormalizedBufferValue => Normalize(BufferValue);
+        protected double NormalizedBufferValue =>  BufferValue.HasValue ? Normalize(BufferValue.Value) : 0;
 
         /// <summary>
         /// Normalizes a given value to a range between 0 and 1 based on the <see cref="Min"/> and <see cref="Max"/> properties.

--- a/Radzen.Blazor/RadzenProgressBarCircular.razor
+++ b/Radzen.Blazor/RadzenProgressBarCircular.razor
@@ -7,6 +7,12 @@
          aria-valuenow="@(Mode == ProgressBarMode.Indeterminate ? null : (double?)Value)" aria-label="@AriaLabel" id="@GetId()">
         <svg class="rz-progressbar-circular-viewbox" viewBox="-19 -19 38 38">
             <circle class="rz-progressbar-circular-background" r="15.91549" fill="none" />
+            
+            @if (Mode == ProgressBarMode.Determinate && HasBufferValue)
+            {
+                <circle class="rz-progressbar-circular-buffer-value" r="15.91549" fill="none" aria-hidden="true" stroke-dashoffset="@(((1 - NormalizedBufferValue) * 100).ToInvariantString())" />
+            }
+
             <circle class="rz-progressbar-circular-value" r="15.91549" fill="none" stroke-dashoffset="@(((1 - NormalizedValue) * 100).ToInvariantString())" />
         </svg>
         @if (ShowValue)

--- a/Radzen.Blazor/themes/_css-variables.scss
+++ b/Radzen.Blazor/themes/_css-variables.scss
@@ -1052,6 +1052,7 @@
   --rz-progressbar-circular-stroke-width:  #{$progressbar-circular-stroke-width};
   --rz-progressbar-circular-value-stroke-width:  #{$progressbar-circular-value-stroke-width};
   --rz-progressbar-circular-value-endpoint:  #{$progressbar-circular-value-endpoint};
+  --rz-progressbar-buffer-opacity:  #{$progressbar-buffer-opacity};
 
   /* Radio */
   --rz-radio-width: #{$radio-width};

--- a/Radzen.Blazor/themes/components/blazor/_progressbar.scss
+++ b/Radzen.Blazor/themes/components/blazor/_progressbar.scss
@@ -10,6 +10,7 @@ $progressbar-value-transition: var(--rz-transition-all) !default;
 $progressbar-circular-stroke-width: 2px !default;
 $progressbar-circular-value-stroke-width: 3px !default;
 $progressbar-circular-value-endpoint: round !default;
+$progressbar-buffer-opacity: 0.35 !default;
 
 $progressbar-base-styles: () !default;
 $progressbar-base-styles: map.merge(
@@ -64,9 +65,21 @@ $progressbar-circular-sizes: map.merge(
   align-items: center;
 }
 
+.rz-progressbar-buffer-value {
+  border-radius: var(--rz-progressbar-border-radius);
+  position: absolute;
+  inset-inline-start: 0;
+  background-color: var(--rz-progressbar-value-background-color);
+  height: 100%;
+  width: var(--rz-progressbar-buffer-value);
+  opacity: $progressbar-buffer-opacity;
+  transition: var(--rz-progressbar-value-transition);
+}
+
 .rz-progressbar-value {
   border-radius: var(--rz-progressbar-border-radius);
   position: absolute;
+  inset-inline-start: 0;
   background-color: var(--rz-progressbar-value-background-color);
   height: 100%;
   width: var(--rz-progressbar-value);
@@ -259,6 +272,7 @@ $progressbar-circular-sizes: map.merge(
   }
   
   .rz-progressbar-determinate.rz-progressbar-#{$style} {
+    .rz-progressbar-buffer-value,
     .rz-progressbar-value {
       background-color: map.get($progressbar, background-color);
     }

--- a/Radzen.Blazor/themes/components/blazor/_progressbar.scss
+++ b/Radzen.Blazor/themes/components/blazor/_progressbar.scss
@@ -72,7 +72,7 @@ $progressbar-circular-sizes: map.merge(
   background-color: var(--rz-progressbar-value-background-color);
   height: 100%;
   width: var(--rz-progressbar-buffer-value);
-  opacity: $progressbar-buffer-opacity;
+  opacity: var(--rz-progressbar-buffer-opacity);
   transition: var(--rz-progressbar-value-transition);
 }
 
@@ -137,14 +137,24 @@ $progressbar-circular-sizes: map.merge(
   stroke-width: var(--rz-progressbar-circular-stroke-width);
 }
 
+.rz-progressbar-circular-buffer-value,
 .rz-progressbar-circular-value {
   stroke-linecap: var(--rz-progressbar-circular-value-endpoint);
   stroke-width: var(--rz-progressbar-circular-value-stroke-width);
-  stroke: var(--rz-progressbar-value-background-color);
   transition: var(--rz-progressbar-value-transition);
 }
 
+.rz-progressbar-circular-buffer-value {
+  stroke: var(--rz-progressbar-value-background-color);
+  opacity: var(--rz-progressbar-buffer-opacity);
+}
+
+.rz-progressbar-circular-value {
+  stroke: var(--rz-progressbar-value-background-color);
+}
+
 .rz-progressbar-determinate {
+  .rz-progressbar-circular-buffer-value,
   .rz-progressbar-circular-value {
     stroke-dasharray: 100;
     transform: rotate(-.25turn);
@@ -277,6 +287,7 @@ $progressbar-circular-sizes: map.merge(
       background-color: map.get($progressbar, background-color);
     }
 
+    .rz-progressbar-circular-buffer-value,
     .rz-progressbar-circular-value {
       stroke: map.get($progressbar, background-color);
     }

--- a/RadzenBlazorDemos/Pages/ProgressBarBuffer.razor
+++ b/RadzenBlazorDemos/Pages/ProgressBarBuffer.razor
@@ -1,0 +1,19 @@
+﻿<RadzenStack Gap="1rem" class="rz-m-12">
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Primary" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Primary loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Secondary" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Secondary loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Base" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Base loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Light" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Light loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Dark" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Dark loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Success" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Success loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Danger" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Danger loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Warning" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Warning loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Info" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Info loading" />
+</RadzenStack>
+
+<RadzenSlider @bind-Value="value" Min="0" Max="100" Step="1" ShowValue="true" class="rz-mt-8" AriaLabel="Set progress value" />
+<RadzenSlider @bind-Value="buffer" Min="0" Max="100" Step="1" ShowValue="true" class="rz-mt-4" AriaLabel="Set buffer value" />
+
+@code {
+    double value = 50;
+    double buffer = 70;
+}

--- a/RadzenBlazorDemos/Pages/ProgressBarBuffer.razor
+++ b/RadzenBlazorDemos/Pages/ProgressBarBuffer.razor
@@ -4,16 +4,18 @@
     <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Base" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Base loading" />
     <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Light" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Light loading" />
     <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Dark" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Dark loading" />
-    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Success" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Success loading" />
-    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Danger" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Danger loading" />
-    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Warning" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Warning loading" />
-    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Info" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="false" AriaLabel="Info loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Success" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Success loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Danger" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Danger loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Warning" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Warning loading" />
+    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Info" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Info loading" />
 </RadzenStack>
 
-<RadzenSlider @bind-Value="value" Min="0" Max="100" Step="1" ShowValue="true" class="rz-mt-8" AriaLabel="Set progress value" />
-<RadzenSlider @bind-Value="buffer" Min="0" Max="100" Step="1" ShowValue="true" class="rz-mt-4" AriaLabel="Set buffer value" />
+<RadzenLabel Text="Set progress value" class="rz-mt-8" Component="valueSlider"/>
+<RadzenSlider @bind-Value="value" Min="0" Max="100" Step="1" ShowValue="true" class="rz-w-100" AriaLabel="Set progress value" Name="valueSlider" />
+<RadzenLabel Text="Set buffer value" class="rz-mt-4" Component="bufferSlider"/>
+<RadzenSlider @bind-Value="buffer" Min="0" Max="100" Step="1" ShowValue="true" class="rz-w-100" AriaLabel="Set buffer value" Name="bufferSlider" />
 
 @code {
     double value = 50;
-    double buffer = 70;
+    double? buffer = 70;
 }

--- a/RadzenBlazorDemos/Pages/ProgressBarCircularBuffer.razor
+++ b/RadzenBlazorDemos/Pages/ProgressBarCircularBuffer.razor
@@ -1,0 +1,21 @@
+﻿<RadzenStack Orientation="Orientation.Horizontal" Wrap="FlexWrap.Wrap" Gap="1rem" class="rz-m-12">
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Primary" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Primary loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Secondary" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Secondary loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Base" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Base loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Light" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Light loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Dark" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Dark loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Success" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Success loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Danger" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Danger loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Warning" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Warning loading" />
+    <RadzenProgressBarCircular ProgressBarStyle="ProgressBarStyle.Info" @bind-Value="value" @bind-BufferValue="buffer" ShowValue="true" AriaLabel="Info loading" />
+</RadzenStack>
+
+<RadzenLabel Text="Set progress value" class="rz-mt-8" Component="valueSlider"/>
+<RadzenSlider @bind-Value="value" Min="0" Max="100" Step="1" ShowValue="true" class="rz-w-100" AriaLabel="Set progress value" Name="valueSlider" />
+<RadzenLabel Text="Set buffer value" class="rz-mt-4" Component="bufferSlider"/>
+<RadzenSlider @bind-Value="buffer" Min="0" Max="100" Step="1" ShowValue="true" class="rz-w-100" AriaLabel="Set buffer value" Name="bufferSlider" />
+
+@code {
+    double value = 50;
+    double? buffer = 70;
+}

--- a/RadzenBlazorDemos/Pages/ProgressBarCircularPage.razor
+++ b/RadzenBlazorDemos/Pages/ProgressBarCircularPage.razor
@@ -49,6 +49,17 @@
     <ProgressBarCircularMinMaxValues />
 </RadzenExample>
 
+<RadzenText Anchor="progressbarcircular#progressbarcircular-buffer" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
+    ProgressBarCircular Buffer Value
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Set the <code>BufferValue</code> property to display a buffer value. The buffer value is displayed as a lighter color behind the main progress bar, indicating the amount of work that has been completed and the amount that is still pending.
+    Use the <code>Min</code> and <code>Max</code> properties to set a custom range.
+</RadzenText>
+<RadzenExample ComponentName="ProgressBarCircular" Example="ProgressBarCircularBuffer">
+    <ProgressBarCircularBuffer />
+</RadzenExample>
+
 <RadzenText Anchor="progressbarcircular#accessibility" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
     Accessibility
 </RadzenText>

--- a/RadzenBlazorDemos/Pages/ProgressBarPage.razor
+++ b/RadzenBlazorDemos/Pages/ProgressBarPage.razor
@@ -41,6 +41,17 @@
     <ProgressBarMinMaxValues />
 </RadzenExample>
 
+<RadzenText Anchor="progressbar#progressbar-buffer" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12 rz-mb-6">
+    ProgressBar Buffer Value
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Set the <code>BufferValue</code> property to display a buffer value. The buffer value is displayed as a lighter color behind the main progress bar, indicating the amount of work that has been completed and the amount that is still pending.
+    Use the <code>Min</code> and <code>Max</code> properties to set a custom range.
+</RadzenText>
+<RadzenExample ComponentName="ProgressBar" Example="ProgressBarBuffer">
+    <ProgressBarBuffer />
+</RadzenExample>
+
 <RadzenText Anchor="progressbar#accessibility" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
     Accessibility
 </RadzenText>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -4345,7 +4345,7 @@ namespace RadzenBlazorDemos
                 },
                 new Example
                 {
-                    Toc = [ new () { Text = "ProgressBarCircular in determinate mode, Get and Set the value", Anchor = "#progressbarcircular-determinate" }, new () { Text = "ProgressBarCircular in indeterminate mode", Anchor = "#progressbarcircular-indeterminate" }, new () { Text = "ProgressBarCircular sizes", Anchor = "#progressbarcircular-sizes" }, new () { Text = "ProgressBarCircular Min and Max values", Anchor = "#progressbarcircular-min-max-values" } ],
+                    Toc = [ new () { Text = "ProgressBarCircular in determinate mode, Get and Set the value", Anchor = "#progressbarcircular-determinate" }, new () { Text = "ProgressBarCircular in indeterminate mode", Anchor = "#progressbarcircular-indeterminate" }, new () { Text = "ProgressBarCircular sizes", Anchor = "#progressbarcircular-sizes" }, new () { Text = "ProgressBarCircular Min and Max values", Anchor = "#progressbarcircular-min-max-values" }, new () { Text = "ProgressBarCircular Buffer Value", Anchor = "#progressbarcircular-buffer" } ],
                     Name = "ProgressBarCircular",
                     Description = "Demonstration and configuration of the Radzen Blazor circular progress bar component.",
                     Path = "progressbarcircular",

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -4336,7 +4336,7 @@ namespace RadzenBlazorDemos
                 },
                 new Example
                 {
-                    Toc = [ new () { Text = "ProgressBar in determinate mode, Get and Set the value", Anchor = "#progressbar-determinate" }, new () { Text = "ProgressBar in indeterminate mode", Anchor = "#progressbar-indeterminate" }, new () { Text = "ProgressBar Min and Max values", Anchor = "#progressbar-min-max-values" } ],
+                    Toc = [ new () { Text = "ProgressBar in determinate mode, Get and Set the value", Anchor = "#progressbar-determinate" }, new () { Text = "ProgressBar in indeterminate mode", Anchor = "#progressbar-indeterminate" }, new () { Text = "ProgressBar Min and Max values", Anchor = "#progressbar-min-max-values" }, new () { Text = "ProgressBar Buffer Value", Anchor = "#progressbar-buffer" } ],
                     Name = "ProgressBar",
                     Description = "Demonstration and configuration of the Radzen Blazor ProgressBar component.",
                     Path = "progressbar",


### PR DESCRIPTION
## Summary
Adds buffered progress support to both `RadzenProgressBar` and `RadzenProgressBarCircular`.

## Changes
- Adds the `BufferValue` parameter to progress bar components.
- Renders a buffered region behind the current value in linear progress bars.
- Renders a buffered arc behind the current value in circular progress bars.
- Hides the buffer when `BufferValue` is not specified or in indeterminate mode.
- Adds demo pages for both components.
- Adds and updates tests for linear and circular buffer behavior.

## Testing
- Added tests for buffer rendering and normalization.
- Added coverage for unset buffer values.
- Added coverage for explicit zero buffer values.
- Verified existing progress bar tests pass.