### PR TITLE
fix: DataGrid column widths jumping when resizing

### DIFF
--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components.Web;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -46,6 +47,151 @@ namespace Radzen.Blazor.Tests
             Assert.Contains(@$"rz-grid-table", component.Markup);
             Assert.Contains(@$"rz-grid-table-fixed", component.Markup);
             Assert.Contains(@$"rz-grid-table-striped", component.Markup);
+        }
+
+        [Fact]
+        public void DataGrid_RendersWidthOnColOnly()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDataGrid<dynamic>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<dynamic>>(p => p.Data, new[] { new { Id = 1, Name = "Alice" } });
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<dynamic>));
+                    builder.AddAttribute(1, "Property", "Id");
+                    builder.AddAttribute(2, "Width", "80px");
+                    builder.CloseComponent();
+                    builder.OpenComponent(3, typeof(RadzenDataGridColumn<dynamic>));
+                    builder.AddAttribute(4, "Property", "Name");
+                    builder.AddAttribute(5, "MinWidth", "150px");
+                    builder.CloseComponent();
+                });
+            });
+
+            var columns = component.FindAll("colgroup col");
+
+            Assert.Contains("width:80px", columns[0].GetAttribute("style"));
+
+            Assert.DoesNotMatch(@"(?:^|;)\s*width:", columns[1].GetAttribute("style"));
+            Assert.Contains("min-width:150px", columns[1].GetAttribute("style"));
+
+            foreach (var cell in component.FindAll("th, td"))
+            {
+                Assert.DoesNotMatch(@"(?:^|;)\s*width:", cell.GetAttribute("style") ?? string.Empty);
+            }
+
+            Assert.Contains("min-width:150px", component.FindAll("thead th")[1].GetAttribute("style"));
+        }
+
+        [Fact]
+        public void DataGrid_CompositeColumns_RenderWidthOnCells()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenDataGrid<dynamic>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<dynamic>>(p => p.Data, new[] { new { Id = 1, Name = "Alice" } });
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<dynamic>));
+                    builder.AddAttribute(1, "Title", "Group");
+                    builder.AddAttribute(2, "Columns", (RenderFragment)(child =>
+                    {
+                        child.OpenComponent(0, typeof(RadzenDataGridColumn<dynamic>));
+                        child.AddAttribute(1, "Property", "Id");
+                        child.AddAttribute(2, "Width", "80px");
+                        child.CloseComponent();
+                        child.OpenComponent(3, typeof(RadzenDataGridColumn<dynamic>));
+                        child.AddAttribute(4, "Property", "Name");
+                        child.CloseComponent();
+                    }));
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.Empty(component.FindAll("colgroup col"));
+            Assert.Contains(component.FindAll("th"), cell => (cell.GetAttribute("style") ?? string.Empty).Contains("width:80px"));
+        }
+
+        private static IRenderedComponent<RadzenDataGrid<dynamic>> RenderTwoColumnGrid(TestContext ctx,
+            out RadzenDataGridColumn<dynamic> first, out RadzenDataGridColumn<dynamic> second,
+            Action<DataGridColumnResizedEventArgs<dynamic>>? columnResized = null)
+        {
+            RadzenDataGridColumn<dynamic> idColumn = null!;
+            RadzenDataGridColumn<dynamic> nameColumn = null!;
+
+            var component = ctx.RenderComponent<RadzenDataGrid<dynamic>>(parameterBuilder =>
+            {
+                parameterBuilder.Add<IEnumerable<dynamic>>(p => p.Data, new[] { new { Id = 1, Name = "Alice" } });
+
+                if (columnResized != null)
+                {
+                    parameterBuilder.Add(p => p.ColumnResized, columnResized);
+                }
+
+                parameterBuilder.Add<RenderFragment>(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<dynamic>));
+                    builder.AddAttribute(1, "Property", "Id");
+                    builder.AddComponentReferenceCapture(2, value => idColumn = (RadzenDataGridColumn<dynamic>)value);
+                    builder.CloseComponent();
+                    builder.OpenComponent(3, typeof(RadzenDataGridColumn<dynamic>));
+                    builder.AddAttribute(4, "Property", "Name");
+                    builder.AddComponentReferenceCapture(5, value => nameColumn = (RadzenDataGridColumn<dynamic>)value);
+                    builder.CloseComponent();
+                });
+            });
+
+            first = idColumn;
+            second = nameColumn;
+
+            return component;
+        }
+
+        [Fact]
+        public async Task DataGrid_Resize_PreservesAllVisibleColumnWidths()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+            DataGridColumnResizedEventArgs<dynamic> args = null!;
+
+            var component = RenderTwoColumnGrid(ctx, out var idColumn, out var nameColumn, e => args = e);
+
+            await component.InvokeAsync(() => component.Instance.OnColumnsResized(1, 240, [90, 240]));
+
+            Assert.Equal("90px", idColumn.GetWidth());
+            Assert.Equal("240px", nameColumn.GetWidth());
+
+            Assert.Equal(nameColumn, args.Column);
+            Assert.Equal(90, args.Widths[idColumn]);
+            Assert.Equal(240, args.Widths[nameColumn]);
+        }
+
+        [Fact]
+        public async Task DataGrid_Resize_LeavesColumnWithoutWidth()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = RenderTwoColumnGrid(ctx, out var idColumn, out var nameColumn);
+
+            await component.InvokeAsync(() => component.Instance.OnColumnsResized(1, 150, [100, 150]));
+
+            Assert.Equal("150px", nameColumn.GetWidth());
+
+            await component.InvokeAsync(() => component.Instance.OnColumnsResized(0, 400, [400, 0]));
+
+            Assert.Equal("400px", idColumn.GetWidth());
+
+            Assert.True(string.IsNullOrEmpty(nameColumn.GetWidth()));
         }
 
         [Fact]

