### PR TITLE
Add Groups parameter to DataGrid

### DIFF
--- a/Radzen.Blazor.Tests/DataGridTests.cs
+++ b/Radzen.Blazor.Tests/DataGridTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components.Web;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -3531,6 +3532,237 @@ namespace Radzen.Blazor.Tests
             Assert.True(loadDataCallCount <= 2, $"LoadData was called {loadDataCallCount} times, expected at most 2 (indicating possible infinite loop)");
         }
 
+        static (IRenderedComponent<RadzenDataGrid<GroupTestItem>> Component,
+            RadzenDataGridColumn<GroupTestItem> CityColumn,
+            RadzenDataGridColumn<GroupTestItem> NameColumn,
+            RadzenDataGridColumn<GroupTestItem> CountryColumn) RenderGroupsDataGrid(
+                TestContext ctx,
+                ObservableCollection<GroupDescriptor> groups,
+                bool hideGroupedColumn = true,
+                bool allowGrouping = false,
+                DataGridSettings settings = null,
+                Action<DataGridSettings> settingsChanged = null,
+                Action<DataGridRenderEventArgs<GroupTestItem>> render = null)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            RadzenDataGridColumn<GroupTestItem> cityColumn = null!;
+            RadzenDataGridColumn<GroupTestItem> nameColumn = null!;
+            RadzenDataGridColumn<GroupTestItem> countryColumn = null!;
+
+            var component = ctx.RenderComponent<RadzenDataGrid<GroupTestItem>>(parameters =>
+            {
+                parameters
+                    .Add(p => p.Data, new[]
+                    {
+                        new GroupTestItem { City = "Sofia", Name = "Ivan", Country = "BG" },
+                        new GroupTestItem { City = "Berlin", Name = "Anna", Country = "BG" }
+                    })
+                    .Add(p => p.AllowGrouping, allowGrouping)
+                    .Add(p => p.HideGroupedColumn, hideGroupedColumn)
+                    .Add(p => p.Groups, groups)
+                    .Add(p => p.Columns, builder =>
+                    {
+                        builder.OpenComponent<RadzenDataGridColumn<GroupTestItem>>(0);
+                        builder.AddAttribute(1, nameof(RadzenDataGridColumn<GroupTestItem>.Property), nameof(GroupTestItem.City));
+                        builder.AddComponentReferenceCapture(2, value => cityColumn = (RadzenDataGridColumn<GroupTestItem>)value);
+                        builder.CloseComponent();
+
+                        builder.OpenComponent<RadzenDataGridColumn<GroupTestItem>>(3);
+                        builder.AddAttribute(4, nameof(RadzenDataGridColumn<GroupTestItem>.Property), nameof(GroupTestItem.Name));
+                        builder.AddComponentReferenceCapture(5, value => nameColumn = (RadzenDataGridColumn<GroupTestItem>)value);
+                        builder.CloseComponent();
+
+                        builder.OpenComponent<RadzenDataGridColumn<GroupTestItem>>(6);
+                        builder.AddAttribute(7, nameof(RadzenDataGridColumn<GroupTestItem>.Property), nameof(GroupTestItem.Country));
+                        builder.AddComponentReferenceCapture(8, value => countryColumn = (RadzenDataGridColumn<GroupTestItem>)value);
+                        builder.CloseComponent();
+                    });
+
+                if (settings != null)
+                {
+                    parameters.Add(p => p.Settings, settings);
+                }
+
+                if (settingsChanged != null)
+                {
+                    parameters.Add(p => p.SettingsChanged, settingsChanged);
+                }
+
+                if (render != null)
+                {
+                    parameters.Add(p => p.Render, render);
+                }
+            });
+
+            return (component, cityColumn, nameColumn, countryColumn);
+        }
+
+        [Fact]
+        public void DataGrid_GroupsParameter_HidesGroupedColumnOnFirstRender()
+        {
+            using var ctx = new TestContext();
+            var groups = new ObservableCollection<GroupDescriptor>
+            {
+                new GroupDescriptor { Property = nameof(GroupTestItem.City) }
+            };
+            bool? cityVisibleOnFirstRender = null;
+
+            var (component, cityColumn, nameColumn, _) = RenderGroupsDataGrid(
+                ctx,
+                groups,
+                allowGrouping: true,
+                render: args =>
+                {
+                    if (args.FirstRender)
+                    {
+                        cityVisibleOnFirstRender = args.Grid.ColumnsCollection
+                            .Single(c => c.Property == nameof(GroupTestItem.City)).GetVisible();
+                    }
+                });
+
+            Assert.False(cityVisibleOnFirstRender);
+            Assert.False(cityColumn.GetVisible());
+            Assert.True(nameColumn.GetVisible());
+            Assert.Single(component.FindAll(".rz-group-header-item"));
+            Assert.Equal(2, component.Instance.GroupedPagedView.Count());
+        }
+
+        [Fact]
+        public void DataGrid_GroupsParameter_TracksCollectionReplacement()
+        {
+            using var ctx = new TestContext();
+            var oldGroups = new ObservableCollection<GroupDescriptor>
+            {
+                new GroupDescriptor { Property = nameof(GroupTestItem.City) }
+            };
+            var newGroups = new ObservableCollection<GroupDescriptor>
+            {
+                new GroupDescriptor { Property = nameof(GroupTestItem.Name) }
+            };
+            var (component, cityColumn, nameColumn, _) = RenderGroupsDataGrid(ctx, oldGroups);
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.Data, component.Instance.Data)
+                .Add(p => p.HideGroupedColumn, true)
+                .Add(p => p.Groups, newGroups)
+                .Add(p => p.Columns, component.Instance.Columns));
+
+            Assert.True(cityColumn.GetVisible());
+            Assert.False(nameColumn.GetVisible());
+
+            component.InvokeAsync(oldGroups.Clear);
+            Assert.False(nameColumn.GetVisible());
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.Data, component.Instance.Data)
+                .Add(p => p.HideGroupedColumn, false)
+                .Add(p => p.Groups, newGroups)
+                .Add(p => p.Columns, component.Instance.Columns));
+            Assert.True(nameColumn.GetVisible());
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.Data, component.Instance.Data)
+                .Add(p => p.HideGroupedColumn, true)
+                .Add(p => p.Groups, newGroups)
+                .Add(p => p.Columns, component.Instance.Columns));
+            Assert.False(nameColumn.GetVisible());
+
+            component.InvokeAsync(newGroups.Clear);
+            Assert.True(nameColumn.GetVisible());
+        }
+
+        [Fact]
+        public void DataGrid_GroupsParameter_DoesNotDuplicateCollectionSubscription()
+        {
+            using var ctx = new TestContext();
+            var groups = new ObservableCollection<GroupDescriptor>();
+            var settingsChangedCount = 0;
+            var (component, _, _, _) = RenderGroupsDataGrid(
+                ctx,
+                groups,
+                allowGrouping: true,
+                settingsChanged: _ => settingsChangedCount++);
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.Data, component.Instance.Data)
+                .Add(p => p.AllowGrouping, true)
+                .Add(p => p.Groups, groups)
+                .Add(p => p.SettingsChanged, _ => settingsChangedCount++)
+                .Add(p => p.Columns, component.Instance.Columns));
+
+            settingsChangedCount = 0;
+            var renderCount = component.RenderCount;
+            component.InvokeAsync(() => groups.Add(new GroupDescriptor { Property = nameof(GroupTestItem.City) }));
+
+            Assert.Equal(1, settingsChangedCount);
+            Assert.True(component.RenderCount > renderCount);
+            Assert.Single(component.FindAll(".rz-group-header-item"));
+        }
+
+        [Fact]
+        public void DataGrid_GroupsParameter_InvalidatesGroupedViewAndSurvivesReset()
+        {
+            using var ctx = new TestContext();
+            var groups = new ObservableCollection<GroupDescriptor>
+            {
+                new GroupDescriptor { Property = nameof(GroupTestItem.City) }
+            };
+            var (component, cityColumn, _, countryColumn) = RenderGroupsDataGrid(ctx, groups);
+
+            Assert.Equal(2, component.Instance.GroupedPagedView.Count());
+
+            component.InvokeAsync(() => groups[0] = new GroupDescriptor { Property = nameof(GroupTestItem.Country) });
+
+            Assert.Equal(1, component.Instance.GroupedPagedView.Count());
+            Assert.True(cityColumn.GetVisible());
+            Assert.False(countryColumn.GetVisible());
+
+            component.InvokeAsync(() => component.Instance.Reset());
+            Assert.False(countryColumn.GetVisible());
+        }
+
+        [Fact]
+        public void DataGrid_GroupsParameter_SettingsRestoreMutatesSameCollection()
+        {
+            using var ctx = new TestContext();
+            var groups = new ObservableCollection<GroupDescriptor>
+            {
+                new GroupDescriptor { Property = nameof(GroupTestItem.City) }
+            };
+            var settings = new DataGridSettings
+            {
+                Groups = new[] { new GroupDescriptor { Property = nameof(GroupTestItem.Name) } },
+                Columns = new[]
+                {
+                    new DataGridColumnSettings { Property = nameof(GroupTestItem.City), Visible = true },
+                    new DataGridColumnSettings { Property = nameof(GroupTestItem.Name), Visible = true }
+                }
+            };
+            var (component, cityColumn, nameColumn, _) = RenderGroupsDataGrid(
+                ctx,
+                groups,
+                settings: settings,
+                settingsChanged: _ => { });
+
+            Assert.Same(groups, component.Instance.Groups);
+            Assert.Equal(nameof(GroupTestItem.Name), Assert.Single(groups).Property);
+            Assert.True(cityColumn.GetVisible());
+            Assert.False(nameColumn.GetVisible());
+
+            component.SetParametersAndRender(parameters => parameters
+                .Add(p => p.Data, component.Instance.Data)
+                .Add(p => p.HideGroupedColumn, true)
+                .Add(p => p.Groups, groups)
+                .Add<DataGridSettings>(p => p.Settings, null)
+                .Add(p => p.SettingsChanged, _ => { })
+                .Add(p => p.Columns, component.Instance.Columns));
+
+            Assert.Empty(groups);
+            Assert.True(nameColumn.GetVisible());
+        }
+
         [Fact]
         public void DataGrid_Sorts_KeepsInternalSortsInSync_OnClearAndRemove()
         {
@@ -4413,5 +4645,12 @@ namespace Radzen.Blazor.Tests
     {
         public string Reference { get; set; } = string.Empty;
         public int Code { get; set; }
+    }
+
+    public class GroupTestItem
+    {
+        public string City { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
     }
 }

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -902,6 +902,8 @@ namespace Radzen.Blazor
                 allColumns.Add(column);
             }
 
