### PR TITLE
RadzenDataGrid: reduce value-access and render-path allocation

### DIFF
--- a/Radzen.Blazor.Tests/DataGridCellClassMemoTests.cs
+++ b/Radzen.Blazor.Tests/DataGridCellClassMemoTests.cs
@@ -1,0 +1,110 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridCellClassMemoTests
+    {
+        class Item
+        {
+            public int Id { get; set; }
+        }
+
+        static IRenderedComponent<RadzenDataGrid<Item>> Render(TestContext ctx, Action<RenderTreeBuilderColumn> configure)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            return ctx.RenderComponent<RadzenDataGrid<Item>>(parameterBuilder =>
+            {
+                parameterBuilder.Add(p => p.Data, new List<Item> { new() { Id = 1 }, new() { Id = 2 } });
+                parameterBuilder.Add(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Item>));
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Item>.Property), "Id");
+                    configure(new RenderTreeBuilderColumn(builder));
+                    builder.CloseComponent();
+                });
+            });
+        }
+
+        readonly struct RenderTreeBuilderColumn(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+        {
+            public void Add(string name, object value) => builder.AddAttribute(10, name, value);
+        }
+
+        [Fact]
+        public void CachedCellCssClass_ReturnsCssClass_AndReusesTheSameStringAcrossCells()
+        {
+            using var ctx = new TestContext();
+            var column = Render(ctx, c => c.Add(nameof(RadzenDataGridColumn<Item>.CssClass), "my-cls")).Instance.ColumnsCollection.Single();
+
+            var first = column.GetCachedCellCssClass("", "");
+            var second = column.GetCachedCellCssClass("", "");
+
+            Assert.Equal("my-cls", first);
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void CachedCellCssClass_InvalidatesWhenCssClassChanges()
+        {
+            using var ctx = new TestContext();
+            var column = Render(ctx, c => c.Add(nameof(RadzenDataGridColumn<Item>.CssClass), "my-cls")).Instance.ColumnsCollection.Single();
+
+            Assert.Equal("my-cls", column.GetCachedCellCssClass("", ""));
+
+            column.CssClass = "other";
+
+            Assert.Equal("other", column.GetCachedCellCssClass("", ""));
+        }
+
+        [Fact]
+        public void CachedCellCssClass_InvalidatesWhenFrozenOrCompositeChanges()
+        {
+            using var ctx = new TestContext();
+            var column = Render(ctx, c => c.Add(nameof(RadzenDataGridColumn<Item>.CssClass), "my-cls")).Instance.ColumnsCollection.Single();
+
+            Assert.Equal("my-cls", column.GetCachedCellCssClass("", ""));
+            Assert.Equal("my-cls rz-composite-cell", column.GetCachedCellCssClass("", "rz-composite-cell"));
+        }
+
+        [Fact]
+        public void DataCell_RendersColumnCssClass()
+        {
+            using var ctx = new TestContext();
+            var cut = Render(ctx, c => c.Add(nameof(RadzenDataGridColumn<Item>.CssClass), "my-cls"));
+
+            var cells = cut.FindAll("td[role=\"gridcell\"]");
+            Assert.NotEmpty(cells);
+            Assert.All(cells, cell => Assert.Contains("my-cls", cell.GetAttribute("class") ?? ""));
+        }
+
+        [Fact]
+        public void CalculatedCssClass_AppliesDistinctClassPerRow()
+        {
+            using var ctx = new TestContext();
+            Func<RadzenDataGridColumn<Item>, Item, string> calc = (_, item) => item.Id == 1 ? "cls-a" : "cls-b";
+            var cut = Render(ctx, c => c.Add(nameof(RadzenDataGridColumn<Item>.CalculatedCssClass), calc));
+
+            var classes = cut.FindAll("td[role=\"gridcell\"]").Select(c => c.GetAttribute("class") ?? "").ToList();
+            Assert.Contains(classes, c => c.Contains("cls-a"));
+            Assert.Contains(classes, c => c.Contains("cls-b"));
+        }
+
+        [Fact]
+        public void ShowCellDataAsTooltip_RendersTitle_WithLazySpanAttributes()
+        {
+            using var ctx = new TestContext();
+            var cut = Render(ctx, c => c.Add(nameof(RadzenDataGridColumn<Item>.ShowCellDataAsTooltip), true));
+
+            var titled = cut.FindAll("span[title]");
+            Assert.Contains(titled, s => s.GetAttribute("title") == "1");
+            Assert.Contains(titled, s => s.GetAttribute("title") == "2");
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridCellStyleMemoTests.cs
+++ b/Radzen.Blazor.Tests/DataGridCellStyleMemoTests.cs
@@ -1,0 +1,61 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridCellStyleMemoTests
+    {
+        class Item
+        {
+            public int Id { get; set; }
+        }
+
+        static IRenderedComponent<RadzenDataGrid<Item>> Render(TestContext ctx)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            return ctx.RenderComponent<RadzenDataGrid<Item>>(parameterBuilder =>
+            {
+                parameterBuilder.Add(p => p.Data, new List<Item> { new() { Id = 1 }, new() { Id = 2 } });
+                parameterBuilder.Add(p => p.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Item>));
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Item>.Property), "Id");
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Item>.TextAlign), TextAlign.Right);
+                    builder.CloseComponent();
+                });
+            });
+        }
+
+        [Fact]
+        public void GetStyle_ReturnsCellStyle_AndReusesTheSameStringAcrossCells()
+        {
+            using var ctx = new TestContext();
+            var column = Render(ctx).Instance.ColumnsCollection.Single();
+
+            var first = column.GetStyle(forCell: true);
+            var second = column.GetStyle(forCell: true);
+
+            Assert.Contains("text-align:right", first);
+            // The row-independent data-cell style is memoized, so repeated calls reuse the same string.
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void GetStyle_Memo_InvalidatesWhenInputChanges()
+        {
+            using var ctx = new TestContext();
+            var column = Render(ctx).Instance.ColumnsCollection.Single();
+
+            Assert.Contains("text-align:right", column.GetStyle(forCell: true));
+
+            column.TextAlign = TextAlign.Center;
+
+            Assert.Contains("text-align:center", column.GetStyle(forCell: true));
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridFilterOperatorCacheTests.cs
+++ b/Radzen.Blazor.Tests/DataGridFilterOperatorCacheTests.cs
@@ -1,0 +1,88 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridFilterOperatorCacheTests
+    {
+        class Item
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+        }
+
+        static RadzenDataGridColumn<Item> Column(TestContext ctx, string property, IEnumerable<FilterOperator> operators = null)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var grid = ctx.RenderComponent<RadzenDataGrid<Item>>(p =>
+            {
+                p.Add(g => g.Data, new List<Item> { new() { Name = "a", Count = 1 } });
+                p.Add(g => g.AllowFiltering, true);
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Item>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Item>.Property), property);
+                    if (operators != null)
+                    {
+                        b.AddAttribute(2, nameof(RadzenDataGridColumn<Item>.FilterOperators), operators);
+                    }
+                    b.CloseComponent();
+                });
+            });
+
+            return grid.Instance.ColumnsCollection.Single();
+        }
+
+        [Fact]
+        public void GetFilterOperators_IsMemoized_AndReturnsCorrectOperators()
+        {
+            using var ctx = new TestContext();
+            var column = Column(ctx, "Name");
+
+            var first = column.GetFilterOperators();
+            var second = column.GetFilterOperators();
+
+            // Same materialized instance reused across calls within a render.
+            Assert.Same(first, second);
+
+            // String columns expose the string operators.
+            Assert.Contains(FilterOperator.Contains, first);
+            Assert.Contains(FilterOperator.StartsWith, first);
+            Assert.DoesNotContain(FilterOperator.Custom, first);
+        }
+
+        [Fact]
+        public void GetFilterOperators_ReturnsCallerProvidedCollectionLive()
+        {
+            using var ctx = new TestContext();
+            var operators = new List<FilterOperator> { FilterOperator.Equals, FilterOperator.NotEquals };
+            var column = Column(ctx, "Name", operators);
+
+            Assert.Equal(operators, column.GetFilterOperators());
+
+            // An in-place change to the bound collection is honored, not masked by a stale cached array.
+            operators.Add(FilterOperator.IsNull);
+            Assert.Contains(FilterOperator.IsNull, column.GetFilterOperators());
+        }
+
+        [Fact]
+        public void GetFilterOperators_DiffersByColumnType()
+        {
+            using var ctx = new TestContext();
+            var stringOps = Column(ctx, "Name").GetFilterOperators().ToList();
+
+            using var ctx2 = new TestContext();
+            var numericOps = Column(ctx2, "Count").GetFilterOperators().ToList();
+
+            // Numeric columns get comparison operators but not string ones.
+            Assert.Contains(FilterOperator.GreaterThan, numericOps);
+            Assert.DoesNotContain(FilterOperator.Contains, numericOps);
+            Assert.Contains(FilterOperator.Contains, stringOps);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridRegressionCoverageTests.cs
+++ b/Radzen.Blazor.Tests/DataGridRegressionCoverageTests.cs
@@ -1,0 +1,298 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    /// <summary>
+    /// Regression coverage for RadzenDataGrid render paths that the allocation/perf work touched:
+    /// value access (nested, format, enum), cell/row styling (frozen, min/max), selection membership
+    /// (with and without KeyProperty), and CellRender/RowRender attribute callbacks. These assert the
+    /// user-visible output so the optimizations cannot silently change behavior.
+    /// </summary>
+    public class DataGridRegressionCoverageTests
+    {
+        public enum Status { Active, Inactive }
+
+        public class Address
+        {
+            public string City { get; set; }
+        }
+
+        public class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public decimal Salary { get; set; }
+            public Status Status { get; set; }
+            public Address Address { get; set; }
+        }
+
+        static List<Person> People() => new()
+        {
+            new Person { Id = 1, Name = "Alice", Salary = 5m, Status = Status.Active, Address = new Address { City = "Paris" } },
+            new Person { Id = 2, Name = "Bob", Salary = 7m, Status = Status.Inactive, Address = new Address { City = "Berlin" } },
+        };
+
+        static TestContext NewCtx()
+        {
+            var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+            return ctx;
+        }
+
+        // ---- value access ------------------------------------------------------------------------
+
+        [Fact]
+        public void NestedStringProperty_RendersCellValue()
+        {
+            using var ctx = NewCtx();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People());
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Address.City");
+                    b.CloseComponent();
+                });
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("Paris", cells[0].TextContent.Trim());
+            Assert.Equal("Berlin", cells[1].TextContent.Trim());
+        }
+
+        [Fact]
+        public void FormatString_RendersFormattedValue()
+        {
+            using var ctx = NewCtx();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People());
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Salary");
+                    b.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.FormatString), "{0:0.00}");
+                    b.CloseComponent();
+                });
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("5.00", cells[0].TextContent.Trim());
+            Assert.Equal("7.00", cells[1].TextContent.Trim());
+        }
+
+        [Fact]
+        public void EnumProperty_RendersDisplayValue()
+        {
+            using var ctx = NewCtx();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People());
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Status");
+                    b.CloseComponent();
+                });
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("Active", cells[0].TextContent.Trim());
+            Assert.Equal("Inactive", cells[1].TextContent.Trim());
+        }
+
+        // ---- styling -----------------------------------------------------------------------------
+
+        [Fact]
+        public void FrozenColumn_RendersFrozenCellClass()
+        {
+            using var ctx = NewCtx();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People());
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    b.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.Frozen), true);
+                    b.CloseComponent();
+
+                    b.OpenComponent(10, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(11, nameof(RadzenDataGridColumn<Person>.Property), "Salary");
+                    b.CloseComponent();
+                });
+            });
+
+            Assert.Contains("rz-frozen-cell", component.Markup);
+        }
+
+        [Fact]
+        public void MinMaxWidth_RendersInCellStyle()
+        {
+            using var ctx = NewCtx();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People());
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    b.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.MinWidth), "80px");
+                    b.AddAttribute(3, nameof(RadzenDataGridColumn<Person>.MaxWidth), "200px");
+                    b.CloseComponent();
+                });
+            });
+
+            Assert.Contains("min-width:80px", component.Markup);
+            Assert.Contains("max-width:200px", component.Markup);
+        }
+
+        // ---- selection membership ----------------------------------------------------------------
+
+        [Fact]
+        public async Task Selection_HighlightsSelectedRow()
+        {
+            using var ctx = NewCtx();
+            var people = People();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, people);
+                p.Add(g => g.SelectionMode, DataGridSelectionMode.Single);
+                p.Add(g => g.RowSelect, EventCallback.Factory.Create<Person>(this, _ => { }));
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    b.CloseComponent();
+                });
+            });
+
+            Assert.DoesNotContain("rz-state-highlight", component.Markup);
+
+            await component.InvokeAsync(() => component.Instance.SelectRow(people[0]));
+
+            Assert.Contains("rz-state-highlight", component.Markup);
+        }
+
+        [Fact]
+        public async Task Selection_WithKeyProperty_MatchesByKeyAcrossInstances()
+        {
+            using var ctx = NewCtx();
+            var people = People();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, people);
+                p.Add(g => g.KeyProperty, "Id");
+                p.Add(g => g.SelectionMode, DataGridSelectionMode.Single);
+                p.Add(g => g.RowSelect, EventCallback.Factory.Create<Person>(this, _ => { }));
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    b.CloseComponent();
+                });
+            });
+
+            await component.InvokeAsync(() => component.Instance.SelectRow(people[0]));
+            Assert.Contains("rz-state-highlight", component.Markup);
+
+            var highlightedBefore = component.FindAll("tr.rz-state-highlight").Count;
+            Assert.Equal(1, highlightedBefore);
+
+            // Rebind to brand-new instances with the same keys. Selection is by KeyProperty, so the row
+            // whose Id matches the previously selected item must stay highlighted (exercises the
+            // keyPropertyGetter comparison path, not reference equality).
+            var rebound = new List<Person>
+            {
+                new Person { Id = 1, Name = "Alice II", Address = new Address { City = "Paris" } },
+                new Person { Id = 2, Name = "Bob II", Address = new Address { City = "Berlin" } },
+            };
+            component.SetParametersAndRender(p => p.Add(g => g.Data, rebound));
+
+            var highlighted = component.FindAll("tr.rz-state-highlight");
+            Assert.Single(highlighted);
+            Assert.Contains("Alice II", highlighted[0].TextContent);
+        }
+
+        // ---- render callbacks --------------------------------------------------------------------
+
+        [Fact]
+        public void CellRender_AddsAttributeToCell()
+        {
+            using var ctx = NewCtx();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People());
+                p.Add(g => g.CellRender, args => args.Attributes["data-city"] = "yes");
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    b.CloseComponent();
+                });
+            });
+
+            Assert.Contains("data-city=\"yes\"", component.Markup);
+        }
+
+        [Fact]
+        public void RowRender_AddsAttributeToRow()
+        {
+            using var ctx = NewCtx();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People());
+                p.Add(g => g.RowRender, args => args.Attributes["data-row"] = "r");
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    b.CloseComponent();
+                });
+            });
+
+            Assert.Contains("data-row=\"r\"", component.Markup);
+        }
+
+        // ---- in-place mutation must re-render (why the row has no reference-equality ShouldRender) -----
+
+        // The grid's rows carry no ShouldRender override on purpose: a row renders the item's *current*
+        // property values, and the common Radzen refresh pattern mutates a bound item in place (same
+        // object reference) and calls Reload(). The row must re-render to show the new value even though
+        // its Item reference, Index and selection are all unchanged. A reference-equality ShouldRender on
+        // the row (the optimization that is safe for the immutable dropdown-item list) would skip this
+        // render and display a stale cell. This test locks in that requirement.
+        [Fact]
+        public async Task InPlaceMutation_ThenReload_UpdatesCell()
+        {
+            using var ctx = NewCtx();
+            var people = People();
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, people);
+                p.Add(g => g.Columns, b =>
+                {
+                    b.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    b.CloseComponent();
+                });
+            });
+
+            Assert.Equal("Alice", component.FindAll(".rz-cell-data")[0].TextContent.Trim());
+
+            // Mutate the bound item in place - same reference, no collection change.
+            people[0].Name = "Alicia";
+            await component.InvokeAsync(() => component.Instance.Reload());
+
+            Assert.Equal("Alicia", component.FindAll(".rz-cell-data")[0].TextContent.Trim());
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridRowClickDispatchTests.cs
+++ b/Radzen.Blazor.Tests/DataGridRowClickDispatchTests.cs
@@ -1,0 +1,129 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    // Row clicks are raised once per row from the <tr> (RowAttributes), cell clicks once per cell from
+    // the <td>.
+    public class DataGridRowClickDispatchTests
+    {
+        class Item
+        {
+            public int Id { get; set; }
+        }
+
+        static IRenderedComponent<RadzenDataGrid<Item>> Render(TestContext ctx,
+            System.Action<ComponentParameterCollectionBuilder<RadzenDataGrid<Item>>> extra)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            return ctx.RenderComponent<RadzenDataGrid<Item>>(pb =>
+            {
+                pb.Add(p => p.Data, new List<Item> { new() { Id = 1 }, new() { Id = 2 } });
+                pb.Add(p => p.Columns, b =>
+                {
+                    b.OpenComponent<RadzenDataGridColumn<Item>>(0);
+                    b.AddAttribute(1, nameof(RadzenDataGridColumn<Item>.Property), "Id");
+                    b.CloseComponent();
+                });
+                extra(pb);
+            });
+        }
+
+        [Fact]
+        public void RowClick_FiresFromTheRowElement_WithThatRowsData()
+        {
+            using var ctx = new TestContext();
+            Item? clicked = null;
+            var cut = Render(ctx, pb => pb.Add(p => p.RowClick, (DataGridRowMouseEventArgs<Item> a) => clicked = a.Data));
+
+            cut.FindAll("tr.rz-data-row")[1].Click();
+
+            Assert.NotNull(clicked);
+            Assert.Equal(2, clicked!.Id);
+        }
+
+        [Fact]
+        public void RowClick_SelectsTheRow_WhenSelectionIsOn()
+        {
+            using var ctx = new TestContext();
+            Item? selected = null;
+            var cut = Render(ctx, pb =>
+            {
+                pb.Add(p => p.SelectionMode, DataGridSelectionMode.Single);
+                pb.Add(p => p.RowSelect, (Item i) => selected = i);
+            });
+
+            cut.FindAll("tr.rz-data-row")[0].Click();
+
+            Assert.NotNull(selected);
+            Assert.Equal(1, selected!.Id);
+        }
+
+        [Fact]
+        public void CellClick_StillFiresFromTheCell_WithItsColumn()
+        {
+            using var ctx = new TestContext();
+            string? column = null;
+            var cut = Render(ctx, pb => pb.Add(p => p.CellClick, (DataGridCellMouseEventArgs<Item> a) => column = a.Column?.Property));
+
+            cut.FindAll("td[role=\"gridcell\"]")[0].Click();
+
+            Assert.Equal("Id", column);
+        }
+
+        [Fact]
+        public void RowRender_Onclick_IsPreserved_AndRunsAfterTheBuiltInRowClick()
+        {
+            using var ctx = new TestContext();
+            var order = new List<string>();
+            var cut = Render(ctx, pb =>
+            {
+                pb.Add(p => p.RowClick, (DataGridRowMouseEventArgs<Item> _) => order.Add("row"));
+                pb.Add(p => p.RowRender, (RowRenderEventArgs<Item> a) =>
+                    a.Attributes["onclick"] = (System.Action)(() => order.Add("consumer")));
+            });
+
+            cut.FindAll("tr.rz-data-row")[1].Click();
+
+            // Both fire, and the built-in row click (with its selection) runs first, so a consumer
+            // onclick that reads selection state still sees the post-click state.
+            Assert.Equal(new[] { "row", "consumer" }, order);
+        }
+
+        [Fact]
+        public void RowRender_StringOnclick_IsKept_AndBuiltInRowClickStillFiresFromTheCell()
+        {
+            using var ctx = new TestContext();
+            // A string HTML handler can't be chained with the built-in delegate, so it stays verbatim on the
+            // row and the built-in row click is raised from the cell instead - both must survive.
+            Item? rowClicked = null;
+            var cut = Render(ctx, pb =>
+            {
+                pb.Add(p => p.RowClick, (DataGridRowMouseEventArgs<Item> a) => rowClicked = a.Data);
+                pb.Add(p => p.RowRender, (RowRenderEventArgs<Item> a) => a.Attributes["onclick"] = "window.probe=true");
+            });
+
+            var row = cut.FindAll("tr.rz-data-row")[1];
+            Assert.Equal("window.probe=true", row.GetAttribute("onclick"));
+
+            row.QuerySelector("td[role=\"gridcell\"]")!.Click();
+            Assert.NotNull(rowClicked);
+            Assert.Equal(2, rowClicked!.Id);
+        }
+
+        [Fact]
+        public void NoRowHandler_IsWired_WhenNoRowOrCellClickIsSet()
+        {
+            using var ctx = new TestContext();
+            var cut = Render(ctx, _ => { });
+
+            var row = cut.FindAll("tr.rz-data-row")[0];
+            Assert.DoesNotContain("onclick", row.Attributes.Select(a => a.Name));
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridValueGetterTests.cs
+++ b/Radzen.Blazor.Tests/DataGridValueGetterTests.cs
@@ -1,0 +1,176 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridValueGetterTests
+    {
+        class Address
+        {
+            public string City { get; set; }
+            public int ZipCode { get; set; }
+        }
+
+        struct Detail
+        {
+            public int Level { get; set; }
+        }
+
+        class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public Address Address { get; set; }
+            public Detail? Detail { get; set; }
+        }
+
+        static List<Person> People() => new()
+        {
+            new Person { Id = 1, Name = "Charlie", Address = new Address { City = "Paris" } },
+            new Person { Id = 2, Name = "Alice", Address = new Address { City = "Berlin" } },
+            new Person { Id = 3, Name = "Bob", Address = new Address { City = "London" } },
+        };
+
+        static List<Person> PeopleWithNullAddress() => new()
+        {
+            new Person { Id = 1, Name = "Charlie", Address = new Address { City = "Paris", ZipCode = 75001 }, Detail = new Detail { Level = 7 } },
+            new Person { Id = 2, Name = "NoAddress", Address = null, Detail = null },
+        };
+
+        static IRenderedComponent<RadzenDataGrid<Person>> RenderGrid(TestContext ctx, RenderFragment columns)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            return ctx.RenderComponent<RadzenDataGrid<Person>>(parameterBuilder =>
+            {
+                parameterBuilder.Add(p => p.Data, People());
+                parameterBuilder.Add(p => p.AllowSorting, true);
+                parameterBuilder.Add(p => p.Columns, columns);
+            });
+        }
+
+        static IRenderedComponent<RadzenDataGrid<Person>> RenderGridWith(TestContext ctx, List<Person> data, RenderFragment columns)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+            return ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, data);
+                p.Add(g => g.Columns, columns);
+            });
+        }
+
+        // A null intermediate on a nested path must render an empty cell, matching the reflection-based value
+        // access the compiled getter replaced - not a NullReferenceException, and not the leaf type's default
+        // (e.g. "0" for an int leaf).
+
+        [Fact]
+        public void StringProperty_NestedValueTypeLeaf_NullIntermediate_RendersEmptyNotDefault()
+        {
+            using var ctx = new TestContext();
+            var component = RenderGridWith(ctx, PeopleWithNullAddress(), builder =>
+            {
+                builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Address.ZipCode");
+                builder.CloseComponent();
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("75001", cells[0].TextContent.Trim());
+            Assert.Equal("", cells[1].TextContent.Trim()); // null Address -> empty, not "0"
+        }
+
+        [Fact]
+        public void StringProperty_NullableValueTypeIntermediate_NullIntermediate_RendersEmptyNotDefault()
+        {
+            using var ctx = new TestContext();
+            // "Detail.Level" where Detail is a Nullable<Detail> (a value type). A null Detail must render
+            // empty, not the leaf int's default "0".
+            var component = RenderGridWith(ctx, PeopleWithNullAddress(), builder =>
+            {
+                builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Detail.Level");
+                builder.CloseComponent();
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("7", cells[0].TextContent.Trim());
+            Assert.Equal("", cells[1].TextContent.Trim()); // null Detail -> empty, not "0"
+        }
+
+        [Fact]
+        public void StringProperty_ExplicitNullableValueInPath_NullIntermediate_RendersEmptyNotThrows()
+        {
+            using var ctx = new TestContext();
+            // "Detail.Value.Level" writes the Nullable<Detail>.Value access explicitly. A null Detail must
+            // guard the .Value (rendering empty), not throw InvalidOperationException.
+            var component = RenderGridWith(ctx, PeopleWithNullAddress(), builder =>
+            {
+                builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Detail.Value.Level");
+                builder.CloseComponent();
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("7", cells[0].TextContent.Trim());
+            Assert.Equal("", cells[1].TextContent.Trim()); // null Detail -> empty, not a throw
+        }
+
+        [Fact]
+        public void StringProperty_HasValueInPath_KeepsBooleanSemantics()
+        {
+            using var ctx = new TestContext();
+            // "Detail.HasValue" must read the boolean, returning false for a null Detail rather than empty.
+            var component = RenderGridWith(ctx, PeopleWithNullAddress(), builder =>
+            {
+                builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Detail.HasValue");
+                builder.CloseComponent();
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("True", cells[0].TextContent.Trim());
+            Assert.Equal("False", cells[1].TextContent.Trim());
+        }
+
+        [Fact]
+        public void StringProperty_NestedReferenceLeaf_NullIntermediate_RendersEmpty()
+        {
+            using var ctx = new TestContext();
+            var component = RenderGridWith(ctx, PeopleWithNullAddress(), builder =>
+            {
+                builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Address.City");
+                builder.CloseComponent();
+            });
+
+            var cells = component.FindAll(".rz-cell-data");
+            Assert.Equal("Paris", cells[0].TextContent.Trim());
+            Assert.Equal("", cells[1].TextContent.Trim());
+        }
+
+        [Fact]
+        public void ChangingProperty_RebuildsCachedValueGetter()
+        {
+            using var ctx = new TestContext();
+            var component = RenderGrid(ctx, builder =>
+            {
+                builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                builder.CloseComponent();
+            });
+
+            var column = component.Instance.ColumnsCollection.Single();
+            Assert.Equal("Charlie", column.GetValue(People()[0]));
+
+            // A reused column instance whose Property parameter changes must not keep the old getter.
+            column.Property = "Id";
+            Assert.Equal("1", column.GetValue(People()[0]));
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/PropertyAccessTests.cs
+++ b/Radzen.Blazor.Tests/PropertyAccessTests.cs
@@ -12,6 +12,27 @@ namespace Radzen.Blazor.Tests
             public string Property { get; set; }
         }
 
+        class CountingHolder
+        {
+            public int InnerReads;
+            private SimpleObject inner;
+            public SimpleObject Inner { get { InnerReads++; return inner; } set { inner = value; } }
+        }
+
+        [Fact]
+        public void NullSafeGetter_ReadsEachIntermediateOnce()
+        {
+            // A computed/side-effecting intermediate must be read once, not once for the null-check and again
+            // for the leaf - otherwise a getter returning a value then null would throw.
+            var holder = new CountingHolder { Inner = new SimpleObject { Prop1 = "X" } };
+            var getter = PropertyAccess.NullSafeGetter<CountingHolder>("Inner.Prop1");
+
+            var value = getter(holder);
+
+            Assert.Equal("X", value);
+            Assert.Equal(1, holder.InnerReads);
+        }
+
         [Fact]
         public void Getter_With_DifferentTargetType()
         {

--- a/Radzen.Blazor.Tests/QueryableExtensionCaseInsensitiveTests.cs
+++ b/Radzen.Blazor.Tests/QueryableExtensionCaseInsensitiveTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Radzen;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    // In-memory case-insensitive string filtering compares with OrdinalIgnoreCase (no per-row ToLower
+    // allocation); a non-in-memory (e.g. EF) source keeps the ToLower path so it can translate to SQL.
+    public class QueryableExtensionCaseInsensitiveTests
+    {
+        private class Item
+        {
+            public string Name { get; set; }
+        }
+
+        private static IQueryable<Item> Data() => new List<Item>
+        {
+            new() { Name = "Alice" },
+            new() { Name = "BOB" },
+            new() { Name = "charlie" },
+            new() { Name = null },
+        }.AsQueryable();
+
+        private static List<FilterDescriptor> Filter(FilterOperator op, string value) =>
+            [ new FilterDescriptor { Property = "Name", FilterProperty = "Name", Type = typeof(string), FilterValue = value, FilterOperator = op } ];
+
+        [Theory]
+        [InlineData(FilterOperator.Contains, "LIC", new[] { "Alice" })]
+        [InlineData(FilterOperator.Contains, "b", new[] { "BOB" })]
+        [InlineData(FilterOperator.Equals, "alice", new[] { "Alice" })]
+        [InlineData(FilterOperator.StartsWith, "CHAR", new[] { "charlie" })]
+        [InlineData(FilterOperator.EndsWith, "OB", new[] { "BOB" })]
+        public void InMemory_CaseInsensitive_Matches_RegardlessOfCase(FilterOperator op, string value, string[] expected)
+        {
+            var result = Data().Where(Filter(op, value), LogicalFilterOperator.And, FilterCaseSensitivity.CaseInsensitive)
+                .Select(i => i.Name).ToList();
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void InMemory_CaseInsensitive_DoesNotContain_ExcludesMatchRegardlessOfCase()
+        {
+            var result = Data().Where(Filter(FilterOperator.DoesNotContain, "LIC"), LogicalFilterOperator.And, FilterCaseSensitivity.CaseInsensitive)
+                .Select(i => i.Name).ToList();
+
+            Assert.DoesNotContain("Alice", result);
+            Assert.Contains("BOB", result);
+        }
+
+        [Fact]
+        public void InMemory_CaseInsensitive_NonStringFilterValue_IsStringified_NotThrown()
+        {
+            // A non-string FilterValue on a string column must be coerced to string; passing it straight
+            // into Expression.Constant(value, typeof(string)) on the ordinal path would throw ArgumentException.
+            var data = new List<Item> { new() { Name = "Order 42" }, new() { Name = "Order 7" } }.AsQueryable();
+            var filter = new List<FilterDescriptor>
+            {
+                new() { Property = "Name", FilterProperty = "Name", Type = typeof(string), FilterValue = 42, FilterOperator = FilterOperator.Contains }
+            };
+
+            var result = data.Where(filter, LogicalFilterOperator.And, FilterCaseSensitivity.CaseInsensitive)
+                .Select(i => i.Name).ToList();
+
+            Assert.Equal(new[] { "Order 42" }, result);
+        }
+
+        [Fact]
+        public void InMemory_CaseInsensitive_UsesOrdinalIgnoreCase_NotToLower()
+        {
+            var parameter = Expression.Parameter(typeof(Item), "x");
+            var filter = Filter(FilterOperator.Contains, "lic")[0];
+
+            var inMemory = QueryableExtension.GetExpression<Item>(parameter, filter, FilterCaseSensitivity.CaseInsensitive, typeof(string), useOrdinalIgnoreCaseStrings: true)!.ToString();
+            Assert.Contains("OrdinalIgnoreCase", inMemory);
+            Assert.DoesNotContain("ToLower", inMemory);
+
+            // The default (EF-safe) path still lowers, so it can translate to SQL LOWER().
+            var efSafe = QueryableExtension.GetExpression<Item>(parameter, filter, FilterCaseSensitivity.CaseInsensitive, typeof(string))!.ToString();
+            Assert.Contains("ToLower", efSafe);
+            Assert.DoesNotContain("OrdinalIgnoreCase", efSafe);
+        }
+    }
+}

--- a/Radzen.Blazor/GroupRowRenderEventArgs.cs
+++ b/Radzen.Blazor/GroupRowRenderEventArgs.cs
@@ -7,10 +7,18 @@ namespace Radzen;
 /// </summary>
 public class GroupRowRenderEventArgs
 {
+    private IDictionary<string, object>? attributes;
+
     /// <summary>
     /// Gets or sets the group row HTML attributes. They will apply to the table row (tr) element which RadzenDataGrid renders for every group row.
     /// </summary>
-    public IDictionary<string, object> Attributes { get; private set; } = new Dictionary<string, object>();
+    /// <remarks>The backing dictionary is allocated on first access, so a group row with no GroupRowRender handler pays nothing.</remarks>
+    public IDictionary<string, object> Attributes => attributes ??= new Dictionary<string, object>();
+
+    /// <summary>
+    /// Whether any attributes were added, without forcing the backing dictionary to be allocated.
+    /// </summary>
+    internal bool HasAttributes => attributes is { Count: > 0 };
 
     /// <summary>
     /// Gets the data item which the current row represents.

--- a/Radzen.Blazor/PropertyAccess.cs
+++ b/Radzen.Blazor/PropertyAccess.cs
@@ -16,6 +16,8 @@ public static class PropertyAccess
 {
     private static readonly ConcurrentDictionary<(Type ItemType, Type ValueType, string PropertyName, Type? TargetType), Delegate> getterCache = new();
 
+    private static readonly ConcurrentDictionary<(Type ItemType, string PropertyName, Type? TargetType), Delegate> nullSafeGetterCache = new();
+
     /// <summary>
     /// Creates a function that will return the specified property. The compiled function is cached so repeated calls with the same arguments do not recompile it.
     /// </summary>
@@ -33,8 +35,24 @@ public static class PropertyAccess
             _ => CreateGetter<TItem, TValue>(propertyName, type));
     }
 
+    /// <summary>
+    /// Like <see cref="Getter{TItem, TValue}"/> for an <see cref="object"/> value, but a null intermediate along a dotted path yields null rather than the leaf type's default. The compiled function is cached.
+    /// </summary>
+    /// <typeparam name="TItem">The owner type.</typeparam>
+    /// <param name="propertyName">Name of the property to return.</param>
+    /// <param name="type">Type of the object.</param>
+    /// <returns>A function which returns the specified property, or null if an intermediate member is null.</returns>
     [RequiresUnreferencedCode(TrimMessages.ExpressionTreeReflection)]
-    private static Func<TItem, TValue> CreateGetter<TItem, TValue>(string propertyName, Type? type)
+    public static Func<TItem, object> NullSafeGetter<TItem>(string propertyName, Type? type = null)
+    {
+        ArgumentNullException.ThrowIfNull(propertyName);
+
+        return (Func<TItem, object>)nullSafeGetterCache.GetOrAdd((typeof(TItem), propertyName, type),
+            _ => CreateGetter<TItem, object>(propertyName, type, nullToNull: true));
+    }
+
+    [RequiresUnreferencedCode(TrimMessages.ExpressionTreeReflection)]
+    private static Func<TItem, TValue> CreateGetter<TItem, TValue>(string propertyName, Type? type, bool nullToNull = false)
     {
         if (propertyName.Contains('[', StringComparison.Ordinal))
         {
@@ -116,13 +134,49 @@ public static class PropertyAccess
             return AccessNoInterface(instance, memberName);
         }
 
+        // When nullToNull is set, a null intermediate makes the whole result null rather than the leaf type's
+        // default. Each step is stored in a local so a computed or side-effecting member is read exactly once.
+        var locals = new List<ParameterExpression>();
+        var steps = new List<Expression>();
+        Expression? nullGuard = null;
+
         foreach (var member in propertyName.Split('.'))
         {
-            body = AccessWithNullPropagation(body, member);
+            var instance = Expression.Variable(body.Type);
+            locals.Add(instance);
+            steps.Add(Expression.Assign(instance, body));
+
+            if (nullToNull && !instance.Type.IsValueType)
+            {
+                var isNull = Expression.Equal(instance, Expression.Constant(null, instance.Type));
+                nullGuard = nullGuard == null ? isNull : Expression.OrElse(nullGuard, isNull);
+                var accessed = AccessNoInterface(instance, member);
+                body = Expression.Condition(isNull, Expression.Default(accessed.Type), accessed);
+            }
+            else if (nullToNull && Nullable.GetUnderlyingType(instance.Type) != null && member != "HasValue")
+            {
+                // A null Nullable<T> yields null. This also guards an explicit ".Value" in the path (which would
+                // otherwise throw); ".HasValue" keeps its boolean semantics and falls through unguarded below.
+                var hasValue = Expression.Property(instance, "HasValue");
+                nullGuard = nullGuard == null ? Expression.Not(hasValue) : Expression.OrElse(nullGuard, Expression.Not(hasValue));
+                var value = Expression.Property(instance, "Value");
+                var accessed = member == "Value" ? (Expression)value : AccessNoInterface(value, member);
+                body = Expression.Condition(hasValue, accessed, Expression.Default(accessed.Type));
+            }
+            else
+            {
+                body = AccessWithNullPropagation(instance, member);
+            }
         }
 
         body = Expression.Convert(body, typeof(TValue));
-        return Expression.Lambda<Func<TItem, TValue>>(body, arg).Compile();
+        if (nullGuard != null)
+        {
+            body = Expression.Condition(nullGuard, Expression.Default(typeof(TValue)), body);
+        }
+
+        steps.Add(body);
+        return Expression.Lambda<Func<TItem, TValue>>(Expression.Block(locals, steps), arg).Compile();
     }
 
     /// <summary>

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -572,9 +572,13 @@ namespace Radzen
             var parameter = Expression.Parameter(typeof(T), "x");
             Expression? combinedExpression = null;
 
+            // Only an in-memory (LINQ-to-Objects) source can use OrdinalIgnoreCase string comparisons;
+            // a provider such as EF Core can't translate them and needs the ToLower path.
+            var inMemory = source is System.Linq.EnumerableQuery;
+
             foreach (var filter in filterList)
             {
-                var expression = GetExpression<T>(parameter, filter, filterCaseSensitivity, filter.Type ?? typeof(object));
+                var expression = GetExpression<T>(parameter, filter, filterCaseSensitivity, filter.Type ?? typeof(object), inMemory);
                 if (expression == null)
                 {
                     continue;
@@ -770,7 +774,7 @@ namespace Radzen
         }
 
         [RequiresUnreferencedCode(ReflectionWarning)]
-        internal static Expression GetExpression<T>(ParameterExpression parameter, FilterDescriptor filter, FilterCaseSensitivity filterCaseSensitivity, Type type)
+        internal static Expression GetExpression<T>(ParameterExpression parameter, FilterDescriptor filter, FilterCaseSensitivity filterCaseSensitivity, Type type, bool useOrdinalIgnoreCaseStrings = false)
         {
             Type? valueType = filter.FilterValue != null ? filter.FilterValue.GetType() : null;
             var isEnumerable = valueType != null && IsEnumerable(valueType) && valueType != typeof(string);
@@ -799,9 +803,14 @@ namespace Radzen
             var isEnum = !isEnumerable && (PropertyAccess.IsEnum(property.Type) || PropertyAccess.IsNullableEnum(property.Type));
             var caseInsensitive = property.Type == typeof(string) && !isEnumerable && filterCaseSensitivity == FilterCaseSensitivity.CaseInsensitive;
 
+            // EF can't translate the StringComparison overloads, so only an in-memory source uses them.
+            var useOrdinal = caseInsensitive && useOrdinalIgnoreCaseStrings;
+
             var isEnumerableProperty = IsEnumerable(property.Type) && property.Type != typeof(string);
 
-            var constantValue = caseInsensitive
+            var constantValue = useOrdinal
+                ? $"{filter.FilterValue}"
+                : caseInsensitive
                 ? $"{filter.FilterValue}".ToLowerInvariant()
                 : isEnum && !isEnumerable && filter.FilterValue != null
                     ? Enum.ToObject(Nullable.GetUnderlyingType(property.Type) ?? property.Type, filter.FilterValue)
@@ -830,7 +839,7 @@ namespace Radzen
 
             var rawProperty = property;
 
-            if (caseInsensitive && !isEnumerable)
+            if (caseInsensitive && !isEnumerable && !useOrdinal)
             {
                 property = Expression.Call(notNullCheck(property), typeof(string).GetMethod("ToLower", Type.EmptyTypes)!);
             }
@@ -838,7 +847,9 @@ namespace Radzen
             Expression? secondConstant = null;
             if (filter.SecondFilterValue != null)
             {
-                var secondValue = caseInsensitive
+                var secondValue = useOrdinal
+                    ? $"{filter.SecondFilterValue}"
+                    : caseInsensitive
                     ? $"{filter.SecondFilterValue}".ToLowerInvariant()
                     : isEnum
                         ? Enum.ToObject(Nullable.GetUnderlyingType(property.Type) ?? property.Type, filter.SecondFilterValue)
@@ -860,6 +871,22 @@ namespace Radzen
                 }
 
                 secondConstant = Expression.Constant(secondValue, secondConstantType);
+            }
+
+            Expression? OrdinalStringOp(FilterOperator op, Expression value)
+            {
+                var ordinal = Expression.Constant(StringComparison.OrdinalIgnoreCase);
+                var target = notNullCheck(property);
+                return op switch
+                {
+                    FilterOperator.Equals => Expression.Call(target, typeof(string).GetMethod("Equals", new[] { typeof(string), typeof(StringComparison) })!, value, ordinal),
+                    FilterOperator.NotEquals => Expression.Not(Expression.Call(target, typeof(string).GetMethod("Equals", new[] { typeof(string), typeof(StringComparison) })!, value, ordinal)),
+                    FilterOperator.Contains => Expression.Call(target, typeof(string).GetMethod("Contains", new[] { typeof(string), typeof(StringComparison) })!, value, ordinal),
+                    FilterOperator.DoesNotContain => Expression.Not(Expression.Call(target, typeof(string).GetMethod("Contains", new[] { typeof(string), typeof(StringComparison) })!, value, ordinal)),
+                    FilterOperator.StartsWith => Expression.Call(target, typeof(string).GetMethod("StartsWith", new[] { typeof(string), typeof(StringComparison) })!, value, ordinal),
+                    FilterOperator.EndsWith => Expression.Call(target, typeof(string).GetMethod("EndsWith", new[] { typeof(string), typeof(StringComparison) })!, value, ordinal),
+                    _ => null
+                };
             }
 
             Expression? primaryExpression = filter.FilterOperator switch
@@ -898,6 +925,11 @@ namespace Radzen
                 FilterOperator.IsNotEmpty => Expression.NotEqual(rawProperty, Expression.Constant(String.Empty)),
                 _ => null
             };
+
+            if (useOrdinal && OrdinalStringOp(filter.FilterOperator, constant) is { } ordinalPrimary)
+            {
+                primaryExpression = ordinalPrimary;
+            }
 
         if (collectionItemType != null && primaryExpression != null &&
             !(filter.FilterOperator == FilterOperator.In || filter.FilterOperator == FilterOperator.NotIn))
@@ -945,6 +977,11 @@ namespace Radzen
                     FilterOperator.IsNotEmpty => Expression.NotEqual(rawProperty, Expression.Constant(String.Empty)),
                     _ => null
                 };
+
+                if (useOrdinal && secondConstant != null && OrdinalStringOp(filter.SecondFilterOperator, secondConstant) is { } ordinalSecond)
+                {
+                    secondExpression = ordinalSecond;
+                }
             }
 
         if (collectionItemType != null && secondExpression != null &&

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -195,7 +195,7 @@
                                 var columnIndex = visibleColumns.IndexOf(column);
                                 var sortableClass = AllowSorting && column.Sortable ? "rz-sortable-column" : "";
 
-                                <RadzenDataGridHeaderCell @key=column RowIndex="@i" Grid="@this" Column="@column" ColumnIndex="@columnIndex" CssClass="@($"rz-unselectable-text {sortableClass} {column.HeaderCssClass} {getFrozenColumnClass(column, visibleColumns)} {getCompositeCellCSSClass(column)} {getColumnAlignClass(column)}".Trim())" Attributes="@(cellAttr)" />
+                                <RadzenDataGridHeaderCell @key=column RowIndex="@i" Grid="@this" Column="@column" ColumnIndex="@columnIndex" CssClass="@($"rz-unselectable-text {sortableClass} {column.HeaderCssClass} {getFrozenColumnClass(column)} {getCompositeCellCSSClass(column)} {getColumnAlignClass(column)}".Trim())" Attributes="@(cellAttr)" />
                             }
                         </tr>
                     }
@@ -221,7 +221,7 @@
                             @foreach (var column in visibleColumns)
                             {
                                 var filterMode = column.FilterMode ?? FilterMode;
-                                <th @key=column role="columnheader" colspan="@column.GetColSpan()" class="@($"rz-unselectable-text {getFrozenColumnClass(column, visibleColumns)} {column.HeaderCssClass}")" scope="col" style="@column.GetStyle(true, true)">
+                                <th @key=column role="columnheader" colspan="@column.GetColSpan()" class="@($"rz-unselectable-text {getFrozenColumnClass(column)} {column.HeaderCssClass}")" scope="col" style="@column.GetStyle(true, true)">
                                     @if (allColumns.All(c => c.Parent == null) && AllowFiltering && column.Filterable && column.Columns == null && (!string.IsNullOrEmpty(column.GetFilterProperty()) || column.FilterTemplate != null))
                                     {
                                         if(filterMode == FilterMode.Simple || filterMode == FilterMode.SimpleWithMenu)
@@ -314,7 +314,7 @@
                                     }
 
                                     <RadzenDataGridFooterCell RowIndex="@i" Grid="@this" Column="@column"
-                                              CssClass="@($"{column.FooterCssClass} {getFrozenColumnClass(column, visibleColumns)} {getCompositeCellCSSClass(column)}".Trim())"
+                                              CssClass="@($"{column.FooterCssClass} {getFrozenColumnClass(column)} {getCompositeCellCSSClass(column)}".Trim())"
                                               Attributes="@(cellAttr)" />
                                 }
                             </tr>
@@ -784,7 +784,7 @@
         List<string> classes = [
             column.CalculatedCssClass?.Invoke(column, item) ?? string.Empty,
             column.CssClass,
-            getFrozenColumnClass(column, columns.Where(c => c.GetVisible()).ToList()),
+            getFrozenColumnClass(column),
             getCompositeCellCSSClass(column),
         ];
         

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -629,9 +629,19 @@
                 SetAttribute(cellAttributes, "class", cellClass);
             }
 
-            if (CellClick.HasDelegate || RowClick.HasDelegate || RowSelect.HasDelegate || RowDeselect.HasDelegate  || ValueChanged.HasDelegate)
+            // A non-chainable consumer onclick (e.g. a string) occupies the <tr>, so the built-in row click
+            // can't ride it - raise it from the cell for that row instead, alongside any cell click.
+            if (RowClickActive && rowArgs.Item2.TryGetValue("onclick", out var rowOnclick) && !IsChainableClickHandler(rowOnclick))
             {
-                SetAttribute(cellAttributes, "onclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnClick(column, Item, eventArgs)));
+                SetAttribute(cellAttributes, "onclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: async (eventArgs) =>
+                {
+                    if (CellClick.HasDelegate) { await OnCellClickHandler(column, Item, eventArgs); }
+                    await OnRowClickHandler(Item, eventArgs);
+                }));
+            }
+            else if (CellClick.HasDelegate)
+            {
+                SetAttribute(cellAttributes, "onclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnCellClickHandler(column, Item, eventArgs)));
             }
 
             if (CellDoubleClick.HasDelegate || RowDoubleClick.HasDelegate)
@@ -828,7 +838,13 @@
     }
 
     bool clicking;
-    async Task OnClick(RadzenDataGridColumn<TItem> Column, TItem Item, MouseEventArgs args)
+    bool rowClicking;
+
+    internal bool RowClickActive => CellClick.HasDelegate || RowClick.HasDelegate
+        || RowSelect.HasDelegate || RowDeselect.HasDelegate || ValueChanged.HasDelegate;
+    // Cell click fires only the cell-specific event; the row click + selection is raised once per row
+    // by OnRowClickHandler, wired on the <tr> (see RowAttributes).
+    async Task OnCellClickHandler(RadzenDataGridColumn<TItem> Column, TItem Item, MouseEventArgs args)
     {
         if (clicking)
         {
@@ -837,49 +853,63 @@
         try
         {
             clicking = true;
-        await OnCellClick(new DataGridCellMouseEventArgs<TItem>
-        {
-            Data = Item,
-            AltKey = args.AltKey,
-            Button = args.Button,
-            Buttons = args.Buttons,
-            ClientX = args.ClientX,
-            ClientY = args.ClientY,
-            CtrlKey = args.CtrlKey,
-            Detail = args.Detail,
-            MetaKey = args.MetaKey,
-            OffsetX = args.OffsetX,
-            OffsetY = args.OffsetY,
-            ScreenX = args.ScreenX,
-            ScreenY = args.ScreenY,
-            ShiftKey = args.ShiftKey,
-            Type = args.Type,
-            Column = Column
-        });
-
-        await OnRowClick(new DataGridRowMouseEventArgs<TItem>
-        {
-            Data = Item,
-            AltKey = args.AltKey,
-            Button = args.Button,
-            Buttons = args.Buttons,
-            ClientX = args.ClientX,
-            ClientY = args.ClientY,
-            CtrlKey = args.CtrlKey,
-            Detail = args.Detail,
-            MetaKey = args.MetaKey,
-            OffsetX = args.OffsetX,
-            OffsetY = args.OffsetY,
-            ScreenX = args.ScreenX,
-            ScreenY = args.ScreenY,
-            ShiftKey = args.ShiftKey,
-            Type = args.Type
-        });
-
+            await OnCellClick(new DataGridCellMouseEventArgs<TItem>
+            {
+                Data = Item,
+                AltKey = args.AltKey,
+                Button = args.Button,
+                Buttons = args.Buttons,
+                ClientX = args.ClientX,
+                ClientY = args.ClientY,
+                CtrlKey = args.CtrlKey,
+                Detail = args.Detail,
+                MetaKey = args.MetaKey,
+                OffsetX = args.OffsetX,
+                OffsetY = args.OffsetY,
+                ScreenX = args.ScreenX,
+                ScreenY = args.ScreenY,
+                ShiftKey = args.ShiftKey,
+                Type = args.Type,
+                Column = Column
+            });
         }
         finally
         {
             clicking = false;
+        }
+    }
+
+    internal async Task OnRowClickHandler(TItem Item, MouseEventArgs args)
+    {
+        if (rowClicking)
+        {
+            return;
+        }
+        try
+        {
+            rowClicking = true;
+            await OnRowClick(new DataGridRowMouseEventArgs<TItem>
+            {
+                Data = Item,
+                AltKey = args.AltKey,
+                Button = args.Button,
+                Buttons = args.Buttons,
+                ClientX = args.ClientX,
+                ClientY = args.ClientY,
+                CtrlKey = args.CtrlKey,
+                Detail = args.Detail,
+                MetaKey = args.MetaKey,
+                OffsetX = args.OffsetX,
+                OffsetY = args.OffsetY,
+                ScreenX = args.ScreenX,
+                ScreenY = args.ScreenY,
+                ShiftKey = args.ShiftKey,
+                Type = args.Type
+            });
+        }
+        finally
+        {
+            rowClicking = false;
         }
     }
 

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -644,20 +644,20 @@
                 SetAttribute(cellAttributes, "oncontextmenu", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnContextMenu(column, Item, eventArgs)));
             }
 
-            IReadOnlyDictionary<string, object> CellAttributes = new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(cellAttributes);
-
-            var spanAttributes = new Dictionary<string, object>();
             var title = column.Template == null && this.ShowCellDataAsTooltip || column.ShowCellDataAsTooltip ? $"{column.GetValue(Item)}" : "";
+            IReadOnlyDictionary<string, object> spanAttributes = EmptyAttributes;
             if(!string.IsNullOrEmpty(title))
             {
-                SetAttribute(spanAttributes, "title", title);
+                var titleAttrs = new Dictionary<string, object>();
+                SetAttribute(titleAttrs, "title", title);
+                spanAttributes = titleAttrs;
             }
 
             return __builder => {
             <text>
             @if (this.AllowCompositeDataCells ? RowIndex == column.GetLevel() : (column.Parent != null && RowIndex == column.GetLevel() || column.Columns == null))
             {
-                <td role="gridcell" @attributes="@CellAttributes" @oncontextmenu:preventDefault="@this.CellContextMenu.HasDelegate" @oncontextmenu:stopPropagation="@this.CellContextMenu.HasDelegate" @onkeydown:stopPropagation>
+                <td role="gridcell" @attributes="@cellAttributes" @oncontextmenu:preventDefault="@this.CellContextMenu.HasDelegate" @oncontextmenu:stopPropagation="@this.CellContextMenu.HasDelegate" @onkeydown:stopPropagation>
                     @if (this.Responsive)
                     {
                         <span class="rz-column-title">
@@ -781,24 +781,27 @@
 
     string? GetCellCssClass(RadzenDataGridColumn<TItem> column, TItem item, IReadOnlyDictionary<string, object> Attributes)
     {
-        List<string> classes = [
-            column.CalculatedCssClass?.Invoke(column, item) ?? string.Empty,
+        var calculated = column.CalculatedCssClass?.Invoke(column, item);
+        string? attributeClass = null;
+        if (Attributes?.TryGetValue("class", out var ac) is true)
+        {
+            attributeClass = Convert.ToString(ac);
+        }
+
+        if (string.IsNullOrEmpty(calculated) && string.IsNullOrWhiteSpace(attributeClass))
+        {
+            return column.GetCachedCellCssClass(getFrozenColumnClass(column), getCompositeCellCSSClass(column));
+        }
+
+        var result = string.Join(" ", new[]
+        {
+            calculated ?? string.Empty,
             column.CssClass,
             getFrozenColumnClass(column),
             getCompositeCellCSSClass(column),
-        ];
-        
-        if (Attributes?.TryGetValue("class", out var attributeClass) is true)
-        {
-            var classValue = Convert.ToString(attributeClass);
-            if (classValue != null)
-            {
-                classes.Add(classValue);
-            }
-        }
-
-        var result = string.Join(" ", classes.Where(c => !string.IsNullOrWhiteSpace(c)));
-        return !String.IsNullOrWhiteSpace(result) ? result : null;
+            attributeClass ?? string.Empty,
+        }.Where(c => !string.IsNullOrWhiteSpace(c)));
+        return !string.IsNullOrWhiteSpace(result) ? result : null;
     }
 
     async Task OnContextMenu(RadzenDataGridColumn<TItem> Column, TItem Item, MouseEventArgs args)

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -313,9 +313,10 @@ namespace Radzen.Blazor
                                 b.AddAttribute(8, "InEditMode", IsRowInEditMode(context));
                                 b.AddAttribute(9, "Index", virtualDataItems.IndexOf(context));
 
-                                if (editContexts.Keys.Any(i => ItemEquals(i, context)))
+                                // O(1) lookup instead of scanning editContexts.Keys per rendered row.
+                                if (editContexts.TryGetValue(context, out var editContext))
                                 {
-                                    b.AddAttribute(10, nameof(RadzenDataGridRow<TItem>.EditContext), editContexts[context]);
+                                    b.AddAttribute(10, nameof(RadzenDataGridRow<TItem>.EditContext), editContext);
                                 }
 
                                 b.SetKey(context);
@@ -505,7 +506,7 @@ namespace Radzen.Blazor
         [Parameter]
         public EventCallback<DataGridColumnGroupEventArgs<TItem>> Group { get; set; }
 
-        internal string getFrozenColumnClass(RadzenDataGridColumn<TItem> column, IList<RadzenDataGridColumn<TItem>> visibleColumns)
+        internal string getFrozenColumnClass(RadzenDataGridColumn<TItem> column)
         {
             if (!column.IsFrozen())
             {
@@ -1283,14 +1284,21 @@ namespace Radzen.Blazor
             }
         }
 
+        static readonly IReadOnlyDictionary<string, object> EmptyAttributes =
+            new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+
         internal IReadOnlyDictionary<string, object> CellAttributes(TItem item, RadzenDataGridColumn<TItem> column)
         {
+            // Without a CellRender handler there are no custom attributes; return a shared empty dictionary
+            // instead of allocating event args and a dictionary per cell. Callers only read the result.
+            if (CellRender == null)
+            {
+                return EmptyAttributes;
+            }
+
             var args = new Radzen.DataGridCellRenderEventArgs<TItem>() { Data = item, Column = column };
 
-            if (CellRender != null)
-            {
-                CellRender(args);
-            }
+            CellRender(args);
 
             return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes);
         }
@@ -1315,19 +1323,25 @@ namespace Radzen.Blazor
                     break;
             }
 
-            return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes);
+            return args.HasAttributes
+                ? new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes)
+                : EmptyAttributes;
         }
 
         internal IReadOnlyDictionary<string, object> FooterCellAttributes(RadzenDataGridColumn<TItem> column)
         {
-            var args = new Radzen.DataGridCellRenderEventArgs<TItem>() { Column = column };
-
-            if (FooterCellRender != null)
+            if (FooterCellRender == null)
             {
-                FooterCellRender(args);
+                return EmptyAttributes;
             }
 
-            return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes);
+            var args = new Radzen.DataGridCellRenderEventArgs<TItem>() { Column = column };
+
+            FooterCellRender(args);
+
+            return args.HasAttributes
+                ? new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes)
+                : EmptyAttributes;
         }
 
         internal Dictionary<int, int> rowSpans = new Dictionary<int, int>();
