### PR TITLE
RadzenDropDown family: reduce selection, search, and render allocation

### DIFF
--- a/Radzen.Blazor.Tests/AutoCompleteTests.cs
+++ b/Radzen.Blazor.Tests/AutoCompleteTests.cs
@@ -178,6 +178,79 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void AutoComplete_RendersItemText_ViaTextProperty()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            var data = new[] { new { Name = "Apple" }, new { Name = "Banana" } };
+
+            var component = ctx.RenderComponent<RadzenAutoComplete>(parameters =>
+            {
+                parameters
+                    .Add(p => p.Data, data)
+                    .Add(p => p.TextProperty, "Name")
+                    .Add(p => p.OpenOnFocus, true);
+            });
+
+            var items = component.FindAll(".rz-autocomplete-list-item");
+            Assert.Contains(items, i => i.TextContent.Trim() == "Apple");
+            Assert.Contains(items, i => i.TextContent.Trim() == "Banana");
+        }
+
+        [Fact]
+        public void AutoComplete_PrimitiveItems_WithTextPropertyNamingRealMember_RendersItemItself()
+        {
+            // Regression: the cached-getter path must keep GetItemOrValueFromProperty's primitive contract -
+            // for a List<string> a non-empty TextProperty that happens to name a real member of string
+            // ("Length") must still render the string itself, not string.Length.
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            var data = new List<string> { "alpha", "beta" };
+
+            var component = ctx.RenderComponent<RadzenAutoComplete>(parameters =>
+            {
+                parameters
+                    .Add(p => p.Data, data)
+                    .Add(p => p.TextProperty, "Length")
+                    .Add(p => p.OpenOnFocus, true);
+            });
+
+            var items = component.FindAll(".rz-autocomplete-list-item");
+            Assert.Contains(items, i => i.TextContent.Trim() == "alpha");
+            Assert.Contains(items, i => i.TextContent.Trim() == "beta");
+            Assert.DoesNotContain(items, i => i.TextContent.Trim() == "5");
+        }
+
+        private class NestedLeaf { public int Id { get; set; } }
+        private class NestedRoot { public NestedLeaf Child { get; set; } }
+
+        [Fact]
+        public void AutoComplete_NestedTextProperty_NullIntermediate_RendersBlankNotLeafDefault()
+        {
+            // "Child.Id" with a null Child must render blank (matching reflection), not the int leaf's default "0"
+            // that a compiled getter would box.
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            var data = new List<NestedRoot>
+            {
+                new NestedRoot { Child = new NestedLeaf { Id = 1 } },
+                new NestedRoot { Child = null },
+            };
+
+            var component = ctx.RenderComponent<RadzenAutoComplete>(parameters =>
+            {
+                parameters
+                    .Add(p => p.Data, data)
+                    .Add(p => p.TextProperty, "Child.Id")
+                    .Add(p => p.OpenOnFocus, true);
+            });
+
+            var items = component.FindAll(".rz-autocomplete-list-item");
+            Assert.Contains(items, i => i.TextContent.Trim() == "1");
+            Assert.DoesNotContain(items, i => i.TextContent.Trim() == "0"); // null Child -> blank, not "0"
+        }
+
+        [Fact]
         public void AutoComplete_Renders_LoadingTemplate_WhenIsLoading()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/DropDownDataGridTests.cs
+++ b/Radzen.Blazor.Tests/DropDownDataGridTests.cs
@@ -268,6 +268,34 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void DropDownDataGrid_Multiple_DoesNotDuplicateItemsForRepeatedBoundValues()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            var data = new List<Customer>
+            {
+                new Customer { Id = 1, CompanyName = "Company1" },
+                new Customer { Id = 2, CompanyName = "Company2" },
+                new Customer { Id = 3, CompanyName = "Company3" }
+            };
+            // A value repeated in the bound collection must map to its item exactly once.
+            var selectedItems = new List<int> { 1, 1, 2 };
+
+            var component = ctx.RenderComponent<RadzenDropDownDataGrid<IEnumerable<int>>>(parameters =>
+            {
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.Chips, true);
+                parameters.Add(p => p.TextProperty, "CompanyName");
+                parameters.Add(p => p.ValueProperty, "Id");
+                parameters.Add(p => p.Data, data);
+                parameters.Add(p => p.Value, selectedItems);
+            });
+
+            var wrapper = component.Find(".rz-dropdown-chips-wrapper");
+            Assert.Equal("Company1,Company2", wrapper.GetAttribute("title"));
+        }
+
+        [Fact]
         public void DropDownDataGrid_Renders_Multiple_WithLabel_SelectedItemsTitle()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/DropDownFilterCaseInsensitiveTests.cs
