### PR TITLE
RadzenMarkdown: skip link destinations that are not valid URIs instead of throwing

### DIFF
--- a/Radzen.Blazor.Tests/MarkdownComponentTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownComponentTests.cs
@@ -196,6 +196,22 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Markdown_Renders_Link_WithInvalidDestination_AsText()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            // "https://" has no host: NavigationManager.ToAbsoluteUri throws UriFormatException for it.
+            var component = ctx.RenderComponent<RadzenMarkdown>(parameters =>
+            {
+                parameters.Add(p => p.Text, "[Click here](https://)");
+            });
+
+            Assert.Contains("Click here", component.Markup);
+            Assert.DoesNotContain("https://", component.Markup);
+        }
+
+        [Fact]
         public void Markdown_EmptyText_StillRenders()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor/Rendering/BlazorMarkdownRenderer.cs
+++ b/Radzen.Blazor/Rendering/BlazorMarkdownRenderer.cs
@@ -212,7 +212,12 @@ internal class BlazorMarkdownRenderer(BlazorMarkdownRendererOptions options, Ren
         {
             builder.OpenComponent<RadzenLink>(0);
 
-            if (!string.IsNullOrEmpty(link.Destination) && !HtmlSanitizer.IsDangerousUrl(link.Destination))
+            // NavLink (used by RadzenLink) calls NavigationManager.ToAbsoluteUri(href), which throws
+            // UriFormatException for destinations like "https://" (empty host). Skip those instead
+            // of letting the exception take down the component tree.
+            if (!string.IsNullOrEmpty(link.Destination)
+                && !HtmlSanitizer.IsDangerousUrl(link.Destination)
+                && Uri.TryCreate(link.Destination, UriKind.RelativeOrAbsolute, out _))
             {
                 builder.AddAttribute(1, nameof(RadzenLink.Path), link.Destination);
             }


### PR DESCRIPTION
Fixes #2671

A markdown link whose destination is not a valid URI — e.g. `[x](https://)` with an empty host — made `RadzenMarkdown` throw `UriFormatException` (`net_uri_BadHostName`): `BlazorMarkdownRenderer.VisitLink` hands the destination to `RadzenLink.Path`, `RadzenLink` renders a `NavLink`, and `NavigationManager.ToAbsoluteUri` throws in `OnParametersSet`. The exception propagates to the nearest `ErrorBoundary`, so stored user content could take down an entire page.

This adds a `Uri.TryCreate(destination, UriKind.RelativeOrAbsolute, out _)` guard next to the existing `IsDangerousUrl` check, so invalid destinations render as link text without a path — the same treatment dangerous URLs already get.

Test added: `Markdown_Renders_Link_WithInvalidDestination_AsText` (fails with `UriFormatException` without the fix).