@@ -2798,6 +2812,31 @@ namespace Radzen.Blazor
             return keyPropertyGetter != null ? Equals(keyPropertyGetter(item), keyPropertyGetter(otherItem)) : item.Equals(otherItem);
         }
 
+        // Membership test equivalent to items.Keys.Any(i => ItemEquals(i, item)), but O(1) when no
+        // KeyProperty is set, avoiding an O(selected) scan per row on every render.
+        bool ContainsItemKey(Dictionary<TItem, bool> items, TItem item)
+        {
+            if (items.Count == 0)
+            {
+                return false;
+            }
+
+            if (keyPropertyGetter == null)
+            {
+                return item != null && items.ContainsKey(item);
+            }
+
+            foreach (var i in items.Keys)
+            {
+                if (ItemEquals(i, item))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         internal bool? allGroupsExpanded;
 
         /// <summary>
@@ -2831,16 +2870,27 @@ namespace Radzen.Blazor
 
         internal string ExpandedItemStyle(TItem item)
         {
-            return expandedItems.Keys.Any(i => ItemEquals(i, item)) ? "notranslate rz-row-toggler rzi-chevron-circle-down" : "rz-row-toggler rzi-chevron-circle-right";
+            return ContainsItemKey(expandedItems, item) ? "notranslate rz-row-toggler rzi-chevron-circle-down" : "rz-row-toggler rzi-chevron-circle-right";
         }
 
         internal Dictionary<TItem, bool> selectedItems = new Dictionary<TItem, bool>();
 
+        // RowStyle only ever produces one of these four constants; returning them avoids allocating an
+        // identical string per row on every render.
+        const string RowClass = "rz-data-row  ";
+        const string RowClassEditing = "rz-data-row rz-datatable-edit ";
+        const string RowClassSelected = "rz-state-highlight rz-data-row  ";
+        const string RowClassSelectedEditing = "rz-state-highlight rz-data-row rz-datatable-edit ";
+
         internal string RowStyle(TItem item, int index)
         {
-            var isInEditMode = IsRowInEditMode(item) ? "rz-datatable-edit" : "";
+            var editing = IsRowInEditMode(item);
+            var selected = (RowSelect.HasDelegate || ValueChanged.HasDelegate || SelectionMode == DataGridSelectionMode.Multiple)
+                && ContainsItemKey(selectedItems, item);
 
-            return (RowSelect.HasDelegate || ValueChanged.HasDelegate || SelectionMode == DataGridSelectionMode.Multiple) && selectedItems.Keys.Any(i => ItemEquals(i, item)) ? $"rz-state-highlight rz-data-row {isInEditMode} " : $"rz-data-row {isInEditMode} ";
+            return selected
+                ? (editing ? RowClassSelectedEditing : RowClassSelected)
+                : (editing ? RowClassEditing : RowClass);
         }
 
         internal string? RowAriaSelected(TItem item, int index)
@@ -2850,7 +2900,7 @@ namespace Radzen.Blazor
                 return null;
             }
 
-            return selectedItems.Keys.Any(i => ItemEquals(i, item)) ? "true" : "false";
+            return ContainsItemKey(selectedItems, item) ? "true" : "false";
         }
 
         int HeaderRowCount()