--- a/Radzen.Blazor/DataGridColumnResizedEventArgs.cs
+++ b/Radzen.Blazor/DataGridColumnResizedEventArgs.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Radzen.Blazor;
 
 namespace Radzen;
@@ -17,5 +18,13 @@ public class DataGridColumnResizedEventArgs<T> where T : notnull
     /// Gets the new width of the resized column.
     /// </summary>
     public double Width { get; internal set; }
+
+    /// <summary>
+    /// Gets the new width in pixels of every column the resize pinned a width on. Resizing one
+    /// column fixes the width of its neighbours as well, so handlers which persist column widths
+    /// themselves need all of them. Columns left without a width of their own are absent here.
+    /// </summary>
+    public IReadOnlyDictionary<RadzenDataGridColumn<T>, double> Widths { get; internal set; }
+        = new Dictionary<RadzenDataGridColumn<T>, double>();
 }
 

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2058,14 +2058,60 @@ namespace Radzen.Blazor
         [JSInvokable("RadzenGrid.OnColumnResized")]
         public async Task OnColumnResized(int columnIndex, double value)
         {
-            var column = columns.Where(c => c.GetVisible()).ToList()[columnIndex];
-            column.SetWidth($"{Math.Round(value)}px");
+            await OnColumnsResized(columnIndex, value, null);
+        }
+
+        private static string ToPixels(double width) => $"{width.ToString("0.####", CultureInfo.InvariantCulture)}px";
+
+        /// <summary>
+        /// Called when a column is resized and the widths of all visible columns are known.
+        /// </summary>
+        /// <param name="columnIndex">Index of the resized column.</param>
+        /// <param name="value">The resized column width.</param>
+        /// <param name="values">The widths of all visible columns.</param>
+        [JSInvokable("RadzenGrid.OnColumnsResized")]
+        public async Task OnColumnsResized(int columnIndex, double value, double[]? values)
+        {
+            var visibleColumns = columns.Where(c => c.GetVisible()).ToList();
+            var column = visibleColumns.ElementAtOrDefault(columnIndex);
+
+            if (column == null)
+            {
+                return;
+            }
+
+            var widths = new Dictionary<RadzenDataGridColumn<TItem>, double>();
+
+            if (values?.Length == visibleColumns.Count)
+            {
+                for (var index = 0; index < visibleColumns.Count; index++)
+                {
+                    var width = values[index];
+
+                    if (width < 1)
+                    {
+                        visibleColumns[index].SetWidth(null);
+                        continue;
+                    }
+
+                    visibleColumns[index].SetWidth(ToPixels(width));
+                    widths.Add(visibleColumns[index], width);
+                }
+            }
+            else
+            {
+                column.SetWidth(ToPixels(value));
+                widths.Add(column, value);
+            }
+
             await ColumnResized.InvokeAsync(new DataGridColumnResizedEventArgs<TItem>
             {
                 Column = column,
                 Width = value,
+                Widths = widths,
             });
             SaveSettings();
+            StateHasChanged();
         }
 
         internal string GetOrderBy()

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -823,7 +823,9 @@ namespace Radzen.Blazor
 
             var width = GetWidthOrGridSetting()?.Trim();
 
