### PR TITLE
Allow spaces in RadzenChat mention search while a mention is active

### DIFF
--- a/Radzen.Blazor.Tests/ChatTests.cs
+++ b/Radzen.Blazor.Tests/ChatTests.cs
@@ -949,6 +949,317 @@ namespace Radzen.Blazor.Tests
             });
         }
 
+        [Fact]
+        public async Task RadzenChat_ShouldTriggerMentionSearchForSingleWordFilter()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            MentionSearchArgs capturedArgs = null;
+            var searchCount = 0;
+
+            var component = ctx.RenderComponent<RadzenChat>(parameters => parameters
+                .Add(p => p.CurrentUserId, "user1")
+                .Add(p => p.Users, new List<ChatUser>())
+                .Add(p => p.Messages, new List<ChatMessage>())
+                .Add(p => p.MentionCharacter, '@')
+                .Add(p => p.MentionSearch, EventCallback.Factory.Create<MentionSearchArgs>(this, args =>
+                {
+                    capturedArgs = args;
+                    searchCount++;
+                    return Task.CompletedTask;
+                }))
+            );
+
+            SetPrivateProperty(component.Instance, "CurrentInput", "@joh");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@joh");
+
+            Assert.NotNull(capturedArgs);
+            Assert.Equal("joh", capturedArgs!.Filter);
+            Assert.Equal(1, searchCount);
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true },
+                    new MentionUserContext { UserId = "user-2", UserName = "John Smith", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 2)
+            );
+
+            Assert.Equal(2, component.FindAll(".rz-chat-mention-item").Count);
+        }
+
+        [Fact]
+        public async Task RadzenChat_ShouldKeepMentionPopupOpenWhenSearchTextContainsSpace()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            MentionSearchArgs capturedArgs = null;
+
+            var component = ctx.RenderComponent<RadzenChat>(parameters => parameters
+                .Add(p => p.CurrentUserId, "user1")
+                .Add(p => p.Users, new List<ChatUser>())
+                .Add(p => p.Messages, new List<ChatMessage>())
+                .Add(p => p.MentionCharacter, '@')
+                .Add(p => p.MentionSearch, EventCallback.Factory.Create<MentionSearchArgs>(this, args =>
+                {
+                    capturedArgs = args;
+                    return Task.CompletedTask;
+                }))
+            );
+
+            // Open the popup with a single-word search
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john");
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true },
+                    new MentionUserContext { UserId = "user-2", UserName = "John Smith", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 2)
+            );
+
+            Assert.Equal(2, component.FindAll(".rz-chat-mention-item").Count);
+
+            // Continue typing a space in the search text
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john do");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john do");
+
+            Assert.NotNull(capturedArgs);
+            Assert.Equal("john do", capturedArgs!.Filter);
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 1)
+            );
+
+            Assert.Equal(1, component.FindAll(".rz-chat-mention-item").Count);
+            Assert.Contains("John Doe", component.Markup);
+        }
+
+        [Fact]
+        public async Task RadzenChat_ShouldCloseMentionPopupWhenMultiWordSearchHasNoResults()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            MentionSearchArgs capturedArgs = null;
+            var searchCount = 0;
+
+            var component = ctx.RenderComponent<RadzenChat>(parameters => parameters
+                .Add(p => p.CurrentUserId, "user1")
+                .Add(p => p.Users, new List<ChatUser>())
+                .Add(p => p.Messages, new List<ChatMessage>())
+                .Add(p => p.MentionCharacter, '@')
+                .Add(p => p.MentionSearch, EventCallback.Factory.Create<MentionSearchArgs>(this, args =>
+                {
+                    capturedArgs = args;
+                    searchCount++;
+                    return Task.CompletedTask;
+                }))
+            );
+
+            // Open the popup with a single-word search
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john");
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 1)
+            );
+
+            Assert.Single(component.FindAll(".rz-chat-mention-item"));
+
+            // A multi-word search without results closes the popup
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john x");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john x");
+
+            Assert.Equal("john x", capturedArgs!.Filter);
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>())
+                .Add(p => p.MentionUsersCount, 0)
+            );
+
+            Assert.Empty(component.FindAll(".rz-chat-mention-item"));
+
+            // Further typing without a new mention character does not trigger more searches
+            var searchCountAfterClose = searchCount;
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john xy");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john xy");
+
+            Assert.Equal(searchCountAfterClose, searchCount);
+
+            // A fresh mention character triggers a new search
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john xy @al");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john xy @al");
+
+            Assert.Equal(searchCountAfterClose + 1, searchCount);
+            Assert.Equal("al", capturedArgs.Filter);
+        }
+
+        [Fact]
+        public async Task RadzenChat_ShouldContinueMentionSearchBeforeResultsArrive()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            MentionSearchArgs capturedArgs = null;
+            var searchCount = 0;
+
+            var component = ctx.RenderComponent<RadzenChat>(parameters => parameters
+                .Add(p => p.CurrentUserId, "user1")
+                .Add(p => p.Users, new List<ChatUser>())
+                .Add(p => p.Messages, new List<ChatMessage>())
+                .Add(p => p.MentionCharacter, '@')
+                .Add(p => p.MentionSearch, EventCallback.Factory.Create<MentionSearchArgs>(this, args =>
+                {
+                    capturedArgs = args;
+                    searchCount++;
+                    return Task.CompletedTask;
+                }))
+            );
+
+            // The user keeps typing while the first search has not resolved yet
+            // (MentionUsers is not updated between the keystrokes)
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john");
+
+            Assert.Equal("john", capturedArgs!.Filter);
+
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john do");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john do");
+
+            Assert.Equal("john do", capturedArgs.Filter);
+            Assert.Equal(2, searchCount);
+
+            // The popup opens once the results finally arrive
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 1)
+            );
+
+            Assert.Single(component.FindAll(".rz-chat-mention-item"));
+            Assert.Contains("John Doe", component.Markup);
+        }
+
+        [Fact]
+        public async Task RadzenChat_ShouldNotReopenMentionPopupFromStaleResultsAfterClose()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = ctx.RenderComponent<RadzenChat>(parameters => parameters
+                .Add(p => p.CurrentUserId, "user1")
+                .Add(p => p.Users, new List<ChatUser>())
+                .Add(p => p.Messages, new List<ChatMessage>())
+                .Add(p => p.MentionCharacter, '@')
+                .Add(p => p.MentionSearch, EventCallback.Factory.Create<MentionSearchArgs>(this, args => Task.CompletedTask))
+            );
+
+            // Open the popup
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john");
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 1)
+            );
+
+            Assert.Single(component.FindAll(".rz-chat-mention-item"));
+
+            // Close the popup with Escape
+            var textarea = component.Find(".rz-chat-textarea");
+            textarea.KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+            component.WaitForAssertion(() => Assert.Empty(component.FindAll(".rz-chat-mention-item")));
+
+            // A stale in-flight search result arriving after the close must not reopen the popup
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 1)
+            );
+
+            Assert.Empty(component.FindAll(".rz-chat-mention-item"));
+
+            // Inserting a mention without a valid mention anchor must be a no-op instead of throwing
+            await InvokePrivateAsync(component.Instance, "InsertMention", new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true });
+
+            component.WaitForAssertion(() =>
+            {
+                var updatedTextarea = component.Find(".rz-chat-textarea");
+                Assert.Equal("@john", updatedTextarea.GetAttribute("value"));
+            });
+        }
+
+        [Fact]
+        public async Task RadzenChat_ShouldInsertMentionAfterMultiWordSearch()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = ctx.RenderComponent<RadzenChat>(parameters => parameters
+                .Add(p => p.CurrentUserId, "user1")
+                .Add(p => p.Users, new List<ChatUser>())
+                .Add(p => p.Messages, new List<ChatMessage>())
+                .Add(p => p.MentionCharacter, '@')
+                .Add(p => p.MentionSearch, EventCallback.Factory.Create<MentionSearchArgs>(this, args => Task.CompletedTask))
+            );
+
+            // Open the popup and filter with a multi-word search text
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john");
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true },
+                    new MentionUserContext { UserId = "user-2", UserName = "John Smith", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 2)
+            );
+
+            SetPrivateProperty(component.Instance, "CurrentInput", "@john do");
+            await InvokePrivateAsync(component.Instance, "DetectMentionTrigger", "@john do");
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.MentionUsers, new List<MentionUserContext>
+                {
+                    new MentionUserContext { UserId = "user-1", UserName = "John Doe", IsInChat = true }
+                })
+                .Add(p => p.MentionUsersCount, 1)
+            );
+
+            // Selecting the user replaces the whole multi-word search text
+            var item = component.Find(".rz-chat-mention-item");
+            item.Click();
+
+            component.WaitForAssertion(() =>
+            {
+                var updatedTextarea = component.Find(".rz-chat-textarea");
+                Assert.Equal("@John Doe", updatedTextarea.GetAttribute("value"));
+            });
+        }
+
         static void SetPrivateField(object instance, string fieldName, object value)
         {
             var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);

