### PR TITLE
GetShortName() retrieval instead of Name

### DIFF
--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -271,9 +271,10 @@ namespace Radzen.Blazor
                 {
                     var displayAttr = propInfo.GetCustomAttributes(typeof(DisplayAttribute), true)
                         .FirstOrDefault() as DisplayAttribute;
-                    if (displayAttr?.Name != null)
+                    var shortName = displayAttr?.GetShortName();
+                    if (shortName != null)
                     {
-                        Title = displayAttr.Name;
+                        Title = shortName;
                     }
                 }
             }


### PR DESCRIPTION
`UseDisplayName` reads the raw `Name` property, which holds a resource key rather than a
display string. With `[Display(Name = "Key", ResourceType = typeof(Res))]` the grid renders
`Key` instead of the localized text.

This switches to `GetShortName()`, which resolves against `ResourceType` and falls back to
`GetName()`.

**Breaking:** a misconfigured `ResourceType` now throws `InvalidOperationException` instead
of rendering the raw key. This matches ASP.NET Core, where `DataAnnotationsMetadataProvider`
propagates the same exception. In Blazor Server it will tear down the circuit, so it's a
real behavior change for anyone currently relying on the silent fallback. The exception is
wrapped with the column and model name, since the BCL message doesn't identify either