+            ApplyGroupedColumnVisibility(column);
+
             if (AllowColumnPicking)
             {
                 selectedColumns = allColumns.Where(c => c.Pickable && c.GetVisible()).ToList();
@@ -960,6 +962,8 @@ namespace Radzen.Blazor
             childColumns.Remove(column);
 
             allColumns.Remove(column);
+
+            groupedColumns.Remove(column);
 
             UpdateColumnsOrder();
 
@@ -2587,6 +2591,7 @@ namespace Radzen.Blazor
                 selectedColumns = allColumns.Where(c => c.Pickable && c.GetVisible()).ToList();
                 sorts.Clear();
                 columns = allColumns.Where(c => c.Parent == null).ToList();
+                ApplyGroupedColumnVisibility();
            }
         }
 
@@ -2911,7 +2916,8 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         public override async Task SetParametersAsync(ParameterView parameters)
         {
-            bool emptyTextChanged = false, allowColumnPickingChanged = false, valueChanged = false, allGroupsExpandedChanged = false;
+            bool emptyTextChanged = false, allowColumnPickingChanged = false, valueChanged = false, allGroupsExpandedChanged = false,
+                groupsChanged = false, hideGroupedColumnChanged = false;
 
             foreach (var parameter in parameters) {
                 switch (parameter.Name) {
@@ -2927,6 +2933,12 @@ namespace Radzen.Blazor
                     case nameof(Settings):
                         settingsChanged = HasChanged(parameter.Value, Settings); break;
 
+                    case nameof(Groups):
+                        groupsChanged = !ReferenceEquals(parameter.Value, groups); break;
+
+                    case nameof(HideGroupedColumn):
+                        hideGroupedColumnChanged = HasChanged(parameter.Value, HideGroupedColumn); break;
+
                     case nameof(AllGroupsExpanded):
                         allGroupsExpandedChanged = HasChanged(parameter.Value, AllGroupsExpanded);
                         if (allGroupsExpandedChanged)
@@ -2941,6 +2953,16 @@ namespace Radzen.Blazor
             }
 
             await base.SetParametersAsync(parameters);
+
+            if (groupsChanged || hideGroupedColumnChanged)
+            {
+                SynchronizeGroupedColumnVisibility();
+
+                if (groupsChanged && !firstRender)
+                {
+                    await InvokeAsync(Reload);
+                }
+            }
 
             if (valueChanged)
             {
@@ -3752,78 +3774,102 @@ namespace Radzen.Blazor
             descriptor.SortOrder = sortOrder;
         }
 
+        void RestoreGroupedColumnVisibility()
+        {
+            foreach (var column in groupedColumns)
+            {
+                column.SetVisible(true);
+            }
+
+            groupedColumns.Clear();
+        }
+
+        void ApplyGroupedColumnVisibility(RadzenDataGridColumn<TItem> column)
+        {
+            if (HideGroupedColumn && groups != null && groups.Any(g => g.Property == column.GetGroupProperty()))
+            {
+                column.SetVisible(false);
+
+                if (!groupedColumns.Contains(column))
+                {
+                    groupedColumns.Add(column);
+                }
+            }
+        }
+
+        void ApplyGroupedColumnVisibility()
+        {
+            foreach (var column in allColumns)
+            {
+                ApplyGroupedColumnVisibility(column);
+            }
+        }
+
+        void SynchronizeGroupedColumnVisibility()
+        {
+            RestoreGroupedColumnVisibility();
+            ApplyGroupedColumnVisibility();
+        }
+
+        void SetGroupsCollection(ObservableCollection<GroupDescriptor>? value)
+        {
+            if (ReferenceEquals(groups, value))
+            {
+                return;
+            }
+
+            if (groups != null)
+            {
+                groups.CollectionChanged -= GroupsCollectionChanged;
+            }
+
+            groups = value;
+
+            if (groups != null)
+            {
+                groups.CollectionChanged += GroupsCollectionChanged;
+            }
+
+            _groupedPagedView = null;
+            SynchronizeGroupedColumnVisibility();
+        }
+
+        bool suppressGroupsCollectionChanged;
+
         void GroupsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args)
         {
-            if (args.Action == NotifyCollectionChangedAction.Add)
+            _groupedPagedView = null;
+
+            if (suppressGroupsCollectionChanged)
             {
-                RadzenDataGridColumn<TItem>? column;
-                column = columns.FirstOrDefault(c => c.GetGroupProperty() == ((GroupDescriptor)args.NewItems![0]!).Property);
-
-                if(column == null && args.NewItems != null && args.NewItems.Count > 0 && args.NewItems[0] is GroupDescriptor newGroup)
-                {
-                   column = allColumns.FirstOrDefault(c => c.GetGroupProperty() == newGroup.Property);
-                }
-
-                if (column != null && HideGroupedColumn)
-                {
-                    column.SetVisible(false);
-                    if (!groupedColumns.Contains(column))
-                    {
-                        groupedColumns.Add(column);
-                    }
-                }
-            }
-            else if (args.Action == NotifyCollectionChangedAction.Remove)
-            {
-                RadzenDataGridColumn<TItem>? column;
-                column = columns.FirstOrDefault(c => c.GetGroupProperty() == ((GroupDescriptor)args.OldItems![0]!).Property);
-
-                if (column == null && args.OldItems != null && args.OldItems.Count > 0 && args.OldItems[0] is GroupDescriptor oldGroup)
-                {
-                    column = allColumns.FirstOrDefault(c => c.GetGroupProperty() == oldGroup.Property);
-                }
-
-                if (column != null && HideGroupedColumn)
-                {
-                    column.SetVisible(true);
-                    groupedColumns.Remove(column);
-                }
-            }
-            else if (args.Action == NotifyCollectionChangedAction.Reset)
-            {
-                foreach (var column in groupedColumns)
-                {
-                    if (HideGroupedColumn)
-                    {
-                        column.SetVisible(true);
-                    }
-                }
+                return;
             }
 
+            SynchronizeGroupedColumnVisibility();
             SaveSettings();
+            InvokeAsync(StateHasChanged);
         }
 
         List<RadzenDataGridColumn<TItem>> groupedColumns = new List<RadzenDataGridColumn<TItem>>();
         /// <summary>
         /// Gets or sets the group descriptors.
         /// </summary>
-        /// <value>The groups.</value>
+        /// <value>The groups. Use a stable collection instance when grouping can be changed interactively.</value>
+        [Parameter]
         public ObservableCollection<GroupDescriptor> Groups
         {
             get
             {
                 if (groups == null)
                 {
-                    groups = new ObservableCollection<GroupDescriptor>();
-                    groups.CollectionChanged -= GroupsCollectionChanged;
-                    groups.CollectionChanged += GroupsCollectionChanged;
+                    SetGroupsCollection(new ObservableCollection<GroupDescriptor>());
                 }
 
-                return groups;
+                return groups!;
             }
             set
             {
-                groups = value;
+                SetGroupsCollection(value);
             }
         }
 
@@ -4222,6 +4268,8 @@ namespace Radzen.Blazor
                     c.SecondFilterOperator == FilterOperator.IsNull || c.SecondFilterOperator == FilterOperator.IsNotNull ||
                     c.SecondFilterOperator == FilterOperator.IsEmpty || c.SecondFilterOperator == FilterOperator.IsNotEmpty);
 