--- a/Radzen.Blazor/RadzenChat.razor.cs
+++ b/Radzen.Blazor/RadzenChat.razor.cs
@@ -142,6 +142,7 @@ namespace Radzen.Blazor
         private bool hasMoreMentionUsers;
         private bool appendMentionUsersOnNextUpdate;
         private bool mentionSearchRequested;
+        private bool ignoreIncomingMentionUsers;
         private readonly List<MentionInputSegment> mentionInputSegments = new();
 
         private sealed class MentionInputSegment
@@ -845,6 +846,23 @@ namespace Radzen.Blazor
                 }
             }
 
+            // While a mention is active keep filtering with the text after the original mention
+            // character even when it contains spaces, so multi-word names like "John Doe" can
+            // be matched. The mention stays anchored at mentionStartPosition, which is set
+            // synchronously when the mention is first detected, so this works even when the
+            // initial search has not resolved yet. The mention state is reset when such a
+            // search yields no results (see ApplyMentionUsersFromParameters).
+            if (mentionStartPosition >= 0 &&
+                mentionStartPosition < trimmedInput.Length &&
+                trimmedInput[mentionStartPosition] == char_code &&
+                (mentionStartPosition == 0 || char.IsWhiteSpace(trimmedInput[mentionStartPosition - 1])))
+            {
+                var continuedSearchText = trimmedInput.Substring(mentionStartPosition + 1);
+                mentionSearchText = continuedSearchText;
+                await PerformMentionSearch(continuedSearchText);
+                return;
+            }
+
             await CloseMentionPopup();
         }
 