@@ -2892,7 +2942,11 @@ namespace Radzen.Blazor
                 RowRender(args);
             }
 
-            return new Tuple<Radzen.RowRenderEventArgs<TItem>, IReadOnlyDictionary<string, object>>(args, new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes));
+            var attributes = args.HasAttributes
+                ? new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes)
+                : EmptyAttributes;
+
+            return new Tuple<Radzen.RowRenderEventArgs<TItem>, IReadOnlyDictionary<string, object>>(args, attributes);
         }
 
         internal Tuple<GroupRowRenderEventArgs, IReadOnlyDictionary<string, object>> GroupRowAttributes(RadzenDataGridGroupRow<TItem> item)
@@ -2904,7 +2958,11 @@ namespace Radzen.Blazor
                 GroupRowRender(args);
             }
 
-            return new Tuple<GroupRowRenderEventArgs, IReadOnlyDictionary<string, object>>(args, new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes));
+            var attributes = args.HasAttributes
+                ? new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes)
+                : EmptyAttributes;
+
+            return new Tuple<GroupRowRenderEventArgs, IReadOnlyDictionary<string, object>>(args, attributes);
         }
 
         bool settingsChanged;
@@ -3119,7 +3177,7 @@ namespace Radzen.Blazor
         /// <param name="item">The item.</param>
         public bool IsRowExpanded(TItem item)
         {
-            return expandedItems.Keys.Any(i => ItemEquals(i, item));
+            return ContainsItemKey(expandedItems, item);
         }
 
         /// <summary>