+++ b/Radzen.Blazor.Tests/DropDownFilterCaseInsensitiveTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using Radzen;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    // The dropdown/autocomplete search's string-property Where overload compares in-memory
+    // case-insensitively with OrdinalIgnoreCase (no per-item ToLower).
+    public class DropDownFilterCaseInsensitiveTests
+    {
+        private class Item
+        {
+            public string Name { get; set; }
+        }
+
+        private static IQueryable<Item> Data() => new List<Item>
+        {
+            new() { Name = "Alice" },
+            new() { Name = "BOB" },
+            new() { Name = "charlie" },
+        }.AsQueryable();
+
+        private static List<string> Search(string value, StringFilterOperator op) =>
+            Data().Where("Name", value, op, FilterCaseSensitivity.CaseInsensitive).OfType<Item>().Select(i => i.Name).ToList();
+
+        [Theory]
+        [InlineData("LIC", StringFilterOperator.Contains, new[] { "Alice" })]
+        [InlineData("b", StringFilterOperator.Contains, new[] { "BOB" })]
+        [InlineData("char", StringFilterOperator.StartsWith, new[] { "charlie" })]
+        [InlineData("OB", StringFilterOperator.EndsWith, new[] { "BOB" })]
+        public void InMemorySearch_CaseInsensitive_MatchesRegardlessOfCase(string value, StringFilterOperator op, string[] expected)
+        {
+            Assert.Equal(expected, Search(value, op));
+        }
+
+        [Fact]
+        public void InMemorySearch_UsesOrdinalIgnoreCase_NotToLower()
+        {
+            var query = Data().Where("Name", "lic", StringFilterOperator.Contains, FilterCaseSensitivity.CaseInsensitive);
+            var expression = query.Expression.ToString();
+
+            Assert.Contains("OrdinalIgnoreCase", expression);
+            Assert.DoesNotContain("ToLower", expression);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DropDownTests.cs
+++ b/Radzen.Blazor.Tests/DropDownTests.cs
@@ -188,6 +188,125 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void DropDown_Multiple_SelectsItemsMatchingBoundValueByValueProperty()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = DropDown<IEnumerable<int>>(ctx, parameters =>
+            {
+                parameters.Add(p => p.ValueProperty, nameof(DataItem.Id));
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.Value, new List<int> { 2 });
+            });
+
+            var selected = component.FindAll(".rz-state-highlight");
+            Assert.Equal(1, selected.Count);
+            Assert.Equal("Item 2", selected[0].TextContent.Trim());
+        }
+
+        [Fact]
+        public void DropDown_Multiple_DoesNotDuplicateItemsForRepeatedBoundValues()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            // A value repeated in the bound collection must still select its item exactly once.
+            var component = DropDown<IEnumerable<int>>(ctx, parameters =>
+            {
+                parameters.Add(p => p.ValueProperty, nameof(DataItem.Id));
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.Value, new List<int> { 1, 1, 2 });
+            });
+
+            var selected = component.FindAll(".rz-state-highlight");
+            Assert.Equal(2, selected.Count);
+            var texts = selected.Select(s => s.TextContent.Trim()).OrderBy(t => t).ToList();
+            Assert.Equal(new[] { "Item 1", "Item 2" }, texts);
+        }
+
+        [Fact]
+        public void DropDown_Multiple_InPlaceValueMutation_UpdatesSelectionOnReRender()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            // Same collection reference kept throughout, as external code doing value.Add(..);
+            // StateHasChanged() would. The selected-values lookup must not go stale.
+            var value = new List<int> { 2 };
+            var component = DropDown<IEnumerable<int>>(ctx, parameters =>
+            {
+                parameters.Add(p => p.ValueProperty, nameof(DataItem.Id));
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.Value, value);
+            });
+
+            Assert.Equal(1, component.FindAll(".rz-state-highlight").Count);
+
+            value.Add(1);
+            component.Render();
+
+            var selected = component.FindAll(".rz-state-highlight");
+            Assert.Equal(2, selected.Count);
+            Assert.Equal(new[] { "Item 1", "Item 2" }, selected.Select(s => s.TextContent.Trim()).OrderBy(t => t).ToArray());
+        }
+
+        [Fact]
+        public void DropDown_Multiple_InPlaceElementReplacement_UpdatesSelectionOnReRender()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            // Same reference and same count: replace element [2] with [1]. A membership set keyed only on the
+            // reference (and count) would stay stale; it must be rebuilt so the highlight moves to Item 1.
+            var value = new List<int> { 2 };
+            var component = DropDown<IEnumerable<int>>(ctx, parameters =>
+            {
+                parameters.Add(p => p.ValueProperty, nameof(DataItem.Id));
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.Value, value);
+            });
+
+            Assert.Equal(new[] { "Item 2" },
+                component.FindAll(".rz-state-highlight").Select(s => s.TextContent.Trim()).ToArray());
+
+            value[0] = 1;
+            component.Render();
+
+            Assert.Equal(new[] { "Item 1" },
+                component.FindAll(".rz-state-highlight").Select(s => s.TextContent.Trim()).ToArray());
+        }
+
+        [Fact]
+        public void DropDown_ItemText_UpdatesWhenItemMutatedInPlace()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            // ShouldRender must compare the resolved text, not the Item reference: mutating an item's
+            // TextProperty value in place (same reference) then re-rendering must update the displayed text.
+            var data = new List<DataItem>
+            {
+                new DataItem { Text = "Item 1", Id = 1 },
+                new DataItem { Text = "Item 2", Id = 2 },
+            };
+            var component = ctx.RenderComponent<RadzenDropDown<int>>(parameters =>
+            {
+                parameters.Add(p => p.Data, data);
+                parameters.Add(p => p.TextProperty, nameof(DataItem.Text));
+                parameters.Add(p => p.ValueProperty, nameof(DataItem.Id));
+            });
+
+            Assert.Contains("Item 1", component.Markup);
+
+            data[0].Text = "Renamed";
+            component.Render();
+
+            Assert.Contains("Renamed", component.Markup);
+            Assert.DoesNotContain("Item 1", component.Markup);
+        }
+
+        [Fact]
         public void DropDown_AppliesSelectionStyleWhenMultipleSelectionIsEnabled()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor.Tests/DropDownTests.cs