@@ -869,6 +887,7 @@ namespace Radzen.Blazor
                 mentionSearchRequested = true;
                 appendMentionUsersOnNextUpdate = append;
                 isLoadingMentionUsers = true;
+                ignoreIncomingMentionUsers = false;
 
                 var searchArgs = new MentionSearchArgs
                 {
@@ -889,7 +908,7 @@ namespace Radzen.Blazor
 
         private async Task InsertMention(MentionUserContext user)
         {
-            if (user?.UserId == null)
+            if (user?.UserId == null || mentionStartPosition < 0)
             {
                 return;
             }
@@ -927,6 +946,7 @@ namespace Radzen.Blazor
             hasMoreMentionUsers = false;
             mentionSearchRequested = false;
             appendMentionUsersOnNextUpdate = false;
+            ignoreIncomingMentionUsers = true;
 
             mentionSearchCts?.Cancel();
             mentionSearchCts?.Dispose();
@@ -974,7 +994,9 @@ namespace Radzen.Blazor
                 return;
             }
 
-            if (!mentionSearchRequested && !isMentionPopupOpen && !appendMentionUsersOnNextUpdate && !(MentionUsers?.Any() == true))
+            // Once the popup has been closed, incoming users from a stale in-flight search must
+            // not reopen it; only a new search (or an already open popup) may apply results.
+            if (!mentionSearchRequested && !isMentionPopupOpen && !appendMentionUsersOnNextUpdate && (ignoreIncomingMentionUsers || !(MentionUsers?.Any() == true)))
             {
                 return;
             }
@@ -1008,6 +1030,22 @@ namespace Radzen.Blazor
             if (selectedMentionIndex >= mentionSearchResults.Count)
             {
                 selectedMentionIndex = mentionSearchResults.Count - 1;
+            }
+
+            // A multi-word search without results means the user is typing regular text after
+            // the mention character, so reset the mention state to stop searching until a new
+            // mention is started.
+            if (!isMentionPopupOpen && mentionSearchResults.Count == 0 && mentionSearchText.Contains(' ', StringComparison.Ordinal))
+            {
+                mentionSearchText = string.Empty;
+                selectedMentionIndex = -1;
+                mentionStartPosition = -1;
+                hasMoreMentionUsers = false;
+                ignoreIncomingMentionUsers = true;
+
+                mentionSearchCts?.Cancel();
+                mentionSearchCts?.Dispose();
+                mentionSearchCts = null;
             }
         }
 


### PR DESCRIPTION
Fixes #2648.

