### PR TITLE
Improve In and NotIn filter logic

### DIFF
--- a/Radzen.Blazor.Tests/QueryableExtensionTests.cs
+++ b/Radzen.Blazor.Tests/QueryableExtensionTests.cs
@@ -2662,6 +2662,94 @@ namespace Radzen.Blazor.Tests
             Assert.Contains(result, r => r.Id == 1);
             Assert.Contains(result, r => r.Id == 3);
         }
+
+        [Fact]
+        public void Where_FiltersNullableScalarProperty_WithIn()
+        {
+            var testData = new[]
+            {
+                new { Id = 1, ClientNr = (long?)100 },
+                new { Id = 2, ClientNr = (long?)200 },
+                new { Id = 3, ClientNr = (long?)300 },
+                new { Id = 4, ClientNr = default(long?) }
+            }.AsQueryable();
+
+            var filters = new List<FilterDescriptor>
+            {
+                new FilterDescriptor
+                {
+                    Property = "ClientNr",
+                    FilterValue = new long[] { 100, 300 },
+                    FilterOperator = FilterOperator.In
+                }
+            };
+
+            var result = testData.Where(filters, LogicalFilterOperator.And, FilterCaseSensitivity.Default).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, r => r.Id == 1);
+            Assert.Contains(result, r => r.Id == 3);
+        }
+
+        [Fact]
+        public void Where_FiltersNullableScalarProperty_WithNotIn()
+        {
+            var testData = new[]
+            {
+                new { Id = 1, ClientNr = (long?)100 },
+                new { Id = 2, ClientNr = (long?)200 },
+                new { Id = 3, ClientNr = (long?)300 },
+                new { Id = 4, ClientNr = default(long?) }
+            }.AsQueryable();
+
+            var filters = new List<FilterDescriptor>
+            {
+                new FilterDescriptor
+                {
+                    Property = "ClientNr",
+                    FilterValue = new long[] { 100, 300 },
+                    FilterOperator = FilterOperator.NotIn
+                }
+            };
+
+            var result = testData.Where(filters, LogicalFilterOperator.And, FilterCaseSensitivity.Default).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, r => r.Id == 2);
+            Assert.Contains(result, r => r.Id == 4);
+        }
+
+        [Fact]
+        public void Where_FiltersNullableScalarProperty_WithSecondFilterValue_In()
+        {
+            var testData = new[]
+            {
+                new { Id = 1, ClientNr = (long?)100 },
+                new { Id = 2, ClientNr = (long?)200 },
+                new { Id = 3, ClientNr = (long?)300 },
+                new { Id = 4, ClientNr = default(long?) }
+            }.AsQueryable();
+
+            var filters = new List<FilterDescriptor>
+            {
+                new FilterDescriptor
+                {
+                    Property = "ClientNr",
+                    FilterValue = 100L,
+                    FilterOperator = FilterOperator.Equals,
+                    SecondFilterValue = new long[] { 200, 300 },
+                    SecondFilterOperator = FilterOperator.In,
+                    LogicalFilterOperator = LogicalFilterOperator.Or
+                }
+            };
+
+            var result = testData.Where(filters, LogicalFilterOperator.And, FilterCaseSensitivity.Default).ToList();
+
+            Assert.Equal(3, result.Count);
+            Assert.Contains(result, r => r.Id == 1);
+            Assert.Contains(result, r => r.Id == 2);
+            Assert.Contains(result, r => r.Id == 3);
+        }
     }
 }
 

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -721,6 +721,7 @@ namespace Radzen
             }
 
             var isEnum = !isEnumerable && (PropertyAccess.IsEnum(property.Type) || PropertyAccess.IsNullableEnum(property.Type));
+            var isNullableValueType = Nullable.GetUnderlyingType(property.Type)?.IsValueType == true && !isEnum;
             var caseInsensitive = property.Type == typeof(string) && !isEnumerable && filterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive;
 
             var isEnumerableProperty = IsEnumerable(property.Type) && property.Type != typeof(string);