+                RestoreGroupedColumnVisibility();
+
                 if (settings.Columns != null)
                 {
                     var allColumns = ColumnsCollection.Concat(ColumnsCollection.SelectManyRecursive(c => c.ColumnsCollection));
@@ -4317,18 +4365,23 @@ namespace Radzen.Blazor
 
                 if (settings.Groups != null && !settings.Groups.SequenceEqual(Groups))
                 {
-                    if (groups != null)
+                    var settingsGroups = settings.Groups.ToList();
+                    suppressGroupsCollectionChanged = true;
+
+                    try
                     {
-                        groups.CollectionChanged -= GroupsCollectionChanged;
+                        Groups.Clear();
+                        settingsGroups.ForEach(Groups.Add);
                     }
-                    Groups.Clear();
-                    settings.Groups.ToList().ForEach(Groups.Add);
+                    finally
+                    {
+                        suppressGroupsCollectionChanged = false;
+                    }
+
                     shouldUpdateState = true;
-                    if (groups != null)
-                    {
-                        groups.CollectionChanged += GroupsCollectionChanged;
-                    }
                 }
+
+                ApplyGroupedColumnVisibility();
 
                 if (settings.CurrentPage != null && settings.CurrentPage != CurrentPage)
                 {


### PR DESCRIPTION
## Summary

Adds `Groups` as a parameter of `RadzenDataGrid<TItem>`, allowing initial grouping to be configured declaratively before the first render.

```razor
<RadzenDataGrid Data="@items"
                Groups="@groups"
                AllowGrouping="true"
                HideGroupedColumn="true">
    ...
</RadzenDataGrid>
```

Previously, initial grouping had to be added through `@ref` after the grid rendered. This caused an ungrouped frame to be displayed first, which was especially visible when DataGrids were rendered inside server-rendered `RadzenTabs`.

## Changes

- Marks `Groups` as a component parameter.
- Transfers the `CollectionChanged` subscription when the collection instance changes.
- Applies `HideGroupedColumn` as columns register, before the first completed render.
- Synchronizes grouped-column visibility when the collection changes or is replaced, `HideGroupedColumn` changes, columns are registered or removed, the grid is reset, or saved settings are restored.
- Invalidates the grouped view when the collection changes.
- Preserves the supplied collection instance when loading settings.

The existing mutable collection behavior is preserved. The parent and grid share the same `ObservableCollection<GroupDescriptor>`, so runtime changes from either side remain observable. A stable collection instance should be retained between parent renders.

## Tests

Added bUnit coverage for:

- declarative grouping and `HideGroupedColumn` on the first render;
- collection replacement and subscription transfer;
- repeated assignment of the same collection;
- grouped-view invalidation and `Reset()`;
- settings restoration and `Settings = null`.

Validation:

- `dotnet test Radzen.Blazor.Tests/Radzen.Blazor.Tests.csproj`: 4856 passed
- `dotnet build Radzen.Blazor/Radzen.Blazor.csproj`: net8.0, net9.0 and net10.0 build successfully