-            if (!string.IsNullOrEmpty(width))
+            var hasColGroup = Grid.allColumns.All(c => c.Parent == null);
+
+            if (!string.IsNullOrEmpty(width) && (isForCol || !hasColGroup))
             {
                 style.Add($"width:{width}");
             }

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -5411,22 +5411,9 @@ window.Radzen = {
       grid.addEventListener('touchmove', Radzen[id + 'touchmove'], { passive: false });
   },
   stopColumnResize: function (id, grid, columnIndex) {
-    var el = document.getElementById(id + '-resizer');
-    if(!el) return;
-    var cell = el.parentNode.parentNode;
-    if (!cell) return;
-    if (Radzen[el]) {
-        try { grid.invokeMethodAsync(
-            'RadzenGrid.OnColumnResized',
-            columnIndex,
-            cell.getBoundingClientRect().width
-        ); } catch { }
-        el.style.width = null;
-        document.removeEventListener('mousemove', Radzen[el].mouseMoveHandler);
-        document.removeEventListener('mouseup', Radzen[el].mouseUpHandler);
-        document.removeEventListener('touchmove', Radzen[el].touchMoveHandler)
-        document.removeEventListener('touchend', Radzen[el].mouseUpHandler);
-        Radzen[el] = null;
+    var resize = Radzen[id + 'columnResize'];
+    if (resize) {
+        resize.mouseUpHandler();
     }
   },
   updateFrozenColumnPositions: function(gridElement) {
@@ -5465,60 +5452,108 @@ window.Radzen = {
   },
   startColumnResize: function(id, grid, columnIndex, clientX) {
       var el = document.getElementById(id + '-resizer');
+      var resizeKey = id + 'columnResize';
       var cell = el.parentNode.parentNode;
       var col = document.getElementById(id + '-col');
-      var dataCol = document.getElementById(id + '-data-col');
-      var footerCol = document.getElementById(id + '-footer-col');
-      var isFrozen = cell.classList.contains('rz-frozen-cell');
-      var gridElement = isFrozen ? cell.closest('.rz-data-grid') : null;
-      Radzen[el] = {
+      var gridElement = cell.closest('.rz-data-grid');
+      var hasFrozenColumns = gridElement != null && gridElement.querySelector('.rz-frozen-cell') != null;
+      var table = cell.closest('.rz-grid-table');
+      var colgroup = table ? table.querySelector(':scope > colgroup') : null;
+      var allColumns = colgroup ? Array.from(colgroup.children) : [];
+      var headerCells = cell.parentNode.children.length === allColumns.length
+          ? Array.from(cell.parentNode.children)
+          : [];
+      var pinned = allColumns.map(function (column) {
+          return column === col || !!column.style.width || !column.id.endsWith('-col');
+      });
+      var columns = [];
+      var bounds = [];
+      allColumns.forEach(function (column, index) {
+          if (!column.id.endsWith('-col')) return;
+          var style = getComputedStyle(headerCells[index] || column);
+          columns.push(column);
+          bounds.push({
+              min: parseFloat(style.minWidth) || 0,
+              max: parseFloat(style.maxWidth),
+              pinned: pinned[index]
+          });
+      });
+      var cellStyle = getComputedStyle(cell);
+      var minWidth = parseFloat(cellStyle.minWidth) || 0;
+      var maxWidth = parseFloat(cellStyle.maxWidth);
+      var declaredWidths = allColumns.map(column => column.style.width);
+      var columnWidths = allColumns.map(column => column.getBoundingClientRect().width);
+      allColumns.forEach(function (column, index) {
+          if (pinned[index]) {
+              column.style.width = columnWidths[index] + 'px';
+          }
+      });
+      Radzen[resizeKey] = {
           clientX: clientX,
           width: cell.getBoundingClientRect().width,
+          resized: false,
           mouseUpHandler: function (e) {
-              if (Radzen[el]) {
-                  try { grid.invokeMethodAsync(
-                      'RadzenGrid.OnColumnResized',
-                      columnIndex,
-                      cell.getBoundingClientRect().width
-                  ); } catch { }
-                  el.style.width = null;
-                  document.removeEventListener('mousemove', Radzen[el].mouseMoveHandler);
-                  document.removeEventListener('mouseup', Radzen[el].mouseUpHandler);
-                  document.removeEventListener('touchmove', Radzen[el].touchMoveHandler)
-                  document.removeEventListener('touchend', Radzen[el].mouseUpHandler);
-                  Radzen[el] = null;
+              var resize = Radzen[resizeKey];
+
+              if (!resize) return;
+
+              if (!resize.resized) {
+                  allColumns.forEach(function (column, index) {
+                      column.style.width = declaredWidths[index];
+                  });
               }
+              else {
+                  var widths = columns.map(function (column, index) {
+                      if (!bounds[index].pinned) {
+                          return 0;
+                      }
+
+                      var width = Math.max(parseFloat(column.style.width), bounds[index].min);
+
+                      return Number.isNaN(bounds[index].max) ? width : Math.min(width, bounds[index].max);
+                  });
+
+                  try {
+                      if (columns.length) {
+                          grid.invokeMethodAsync('RadzenGrid.OnColumnsResized', columnIndex, widths[columnIndex], widths);
+                      } else {
+                          grid.invokeMethodAsync('RadzenGrid.OnColumnResized', columnIndex, cell.getBoundingClientRect().width);
+                      }
+                  } catch { }
+              }
+
+              el.style.width = null;
+              document.removeEventListener('mousemove', resize.mouseMoveHandler);
+              document.removeEventListener('mouseup', resize.mouseUpHandler);
+              document.removeEventListener('touchmove', resize.touchMoveHandler)
+              document.removeEventListener('touchend', resize.mouseUpHandler);
+              Radzen[resizeKey] = null;
           },
           mouseMoveHandler: function (e) {
-              if (Radzen[el]) {
-                  var widthFloat = (Radzen[el].width - (Radzen.isRTL(cell) ? -1 : 1) * (Radzen[el].clientX - e.clientX));
-                  var minWidth = parseFloat(cell.style.minWidth || 0)
-                  var maxWidth = parseFloat(cell.style.maxWidth || 0)
+              if (Radzen[resizeKey]) {
+                  var widthFloat = (Radzen[resizeKey].width - (Radzen.isRTL(cell) ? -1 : 1) * (Radzen[resizeKey].clientX - e.clientX));
 
                   if (widthFloat < minWidth) {
                       widthFloat = minWidth;
                   }
 
-                  if (cell.style.maxWidth && widthFloat > maxWidth) {
+                  if (!Number.isNaN(maxWidth) && widthFloat > maxWidth) {
                       widthFloat = maxWidth;
+                  }
+
+                  if (widthFloat !== Radzen[resizeKey].width) {
+                      Radzen[resizeKey].resized = true;
                   }
 
                   var width = widthFloat + 'px';
 
-                  if (cell) {
-                      cell.style.width = width;
-                  }
                   if (col) {
                       col.style.width = width;
-                  }
-                  if (dataCol) {
-                      dataCol.style.width = width;
-                  }
-                  if (footerCol) {
-                      footerCol.style.width = width;
+                  } else {
+                      cell.style.width = width;
                   }
 
-                  if (gridElement) {
+                  if (hasFrozenColumns) {
                       Radzen.updateFrozenColumnPositions(gridElement);
                   }
               }
@@ -5526,15 +5561,15 @@ window.Radzen = {
           touchMoveHandler: function (e) {
               if (e.targetTouches[0]) {
                   e.preventDefault();
-                  Radzen[el].mouseMoveHandler(e.targetTouches[0]);
+                  Radzen[resizeKey].mouseMoveHandler(e.targetTouches[0]);
               }
           }
       };
       el.style.width = "100%";
-      document.addEventListener('mousemove', Radzen[el].mouseMoveHandler);
-      document.addEventListener('mouseup', Radzen[el].mouseUpHandler);
-      document.addEventListener('touchmove', Radzen[el].touchMoveHandler, { passive: false })
-      document.addEventListener('touchend', Radzen[el].mouseUpHandler);
+      document.addEventListener('mousemove', Radzen[resizeKey].mouseMoveHandler);
+      document.addEventListener('mouseup', Radzen[resizeKey].mouseUpHandler);
+      document.addEventListener('touchmove', Radzen[resizeKey].touchMoveHandler, { passive: false })
+      document.addEventListener('touchend', Radzen[resizeKey].mouseUpHandler);
   },
       startSplitterResize: function(id,
         splitter,


### PR DESCRIPTION
Related issue: #1731

In a table with `width: 100%`, setting the width for all columns will cause a discrepancy between the actual rendered column width and the declared column width. This will result in a width jump when the resize handler writes the actual rendered column width. The solution is to write the actual rendered column width for all columns before resize if a width is declared for all columns.

- Width was repeated on the cells as well as on the col, and a fixed layout falls back to the first row's cell whenever a col has none. Clearing a col during a drag handed the column back to a stale cell width. Where a colgroup is rendered it is now the only carrier of a width; composite grids render none and keep theirs on the cells.
- A press which never became a drag committed those widths as if the user had set them. Widths are committed only once a move has changed one, and a bare press restores what the renderer declared.

A column with no width of its own is left alone: it absorbs what the drag frees or claims while the drag is under way, and is reported with no width so that it goes on following the container afterwards.

What is committed is what the drag left declared rather than what the layout drew from it, clamped to the bounds of the column, and at the precision a browser keeps a CSS length at. ColumnResized carries every pinned width in Widths, one drag now fixing more than one column.

Also in the resize path: the state was keyed by the DOM element, which stringifies to "[object HTMLDivElement]" and gave the whole page one shared slot; the colgroup lookup was unscoped and could find a nested grid's; stopColumnResize carried a second copy of the teardown; the frozen column offsets were refreshed only when the frozen column itself was dragged; and the -data-col and -footer-col elements it looked for no longer exist.