@@ -802,7 +803,28 @@ namespace Radzen
                 FilterOperator.In => isEnumerable &&
                                     isEnumerableProperty ?
                     Expression.Call(typeof(Enumerable), nameof(Enumerable.Any), new Type[] { collectionItemType! },
-                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Intersect), new Type[] { collectionItemType! }, constant, notNullCheck(property))) : Expression.Constant(true),
+                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Intersect), new Type[] { collectionItemType! }, constant, notNullCheck(property))) :
+                    isNullableValueType ?
+                        (valueType!.IsArray ?
+                            Expression.Condition(
+                                Expression.Property(property, "HasValue"),
+                                Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                    new Type[] { valueType.GetElementType()! },
+                                    constant,
+                                    Expression.Property(property, "Value")),
+                                Expression.Constant(false, typeof(bool))) :
+                            Expression.Condition(
+                                Expression.Property(property, "HasValue"),
+                                Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                    new Type[] { Nullable.GetUnderlyingType(property.Type!)! },
+                                    constant,
+                                    Expression.Property(property, "Value")),
+                                Expression.Constant(false, typeof(bool)))) :
+                    isEnum ?
+                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                            new Type[] { property.Type! }, constant, notNullCheck(property)) :
+                    Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                        new Type[] { property.Type ?? typeof(object) }, constant, notNullCheck(property)),
                 FilterOperator.DoesNotContain => isEnumerable ?
                     Expression.Not(Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains), new Type[] { property.Type }, constant, notNullCheck(property))) :
                         isEnumerableProperty ?
@@ -811,7 +833,30 @@ namespace Radzen
                 FilterOperator.NotIn => isEnumerable &&
                                     isEnumerableProperty ?
                     Expression.Call(typeof(Enumerable), nameof(Enumerable.Any), new Type[] { collectionItemType! },
-                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Except), new Type[] { collectionItemType! }, constant, notNullCheck(property))) : Expression.Constant(true),
+                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Except), new Type[] { collectionItemType! }, constant, notNullCheck(property))) :
+                    isNullableValueType ?
+                        (valueType!.IsArray ?
+                            Expression.Condition(
+                                Expression.Property(property, "HasValue"),
+                                Expression.Not(
+                                    Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                        new Type[] { valueType.GetElementType()! },
+                                        constant,
+                                        Expression.Property(property, "Value"))),
+                                Expression.Constant(true, typeof(bool))) :
+                            Expression.Condition(
+                                Expression.Property(property, "HasValue"),
+                                Expression.Not(
+                                    Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                        new Type[] { Nullable.GetUnderlyingType(property.Type!)! },
+                                        constant,
+                                        Expression.Property(property, "Value"))),
+                                Expression.Constant(true, typeof(bool)))) :
+                    isEnum ?
+                        Expression.Not(Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                            new Type[] { property.Type! }, constant, notNullCheck(property))) :
+                    Expression.Not(Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                        new Type[] { property.Type! }, constant, notNullCheck(property))),
                 FilterOperator.StartsWith => Expression.Call(notNullCheck(property), typeof(string).GetMethod("StartsWith", new[] { typeof(string) })!, constant),
                 FilterOperator.EndsWith => Expression.Call(notNullCheck(property), typeof(string).GetMethod("EndsWith", new[] { typeof(string) })!, constant),
                 FilterOperator.IsNull => Expression.Equal(rawProperty, Expression.Constant(null, rawProperty.Type)),
@@ -848,7 +893,59 @@ namespace Radzen
                     FilterOperator.GreaterThan => Expression.GreaterThan(notNullCheck(property), secondConstant!),
                     FilterOperator.GreaterThanOrEquals => Expression.GreaterThanOrEqual(notNullCheck(property), secondConstant!),
                     FilterOperator.Contains => Expression.Call(notNullCheck(property), typeof(string).GetMethod("Contains", new[] { typeof(string) })!, secondConstant!),
