### PR TITLE
PanelMenu: automatic indentation for N-level nested items

### DIFF
--- a/Radzen.Blazor.Tests/PanelMenuItemTests.cs
+++ b/Radzen.Blazor.Tests/PanelMenuItemTests.cs
@@ -199,5 +199,58 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains("_blank", component.Markup);
         }
+
+        [Fact]
+        public void PanelMenuItem_Renders_LevelVariable_ForNestedItems()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = ctx.RenderComponent<RadzenPanelMenu>(parameters =>
+            {
+                parameters.Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<RadzenPanelMenuItem>(0);
+                    builder.AddAttribute(1, nameof(RadzenPanelMenuItem.Text), "Level1");
+                    builder.AddAttribute(2, nameof(RadzenPanelMenuItem.ChildContent), (RenderFragment)(level2Builder =>
+                    {
+                        level2Builder.OpenComponent<RadzenPanelMenuItem>(0);
+                        level2Builder.AddAttribute(1, nameof(RadzenPanelMenuItem.Text), "Level2");
+                        level2Builder.AddAttribute(2, nameof(RadzenPanelMenuItem.ChildContent), (RenderFragment)(level3Builder =>
+                        {
+                            level3Builder.OpenComponent<RadzenPanelMenuItem>(0);
+                            level3Builder.AddAttribute(1, nameof(RadzenPanelMenuItem.Text), "Level3");
+                            level3Builder.CloseComponent();
+                        }));
+                        level2Builder.CloseComponent();
+                    }));
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.Contains("--rz-navigation-item-level: 1", component.Markup);
+            Assert.Contains("--rz-navigation-item-level: 2", component.Markup);
+            Assert.Contains("--rz-navigation-item-level: 3", component.Markup);
+        }
+
+        [Fact]
+        public void PanelMenuItem_Renders_LevelVariable_WithCustomStyle()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var component = ctx.RenderComponent<RadzenPanelMenu>(parameters =>
+            {
+                parameters.Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<RadzenPanelMenuItem>(0);
+                    builder.AddAttribute(1, nameof(RadzenPanelMenuItem.Text), "Styled");
+                    builder.AddAttribute(2, nameof(RadzenPanelMenuItem.Style), "color: red");
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.Contains("--rz-navigation-item-level: 1; color: red", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor
@@ -3,7 +3,7 @@
 @inherits RadzenComponent
 @if (Visible)
 {
-    <li @ref=@Element style=@Style @attributes=@Attributes class="@(GetCssClass() + ExpandableClass)" id=@GetId()
+    <li @ref=@Element style=@ItemStyle @attributes=@Attributes class="@(GetCssClass() + ExpandableClass)" id=@GetId()
         role="menuitem" tabindex="-1" aria-disabled="@(Disabled ? "true" : "false")"
         aria-controls="@(RenderSubmenu ? $"{GetId()}-submenu" : null)"
         aria-expanded="@(ChildContent != null ? expanded.ToString().ToLowerInvariant() : null)"

--- a/Radzen.Blazor/RadzenPanelMenuItem.razor.cs
+++ b/Radzen.Blazor/RadzenPanelMenuItem.razor.cs
@@ -286,6 +286,10 @@ namespace Radzen.Blazor
             SyncWithNavigationManager();
         }
 
+        internal int Level => ParentItem != null ? ParentItem.Level + 1 : 1;
+
+        string ItemStyle => string.IsNullOrEmpty(Style) ? $"--rz-navigation-item-level: {Level}" : $"--rz-navigation-item-level: {Level}; {Style}";
+
         string WrapperClass => ClassList.Create("rz-navigation-item-wrapper")
             .Add("rz-navigation-item-wrapper-active", selected)
             .ToString();

--- a/Radzen.Blazor/themes/_css-variables.scss
+++ b/Radzen.Blazor/themes/_css-variables.scss
@@ -982,6 +982,7 @@
   --rz-panel-menu-item-2nd-level-margin-inline: #{$panel-menu-item-2nd-level-margin-inline};
   --rz-panel-menu-item-2nd-level-border-radius: #{$panel-menu-item-2nd-level-border-radius};
   --rz-panel-menu-item-2nd-level-offset: #{$panel-menu-item-2nd-level-offset};
+  --rz-panel-menu-item-nested-offset: #{$panel-menu-item-nested-offset};
   --rz-panel-menu-item-2nd-level-font-size: #{$panel-menu-item-2nd-level-font-size};
   --rz-panel-menu-item-2nd-level-font-weight: #{$panel-menu-item-2nd-level-font-weight};
   --rz-panel-menu-item-2nd-level-color: #{$panel-menu-item-2nd-level-color};

--- a/Radzen.Blazor/themes/components/blazor/_panel-menu.scss
+++ b/Radzen.Blazor/themes/components/blazor/_panel-menu.scss
@@ -27,6 +27,7 @@ $panel-menu-item-2nd-level-margin-block: 0 !default;
 $panel-menu-item-2nd-level-margin-inline: 0 !default;
 $panel-menu-item-2nd-level-border-radius: 0 !default;
 $panel-menu-item-2nd-level-offset: 2.75rem !default;
+$panel-menu-item-nested-offset: 1rem !default;
 $panel-menu-item-2nd-level-font-size: var(--rz-body-font-size) !default;
 $panel-menu-item-2nd-level-font-weight: 400 !default;
 $panel-menu-item-2nd-level-color: inherit !default;
@@ -260,7 +261,7 @@ $panel-menu-toggle-icon-opacity: 1 !default;
       .rz-navigation-item-link {
         padding-block: var(--rz-panel-menu-item-2nd-level-padding-block);
         padding-inline: var(--rz-panel-menu-item-2nd-level-padding-inline);
-        padding-inline-start: var(--rz-panel-menu-item-2nd-level-offset);
+        padding-inline-start: calc(var(--rz-panel-menu-item-2nd-level-offset) + (var(--rz-navigation-item-level, 2) - 2) * var(--rz-panel-menu-item-nested-offset));
       }
     }
 


### PR DESCRIPTION
Fixes #2675

## What

Nested `RadzenPanelMenuItem` components at level 3 and deeper rendered at the exact same horizontal offset as level 2 — the only hierarchy cue was a slightly darker background, which made deep menus (3+ levels) hard to read.

## How

- `RadzenPanelMenuItem` now renders its nesting depth as an inline `--rz-navigation-item-level` CSS custom property on the item element (computed from the existing `ParentItem` cascade). This also gives users a styling hook for per-level customization.
- The nested item padding in `_panel-menu.scss` becomes `calc(var(--rz-panel-menu-item-2nd-level-offset) + (var(--rz-navigation-item-level, 2) - 2) * var(--rz-panel-menu-item-nested-offset))`.
- New theme variable `$panel-menu-item-nested-offset` (default `1rem`), exposed as `--rz-panel-menu-item-nested-offset`, controls the per-level step. Setting it to `0` restores the old flat look.

Levels 1 and 2 keep their exact current offsets in every theme; each deeper level shifts right by one step.

## Verified

- 2 new bUnit tests (level variable rendered per depth, merge with user `Style`); full suite green (5003 tests).
- Playwright measurement on the `/panelmenu` demo (4-level structure from the issue) across material, material-dark, standard and default themes — level 2 unchanged (e.g. 48px in material), level 3 now 64px, level 4 80px.

| Before | After |
|---|---|
| levels 2/3/4 all at 48px | 48px / 64px / 80px |

Note: prebuilt premium theme CSS (material3, fluent) picks the rule up on its next rebuild; until then those themes keep the current behavior.