# Allow spaces in RadzenChat mention search while a mention is active

## Problem

`RadzenChat` closes the mention popup as soon as the mention search text contains a space. `DetectMentionTrigger` stops scanning for the mention character at the first whitespace and additionally rejects any search text containing a space. As a result, users whose display names consist of multiple words (e.g. "John Doe") can never be filtered past the first word — typing `@john d` immediately closes the popup instead of narrowing the results.

## Change

- **`DetectMentionTrigger`**: when a mention is active — i.e. `mentionStartPosition` is set and still valid for the current input (in bounds, still the mention character, at position 0 or preceded by whitespace) — the text after the mention character is used as the search filter even when it contains spaces. The continuation is keyed on `mentionStartPosition` rather than on the popup being open, because the anchor is set synchronously when the mention is first detected: continued typing keeps filtering even when the initial async `MentionSearch` has not resolved yet. The existing backward scan is unchanged and still handles initial trigger detection (and takes precedence, so typing a fresh `@` while a mention is active starts a new mention as before).
- **`ApplyMentionUsersFromParameters`**: when a search whose filter contains a space yields no results, the mention state is fully reset (same as closing the popup). This stops the component from re-searching on every keystroke when the user is simply typing a regular sentence after a mention character. A new mention character afterwards re-triggers the popup through the existing scan.
- **Stale search-result hardening** (pre-existing hazard, made more reachable by the above): `MentionSearch` cancellation is not plumbed into the callback, so results of an in-flight search can arrive after the popup was closed (Escape, insertion, or the reset above) and reopen it without a valid mention anchor — and clicking an item then threw `ArgumentOutOfRangeException` in `InsertMention` (`Substring(0, -1)`). Two minimal guards:
  - Once the popup is closed, incoming `MentionUsers` no longer reopen it until a new search starts (`ignoreIncomingMentionUsers` flag, set on close, cleared on the next search). Opening the popup declaratively by providing `MentionUsers` up front is unaffected.
  - `InsertMention` is a no-op when there is no valid mention anchor, instead of throwing.

`InsertMention` already replaces `mentionStartPosition + 1 + mentionSearchText.Length` characters, so selecting a user after a multi-word search replaces the entire typed query (e.g. `@john do` becomes `@John Doe`) — covered by a test.

Note: the `!searchText.Contains(' ')` check in the backward scan is now vestigial (the scan breaks at the first whitespace, so its search text can never contain a space); it is left untouched to keep the diff minimal.

## Behavior summary

| Input | Before | After |
|---|---|---|
| `@joh` | popup opens, filter `joh` | unchanged |
| `@john d` (mention active, even if the first search is still in flight) | popup closes / mention lost | mention stays active, filter `john d` |
| `@john x` with no matches | popup closes, every further keystroke fires another search once a new word starts | popup closes and mention state resets; no further searches until a new `@` |
| select "John Doe" after `@john do` | n/a (popup already closed) | `@john do` is replaced by `@John Doe` |
| stale search result arrives after the popup was closed | popup reopens without an anchor; clicking an item throws | popup stays closed; insertion without an anchor is a no-op |

## Tests

Added to `ChatTests`:

- `RadzenChat_ShouldTriggerMentionSearchForSingleWordFilter` — existing single-word behavior still works.
- `RadzenChat_ShouldKeepMentionPopupOpenWhenSearchTextContainsSpace` — popup stays open and the filter includes the space.
- `RadzenChat_ShouldContinueMentionSearchBeforeResultsArrive` — typing the space and next word before the first search resolves (no `MentionUsers` update between keystrokes) still fires the multi-word search, and the popup opens once results arrive.
- `RadzenChat_ShouldCloseMentionPopupWhenMultiWordSearchHasNoResults` — empty multi-word result closes the popup, further typing fires no more searches, and a fresh `@` re-triggers.
- `RadzenChat_ShouldNotReopenMentionPopupFromStaleResultsAfterClose` — results arriving after Escape do not reopen the popup, and inserting without an anchor does not throw.
- `RadzenChat_ShouldInsertMentionAfterMultiWordSearch` — selecting a user replaces the whole multi-word query in the input.

All `ChatTests` pass (61/61). `Radzen.Blazor` builds for net8.0/net9.0/net10.0 with no new warnings. (The three pre-existing `Radzen.Blazor.Spreadsheet.Tests.FilteringTests` failures on a clean checkout are unrelated and unchanged.)