-                    FilterOperator.DoesNotContain => Expression.Not(Expression.Call(notNullCheck(property), property.Type.GetMethod("Contains", new[] { typeof(string) })!, secondConstant!)),
+                    FilterOperator.DoesNotContain => Expression.Not(Expression.Call(notNullCheck(property), typeof(string).GetMethod("Contains", new[] { typeof(string) })!, secondConstant!)),
+                    FilterOperator.In => isEnumerable &&
+                                        isEnumerableProperty ?
+                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Any), new Type[] { collectionItemType! },
+                            Expression.Call(typeof(Enumerable), nameof(Enumerable.Intersect), new Type[] { collectionItemType! }, secondConstant!, notNullCheck(property))) :
+                        isNullableValueType ?
+                            (secondValueType!.IsArray ?
+                                Expression.Condition(
+                                    Expression.Property(property, "HasValue"),
+                                    Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                        new Type[] { secondValueType.GetElementType()! },
+                                        secondConstant!,
+                                        Expression.Property(property, "Value")),
+                                    Expression.Constant(false, typeof(bool))) :
+                                Expression.Condition(
+                                    Expression.Property(property, "HasValue"),
+                                    Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                        new Type[] { Nullable.GetUnderlyingType(property.Type!)! },
+                                        secondConstant!,
+                                        Expression.Property(property, "Value")),
+                                    Expression.Constant(false, typeof(bool)))) :
+                        isEnum ?
+                            Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                new Type[] { property.Type! }, secondConstant!, notNullCheck(property)) :
+                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                            new Type[] { property.Type ?? typeof(object) }, secondConstant!, notNullCheck(property)),
+                    FilterOperator.NotIn => isEnumerable &&
+                                        isEnumerableProperty ?
+                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Any), new Type[] { collectionItemType! },
+                            Expression.Call(typeof(Enumerable), nameof(Enumerable.Except), new Type[] { collectionItemType! }, secondConstant!, notNullCheck(property))) :
+                        isNullableValueType ?
+                            (secondValueType!.IsArray ?
+                                Expression.Condition(
+                                    Expression.Property(property, "HasValue"),
+                                    Expression.Not(
+                                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                            new Type[] { secondValueType.GetElementType()! },
+                                            secondConstant!,
+                                            Expression.Property(property, "Value"))),
+                                    Expression.Constant(true, typeof(bool))) :
+                                Expression.Condition(
+                                    Expression.Property(property, "HasValue"),
+                                    Expression.Not(
+                                        Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                            new Type[] { Nullable.GetUnderlyingType(property.Type!)! },
+                                            secondConstant!,
+                                            Expression.Property(property, "Value"))),
+                                    Expression.Constant(true, typeof(bool)))) :
+                        isEnum ?
+                            Expression.Not(Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                                new Type[] { property.Type! }, secondConstant!, notNullCheck(property))) :
+                        Expression.Not(Expression.Call(typeof(Enumerable), nameof(Enumerable.Contains),
+                            new Type[] { property.Type! }, secondConstant!, notNullCheck(property))),
                     FilterOperator.StartsWith => Expression.Call(notNullCheck(property), typeof(string).GetMethod("StartsWith", new[] { typeof(string) })!, secondConstant!),
                     FilterOperator.EndsWith => Expression.Call(notNullCheck(property), typeof(string).GetMethod("EndsWith", new[] { typeof(string) })!, secondConstant!),
                     FilterOperator.IsNull => Expression.Equal(rawProperty, Expression.Constant(null, rawProperty.Type)),


### PR DESCRIPTION
This pull request enhances the In and NotIn operators, particularly for nullable data types, and fixes inconsistencies when using combined filters.

- Nullable Support: In and NotIn now correctly check for HasValue before accessing nullable value types (e.g., int?, long?) to prevent exceptions.
- SecondFilterValue: Added support for these operators when used as the second part of a filter (e.g., via an OR connection).
- Bugfix: Fixed an issue in the DoesNotContain logic regarding the target type for string operations.
- Tests: Added new unit tests to validate filtering of nullable properties for both simple and combined filter scenarios.