+++ b/Radzen.Blazor.Tests/DropDownTests.cs
@@ -278,6 +278,35 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void DropDown_Multiple_InPlaceDataMutation_ResolvesSelectedLabelOnReRender()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            // Bind value 3, whose item is not in Data yet, then add the matching item to the SAME Data
+            // list (same reference) and re-render. Resolving the bound value must see the new item so its
+            // label shows - a value->item lookup keyed only on the Data reference would stay stale and blank.
+            var data = new List<DataItem>
+            {
+                new DataItem { Text = "Item 1", Id = 1 },
+                new DataItem { Text = "Item 2", Id = 2 },
+            };
+            var component = ctx.RenderComponent<RadzenDropDown<IEnumerable<int>>>(parameters =>
+            {
+                parameters.Add(p => p.Data, data);
+                parameters.Add(p => p.TextProperty, nameof(DataItem.Text));
+                parameters.Add(p => p.ValueProperty, nameof(DataItem.Id));
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.Value, new List<int> { 3 });
+            });
+
+            data.Add(new DataItem { Text = "Item 3", Id = 3 });
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.Data, data));
+
+            Assert.Contains(component.FindAll(".rz-dropdown-label"), l => l.TextContent.Contains("Item 3"));
+        }
+
+        [Fact]
         public void DropDown_ItemText_UpdatesWhenItemMutatedInPlace()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -480,6 +480,10 @@ namespace Radzen
         {
             base.OnParametersSet();
 
+            // Drop the memoized multiselect membership set each render so an in-place change to the bound
+            // value collection (same reference, mutated elements) is reflected on the next render.
+            _selectedValuesSet = null;
+
             if (_data != null)
             {
                 var query = _data.AsQueryable();
@@ -1607,17 +1611,16 @@ namespace Radzen
                     {
                         if (!string.IsNullOrEmpty(ValueProperty))
                         {
-                            foreach (object v in values.Cast<dynamic>().ToList())
+                            if (typeof(EnumerableQuery).IsAssignableFrom(view.GetType()))
                             {
-                                dynamic item;
-
-                                if (typeof(EnumerableQuery).IsAssignableFrom(view.GetType()))
+                                AddSelectedItemsByValue(view, values);
+                            }
+                            else
+                            {
+                                // Non-in-memory (e.g. EF): keep the per-value query so the lookup stays server-side.
+                                foreach (object v in values.Cast<dynamic>().ToList())
                                 {
-                                    item = view.OfType<object>().Where(i => object.Equals(GetItemOrValueFromProperty(i, ValueProperty), v)).FirstOrDefault()!;
-                                }
-                                else
-                                {
-                                    item = view.AsQueryable().Where(new FilterDescriptor[]
+                                    dynamic item = view.AsQueryable().Where(new FilterDescriptor[]
                                     {
                                         new FilterDescriptor()
                                         {
@@ -1627,11 +1630,11 @@ namespace Radzen
                                     },
                                     LogicalFilterOperator.And,
                                     FilterCaseSensitivity.Default).FirstOrDefault()!;
-                                }
 
-                                if (!object.Equals(item, null) && !selectedItems.AsQueryable().Where(i => object.Equals(GetItemOrValueFromProperty(i, ValueProperty), v)).Any())
-                                {
-                                    selectedItems.Add(item);
+                                    if (!object.Equals(item, null) && !selectedItems.AsQueryable().Where(i => object.Equals(GetItemOrValueFromProperty(i, ValueProperty), v)).Any())
+                                    {
+                                        selectedItems.Add(item);
+                                    }
                                 }
                             }
                         }
@@ -1653,6 +1656,45 @@ namespace Radzen
         /// </summary>
         [Parameter] public IEqualityComparer<object>? ItemComparer { get; set; }
 
+        /// <summary>
+        /// Resolves each bound value against the in-memory <paramref name="source"/> and adds any not already selected, using a value-&gt;item lookup so a multiselect binding is O(items + selected) rather than O(items x selected). The non-in-memory (e.g. EF) path stays at each call site so its lookup remains server-side.
+        /// </summary>
+        private protected void AddSelectedItemsByValue(IEnumerable source, IEnumerable values)
+        {
+            var itemsByValue = new Dictionary<object, object>();
+            foreach (var i in source.OfType<object>())
+            {
+                var iv = GetItemOrValueFromProperty(i, ValueProperty!);
+                if (iv != null)
+                {
+                    itemsByValue.TryAdd(iv, i);
+                }
+            }
+
+            var existingValues = new HashSet<object>();
+            foreach (var si in selectedItems)
+            {
+                var sv = GetItemOrValueFromProperty(si, ValueProperty!);
+                if (sv != null)
+                {
+                    existingValues.Add(sv);
+                }
+            }
+
+            foreach (object v in values.Cast<object>())
+            {
+                if (v != null && itemsByValue.TryGetValue(v, out var item) && existingValues.Add(v))
+                {
+                    selectedItems.Add(item);
+                }
+            }
+        }
+
+        // O(1) IsItemSelectedByValue membership. Cleared each render (OnParametersSet), so an in-place change
+        // to the bound value collection is reflected on the next lookup.
+        IEnumerable? _selectedValuesSource;
+        HashSet<object>? _selectedValuesSet;
+
         internal bool IsItemSelectedByValue(object v)
         {
             switch (internalValue)
@@ -1660,7 +1702,12 @@ namespace Radzen
                 case string s:
                     return object.Equals(s, v);
                 case IEnumerable enumerable:
-                    return enumerable.Cast<object>().Contains(v);
+                    if (_selectedValuesSet == null || !ReferenceEquals(_selectedValuesSource, enumerable))
+                    {
+                        _selectedValuesSource = enumerable;
+                        _selectedValuesSet = new HashSet<object>(enumerable.Cast<object>());
+                    }
+                    return _selectedValuesSet.Contains(v);
                 case null:
                     return false;
                 default:

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -170,18 +170,9 @@ namespace Radzen
             //
         }
 
-        HashSet<object> keys = new HashSet<object>();
-
         internal object? GetKey(object item)
         {
-            var value = GetItemOrValueFromProperty(item, ValueProperty ?? string.Empty);
-
-            if (value != null)
-            {
-                keys.Add(value);
-            }
-
-            return value;
+            return GetItemOrValueFromProperty(item, ValueProperty ?? string.Empty);
         }
 
         /// <summary>
@@ -1719,8 +1710,6 @@ namespace Radzen
         public override void Dispose()
         {
             base.Dispose();
-
-            keys.Clear();
 
             GC.SuppressFinalize(this);
         }

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -1770,30 +1770,48 @@ namespace Radzen
                     propertyExpression = Expression.Call(string.IsNullOrEmpty(property) && inMemory ? notNullCheck(parameter) : notNullCheck(propertyExpression), "ToString", Type.EmptyTypes);
                 }
 
-                if (ignoreCase && propertyExpression != null)
+                // EF can't translate the StringComparison overloads, so only an in-memory source uses them.
+                var useOrdinal = ignoreCase && inMemory;
+
+                if (ignoreCase && !useOrdinal && propertyExpression != null)
                 {
                     propertyExpression = Expression.Call(notNullCheck(propertyExpression!), "ToLower", Type.EmptyTypes);
                 }
 
-                var constantExpression = Expression.Constant(ignoreCase ? value.ToLower(CultureInfo.InvariantCulture) : value, typeof(string));
+                var constantExpression = Expression.Constant(!ignoreCase || useOrdinal ? value : value.ToLower(CultureInfo.InvariantCulture), typeof(string));
                 Expression? comparisonExpression = null;
 
                 if (propertyExpression != null)
                 {
-                    switch (op)
+                    if (useOrdinal)
                     {
-                        case StringFilterOperator.Contains:
-                            comparisonExpression = Expression.Call(notNullCheck(propertyExpression), "Contains", null, constantExpression);
-                            break;
-                        case StringFilterOperator.StartsWith:
-                            comparisonExpression = Expression.Call(notNullCheck(propertyExpression), "StartsWith", null, constantExpression);
-                            break;
-                        case StringFilterOperator.EndsWith:
-                            comparisonExpression = Expression.Call(notNullCheck(propertyExpression), "EndsWith", null, constantExpression);
-                            break;
-                        default:
-                            comparisonExpression = Expression.Equal(propertyExpression, constantExpression);
-                            break;
+                        var ordinal = Expression.Constant(StringComparison.OrdinalIgnoreCase);
+                        var target = notNullCheck(propertyExpression);
+                        comparisonExpression = op switch
+                        {
+                            StringFilterOperator.Contains => Expression.Call(target, typeof(string).GetMethod("Contains", new[] { typeof(string), typeof(StringComparison) })!, constantExpression, ordinal),
+                            StringFilterOperator.StartsWith => Expression.Call(target, typeof(string).GetMethod("StartsWith", new[] { typeof(string), typeof(StringComparison) })!, constantExpression, ordinal),
+                            StringFilterOperator.EndsWith => Expression.Call(target, typeof(string).GetMethod("EndsWith", new[] { typeof(string), typeof(StringComparison) })!, constantExpression, ordinal),
+                            _ => Expression.Call(target, typeof(string).GetMethod("Equals", new[] { typeof(string), typeof(StringComparison) })!, constantExpression, ordinal),
+                        };
+                    }
+                    else
+                    {
+                        switch (op)
+                        {
+                            case StringFilterOperator.Contains:
+                                comparisonExpression = Expression.Call(notNullCheck(propertyExpression), "Contains", null, constantExpression);
+                                break;
+                            case StringFilterOperator.StartsWith:
+                                comparisonExpression = Expression.Call(notNullCheck(propertyExpression), "StartsWith", null, constantExpression);
+                                break;
+                            case StringFilterOperator.EndsWith:
+                                comparisonExpression = Expression.Call(notNullCheck(propertyExpression), "EndsWith", null, constantExpression);
+                                break;
+                            default:
+                                comparisonExpression = Expression.Equal(propertyExpression, constantExpression);
+                                break;
+                        }
                     }
                 }
 

--- a/Radzen.Blazor/RadzenAutoComplete.razor
+++ b/Radzen.Blazor/RadzenAutoComplete.razor
@@ -55,7 +55,7 @@
                                     }
                                     else
                                     {
-                                        @PropertyAccess.GetItemOrValueFromProperty(item, TextProperty)
+                                        @GetItemText(item)
                                     }
                                 </span>
                             </li>

--- a/Radzen.Blazor/RadzenAutoComplete.razor.cs
+++ b/Radzen.Blazor/RadzenAutoComplete.razor.cs
@@ -320,6 +320,43 @@ namespace Radzen.Blazor
             }
         }
 
+        Func<object, object?>? textPropertyGetter;
+        Type? textPropertyGetterType;
+        string? textPropertyGetterProperty;
+
+        /// <summary>
+        /// Reads an item's TextProperty through a getter compiled once per (item type, TextProperty) and cached, falling back to reflection for anything it cannot compile.
+        /// </summary>
+        internal object? GetItemText(object? item)
+        {
+            // A primitive/string item or empty TextProperty yields the item itself, matching
+            // GetItemOrValueFromProperty (so List<string> with TextProperty="Length" shows the string, not its length).
+            // A nested path also stays on reflection: the compiled getter would render a null intermediate as the
+            // leaf type's default (e.g. "0") instead of blank, so only single-member paths are compiled.
+            if (item == null || string.IsNullOrEmpty(TextProperty) || TextProperty.Contains('.', StringComparison.Ordinal)
+                || Convert.GetTypeCode(item) != TypeCode.Object)
+            {
+                return PropertyAccess.GetItemOrValueFromProperty(item, TextProperty ?? string.Empty);
+            }
+
+            var type = item.GetType();
+            if (textPropertyGetterType != type || textPropertyGetterProperty != TextProperty)
+            {
+                textPropertyGetterType = type;
+                textPropertyGetterProperty = TextProperty;
+                try
+                {
+                    textPropertyGetter = PropertyAccess.Getter<object, object?>(TextProperty, type);
+                }
+                catch
+                {
+                    textPropertyGetter = null;
+                }
+            }
+
+            return textPropertyGetter != null ? textPropertyGetter(item) : PropertyAccess.GetItemOrValueFromProperty(item, TextProperty);
+        }
+
         /// <summary>
         /// Handles the @bind:set binding of the underlying input element.
         /// </summary>
@@ -340,7 +377,7 @@ namespace Radzen.Blazor
         {
             if (!string.IsNullOrEmpty(TextProperty))
             {
-                Value = PropertyAccess.GetItemOrValueFromProperty(item, TextProperty)?.ToString();
+                Value = GetItemText(item)?.ToString();
             }
             else
             {

--- a/Radzen.Blazor/RadzenDropDown.razor.cs
+++ b/Radzen.Blazor/RadzenDropDown.razor.cs
@@ -134,15 +134,21 @@ namespace Radzen.Blazor
         [Parameter]
         public Action<DropDownItemRenderEventArgs<TValue>>? ItemRender { get; set; }
 
+        // Shared resolution of the item-level disabled state (DisabledProperty), read by both the render
+        // args and RadzenDropDownItem.ShouldRender so the two cannot drift.
+        internal bool GetItemDisabled(object? item)
+        {
+            return !string.IsNullOrEmpty(DisabledProperty)
+                && GetItemOrValueFromProperty(item, DisabledProperty) is bool disabled && disabled;
+        }
+
         internal DropDownItemRenderEventArgs<TValue> ItemAttributes(RadzenDropDownItem<TValue> item)
         {
-            var disabled = !string.IsNullOrEmpty(DisabledProperty) ? GetItemOrValueFromProperty(item.Item, DisabledProperty) : false;
-
-            var args = new DropDownItemRenderEventArgs<TValue>() 
-            { 
-                DropDown = this, 
-                Item = item.Item, 
-                Disabled = disabled is bool ? (bool)disabled : false,
+            var args = new DropDownItemRenderEventArgs<TValue>()
+            {
+                DropDown = this,
+                Item = item.Item,
+                Disabled = GetItemDisabled(item.Item),
             };
 
             if (ItemRender != null)

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -928,16 +928,24 @@ namespace Radzen.Blazor
                         var valueList = values.Cast<object>().ToList();
                         if (!string.IsNullOrEmpty(ValueProperty))
                         {
-                            foreach (object v in valueList)
+                            if (typeof(EnumerableQuery).IsAssignableFrom(Query.GetType()))
                             {
-                                var item = Query.Where(new FilterDescriptor[]
-                                    {
-                                        new FilterDescriptor() { Property = ValueProperty, FilterValue = v }
-                                    }, LogicalFilterOperator.And, FilterCaseSensitivity.Default).FirstOrDefault();
-
-                                if (item != null && !selectedItems.AsQueryable().Where(i => object.Equals(GetItemOrValueFromProperty(i, ValueProperty), v)).Any())
+                                AddSelectedItemsByValue(Query, valueList);
+                            }
+                            else
+                            {
+                                // Non-in-memory (e.g. EF): keep the per-value query so the lookup stays server-side.
+                                foreach (object v in valueList)
                                 {
-                                    selectedItems.Add(item);
+                                    var item = Query.Where(new FilterDescriptor[]
+                                        {
+                                            new FilterDescriptor() { Property = ValueProperty, FilterValue = v }
+                                        }, LogicalFilterOperator.And, FilterCaseSensitivity.Default).FirstOrDefault();
+
+                                    if (item != null && !selectedItems.AsQueryable().Where(i => object.Equals(GetItemOrValueFromProperty(i, ValueProperty), v)).Any())
+                                    {
+                                        selectedItems.Add(item);
+                                    }
                                 }
                             }
                         }

--- a/Radzen.Blazor/RadzenDropDownItem.razor
+++ b/Radzen.Blazor/RadzenDropDownItem.razor
@@ -67,6 +67,51 @@ else
     [Parameter]
     public object Item { get; set; } = default!;
 
+    bool hasRendered;
+    object? lastText;
+    bool lastSelected;
+    bool lastItemDisabled;
+    bool lastDropDownDisabled;
+    bool lastMultiple;
+
+    /// <summary>
+    /// Skips re-rendering a plain item whose output has not changed, avoiding O(items) wasted work when the parent re-renders for an unrelated reason. A Template or ItemRender item always re-renders; the plain item is tracked by its resolved text, selected state, disabled state and layout, so an in-place mutation still re-renders.
+    /// </summary>
+    protected override bool ShouldRender()
+    {
+        var dropDown = DropDown;
+        if (dropDown == null || dropDown.Template != null || dropDown.ItemRender != null)
+        {
+            // Invalidate the plain-render snapshot so removing the Template/ItemRender at runtime forces a re-render.
+            hasRendered = false;
+            return true;
+        }
+
+        var text = dropDown.GetItemOrValueFromProperty(Item, dropDown.TextProperty ?? string.Empty);
+        var selected = dropDown.IsSelected(Item);
+        var multiple = dropDown.Multiple;
+        var dropDownDisabled = dropDown.Disabled;
+        var itemDisabled = dropDown.GetItemDisabled(Item);
+
+        if (hasRendered
+            && Equals(lastText, text)
+            && lastSelected == selected
+            && lastItemDisabled == itemDisabled
+            && lastDropDownDisabled == dropDownDisabled
+            && lastMultiple == multiple)
+        {
+            return false;
+        }
+
+        hasRendered = true;
+        lastText = text;
+        lastSelected = selected;
+        lastItemDisabled = itemDisabled;
+        lastDropDownDisabled = dropDownDisabled;
+        lastMultiple = multiple;
+        return true;
+    }
+
     async Task SelectItem(MouseEventArgs args,bool isclick)
     {
         var dropDown = DropDown;


### PR DESCRIPTION
In our app, we use quite a few large in-memory RadzenGrids and RadzenDropDows, and in profiling our app, I spent some time finding and addressing some fairly low hanging performance improvements. For us, they speed up the experience considerably, and we serve about 1000 users on a 4 core / 16GB server, so low allocations are helpful.

I understand this is a large change-set, but I wanted to leave it to the maintainers if they want to take on the benefit/risk.  If there is a larger regression suite you'd like me to exercise, let me know.

AI Tools: Claude Code CLI (Opus 4.8), Codex for review (5.6 Sol)

--------

Allocation- and CPU-focused optimizations for `RadzenDropDown`,
`RadzenDropDownDataGrid`, and `RadzenAutoComplete`. **No public API changes.**
Behaviour is preserved (with regression tests), except for one deliberate,
documented change: in-memory case-insensitive search becomes ordinal (§4).

## Method

Measure-first: BenchmarkDotNet (`[MemoryDiagnoser]`, `--job short`) plus
`dotnet-trace` (GC/AllocationTick) to attribute allocation. Every change is
backed by a measured before/after; allocation figures are exact. .NET 10.

## Changes & measured impact

### 1. Multiselect selection O(items × selected) → O(items + selected)
A multiselect dropdown bound by `ValueProperty` resolved each bound value by
scanning the whole view and re-scanning `selectedItems` with a LINQ query
allocated **per value**, and `IsItemSelectedByValue` (called 3–4× per rendered
item) did a linear `Contains` over the selected values per item. In-memory data
now resolves against a value→item lookup built once (shared
`DropDownBase.AddSelectedItemsByValue`, reused by `RadzenDropDownDataGrid`), and
`IsItemSelectedByValue` is backed by a `HashSet` rebuilt on a reference change and
cleared each render (`OnParametersSet`), so an in-place mutation of the same bound
collection is reflected. The per-value query is kept for a non-in-memory (EF) view.
Render time is now flat in the selected count.

Render a 500-item multiselect:

| Component | Selected | Before | After | |
|---|---|---|---|---|
| RadzenDropDown | 10 | 23.9 ms / 6.4 MB | 10.2 ms / 5.7 MB | 2.3× |
| RadzenDropDown | 100 | 147 ms / 11.7 MB | 10.5 ms / 5.8 MB | **14×** |
| RadzenDropDown | 250 | 380 ms / 19.8 MB | 13.6 ms / 6.0 MB | **28×** (−70% alloc) |
| RadzenDropDownDataGrid | 100 | 239 ms / 3.81 MB | 4.9 ms / 537 KB | **48×** |
| RadzenDropDownDataGrid | 250 | 557 ms / 9.26 MB | 5.1 ms / 608 KB | **110×** (−93% alloc) |

### 2. AutoComplete item-text getter cache
`RadzenAutoComplete` does not derive from `DropDownBase`, so it read each
suggestion's `TextProperty` via uncached reflection per item per render. Now a
getter is compiled once per `(item type, TextProperty)` and reused (reflection
fallback preserved, including the primitive-item contract).

| Render suggestion list | Before | After | |
|---|---|---|---|
| 1,000 items | 7.42 ms / 3.24 MB | 3.00 ms / 3.21 MB | **2.5× faster** (CPU; allocation is framework-bound) |

### 3. Skip re-rendering unchanged items; drop a dead set
`RadzenDropDownItem` overrides `ShouldRender` to skip an item whose rendered
output (resolved text, selected/disabled/component-disabled, layout) is
unchanged; a `Template`/`ItemRender` always re-renders. Also removes a
write-only `HashSet` in `DropDownBase` that was populated on every key
resolution but never read.

| Forced no-op re-render, 500 items | Before | After | |
|---|---|---|---|
| allocation | 4.1 MB | 3.8 MB | ~7% |

Modest by design — the dominant re-render cost is the parent rendering all N
item frames, which an item-level `ShouldRender` cannot remove; virtualization is
the lever there.

### 4. In-memory search skips the per-item `ToLower`
The string-property filter used by the dropdown and autocomplete search built
`item.Property.ToLower().Contains(value)` per item per keystroke, lowering every
item on every keystroke. The overload already detected an in-memory
(`EnumerableQuery`) source; it now uses that to compare with
`StringComparison.OrdinalIgnoreCase`, which needs no per-item allocation. A
non-in-memory source (e.g. EF Core) still lowers so it maps to SQL `LOWER()`.

**Behaviour note:** as with the grid, this makes **in-memory** case-insensitive
matching ordinal (culture-independent) rather than a current-culture `ToLower`.
Unchanged for ordinary text; can differ for culture-specific casing.

| In-memory search, 5,000 items, Contains (all match) | Before | After | |
|---|---|---|---|
| per keystroke | 428.4 KB | 145.8 KB | −66% (~22% faster) |

## Testing
Regression tests: multiselect selection by `ValueProperty` (matching, no
duplicates, in-place value-collection mutation reflected, and an in-place `Data`
mutation resolved on the next render) for both `RadzenDropDown` and
`RadzenDropDownDataGrid`; AutoComplete text via `TextProperty` and the
primitive-item contract; item text updates on in-place mutation; and the ordinal
in-memory search across operators (EF path still lowering). Full suite green;
builds on net8/9/10.

## Benchmark harness
The BenchmarkDotNet harness that produced these numbers — a
[`Radzen.Blazor.Benchmarks`](https://github.com/pianomanjh/radzen-blazor/tree/tech/radzen-dropdown-optimizations/Radzen.Blazor.Benchmarks)
project, including the headless `BenchmarkRenderer` — lives on a linked branch,
[`tech/radzen-dropdown-optimizations`](https://github.com/pianomanjh/radzen-blazor/tree/tech/radzen-dropdown-optimizations).
Happy to fold it into this PR or keep it linked — whichever fits the repo.