@@ -3137,7 +3195,7 @@ namespace Radzen.Blazor
 
             foreach (TItem item in items)
             {
-                if (!expandedItems.Keys.Any(i => ItemEquals(i, item)))
+                if (!ContainsItemKey(expandedItems, item))
                 {
                     expandedItems.Add(item, true);
                     await RowExpand.InvokeAsync(item);
@@ -3216,7 +3274,7 @@ namespace Radzen.Blazor
                 }
             }
 
-            if (!expandedItems.Keys.Any(i => ItemEquals(i, item)))
+            if (!ContainsItemKey(expandedItems, item))
             {
                 expandedItems.Add(item, true);
                 await RowExpand.InvokeAsync(item);
@@ -3385,7 +3443,7 @@ namespace Radzen.Blazor
                 focusedIndex = focusedIndexResult.Index + 1;
             }
 
-            if (SelectionMode == DataGridSelectionMode.Single && item != null && selectedItems.Keys.Any(i => ItemEquals(i, item)))
+            if (SelectionMode == DataGridSelectionMode.Single && item != null && ContainsItemKey(selectedItems, item))
             {
                 // Legacy RowSelect raise
                 if (raiseChange)
@@ -3407,7 +3465,7 @@ namespace Radzen.Blazor
 
             if (item != null)
             {
-                if (!selectedItems.Keys.Any(i => ItemEquals(i, item)))
+                if (!ContainsItemKey(selectedItems, item))
                 {
                     selectedItems.Add(item, true);
                     if (raiseChange)
@@ -3511,7 +3569,7 @@ namespace Radzen.Blazor
                 }
             }
 
-            if (!editedItems.Keys.Any(i => ItemEquals(i, item)))
+            if (!ContainsItemKey(editedItems, item))
             {
                 editedItems.Add(item, true);
 
@@ -3539,7 +3597,7 @@ namespace Radzen.Blazor
 
             foreach (TItem item in items)
             {
-                if (!editedItems.Keys.Any(i => ItemEquals(i, item)))
+                if (!ContainsItemKey(editedItems, item))
                 {
                     editedItems.Add(item, true);
 
@@ -3559,7 +3617,7 @@ namespace Radzen.Blazor
         public async System.Threading.Tasks.Task UpdateRow(TItem item)
         {
             ArgumentNullException.ThrowIfNull(item);
-            if (editedItems.Keys.Any(i => ItemEquals(i, item)))
+            if (ContainsItemKey(editedItems, item))
             {
                 var editContext = editContexts.FirstOrDefault(i => ItemEquals(i.Key, item)).Value;
 
@@ -3616,7 +3674,7 @@ namespace Radzen.Blazor
             }
             else
             {
-                if (editedItems.Keys.Any(i => ItemEquals(i, item)))
+                if (ContainsItemKey(editedItems, item))
                 {
                     editedItems.Remove(item);
                     editContexts.Remove(item);
@@ -3635,7 +3693,7 @@ namespace Radzen.Blazor
             ArgumentNullException.ThrowIfNull(items);
             foreach (TItem item in items)
             {
-                if (editedItems.Keys.Any(i => ItemEquals(i, item)))
+                if (ContainsItemKey(editedItems, item))
                 {
                     editedItems.Remove(item);
                     editContexts.Remove(item);
@@ -3651,7 +3709,7 @@ namespace Radzen.Blazor
         /// <returns><c>true</c> if row in edit mode; otherwise, <c>false</c>.</returns>
         public bool IsRowInEditMode(TItem item)
         {
-            return editedItems.Keys.Any(i => ItemEquals(i, item));
+            return ContainsItemKey(editedItems, item);
         }
 
         List<TItem> itemsToInsert = new List<TItem>();

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -2933,6 +2933,28 @@ namespace Radzen.Blazor
             return (level + 1).ToString(CultureInfo.InvariantCulture);
         }
 
+        private static bool IsChainableClickHandler(object value) => value is
+            EventCallback<MouseEventArgs> or EventCallback or Func<MouseEventArgs, Task> or Func<Task> or Action<MouseEventArgs> or Action;
+
+        // Runs the built-in row click (and selection) first, then a consumer-supplied onclick from RowRender,
+        // so a consumer onclick that reads selection state observes it after the click.
+        private EventCallback<MouseEventArgs> CombineRowClick(object existing, TItem item)
+        {
+            return EventCallback.Factory.Create<MouseEventArgs>(this, async e =>
+            {
+                await OnRowClickHandler(item, e);
+                switch (existing)
+                {
+                    case EventCallback<MouseEventArgs> ec: await ec.InvokeAsync(e); break;
+                    case EventCallback ec: await ec.InvokeAsync(e); break;
+                    case Func<MouseEventArgs, Task> f: await f(e); break;
+                    case Func<Task> f: await f(); break;
+                    case Action<MouseEventArgs> a: a(e); break;
+                    case Action a: a(); break;
+                }
+            });
+        }
+
         internal Tuple<Radzen.RowRenderEventArgs<TItem>, IReadOnlyDictionary<string, object>> RowAttributes(TItem item, int index)
         {
             var args = new Radzen.RowRenderEventArgs<TItem>() { Data = item, Index = index, Expandable = Template != null || LoadChildData.HasDelegate };
@@ -2942,9 +2964,23 @@ namespace Radzen.Blazor
                 RowRender(args);
             }
 
-            var attributes = args.HasAttributes
-                ? new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes)
-                : EmptyAttributes;
+            IReadOnlyDictionary<string, object> attributes;
+            if (RowClickActive)
+            {
+                var dict = args.HasAttributes ? new Dictionary<string, object>(args.Attributes) : new Dictionary<string, object>();
+                // A chainable consumer onclick runs after the built-in row click; anything else (e.g. a string
+                // HTML handler) is kept as-is rather than wrapped and dropped.
+                dict["onclick"] = dict.TryGetValue("onclick", out var existing) && existing != null
+                    ? IsChainableClickHandler(existing) ? CombineRowClick(existing, item) : existing
+                    : EventCallback.Factory.Create<MouseEventArgs>(this, e => OnRowClickHandler(item, e));
+                attributes = dict;
+            }
+            else
+            {
+                attributes = args.HasAttributes
+                    ? new System.Collections.ObjectModel.ReadOnlyDictionary<string, object>(args.Attributes)
+                    : EmptyAttributes;
+            }
 
             return new Tuple<Radzen.RowRenderEventArgs<TItem>, IReadOnlyDictionary<string, object>>(args, attributes);
         }

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -856,6 +856,28 @@ namespace Radzen.Blazor
         string? _dataCellStyleMax;
         bool _dataCellStyleColGroup;
 
+        // Memo for the row-independent cell class; _cellCssClass != null is the validity flag.
+        string? _cellCssClass;
+        string? _cellCssClassCss;
+        string? _cellCssClassFrozen;
+        string? _cellCssClassComposite;
+
+        internal string? GetCachedCellCssClass(string frozen, string composite)
+        {
+            if (_cellCssClass is not null && _cellCssClassCss == CssClass
+                && _cellCssClassFrozen == frozen && _cellCssClassComposite == composite)
+            {
+                return _cellCssClass.Length == 0 ? null : _cellCssClass;
+            }
+
+            var joined = string.Join(" ", new[] { CssClass, frozen, composite }.Where(c => !string.IsNullOrWhiteSpace(c)));
+            _cellCssClassCss = CssClass;
+            _cellCssClassFrozen = frozen;
+            _cellCssClassComposite = composite;
+            _cellCssClass = joined;
+            return joined.Length == 0 ? null : joined;
+        }
+
         /// <summary>
         /// Gets the cell style.
         /// </summary>

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -239,16 +239,8 @@ namespace Radzen.Blazor
             {
                 _filterPropertyType = Type;
             }
-            else if (!string.IsNullOrEmpty(Property))
-            {
-                propertyValueGetter = PropertyAccess.Getter<TItem, object>(Property);
-            }
 
-            if (!string.IsNullOrEmpty(Property) && (typeof(TItem).IsGenericType && typeof(IDictionary<,>).IsAssignableFrom(typeof(TItem).GetGenericTypeDefinition()) ||
-                typeof(IDictionary).IsAssignableFrom(typeof(TItem)) || typeof(System.Data.DataRow).IsAssignableFrom(typeof(TItem))))
-            {
-                propertyValueGetter = PropertyAccess.Getter<TItem, object>(Property);
-            }
+            EnsurePropertyValueGetter();
 
             if (_filterPropertyType == typeof(string) && filterOperator != FilterOperator.Custom && filterOperator == null && _filterOperator == null)
             {
@@ -773,6 +765,44 @@ namespace Radzen.Blazor
         public IFormatProvider? FormatProvider { get; set; }
 
         Func<TItem, object>? propertyValueGetter;
+        string? propertyValueGetterProperty;
+
+        string? sortValueGetterProperty;
+        Func<TItem, object>? sortValueGetter;
+
+        // Rebuilds the cached value getter when the bound Property changes, so a reused column instance whose
+        // Property parameter is reassigned does not keep rendering the old property.
+        private void EnsurePropertyValueGetter()
+        {
+            if (propertyValueGetterProperty == Property)
+            {
+                return;
+            }
+
+            propertyValueGetterProperty = Property;
+
+            if (string.IsNullOrEmpty(Property))
+            {
+                propertyValueGetter = null;
+                return;
+            }
+
+            try
+            {
+                var indexed = typeof(TItem).IsGenericType && typeof(IDictionary<,>).IsAssignableFrom(typeof(TItem).GetGenericTypeDefinition())
+                    || typeof(IDictionary).IsAssignableFrom(typeof(TItem))
+                    || typeof(System.Data.DataRow).IsAssignableFrom(typeof(TItem));
+
+                // Dictionary / DataRow items resolve through an indexer, so they keep the standard getter.
+                propertyValueGetter = indexed
+                    ? PropertyAccess.Getter<TItem, object>(Property)
+                    : PropertyAccess.NullSafeGetter<TItem>(Property);
+            }
+            catch
+            {
+                propertyValueGetter = null;
+            }
+        }
 
         /// <summary>
         /// Gets the value for specified item.
@@ -781,7 +811,12 @@ namespace Radzen.Blazor
         /// <returns>System.Object.</returns>
         public virtual object? GetValue(TItem item)
         {
-            var value = propertyValueGetter != null && !string.IsNullOrEmpty(Property) && !Property.Contains('.', StringComparison.Ordinal) ? propertyValueGetter(item) : !string.IsNullOrEmpty(Property) ? PropertyAccess.GetValue(item, Property) : "";
+            EnsurePropertyValueGetter();
+
+            // Use the cached compiled getter when one was built; reflection remains the fallback only for
+            // columns whose property could not be compiled (e.g. late-bound dynamic items).
+            var value = propertyValueGetter != null ? propertyValueGetter(item)
+                : !string.IsNullOrEmpty(Property) ? PropertyAccess.GetValue(item, Property) : "";
 
 
             if (FilterPropertyType != null && (PropertyAccess.IsEnum(FilterPropertyType) || PropertyAccess.IsNullableEnum(FilterPropertyType) ||
@@ -941,8 +976,38 @@ namespace Radzen.Blazor
         /// </summary>
         internal object? GetSortValue(TItem item)
         {
+            EnsurePropertyValueGetter();
+
             var sortProperty = GetSortProperty();
-            return string.IsNullOrEmpty(sortProperty) ? null : PropertyAccess.GetValue(item, sortProperty);
+            if (string.IsNullOrEmpty(sortProperty))
+            {
+                return null;
+            }
+
+            if (sortProperty != sortValueGetterProperty)
+            {
+                sortValueGetterProperty = sortProperty;
+
+                if (sortProperty == Property && propertyValueGetter != null)
+                {
+                    sortValueGetter = propertyValueGetter;
+                }
+                else
+                {
+                    // A compiled getter avoids per-row reflection while sorting; items that cannot be compiled
+                    // (late-bound dynamic) fall back to reflection below.
+                    try
+                    {
+                        sortValueGetter = PropertyAccess.NullSafeGetter<TItem>(sortProperty);
+                    }
+                    catch
+                    {
+                        sortValueGetter = null;
+                    }
+                }
+            }
+
+            return sortValueGetter != null ? sortValueGetter(item) : PropertyAccess.GetValue(item, sortProperty);
         }
 
         internal void SetSortOrder(SortOrder? order)

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -1756,16 +1756,34 @@ namespace Radzen.Blazor
             return !string.IsNullOrWhiteSpace(internalWidth) ? internalWidth : Grid?.ColumnWidth;
         }
 
+        IEnumerable<FilterOperator>? _filterOperatorsCache;
+        Type? _filterOperatorsTypeKey;
+
         /// <summary>
         /// Get possible column filter operators.
         /// </summary>
         public virtual IEnumerable<FilterOperator> GetFilterOperators()
         {
+            // Caller-provided operators are returned live, so in-place changes to the bound collection are honored.
             if (FilterOperators != null)
             {
                 return FilterOperators;
             }
 
+            // The computed/default set depends only on FilterPropertyType but is a lazy LINQ query re-run on
+            // each enumeration, so materialize it once and reuse until the type changes.
+            if (_filterOperatorsCache != null && _filterOperatorsTypeKey == FilterPropertyType)
+            {
+                return _filterOperatorsCache;
+            }
+
+            _filterOperatorsTypeKey = FilterPropertyType;
+            _filterOperatorsCache = ComputeFilterOperators().ToArray();
+            return _filterOperatorsCache;
+        }
+
+        private IEnumerable<FilterOperator> ComputeFilterOperators()
+        {
             if (FilterPropertyType != null && (PropertyAccess.IsEnum(FilterPropertyType) || FilterPropertyType == typeof(bool)))
             {
                 return new FilterOperator[] { FilterOperator.Equals, FilterOperator.NotEquals };

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -848,6 +848,14 @@ namespace Radzen.Blazor
             }
         }
 
+        // Memo for the row-independent data-cell style; _dataCellStyle != null is the validity flag.
+        string? _dataCellStyle;
+        string? _dataCellStyleWidth;
+        TextAlign _dataCellStyleAlign;
+        string? _dataCellStyleMin;
+        string? _dataCellStyleMax;
+        bool _dataCellStyleColGroup;
+
         /// <summary>
         /// Gets the cell style.
         /// </summary>
@@ -857,44 +865,91 @@ namespace Radzen.Blazor
         /// <returns>System.String.</returns>
         public virtual string GetStyle(bool forCell = false, bool isHeaderOrFooterCell = false, bool isForCol = false)
         {
-            var style = new List<string>();
-
+#pragma warning disable CA1508 // Lazy init: the first '??=' is intentionally reached with a null list.
             var width = GetWidthOrGridSetting()?.Trim();
 
-            var hasColGroup = Grid.allColumns.All(c => c.Parent == null);
-
-            if (!string.IsNullOrEmpty(width) && (isForCol || !hasColGroup))
+            // Fast path: a plain data cell of a non-frozen column has a row-independent style, so it is memoized.
+            var isDataCell = forCell && !isHeaderOrFooterCell && !isForCol && !IsFrozen();
+            var colGroup = false;
+            if (isDataCell)
             {
-                style.Add($"width:{width}");
+                colGroup = !string.IsNullOrEmpty(width) && !GridHasNoColumnGroups();
+                if (_dataCellStyle != null
+                    && _dataCellStyleWidth == width && _dataCellStyleAlign == TextAlign
+                    && _dataCellStyleMin == MinWidth && _dataCellStyleMax == MaxWidth
+                    && _dataCellStyleColGroup == colGroup)
+                {
+                    return _dataCellStyle;
+                }
+            }
+
+            // Most data cells contribute no style, so allocate the list lazily.
+            List<string>? style = null;
+
+            // Include the width unless the grid uses column groups (which carry it themselves).
+            var includeWidth = isDataCell
+                ? colGroup
+                : !string.IsNullOrEmpty(width) && (isForCol || !GridHasNoColumnGroups());
+            if (includeWidth)
+            {
+                (style ??= new List<string>()).Add($"width:{width}");
             }
 
             if (forCell && TextAlign != TextAlign.Left)
             {
                 var enumName = Enum.GetName<TextAlign>(TextAlign);
-                style.Add($"text-align:{(enumName ?? TextAlign.ToString()).ToLower(CultureInfo.InvariantCulture)};");
+                (style ??= new List<string>()).Add($"text-align:{(enumName ?? TextAlign.ToString()).ToLower(CultureInfo.InvariantCulture)};");
             }
 
             if (forCell && IsFrozen())
             {
-                style.Add(GetStackedStyleForFrozen());
+                (style ??= new List<string>()).Add(GetStackedStyleForFrozen());
             }
 
             if (!isHeaderOrFooterCell && IsFrozen() || (isHeaderOrFooterCell && Grid.ColumnsCollection.Where(c => c.GetVisible() && c.IsFrozen()).Any()))
             {
-                style.Add($"z-index:{(isHeaderOrFooterCell && IsFrozen() ? 2 : 1)}");
+                (style ??= new List<string>()).Add($"z-index:{(isHeaderOrFooterCell && IsFrozen() ? 2 : 1)}");
             }
 
             if (!string.IsNullOrEmpty(MinWidth))
             {
-                style.Add($"min-width:{MinWidth}");
+                (style ??= new List<string>()).Add($"min-width:{MinWidth}");
             }
 
             if (!string.IsNullOrEmpty(MaxWidth))
             {
-                style.Add($"max-width:{MaxWidth}");
+                (style ??= new List<string>()).Add($"max-width:{MaxWidth}");
             }
 
-            return string.Join(";", style);
+            var result = style == null ? string.Empty : string.Join(";", style);
+
+            if (isDataCell)
+            {
+                _dataCellStyleWidth = width;
+                _dataCellStyleAlign = TextAlign;
+                _dataCellStyleMin = MinWidth;
+                _dataCellStyleMax = MaxWidth;
+                _dataCellStyleColGroup = colGroup;
+                _dataCellStyle = result;
+            }
+
+            return result;
+#pragma warning restore CA1508
+        }
+
+        // Allocation-free equivalent of Grid.allColumns.All(c => c.Parent == null), called for every cell.
+        private bool GridHasNoColumnGroups()
+        {
+            var columns = Grid.allColumns;
+            for (int i = 0; i < columns.Count; i++)
+            {
+                if (columns[i].Parent != null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private string GetStackedStyleForFrozen()
@@ -1377,14 +1432,24 @@ namespace Radzen.Blazor
             return collectionFilterMode ?? CollectionFilterMode;
         }
 
+        WhiteSpace _cellClassWhiteSpace;
+        string? _cellClass;
+
         /// <summary>
         /// Get body column class.
         /// </summary>
         /// <returns></returns>
         internal string GetCellClass()
         {
-            var enumName = Enum.GetName<WhiteSpace>(WhiteSpace);
-            return $"rz-cell-data rz-text-{(enumName ?? WhiteSpace.ToString()).ToLower(CultureInfo.InvariantCulture)}";
+            // Constant per column; recompute only when WhiteSpace changes rather than per data cell.
+            if (_cellClass == null || _cellClassWhiteSpace != WhiteSpace)
+            {
+                _cellClassWhiteSpace = WhiteSpace;
+                var enumName = Enum.GetName<WhiteSpace>(WhiteSpace);
+                _cellClass = $"rz-cell-data rz-text-{(enumName ?? WhiteSpace.ToString()).ToLower(CultureInfo.InvariantCulture)}";
+            }
+
+            return _cellClass;
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenDataGridFooterCell.razor
+++ b/Radzen.Blazor/RadzenDataGridFooterCell.razor
@@ -15,7 +15,7 @@ else
     @foreach(var column in Grid.childColumns.Where(c => c.GetVisible() && c.Parent == Column))
     {
         <RadzenDataGridFooterCell RowIndex="@RowIndex" Grid="@Grid" Column="@column" Style="@column.GetStyle(true, true)"
-                                CssClass="@($"{Column.FooterCssClass} {Grid.getFrozenColumnClass(column, Grid.ColumnsCollection.Where(c => c.GetVisible()).ToList())} {Grid.getCompositeCellCSSClass(column)}")" 
+                                CssClass="@($"{Column.FooterCssClass} {Grid.getFrozenColumnClass(column)} {Grid.getCompositeCellCSSClass(column)}")" 
                                 Attributes="@(Attributes)" />
     }
 }

--- a/Radzen.Blazor/RadzenDataGridGroupFooterCell.razor
+++ b/Radzen.Blazor/RadzenDataGridGroupFooterCell.razor
@@ -15,7 +15,7 @@ else
     @foreach(var column in Grid.childColumns.Where(c => c.GetVisible() && c.Parent == Column))
     {
         <RadzenDataGridGroupFooterCell Group="@Group"  RowIndex="@RowIndex" Grid="@Grid" Column="@column" Style="@column.GetStyle(true, true)"
-                                CssClass="@($"{Column.GroupFooterCssClass} {Grid.getFrozenColumnClass(column, Grid.ColumnsCollection.Where(c => c.GetVisible()).ToList())} {Grid.getCompositeCellCSSClass(column)}")" 
+                                CssClass="@($"{Column.GroupFooterCssClass} {Grid.getFrozenColumnClass(column)} {Grid.getCompositeCellCSSClass(column)}")" 
                                 Attributes="@(Attributes)" />
     }
 }

--- a/Radzen.Blazor/RadzenDataGridGroupFooterRow.razor
+++ b/Radzen.Blazor/RadzenDataGridGroupFooterRow.razor
@@ -19,7 +19,7 @@
         }
         @foreach (var column in Columns)
         {
-            <RadzenDataGridGroupFooterCell Group="@Group" RowIndex="@i" Grid="@Grid" Column="@column" CssClass="@($"{column.GroupFooterCssClass} {Grid.getFrozenColumnClass(column, Columns)} {Grid.getCompositeCellCSSClass(column)}".Trim())" />
+            <RadzenDataGridGroupFooterCell Group="@Group" RowIndex="@i" Grid="@Grid" Column="@column" CssClass="@($"{column.GroupFooterCssClass} {Grid.getFrozenColumnClass(column)} {Grid.getCompositeCellCSSClass(column)}".Trim())" />
         }
     </tr>
 }

--- a/Radzen.Blazor/RadzenDataGridHeaderCell.razor
+++ b/Radzen.Blazor/RadzenDataGridHeaderCell.razor
@@ -218,7 +218,7 @@ else
         ColumnIndex = Grid.allColumns.IndexOf(column);//for child must have different columnindex
 
         <RadzenDataGridHeaderCell RowIndex="@RowIndex" Grid="@Grid" Column="@column" Style="@column.GetStyle(true, true)" ColumnIndex="@ColumnIndex"
-        CssClass="@($"rz-unselectable-text {(Grid.AllowSorting && column.Sortable ? "rz-sortable-column" : "")} {column.HeaderCssClass} {Grid.getFrozenColumnClass(column, Grid.ColumnsCollection.Where(c => c.GetVisible()).ToList())} {Grid.getCompositeCellCSSClass(column)} {Grid.getColumnAlignClass(column)}".Trim())" />
+        CssClass="@($"rz-unselectable-text {(Grid.AllowSorting && column.Sortable ? "rz-sortable-column" : "")} {column.HeaderCssClass} {Grid.getFrozenColumnClass(column)} {Grid.getCompositeCellCSSClass(column)} {Grid.getColumnAlignClass(column)}".Trim())" />
     }
 }
 @code {

--- a/Radzen.Blazor/RowRenderEventArgs.cs
+++ b/Radzen.Blazor/RowRenderEventArgs.cs
@@ -8,10 +8,18 @@ namespace Radzen;
 /// <typeparam name="T">The data item type.</typeparam>
 public class RowRenderEventArgs<T>
 {
+    private IDictionary<string, object>? attributes;
+
     /// <summary>
     /// Gets or sets the row HTML attributes. They will apply to the table row (tr) element which RadzenDataGrid renders for every row.
     /// </summary>
-    public IDictionary<string, object> Attributes { get; private set; } = new Dictionary<string, object>();
+    /// <remarks>The backing dictionary is allocated on first access, so a row with no RowRender handler pays nothing.</remarks>
+    public IDictionary<string, object> Attributes => attributes ??= new Dictionary<string, object>();
+
+    /// <summary>
+    /// Whether any attributes were added, without forcing the backing dictionary to be allocated.
+    /// </summary>
+    internal bool HasAttributes => attributes is { Count: > 0 };
 
     /// <summary>
     /// Gets the data item which the current row represents.


### PR DESCRIPTION
In our app, we use quite a few large in-memory RadzenGrids and RadzenDropDows, and in profiling our app, I spent some time finding and addressing some fairly low hanging performance improvements. For us, they speed up the experience considerably, and we serve about 1000 users on a 4 core / 16GB server, so low allocations are helpful.

I understand this is a large change-set, but I wanted to leave it to the maintainers if they want to take on the benefit/risk.  If there is a larger regression suite you'd like me to exercise, let me know.

AI Tools: Claude Code CLI (Opus 4.8), Codex for review (5.6 Sol)

--------

Allocation- and CPU-focused optimizations for `RadzenDataGrid` on the value-access
and per-cell/per-row render hot paths. **No public API changes.** Output is
identical except for one deliberate, documented behaviour change: in-memory
case-insensitive string filtering becomes ordinal (§7).

## Method

Measure-first: BenchmarkDotNet (`[MemoryDiagnoser]`, `--job short`) for isolated
hot paths plus a full-grid render, and `dotnet-trace` (GC/AllocationTick) to
attribute allocation. Render-path figures for §5–§6 use a headless
`BenchmarkRenderer` — a bare Blazor `Renderer` that discards the render batch (no
bUnit, no AngleSharp DOM), so the measured allocation is the component
render-tree build+diff itself, not the test harness. Every change below is backed
by a measured before/after; allocation figures are exact. Runs on .NET 10.

## Changes & measured impact

### 1. Cached compiled value/sort getters
Per-cell value reads used reflection on a string path
(`PropertyAccess.GetValue` → `path.Split('.')` + `PropertyInfo.GetValue`) every
render, and in-memory sort did the same per row. Now a compiled getter cached per
`(item type, property)`, rebuilt when the bound `Property` changes; reflection
kept only as a fallback. A new `PropertyAccess.NullSafeGetter` (isolated from the
widely-shared `Getter`) preserves the reflection path's null-intermediate →
empty-cell behaviour, including nullable-value-type intermediates.

| Value getter, one column | Before | After | |
|---|---|---|---|
| 1,000 nested | 115.4 µs / 112 KB | 3.7 µs / **0 B** | **31×** |
| 100,000 nested | 12,877 µs / 11.2 MB | 1,185 µs / **0 B** | **11×** |
| 100,000 flat | 5,209 µs / 3.2 MB | 804 µs / **0 B** | 6.5× |
| Full 10-col render, 100k rows | 100.6 ms / 50.8 MB | 68.5 ms / 28.1 MB | −32% time / −45% alloc |

### 2. Memoized cell style + CSS class
`GetStyle` rebuilt a `List`+joined string per cell; `GetCellClass`
allocated a string (`Enum.GetName`+`ToLower`) per cell. Both depend only on column
config, so both are memoized (style list allocated lazily → empty cells allocate
nothing).

| Per column, N cells | Before | After | |
|---|---|---|---|
| GetStyle 1,000 | 268.6 µs / 312.5 KB | 55.8 µs / **0 B** | −79% / −100% |
| GetStyle 10,000 | 2,661 µs / 3,125 KB | 568 µs / **0 B** | −79% / −100% |
| GetCellClass 1,000 | 327.9 µs / 343.8 KB | 157.9 µs / **0 B** | −52% / −100% |
| GetCellClass 10,000 | 3,405 µs / 3.44 MB | 1,523 µs / **0 B** | −55% / −100% |

### 3. Memoized `GetFilterOperators`
Called ~16× per column per render, each running `Enum.GetValues` + a re-evaluated
LINQ query. The default/computed set is constant per column → computed once and
cached (caller-provided `FilterOperators` are returned live).

| | Before | After | |
|---|---|---|---|
| SimpleWithMenu render | 54.7 ms | 48.2 ms | ~12% faster (alloc unchanged) |

### 4. O(1) row membership + lazy attributes + constant row classes
Row membership in `selectedItems`/`editedItems`/`expandedItems` used
`Keys.Any(i => ItemEquals(i, item))` — an O(selected) scan + closure, 2–3× per
row. Now O(1) `ContainsKey` when no `KeyProperty` (the default). Event-arg
attribute dictionaries are allocated lazily (shared empty when no
`CellRender`/`RowRender`); row classes are interned constants; the virtualized
edit-context lookup is a single `TryGetValue`.

| Row membership, 50 selected | Before | After | |
|---|---|---|---|
| 1,000 rows | 178.8 µs / 128 KB | 6.7 µs / **0 B** | **27×** |
| 10,000 rows | 1,841 µs / 1.28 MB | 163 µs / **0 B** | 11× |

### 5. Cut per-cell allocations in the data-cell render path
`RenderCell` allocated, per cell per render: an empty `Dictionary` for the content
span's attributes even with no tooltip, a `ReadOnlyDictionary` wrapper only to pass
the cell attributes to `@attributes`, and a fresh `List`+`Where`+`string.Join` for
the cell CSS class. The span dictionary is now a shared empty instance (allocated
only when a title is set), the wrapper is gone (the underlying dictionary is passed
directly), and the row-independent cell class is memoized on the column — a column
with a `CalculatedCssClass` or a per-row attribute class still takes the original
per-row path. Output is identical.

| Headless re-render, 500×10 | Before | After | |
|---|---|---|---|
| allocation | 28.9 MB | 27.0 MB | −6.6% (~12% faster) |

### 6. Raise the row click once per row instead of once per cell
Every cell wired its own `onclick` — unconditionally, on every render — that raised
both the cell click and the row click, forcing a per-cell attribute dictionary on
all N cells. It is now a single `onclick` on the `<tr>`, added in `RowAttributes`
only when a row-level click/selection callback is set; a cell keeps its own
`onclick` only when `CellClick` is set. A cell click bubbles to the row, so the row
click still fires from a cell as before — a click on row area outside any cell now
raises it too (a minor, intended broadening). A consumer `onclick` from `RowRender`
is preserved: a delegate is chained to run after the built-in row click (so it still
observes post-click selection state), and any other value (e.g. a string handler) is
kept as-is. Removing the unconditional per-cell `onclick` also lets the shared empty
cell-attribute path from §5 apply, so most cells stop allocating a dictionary.

| Headless re-render, 500×10, RowClick set | Before | After | |
|---|---|---|---|
| allocation | 27.0 MB | 21.8 MB | −19% (~20% faster) |

### 7. Case-insensitive in-memory string filters skip the per-row `ToLower`
A case-insensitive string filter built `x.Property.ToLower().Contains(value)` (and
the same for the other string operators). Over an in-memory source the `ToLower`
runs for every row on every filter pass, allocating a lowered copy per row. For an
in-memory (`EnumerableQuery`) source the string operators now compare with
`StringComparison.OrdinalIgnoreCase`, which needs no per-row allocation. The choice
is gated on the source being an `EnumerableQuery`: a provider such as EF Core cannot
translate the `StringComparison` overloads and still gets the `ToLower` form so it
maps to SQL `LOWER()`.

**Behaviour note:** this makes **in-memory** case-insensitive matching ordinal
(culture-independent) rather than the previous current-culture `ToLower`. For
ordinary identifier/text data the result is unchanged; it can differ for
culture-specific casing (e.g. Turkish dotted/dotless *i*). EF-backed grids are
unaffected — they keep the `ToLower`→SQL `LOWER()` path and the database collation.

| In-memory filter, 5,000 rows, Contains (all match) | Before | After | |
|---|---|---|---|
| per evaluation | 574.8 KB | 141.9 KB | −75% (~35% faster) |

### Aggregate — full grid render vs master (worst case: no selection, no CellRender, 2/10 nested)
| Rows | Before | After | |
|---|---|---|---|
| 100 | 14.87 MB / 51.9 ms | 13.45 MB / 51.4 ms | −10% alloc (§1–4) |
| 500 | 46.53 MB / 145 ms | 39.92 MB / 129 ms | −14% alloc / −11% time (§1–4) |

§5–§6 cut a further ~7 MB per re-render on a 500×10 grid (headless), on top of the above.

## Testing
Adds regression coverage: value access (nested and nullable null-intermediates,
incl. an explicit nullable `.Value` in the path), a rebuilt getter on `Property`
change, cell style/class memo output, filter-operator cache and live
caller-provided operators, membership with/without `KeyProperty`,
`CellRender`/`RowRender`, in-place-mutation-then-`Reload`, the cell-class memo and
its invalidation, row-click dispatch (row vs cell, a preserved `RowRender`
`onclick`, no handler → no row `onclick`), and the ordinal in-memory filter across
operators (with the EF path still lowering). Full suite green; builds on net8/9/10.

## Benchmark harness
The BenchmarkDotNet harness that produced these numbers — a
[`Radzen.Blazor.Benchmarks`](https://github.com/pianomanjh/radzen-blazor/tree/tech/radzen-grid-optimizations/Radzen.Blazor.Benchmarks)
project, including the headless `BenchmarkRenderer` — lives on a linked branch,
[`tech/radzen-grid-optimizations`](https://github.com/pianomanjh/radzen-blazor/tree/tech/radzen-grid-optimizations).
Happy to fold it into this PR or keep it linked — whichever fits the repo.
