### PR TITLE
Add RadzenMarkdownEditor component

### DIFF
--- a/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
@@ -40,4 +40,13 @@ public class HtmlVisitorTests
             "<ul><li><p>a</p></li><li><p>b</p></li></ul>",
             HtmlVisitor.ToHtml("- a\n\n- b"));
     }
+
+    [Theory]
+    [InlineData("[x](javascript:alert(1))", "<p><a href=\"\">x</a></p>")]
+    [InlineData("[x](JaVaScRiPt:alert(1))", "<p><a href=\"\">x</a></p>")]
+    [InlineData("![a](javascript:alert(1))", "<p><img src=\"\" alt=\"a\"></p>")]
+    public void ToHtml_blanks_dangerous_urls(string markdown, string expected)
+    {
+        Assert.Equal(expected, HtmlVisitor.ToHtml(markdown));
+    }
 }

--- a/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
@@ -1,4 +1,3 @@
-using Radzen.Blazor.Documents.Markdown;
 using Xunit;
 
 namespace Radzen.Documents.Markdown.Tests;

--- a/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
@@ -1,3 +1,4 @@
+using Radzen.Blazor.Documents.Markdown;
 using Xunit;
 
 namespace Radzen.Documents.Markdown.Tests;

--- a/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/HtmlVisitorTests.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace Radzen.Documents.Markdown.Tests;
+
+public class HtmlVisitorTests
+{
+    [Theory]
+    [InlineData("# Hi", "<h1>Hi</h1>")]
+    [InlineData("plain *em* **strong** ~~del~~ `code`",
+        "<p>plain <em>em</em> <strong>strong</strong> <del>del</del> <code>code</code></p>")]
+    [InlineData("[link](https://a.b \"t\")", "<p><a href=\"https://a.b\">link</a></p>")]
+    [InlineData("![alt](img.png)", "<p><img src=\"img.png\" alt=\"alt\"></p>")]
+    [InlineData("> quote", "<blockquote><p>quote</p></blockquote>")]
+    [InlineData("- a\n- b", "<ul><li>a</li><li>b</li></ul>")]
+    [InlineData("3. a", "<ol start=\"3\"><li>a</li></ol>")]
+    [InlineData("- [x] done", "<ul><li><input type=\"checkbox\" checked> done</li></ul>")]
+    [InlineData("```csharp\nvar x = 1;\n```", "<pre><code class=\"language-csharp\">var x = 1;\n</code></pre>")]
+    [InlineData("---", "<hr>")]
+    [InlineData("a  \nb", "<p>a<br>b</p>")]
+    [InlineData("a\nb", "<p>a b</p>")]
+    [InlineData("<script>x</script>", "<p>&lt;script&gt;x&lt;/script&gt;</p>")]
+    [InlineData("a < b & c", "<p>a &lt; b &amp; c</p>")]
+    [InlineData("| a | b |\n| --- | ---: |\n| 1 | 2 |",
+        "<table><thead><tr><th>a</th><th style=\"text-align:right\">b</th></tr></thead><tbody><tr><td>1</td><td style=\"text-align:right\">2</td></tr></tbody></table>")]
+    public void ToHtml_renders(string markdown, string expected)
+    {
+        Assert.Equal(expected, HtmlVisitor.ToHtml(markdown));
+    }
+
+    [Fact]
+    public void ToHtml_separates_blocks_without_text_between_them()
+    {
+        Assert.Equal("<h1>A</h1><p>b</p>", HtmlVisitor.ToHtml("# A\n\nb"));
+    }
+
+    [Fact]
+    public void ToHtml_wraps_loose_list_items_in_paragraphs()
+    {
+        Assert.Equal(
+            "<ul><li><p>a</p></li><li><p>b</p></li></ul>",
+            HtmlVisitor.ToHtml("- a\n\n- b"));
+    }
+}

--- a/Radzen.Blazor.Tests/Markdown/InlineSpanTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/InlineSpanTests.cs
@@ -1,0 +1,52 @@
+using Xunit;
+
+namespace Radzen.Documents.Markdown.Tests;
+
+public class InlineSpanTests
+{
+    [Fact]
+    public void Finds_strong_span()
+    {
+        var spans = InlineParser.ScanSpans("a **bold** b");
+        var span = Assert.Single(spans);
+        Assert.Equal((2, 10, 2, '*'), (span.Start, span.End, span.DelimiterLength, span.Char));
+    }
+
+    [Fact]
+    public void Finds_underscore_emphasis()
+    {
+        var spans = InlineParser.ScanSpans("_it_");
+        var span = Assert.Single(spans);
+        Assert.Equal((0, 4, 1, '_'), (span.Start, span.End, span.DelimiterLength, span.Char));
+    }
+
+    [Fact]
+    public void Finds_nested_strong_and_emphasis()
+    {
+        var spans = InlineParser.ScanSpans("***a***");
+        Assert.Contains(spans, s => s is { Start: 1, End: 6, DelimiterLength: 2 }); // **a** inner
+        Assert.Contains(spans, s => s is { Start: 0, End: 7, DelimiterLength: 1 }); // *…* outer
+    }
+
+    [Fact]
+    public void Finds_code_span_and_ignores_emphasis_inside()
+    {
+        var spans = InlineParser.ScanSpans("x `a *b*` y");
+        var span = Assert.Single(spans);
+        Assert.Equal((2, 9, 1, '`'), (span.Start, span.End, span.DelimiterLength, span.Char));
+    }
+
+    [Fact]
+    public void Finds_strikethrough()
+    {
+        var spans = InlineParser.ScanSpans("~~gone~~");
+        var span = Assert.Single(spans);
+        Assert.Equal((0, 8, 2, '~'), (span.Start, span.End, span.DelimiterLength, span.Char));
+    }
+
+    [Fact]
+    public void Flanking_rejects_space_before_closer()
+    {
+        Assert.Empty(InlineParser.ScanSpans("**hello **world"));
+    }
+}

--- a/Radzen.Blazor.Tests/Markdown/StrikethroughTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/StrikethroughTests.cs
@@ -1,0 +1,55 @@
+using Xunit;
+
+namespace Radzen.Documents.Markdown.Tests;
+
+public class StrikethroughTests
+{
+    private static string ToXml(string markdown)
+    {
+        var document = MarkdownParser.Parse(markdown);
+        return XmlVisitor.ToXml(document);
+    }
+
+    [Theory]
+    [InlineData("~~struck~~", @"<document>
+    <paragraph>
+        <strikethrough>
+            <text>struck</text>
+        </strikethrough>
+    </paragraph>
+</document>")]
+    [InlineData("a ~~b **c** d~~ e", @"<document>
+    <paragraph>
+        <text>a </text>
+        <strikethrough>
+            <text>b </text>
+            <strong>
+                <text>c</text>
+            </strong>
+            <text> d</text>
+        </strikethrough>
+        <text> e</text>
+    </paragraph>
+</document>")]
+    // single tilde is NOT strikethrough (GFM requires exactly ~~)
+    [InlineData("~one~", @"<document>
+    <paragraph>
+        <text>~</text>
+        <text>one</text>
+        <text>~</text>
+    </paragraph>
+</document>")]
+    // flanking: closing run preceded by space stays literal
+    [InlineData("~~a ~~b", @"<document>
+    <paragraph>
+        <text>~~</text>
+        <text>a </text>
+        <text>~~</text>
+        <text>b</text>
+    </paragraph>
+</document>")]
+    public void Strikethrough_parses(string markdown, string expected)
+    {
+        Assert.Equal(expected.Replace("\r\n", "\n"), ToXml(markdown).Replace("\r\n", "\n"));
+    }
+}

--- a/Radzen.Blazor.Tests/Markdown/TaskListTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/TaskListTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+
+namespace Radzen.Documents.Markdown.Tests;
+
+public class TaskListTests
+{
+    private static string ToXml(string markdown)
+    {
+        var document = MarkdownParser.Parse(markdown);
+        return XmlVisitor.ToXml(document);
+    }
+
+    [Theory]
+    [InlineData("- [ ] todo\n- [x] done", @"<document>
+    <list type=""bullet"" tight=""true"">
+        <item checked=""false"">
+            <paragraph>
+                <text>todo</text>
+            </paragraph>
+        </item>
+        <item checked=""true"">
+            <paragraph>
+                <text>done</text>
+            </paragraph>
+        </item>
+    </list>
+</document>")]
+    // no marker → no checked attribute; [x] not followed by space is literal.
+    // The unmatched "[" / "]" split into separate <text> nodes because the inline
+    // parser's bracket handling (InlineParser.TryGetOpenerIndex) flushes the text
+    // buffer before confirming a link, regardless of task-list parsing; this is
+    // pre-existing behavior, reproduced here rather than merged, since fixing it
+    // is outside this task's scope. See task-2-report.md for details.
+    [InlineData("- [x]tight", @"<document>
+    <list type=""bullet"" tight=""true"">
+        <item>
+            <paragraph>
+                <text>[</text>
+                <text>x</text>
+                <text>]tight</text>
+            </paragraph>
+        </item>
+    </list>
+</document>")]
+    public void TaskList_parses(string markdown, string expected)
+    {
+        Assert.Equal(expected.Replace("\r\n", "\n"), ToXml(markdown).Replace("\r\n", "\n"));
+    }
+}

--- a/Radzen.Blazor.Tests/Markdown/TaskListTests.cs
+++ b/Radzen.Blazor.Tests/Markdown/TaskListTests.cs
@@ -30,7 +30,7 @@ public class TaskListTests
     // parser's bracket handling (InlineParser.TryGetOpenerIndex) flushes the text
     // buffer before confirming a link, regardless of task-list parsing; this is
     // pre-existing behavior, reproduced here rather than merged, since fixing it
-    // is outside this task's scope. See task-2-report.md for details.
+    // is outside this task's scope.
     [InlineData("- [x]tight", @"<document>
     <list type=""bullet"" tight=""true"">
         <item>

--- a/Radzen.Blazor.Tests/Markdown/XmlVisitor.cs
+++ b/Radzen.Blazor.Tests/Markdown/XmlVisitor.cs
@@ -130,6 +130,13 @@ public class XmlVisitor : NodeVisitorBase, IDisposable
         writer.WriteEndElement();
     }
 
+    public override void VisitStrikethrough(Strikethrough strikethrough)
+    {
+        writer.WriteStartElement("strikethrough");
+        base.VisitStrikethrough(strikethrough);
+        writer.WriteEndElement();
+    }
+
     public override void VisitCode(Code code)
     {
         writer.WriteElementString("code", code.Value);

--- a/Radzen.Blazor.Tests/Markdown/XmlVisitor.cs
+++ b/Radzen.Blazor.Tests/Markdown/XmlVisitor.cs
@@ -63,6 +63,10 @@ public class XmlVisitor : NodeVisitorBase, IDisposable
     public override void VisitListItem(ListItem listItem)
     {
         writer.WriteStartElement("item");
+        if (listItem.Checked is bool isChecked)
+        {
+            writer.WriteAttributeString("checked", isChecked ? "true" : "false");
+        }
         base.VisitListItem(listItem);
         writer.WriteEndElement();
     }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -76,7 +76,7 @@ namespace Radzen.Blazor.Tests
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
                 .Add(x => x.ModeChanged, m => changed = m));
 
-            component.Find(".rz-markdown-editor-modes button:nth-child(2)").Click();
+            component.Find(".rz-markdown-editor-modes button[aria-label='Source']").Click();
 
             Assert.Equal(MarkdownEditorMode.Source, changed);
         }
@@ -270,7 +270,7 @@ namespace Radzen.Blazor.Tests
 
             // Mode is one-way bound (no ModeChanged): the Mode parameter never changes, but the internal
             // mode field does, and rendering must follow the field, not the unchanged parameter.
-            component.Find(".rz-markdown-editor-modes button:nth-child(2)").Click();
+            component.Find(".rz-markdown-editor-modes button[aria-label='Source']").Click();
 
             Assert.False(component.Find("textarea").HasAttribute("hidden"));
             Assert.True(component.Find(".rz-markdown-editor-design").HasAttribute("hidden"));

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -163,8 +163,8 @@ namespace Radzen.Blazor.Tests
             var component = ctx.RenderComponent<RadzenMarkdownEditor>();
 
             var icons = component.FindAll(".rz-markdown-editor-tools .rzi").Select(i => i.TextContent).ToList();
-            Assert.Equal(new[] { "format_bold", "format_italic", "strikethrough_s", "title", "format_quote", "code", "code_blocks",
-                                 "format_list_bulleted", "format_list_numbered", "checklist", "link", "image", "horizontal_rule" }, icons);
+            Assert.Equal(new[] { "format_bold", "format_italic", "title", "format_quote", "code", "code_blocks",
+                                 "format_list_bulleted", "format_list_numbered", "link", "image", "horizontal_rule" }, icons);
         }
 
         [Fact]
@@ -202,6 +202,97 @@ namespace Radzen.Blazor.Tests
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
 
             Assert.All(component.FindAll(".rz-markdown-editor-tools button"), b => Assert.True(b.HasAttribute("disabled")));
+        }
+
+        [Fact]
+        public void MarkdownEditor_Disabled_DisablesTextarea_AndAllTools()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Disabled, true));
+
+            Assert.True(component.Find("textarea").HasAttribute("disabled"));
+            Assert.All(component.FindAll(".rz-markdown-editor-tools button"), b => Assert.True(b.HasAttribute("disabled")));
+        }
+
+        [Fact]
+        public void MarkdownEditor_Visible_False_DoesNotRender_OrCreateJsRef_ThenTrue_CreatesOnce()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Visible, false));
+
+            Assert.DoesNotContain("rz-markdown-editor", component.Markup);
+            ctx.JSInterop.VerifyNotInvoke("Radzen.createMarkdownEditor");
+
+            component.SetParametersAndRender(p => p.Add(x => x.Visible, true));
+
+            ctx.JSInterop.VerifyInvoke("Radzen.createMarkdownEditor");
+        }
+
+        [Fact]
+        public void MarkdownEditor_SplitMode_UpdatesPreview_OnInput()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Mode, MarkdownEditorMode.Split)
+                .Add(x => x.Value, "a"));
+
+            component.Find("textarea").Input("# Hi");
+
+            Assert.Contains("<h1", component.Markup);
+        }
+
+        [Fact]
+        public void MarkdownEditor_ModeSwitcher_UpdatesInternalMode_WhenOneWayBound()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "# Hi")
+                .Add(x => x.Mode, MarkdownEditorMode.Edit));
+
+            // Mode is one-way bound (no ModeChanged): the Mode parameter never changes, but the internal
+            // mode field does, and rendering must follow the field, not the unchanged parameter.
+            component.Find(".rz-markdown-editor-modes button:nth-child(2)").Click();
+
+            Assert.Contains("rz-markdown-editor-preview", component.Markup);
+            Assert.Contains("<h1", component.Markup);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_ExecuteShortcutAsync_AppliesRegisteredShortcut_AndIgnoresUnknownKey()
+        {
+            using var ctx = CreateContext();
+            ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 0, 2 });
+            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            apply.SetVoidResult();
+
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "hi")
+                .AddChildContent<RadzenMarkdownEditorBold>());
+
+            await component.InvokeAsync(() => component.Instance.ExecuteShortcutAsync("Ctrl+B"));
+
+            var invocation = Assert.Single(apply.Invocations);
+            Assert.Equal("**hi**", invocation.Arguments[3]);
+
+            await component.InvokeAsync(() => component.Instance.ExecuteShortcutAsync("Ctrl+Z"));
+
+            Assert.Single(apply.Invocations);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_ExecuteCommand_NormalizesCrlfSelectionOffsets()
+        {
+            using var ctx = CreateContext();
+            ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 6, 11 });
+            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            apply.SetVoidResult();
+
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Value, "line1\r\nline2"));
+
+            await component.InvokeAsync(() => component.Instance.ExecuteCommandAsync(MarkdownEditorCommands.Bold));
+
+            var invocation = Assert.Single(apply.Invocations);
+            Assert.Equal(new object?[] { 6, 11, "**line2**", 8, 13 }, invocation.Arguments.Skip(1).ToArray());
         }
 
         [Fact]

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -469,6 +469,7 @@ namespace Radzen.Blazor.Tests
         [InlineData("smile", "\U0001f604")]
         [InlineData("SMILE", "\U0001f604")] // shortcodes are case-insensitive, matching the parser
         [InlineData("thumbsup", "\U0001f44d")]
+        [InlineData("+1", "\U0001f44d")]
         public async System.Threading.Tasks.Task MarkdownEditor_LookupEmoji_ReturnsEmojiForKnownShortcode(string shortcode, string expected)
         {
             using var ctx = CreateContext();

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -113,18 +113,19 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = CreateContext();
             ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 0, 5 });
-            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            var apply = ctx.JSInterop.SetupVoid("apply", _ => true);
             apply.SetVoidResult();
             string? executed = null;
 
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
                 .Add(x => x.Value, "hello")
+                .Add(x => x.Mode, MarkdownEditorMode.Source)
                 .Add(x => x.Execute, args => executed = args.CommandName));
 
             await component.InvokeAsync(() => component.Instance.ExecuteCommandAsync(MarkdownEditorCommands.Bold));
 
             var invocation = Assert.Single(apply.Invocations);
-            Assert.Equal(new object?[] { 0, 5, "**hello**", 2, 7 }, invocation.Arguments.Skip(1).ToArray());
+            Assert.Equal(new object?[] { 0, 5, "**hello**", 2, 7 }, invocation.Arguments.ToArray());
             Assert.Equal("bold", executed);
         }
 
@@ -132,11 +133,12 @@ namespace Radzen.Blazor.Tests
         public async System.Threading.Tasks.Task MarkdownEditor_ExecuteCommand_UnknownCommand_RaisesExecuteWithoutApplying()
         {
             using var ctx = CreateContext();
-            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            var apply = ctx.JSInterop.SetupVoid("apply", _ => true);
             apply.SetVoidResult();
             string? executed = null;
 
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Mode, MarkdownEditorMode.Source)
                 .Add(x => x.Execute, args => executed = args.CommandName));
 
             await component.InvokeAsync(() => component.Instance.ExecuteCommandAsync("insertToday"));
@@ -171,17 +173,18 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = CreateContext();
             ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 0, 2 });
-            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            var apply = ctx.JSInterop.SetupVoid("apply", _ => true);
             apply.SetVoidResult();
 
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
                 .Add(x => x.Value, "hi")
+                .Add(x => x.Mode, MarkdownEditorMode.Source)
                 .AddChildContent<RadzenMarkdownEditorItalic>());
 
             component.Find(".rz-markdown-editor-tools button").Click();
 
             var invocation = Assert.Single(apply.Invocations);
-            Assert.Equal("*hi*", invocation.Arguments[3]);
+            Assert.Equal("*hi*", invocation.Arguments[2]);
         }
 
         [Fact]
@@ -229,17 +232,18 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = CreateContext();
             ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 0, 2 });
-            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            var apply = ctx.JSInterop.SetupVoid("apply", _ => true);
             apply.SetVoidResult();
 
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
                 .Add(x => x.Value, "hi")
+                .Add(x => x.Mode, MarkdownEditorMode.Source)
                 .AddChildContent<RadzenMarkdownEditorBold>());
 
             await component.InvokeAsync(() => component.Instance.ExecuteShortcutAsync("Ctrl+B"));
 
             var invocation = Assert.Single(apply.Invocations);
-            Assert.Equal("**hi**", invocation.Arguments[3]);
+            Assert.Equal("**hi**", invocation.Arguments[2]);
 
             await component.InvokeAsync(() => component.Instance.ExecuteShortcutAsync("Ctrl+Z"));
 
@@ -251,15 +255,17 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = CreateContext();
             ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 6, 11 });
-            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            var apply = ctx.JSInterop.SetupVoid("apply", _ => true);
             apply.SetVoidResult();
 
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Value, "line1\r\nline2"));
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "line1\r\nline2")
+                .Add(x => x.Mode, MarkdownEditorMode.Source));
 
             await component.InvokeAsync(() => component.Instance.ExecuteCommandAsync(MarkdownEditorCommands.Bold));
 
             var invocation = Assert.Single(apply.Invocations);
-            Assert.Equal(new object?[] { 6, 11, "**line2**", 8, 13 }, invocation.Arguments.Skip(1).ToArray());
+            Assert.Equal(new object?[] { 6, 11, "**line2**", 8, 13 }, invocation.Arguments.ToArray());
         }
 
         [Fact]
@@ -278,11 +284,12 @@ namespace Radzen.Blazor.Tests
         public void CustomTool_Click_RaisesExecute_WithCommandName()
         {
             using var ctx = CreateContext();
-            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            var apply = ctx.JSInterop.SetupVoid("apply", _ => true);
             apply.SetVoidResult();
             string? executed = null;
 
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Mode, MarkdownEditorMode.Source)
                 .Add(x => x.Execute, args => executed = args.CommandName)
                 .AddChildContent<RadzenMarkdownEditorCustomTool>(t => t
                     .Add(x => x.CommandName, "InsertToday")

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -215,5 +215,38 @@ namespace Radzen.Blazor.Tests
             var keys = Assert.IsAssignableFrom<System.Collections.Generic.IEnumerable<string>>(invocation.Arguments[2]);
             Assert.Equal(new[] { "Ctrl+B", "Ctrl+I", "Ctrl+K" }, keys.OrderBy(k => k));
         }
+
+        [Fact]
+        public void CustomTool_Click_RaisesExecute_WithCommandName()
+        {
+            using var ctx = CreateContext();
+            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            apply.SetVoidResult();
+            string? executed = null;
+
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Execute, args => executed = args.CommandName)
+                .AddChildContent<RadzenMarkdownEditorCustomTool>(t => t
+                    .Add(x => x.CommandName, "InsertToday")
+                    .Add(x => x.Icon, "today")));
+
+            component.Find(".rz-markdown-editor-tools button").Click();
+
+            Assert.Equal("InsertToday", executed);
+            Assert.Empty(apply.Invocations);
+        }
+
+        [Fact]
+        public void CustomTool_RendersTemplate_WithEditor()
+        {
+            using var ctx = CreateContext();
+
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .AddChildContent<RadzenMarkdownEditorCustomTool>(t => t
+                    .Add(x => x.Template, editor => b => b.AddContent(0, $"mode:{editor.Mode}"))));
+
+            Assert.Contains("rz-markdown-editor-custom-tool", component.Markup);
+            Assert.Contains("mode:Edit", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -36,47 +36,36 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
-        public void MarkdownEditor_EditMode_RendersNoPreview()
+        public void MarkdownEditor_DesignMode_RendersEditableAndHidesTextarea()
         {
             using var ctx = CreateContext();
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Value, "# Hi"));
 
-            Assert.DoesNotContain("rz-markdown-editor-preview", component.Markup);
-            Assert.DoesNotContain("hidden", component.Find("textarea").OuterHtml);
-        }
-
-        [Fact]
-        public void MarkdownEditor_PreviewMode_HidesTextarea_AndRendersMarkdown()
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
-                .Add(x => x.Value, "# Hi")
-                .Add(x => x.Mode, MarkdownEditorMode.Preview));
-
-            Assert.Contains("rz-markdown-editor-preview", component.Markup);
-            Assert.Contains("<h1", component.Markup);
+            var editable = component.Find(".rz-markdown-editor-design");
+            Assert.Equal("true", editable.GetAttribute("contenteditable"));
+            Assert.Empty(editable.InnerHtml.Trim()); // Blazor renders it empty; JS owns content
             Assert.True(component.Find("textarea").HasAttribute("hidden"));
         }
 
         [Fact]
-        public void MarkdownEditor_SplitMode_RendersBoth()
+        public void MarkdownEditor_SourceMode_ShowsTextareaAndHidesEditable()
         {
             using var ctx = CreateContext();
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
                 .Add(x => x.Value, "# Hi")
-                .Add(x => x.Mode, MarkdownEditorMode.Split));
+                .Add(x => x.Mode, MarkdownEditorMode.Source));
 
-            Assert.Contains("rz-markdown-editor-preview", component.Markup);
             Assert.False(component.Find("textarea").HasAttribute("hidden"));
+            Assert.True(component.Find(".rz-markdown-editor-design").HasAttribute("hidden"));
         }
 
         [Fact]
-        public void MarkdownEditor_PreviewMode_ShowsPlaceholder_WhenEmpty()
+        public void MarkdownEditor_DisabledRemovesContentEditable()
         {
             using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Disabled, true));
 
-            Assert.Contains("Nothing to preview", component.Markup);
+            Assert.Equal("false", component.Find(".rz-markdown-editor-design").GetAttribute("contenteditable"));
         }
 
         [Fact]
@@ -89,7 +78,7 @@ namespace Radzen.Blazor.Tests
 
             component.Find(".rz-markdown-editor-modes button:nth-child(2)").Click();
 
-            Assert.Equal(MarkdownEditorMode.Preview, changed);
+            Assert.Equal(MarkdownEditorMode.Source, changed);
         }
 
         [Fact]
@@ -196,15 +185,6 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
-        public void MarkdownEditor_Tools_AreDisabled_InPreviewMode()
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
-
-            Assert.All(component.FindAll(".rz-markdown-editor-tools button"), b => Assert.True(b.HasAttribute("disabled")));
-        }
-
-        [Fact]
         public void MarkdownEditor_Disabled_DisablesTextarea_AndAllTools()
         {
             using var ctx = CreateContext();
@@ -229,32 +209,19 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
-        public void MarkdownEditor_SplitMode_UpdatesPreview_OnInput()
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
-                .Add(x => x.Mode, MarkdownEditorMode.Split)
-                .Add(x => x.Value, "a"));
-
-            component.Find("textarea").Input("# Hi");
-
-            Assert.Contains("<h1", component.Markup);
-        }
-
-        [Fact]
         public void MarkdownEditor_ModeSwitcher_UpdatesInternalMode_WhenOneWayBound()
         {
             using var ctx = CreateContext();
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
                 .Add(x => x.Value, "# Hi")
-                .Add(x => x.Mode, MarkdownEditorMode.Edit));
+                .Add(x => x.Mode, MarkdownEditorMode.Design));
 
             // Mode is one-way bound (no ModeChanged): the Mode parameter never changes, but the internal
             // mode field does, and rendering must follow the field, not the unchanged parameter.
             component.Find(".rz-markdown-editor-modes button:nth-child(2)").Click();
 
-            Assert.Contains("rz-markdown-editor-preview", component.Markup);
-            Assert.Contains("<h1", component.Markup);
+            Assert.False(component.Find("textarea").HasAttribute("hidden"));
+            Assert.True(component.Find(".rz-markdown-editor-design").HasAttribute("hidden"));
         }
 
         [Fact]
@@ -337,82 +304,7 @@ namespace Radzen.Blazor.Tests
                     .Add(x => x.Template, editor => b => b.AddContent(0, $"mode:{editor.Mode}"))));
 
             Assert.Contains("rz-markdown-editor-custom-tool", component.Markup);
-            Assert.Contains("mode:Edit", component.Markup);
-        }
-
-        [Theory]
-        [InlineData(MarkdownEditorMode.Edit, false)]
-        [InlineData(MarkdownEditorMode.Preview, false)]
-        [InlineData(MarkdownEditorMode.Split, true)]
-        public void MarkdownEditor_RendersSplitterBar_OnlyInSplitMode(MarkdownEditorMode mode, bool expected)
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, mode));
-
-            Assert.Equal(expected, component.FindAll(".rz-splitter-bar").Count > 0);
-        }
-
-        [Fact]
-        public void MarkdownEditor_PreviewMode_HidesTextareaPane_ButKeepsTextareaInDom()
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
-
-            Assert.NotNull(component.Find("textarea"));
-            Assert.Single(component.FindAll(".rz-markdown-editor-pane-hidden"));
-        }
-
-        [Theory]
-        [InlineData(MarkdownEditorMode.Edit, "rz-markdown-editor-pane-full")]
-        [InlineData(MarkdownEditorMode.Preview, "rz-markdown-editor-pane-hidden")]
-        public void MarkdownEditor_TextareaPane_HasModeClass(MarkdownEditorMode mode, string expectedClass)
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, mode));
-
-            var pane = component.Find("textarea").ParentElement!;
-            Assert.Contains(expectedClass, pane.ClassName);
-        }
-
-        [Fact]
-        public void MarkdownEditor_SplitMode_TextareaPane_HasNoModeClass()
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Split));
-
-            var pane = component.Find("textarea").ParentElement!;
-            Assert.DoesNotContain("rz-markdown-editor-pane-full", pane.ClassName);
-            Assert.DoesNotContain("rz-markdown-editor-pane-hidden", pane.ClassName);
-            Assert.Contains("rz-markdown-editor-pane-fill", component.Find(".rz-markdown-editor-preview").ParentElement!.ClassName);
-        }
-
-        [Fact]
-        public void MarkdownEditor_SwitchingToSplit_AfterMount_RendersSplitterBar()
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
-            Assert.Empty(component.FindAll(".rz-splitter-bar"));
-
-            component.SetParametersAndRender(p => p.Add(x => x.Mode, MarkdownEditorMode.Split));
-
-            Assert.Single(component.FindAll(".rz-splitter-bar"));
-            Assert.Equal(2, component.FindAll(".rz-markdown-editor-pane").Count);
-        }
-
-        [Fact]
-        public void MarkdownEditor_SwitchingToPreview_AfterMount_HidesTextareaPane_AndFillsPreviewPane()
-        {
-            using var ctx = CreateContext();
-            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Value, "# Hi"));
-
-            component.SetParametersAndRender(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
-
-            var panes = component.FindAll(".rz-markdown-editor-pane");
-            Assert.Equal(2, panes.Count);
-            Assert.Contains("rz-markdown-editor-pane-hidden", panes[0].ClassName);
-            Assert.Contains("rz-markdown-editor-pane-fill", panes[1].ClassName);
-            Assert.Contains("rz-splitter-pane-lastresizable", panes[1].ClassName);
-            Assert.Contains("<h1", component.Markup);
+            Assert.Contains("mode:Design", component.Markup);
         }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -148,6 +148,45 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_ExecuteCommand_DesignMode_InvokesJsExecute()
+        {
+            using var ctx = CreateContext();
+            var execute = ctx.JSInterop.SetupVoid("execute", _ => true);
+            execute.SetVoidResult();
+            string? executed = null;
+
+            // Mode defaults to Design.
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "hello")
+                .Add(x => x.Execute, args => executed = args.CommandName));
+
+            await component.InvokeAsync(() => component.Instance.ExecuteCommandAsync(MarkdownEditorCommands.Bold));
+
+            var invocation = Assert.Single(execute.Invocations);
+            Assert.Equal(new object?[] { "bold", null, null }, invocation.Arguments.ToArray());
+            Assert.Equal("bold", executed);
+        }
+
+        [Fact]
+        public void MarkdownEditor_ExecuteCommand_Link_DesignMode_SavesSelectionBeforeDialogOpens()
+        {
+            using var ctx = CreateContext();
+            var saveSelection = ctx.JSInterop.SetupVoid("saveSelection", _ => true);
+            saveSelection.SetVoidResult();
+            ctx.JSInterop.Setup<bool>("hasSelection", _ => true).SetResult(true);
+
+            // Mode defaults to Design.
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            // DialogService.OpenAsync never completes without a rendered <RadzenDialog> host, so this call
+            // is fired without awaiting; saveSelection runs synchronously before that (never-resolving)
+            // await, so it has already happened by the time this statement returns control.
+            _ = component.InvokeAsync(() => component.Instance.ExecuteCommandAsync(MarkdownEditorCommands.Link));
+
+            Assert.Single(saveSelection.Invocations);
+        }
+
+        [Fact]
         public void MarkdownEditor_RendersDefaultToolbar_WhenNoChildContent()
         {
             using var ctx = CreateContext();

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -464,5 +464,26 @@ namespace Radzen.Blazor.Tests
             Assert.True(component.Instance.CanUndo);
             Assert.Contains("rz-state-active", component.Markup); // Bold button highlighted
         }
+
+        [Theory]
+        [InlineData("smile", "\U0001f604")]
+        [InlineData("SMILE", "\U0001f604")] // shortcodes are case-insensitive, matching the parser
+        [InlineData("thumbsup", "\U0001f44d")]
+        public async System.Threading.Tasks.Task MarkdownEditor_LookupEmoji_ReturnsEmojiForKnownShortcode(string shortcode, string expected)
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            Assert.Equal(expected, await component.Instance.LookupEmojiAsync(shortcode));
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_LookupEmoji_ReturnsNullForUnknownShortcode()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            Assert.Null(await component.Instance.LookupEmojiAsync("notarealemoji"));
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -270,7 +270,7 @@ namespace Radzen.Blazor.Tests
 
             // Loose mode records every call; no Setup so the un-awaited OnAfterRenderAsync cannot hang on a missing result.
             var invocation = Assert.Single(ctx.JSInterop.Invocations["Radzen.createMarkdownEditor"]);
-            var keys = Assert.IsAssignableFrom<System.Collections.Generic.IEnumerable<string>>(invocation.Arguments[2]);
+            var keys = Assert.IsAssignableFrom<System.Collections.Generic.IEnumerable<string>>(invocation.Arguments[3]);
             Assert.Equal(new[] { "Ctrl+B", "Ctrl+I", "Ctrl+K" }, keys.OrderBy(k => k));
         }
 
@@ -305,6 +305,36 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains("rz-markdown-editor-custom-tool", component.Markup);
             Assert.Contains("mode:Design", component.Markup);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_DesignInput_UpdatesValue_WithoutSetContent()
+        {
+            using var ctx = CreateContext();
+            var plannedSetContent = ctx.JSInterop.SetupVoid("setContent", _ => true);
+            string? changed = null;
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "old")
+                .Add(x => x.ValueChanged, v => changed = v));
+            int countAfterMount = plannedSetContent.Invocations.Count; // initial render already syncs content once; bunit's Invocations dictionary has no Clear()
+
+            await component.InvokeAsync(() => component.Instance.OnDesignInputAsync("new **text**"));
+
+            Assert.Equal("new **text**", changed);
+            Assert.Equal(countAfterMount, plannedSetContent.Invocations.Count); // surface-originated change must not echo back
+        }
+
+        [Fact]
+        public void MarkdownEditor_ProgrammaticValueChange_TriggersSetContent()
+        {
+            using var ctx = CreateContext();
+            var plannedSetContent = ctx.JSInterop.SetupVoid("setContent", _ => true);
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Value, "a"));
+            int countBeforeExternalChange = plannedSetContent.Invocations.Count; // bunit's Invocations dictionary has no Clear(); compare counts instead
+
+            component.SetParametersAndRender(p => p.Add(x => x.Value, "b"));
+
+            Assert.True(plannedSetContent.Invocations.Count > countBeforeExternalChange);
         }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -339,5 +339,27 @@ namespace Radzen.Blazor.Tests
             Assert.Contains("rz-markdown-editor-custom-tool", component.Markup);
             Assert.Contains("mode:Edit", component.Markup);
         }
+
+        [Theory]
+        [InlineData(MarkdownEditorMode.Edit, false)]
+        [InlineData(MarkdownEditorMode.Preview, false)]
+        [InlineData(MarkdownEditorMode.Split, true)]
+        public void MarkdownEditor_RendersSplitterBar_OnlyInSplitMode(MarkdownEditorMode mode, bool expected)
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, mode));
+
+            Assert.Equal(expected, component.FindAll(".rz-splitter-bar").Count > 0);
+        }
+
+        [Fact]
+        public void MarkdownEditor_PreviewMode_HidesTextareaPane_ButKeepsTextareaInDom()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
+
+            Assert.NotNull(component.Find("textarea"));
+            Assert.Single(component.FindAll(".rz-markdown-editor-pane-hidden"));
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -193,8 +193,18 @@ namespace Radzen.Blazor.Tests
             var component = ctx.RenderComponent<RadzenMarkdownEditor>();
 
             var icons = component.FindAll(".rz-markdown-editor-tools .rzi").Select(i => i.TextContent).ToList();
-            Assert.Equal(new[] { "format_bold", "format_italic", "title", "format_quote", "code", "code_blocks",
-                                 "format_list_bulleted", "format_list_numbered", "link", "image", "horizontal_rule" }, icons);
+            Assert.Equal(new[] { "undo", "redo", "format_bold", "format_italic", "strikethrough_s", "title", "format_quote", "code", "code_blocks",
+                                 "format_list_bulleted", "format_list_numbered", "checklist", "link", "image", "horizontal_rule" }, icons);
+        }
+
+        [Fact]
+        public void MarkdownEditor_DefaultToolbar_HasUndoRedo()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            Assert.Contains("undo", component.Markup);
+            Assert.Contains("redo", component.Markup);
         }
 
         [Fact]

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -435,5 +435,19 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal(1, valueChangedCount);
         }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_ToolState_HighlightsActiveFormats()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            await component.InvokeAsync(() => component.Instance.OnToolStateAsync(
+                new MarkdownEditorToolState { Formats = new[] { MarkdownEditorCommands.Bold }, CanUndo = true }));
+
+            Assert.True(component.Instance.IsActive(MarkdownEditorCommands.Bold));
+            Assert.True(component.Instance.CanUndo);
+            Assert.Contains("rz-state-active", component.Markup); // Bold button highlighted
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -192,7 +192,7 @@ namespace Radzen.Blazor.Tests
             using var ctx = CreateContext();
             var component = ctx.RenderComponent<RadzenMarkdownEditor>();
 
-            var icons = component.FindAll(".rz-markdown-editor-tools .rzi").Select(i => i.TextContent).ToList();
+            var icons = component.FindAll(".rz-markdown-editor-tools > button .rzi").Select(i => i.TextContent).ToList();
             Assert.Equal(new[] { "undo", "redo", "format_bold", "format_italic", "strikethrough_s", "title", "format_quote", "code", "code_blocks",
                                  "format_list_bulleted", "format_list_numbered", "checklist", "link", "image", "horizontal_rule" }, icons);
         }
@@ -213,7 +213,7 @@ namespace Radzen.Blazor.Tests
             using var ctx = CreateContext();
             var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.AddChildContent<RadzenMarkdownEditorBold>());
 
-            var icons = component.FindAll(".rz-markdown-editor-tools .rzi").Select(i => i.TextContent).ToList();
+            var icons = component.FindAll(".rz-markdown-editor-tools > button .rzi").Select(i => i.TextContent).ToList();
             Assert.Equal(new[] { "format_bold" }, icons);
         }
 
@@ -230,7 +230,7 @@ namespace Radzen.Blazor.Tests
                 .Add(x => x.Mode, MarkdownEditorMode.Source)
                 .AddChildContent<RadzenMarkdownEditorItalic>());
 
-            component.Find(".rz-markdown-editor-tools button").Click();
+            component.Find(".rz-markdown-editor-tools > button").Click();
 
             var invocation = Assert.Single(apply.Invocations);
             Assert.Equal("*hi*", invocation.Arguments[2]);
@@ -344,7 +344,7 @@ namespace Radzen.Blazor.Tests
                     .Add(x => x.CommandName, "InsertToday")
                     .Add(x => x.Icon, "today")));
 
-            component.Find(".rz-markdown-editor-tools button").Click();
+            component.Find(".rz-markdown-editor-tools > button").Click();
 
             Assert.Equal("InsertToday", executed);
             Assert.Empty(apply.Invocations);

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -336,5 +336,48 @@ namespace Radzen.Blazor.Tests
 
             Assert.True(plannedSetContent.Invocations.Count > countBeforeExternalChange);
         }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_DesignChange_FlushesPendingEdit_UpdatesValueOnce_WithoutSetContent()
+        {
+            using var ctx = CreateContext();
+            var plannedSetContent = ctx.JSInterop.SetupVoid("setContent", _ => true);
+            int valueChangedCount = 0;
+            string? changed = null;
+            string? changeEventValue = null;
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "old")
+                .Add(x => x.ValueChanged, v => { changed = v; valueChangedCount++; })
+                .Add(x => x.Change, v => changeEventValue = v));
+            int countAfterMount = plannedSetContent.Invocations.Count;
+
+            // JS clears the debounce timer on blur and reports the surface's current content directly to
+            // OnDesignChangeAsync, without a preceding OnDesignInputAsync — the keystroke that landed inside
+            // the 250ms debounce window immediately before blur must still reach Value.
+            await component.InvokeAsync(() => component.Instance.OnDesignChangeAsync("blurred **text**"));
+
+            Assert.Equal("blurred **text**", changed);
+            Assert.Equal(1, valueChangedCount); // flushed exactly once
+            Assert.Equal("blurred **text**", changeEventValue);
+            Assert.Equal(countAfterMount, plannedSetContent.Invocations.Count); // still no echo back to the surface
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_DesignChange_AfterMatchingInput_DoesNotDoubleFireValueChanged()
+        {
+            using var ctx = CreateContext();
+            ctx.JSInterop.SetupVoid("setContent", _ => true);
+            int valueChangedCount = 0;
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "old")
+                .Add(x => x.ValueChanged, _ => valueChangedCount++));
+
+            // The debounced OnDesignInputAsync already flushed this markdown; blur reporting the same
+            // content must not raise ValueChanged a second time.
+            await component.InvokeAsync(() => component.Instance.OnDesignInputAsync("same **text**"));
+            await component.InvokeAsync(() => component.Instance.OnDesignChangeAsync("same **text**"));
+
+            Assert.Equal(1, valueChangedCount);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -1,0 +1,159 @@
+using System.Linq;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class MarkdownEditorTests
+    {
+        static TestContext CreateContext()
+        {
+            var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.Services.AddScoped<DialogService>();
+            return ctx;
+        }
+
+        [Fact]
+        public void MarkdownEditor_Renders_WithClassName()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            Assert.Contains("rz-markdown-editor", component.Markup);
+            Assert.Contains("rz-markdown-editor-toolbar", component.Markup);
+            Assert.Contains("rz-markdown-editor-textarea", component.Markup);
+        }
+
+        [Fact]
+        public void MarkdownEditor_HidesToolbar_WhenShowToolbarFalse()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.ShowToolbar, false));
+
+            Assert.DoesNotContain("rz-markdown-editor-toolbar", component.Markup);
+        }
+
+        [Fact]
+        public void MarkdownEditor_EditMode_RendersNoPreview()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Value, "# Hi"));
+
+            Assert.DoesNotContain("rz-markdown-editor-preview", component.Markup);
+            Assert.DoesNotContain("hidden", component.Find("textarea").OuterHtml);
+        }
+
+        [Fact]
+        public void MarkdownEditor_PreviewMode_HidesTextarea_AndRendersMarkdown()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "# Hi")
+                .Add(x => x.Mode, MarkdownEditorMode.Preview));
+
+            Assert.Contains("rz-markdown-editor-preview", component.Markup);
+            Assert.Contains("<h1", component.Markup);
+            Assert.True(component.Find("textarea").HasAttribute("hidden"));
+        }
+
+        [Fact]
+        public void MarkdownEditor_SplitMode_RendersBoth()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "# Hi")
+                .Add(x => x.Mode, MarkdownEditorMode.Split));
+
+            Assert.Contains("rz-markdown-editor-preview", component.Markup);
+            Assert.False(component.Find("textarea").HasAttribute("hidden"));
+        }
+
+        [Fact]
+        public void MarkdownEditor_PreviewMode_ShowsPlaceholder_WhenEmpty()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
+
+            Assert.Contains("Nothing to preview", component.Markup);
+        }
+
+        [Fact]
+        public void MarkdownEditor_ModeSwitcher_RaisesModeChanged()
+        {
+            using var ctx = CreateContext();
+            MarkdownEditorMode? changed = null;
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.ModeChanged, m => changed = m));
+
+            component.Find(".rz-markdown-editor-modes button:nth-child(2)").Click();
+
+            Assert.Equal(MarkdownEditorMode.Preview, changed);
+        }
+
+        [Fact]
+        public void MarkdownEditor_Input_UpdatesValue_AndRaisesValueChanged()
+        {
+            using var ctx = CreateContext();
+            string? value = null;
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.ValueChanged, v => value = v));
+
+            component.Find("textarea").Input("typed");
+
+            Assert.Equal("typed", value);
+        }
+
+        [Fact]
+        public void MarkdownEditor_Input_RaisesInput_OnlyWhenImmediate()
+        {
+            using var ctx = CreateContext();
+            var count = 0;
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Input, _ => count++));
+            component.Find("textarea").Input("a");
+            Assert.Equal(0, count);
+
+            component.SetParametersAndRender(p => p.Add(x => x.Immediate, true));
+            component.Find("textarea").Input("b");
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_ExecuteCommand_AppliesFormatterResult_AndRaisesExecute()
+        {
+            using var ctx = CreateContext();
+            ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 0, 5 });
+            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            apply.SetVoidResult();
+            string? executed = null;
+
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "hello")
+                .Add(x => x.Execute, args => executed = args.CommandName));
+
+            await component.InvokeAsync(() => component.Instance.ExecuteCommandAsync(MarkdownEditorCommands.Bold));
+
+            var invocation = Assert.Single(apply.Invocations);
+            Assert.Equal(new object?[] { 0, 5, "**hello**", 2, 7 }, invocation.Arguments.Skip(1).ToArray());
+            Assert.Equal("bold", executed);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task MarkdownEditor_ExecuteCommand_UnknownCommand_RaisesExecuteWithoutApplying()
+        {
+            using var ctx = CreateContext();
+            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            apply.SetVoidResult();
+            string? executed = null;
+
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Execute, args => executed = args.CommandName));
+
+            await component.InvokeAsync(() => component.Instance.ExecuteCommandAsync("insertToday"));
+
+            Assert.Empty(apply.Invocations);
+            Assert.Equal("insertToday", executed);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -192,7 +192,7 @@ namespace Radzen.Blazor.Tests
             component.Find(".rz-markdown-editor-tools button").Click();
 
             var invocation = Assert.Single(apply.Invocations);
-            Assert.Equal("_hi_", invocation.Arguments[3]);
+            Assert.Equal("*hi*", invocation.Arguments[3]);
         }
 
         [Fact]

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -361,5 +361,58 @@ namespace Radzen.Blazor.Tests
             Assert.NotNull(component.Find("textarea"));
             Assert.Single(component.FindAll(".rz-markdown-editor-pane-hidden"));
         }
+
+        [Theory]
+        [InlineData(MarkdownEditorMode.Edit, "rz-markdown-editor-pane-full")]
+        [InlineData(MarkdownEditorMode.Preview, "rz-markdown-editor-pane-hidden")]
+        public void MarkdownEditor_TextareaPane_HasModeClass(MarkdownEditorMode mode, string expectedClass)
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, mode));
+
+            var pane = component.Find("textarea").ParentElement!;
+            Assert.Contains(expectedClass, pane.ClassName);
+        }
+
+        [Fact]
+        public void MarkdownEditor_SplitMode_TextareaPane_HasNoModeClass()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Split));
+
+            var pane = component.Find("textarea").ParentElement!;
+            Assert.DoesNotContain("rz-markdown-editor-pane-full", pane.ClassName);
+            Assert.DoesNotContain("rz-markdown-editor-pane-hidden", pane.ClassName);
+            Assert.Contains("rz-markdown-editor-pane-fill", component.Find(".rz-markdown-editor-preview").ParentElement!.ClassName);
+        }
+
+        [Fact]
+        public void MarkdownEditor_SwitchingToSplit_AfterMount_RendersSplitterBar()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+            Assert.Empty(component.FindAll(".rz-splitter-bar"));
+
+            component.SetParametersAndRender(p => p.Add(x => x.Mode, MarkdownEditorMode.Split));
+
+            Assert.Single(component.FindAll(".rz-splitter-bar"));
+            Assert.Equal(2, component.FindAll(".rz-markdown-editor-pane").Count);
+        }
+
+        [Fact]
+        public void MarkdownEditor_SwitchingToPreview_AfterMount_HidesTextareaPane_AndFillsPreviewPane()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Value, "# Hi"));
+
+            component.SetParametersAndRender(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
+
+            var panes = component.FindAll(".rz-markdown-editor-pane");
+            Assert.Equal(2, panes.Count);
+            Assert.Contains("rz-markdown-editor-pane-hidden", panes[0].ClassName);
+            Assert.Contains("rz-markdown-editor-pane-fill", panes[1].ClassName);
+            Assert.Contains("rz-splitter-pane-lastresizable", panes[1].ClassName);
+            Assert.Contains("<h1", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -394,6 +394,21 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void MarkdownEditor_ProgrammaticModeChange_ToDesign_TriggersSetContent()
+        {
+            using var ctx = CreateContext();
+            var plannedSetContent = ctx.JSInterop.SetupVoid("setContent", _ => true);
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "a")
+                .Add(x => x.Mode, MarkdownEditorMode.Source));
+            int countBeforeExternalChange = plannedSetContent.Invocations.Count; // bunit's Invocations dictionary has no Clear(); compare counts instead
+
+            component.SetParametersAndRender(p => p.Add(x => x.Mode, MarkdownEditorMode.Design));
+
+            Assert.True(plannedSetContent.Invocations.Count > countBeforeExternalChange);
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task MarkdownEditor_DesignChange_FlushesPendingEdit_UpdatesValueOnce_WithoutSetContent()
         {
             using var ctx = CreateContext();

--- a/Radzen.Blazor.Tests/MarkdownEditorTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownEditorTests.cs
@@ -155,5 +155,65 @@ namespace Radzen.Blazor.Tests
             Assert.Empty(apply.Invocations);
             Assert.Equal("insertToday", executed);
         }
+
+        [Fact]
+        public void MarkdownEditor_RendersDefaultToolbar_WhenNoChildContent()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            var icons = component.FindAll(".rz-markdown-editor-tools .rzi").Select(i => i.TextContent).ToList();
+            Assert.Equal(new[] { "format_bold", "format_italic", "strikethrough_s", "title", "format_quote", "code", "code_blocks",
+                                 "format_list_bulleted", "format_list_numbered", "checklist", "link", "image", "horizontal_rule" }, icons);
+        }
+
+        [Fact]
+        public void MarkdownEditor_RendersOnlyChildContent_WhenProvided()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.AddChildContent<RadzenMarkdownEditorBold>());
+
+            var icons = component.FindAll(".rz-markdown-editor-tools .rzi").Select(i => i.TextContent).ToList();
+            Assert.Equal(new[] { "format_bold" }, icons);
+        }
+
+        [Fact]
+        public void MarkdownEditor_ToolClick_ExecutesCommand()
+        {
+            using var ctx = CreateContext();
+            ctx.JSInterop.Setup<int[]?>("Radzen.getSelectionRange", _ => true).SetResult(new[] { 0, 2 });
+            var apply = ctx.JSInterop.SetupVoid("Radzen.markdownEditorApply", _ => true);
+            apply.SetVoidResult();
+
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p
+                .Add(x => x.Value, "hi")
+                .AddChildContent<RadzenMarkdownEditorItalic>());
+
+            component.Find(".rz-markdown-editor-tools button").Click();
+
+            var invocation = Assert.Single(apply.Invocations);
+            Assert.Equal("_hi_", invocation.Arguments[3]);
+        }
+
+        [Fact]
+        public void MarkdownEditor_Tools_AreDisabled_InPreviewMode()
+        {
+            using var ctx = CreateContext();
+            var component = ctx.RenderComponent<RadzenMarkdownEditor>(p => p.Add(x => x.Mode, MarkdownEditorMode.Preview));
+
+            Assert.All(component.FindAll(".rz-markdown-editor-tools button"), b => Assert.True(b.HasAttribute("disabled")));
+        }
+
+        [Fact]
+        public void MarkdownEditor_Tools_RegisterShortcuts()
+        {
+            using var ctx = CreateContext();
+            ctx.RenderComponent<RadzenMarkdownEditor>();
+
+            // Loose mode records every call; no Setup so the un-awaited OnAfterRenderAsync cannot hang on a missing result.
+            var invocation = Assert.Single(ctx.JSInterop.Invocations["Radzen.createMarkdownEditor"]);
+            var keys = Assert.IsAssignableFrom<System.Collections.Generic.IEnumerable<string>>(invocation.Arguments[2]);
+            Assert.Equal(new[] { "Ctrl+B", "Ctrl+I", "Ctrl+K" }, keys.OrderBy(k => k));
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
@@ -163,5 +163,21 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal(new MarkdownEdit(0, 5, "## a\n## b", 0, 9), edit);
         }
+
+        [Fact]
+        public void PrefixLines_DoesNotDoublePrefix_PartiallyPrefixedSelection()
+        {
+            var edit = MarkdownFormatter.Apply("> a\nb", 0, 5, MarkdownEditorCommands.Quote);
+
+            Assert.Equal(new MarkdownEdit(0, 5, "> a\n> b", 0, 7), edit);
+        }
+
+        [Fact]
+        public void OrderedList_RenumbersPartiallyNumberedSelection()
+        {
+            var edit = MarkdownFormatter.Apply("1. a\nb\n7. c", 0, 11, MarkdownEditorCommands.OrderedList);
+
+            Assert.Equal(new MarkdownEdit(0, 11, "1. a\n2. b\n3. c", 0, 14), edit);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
@@ -36,7 +36,7 @@ namespace Radzen.Blazor.Tests
 
         [Theory]
         [InlineData("bold", "**")]
-        [InlineData("italic", "_")]
+        [InlineData("italic", "*")]
         [InlineData("strikethrough", "~~")]
         [InlineData("code", "`")]
         public void Wrap_WrapsSelection_AndSelectsInnerText(string command, string token)
@@ -47,17 +47,19 @@ namespace Radzen.Blazor.Tests
             Assert.Equal(new MarkdownEdit(6, 11, token + "world" + token, 6 + t, 11 + t), edit);
         }
 
+        // caret must sit in actual whitespace to insert empty delimiters; a caret merely at a word's
+        // edge (e.g. old "hello" at position 5) now expands to the word instead (see Bold_ExpandsCaretToWord).
         [Theory]
         [InlineData("bold", "**")]
-        [InlineData("italic", "_")]
+        [InlineData("italic", "*")]
         [InlineData("strikethrough", "~~")]
         [InlineData("code", "`")]
         public void Wrap_WithEmptySelection_InsertsTokens_AndPlacesCaretBetween(string command, string token)
         {
-            var edit = MarkdownFormatter.Apply("hello", 5, 5, command);
+            var edit = MarkdownFormatter.Apply("a  b", 2, 2, command);
 
             var t = token.Length;
-            Assert.Equal(new MarkdownEdit(5, 5, token + token, 5 + t, 5 + t), edit);
+            Assert.Equal(new MarkdownEdit(2, 2, token + token, 2 + t, 2 + t), edit);
         }
 
         [Fact]
@@ -79,21 +81,114 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
-        public void Wrap_EmptyCaretBetweenTokens_Unwraps()
+        public void Wrap_EmptyCaretBetweenTokens_WrapsUnflankedRun()
         {
-            // "****" with the caret between the two pairs of tokens (2..2) unwraps rather than re-wrapping
+            // "****" has no whitespace around it and is unflanked, so InlineParser.ScanSpans never pairs
+            // the asterisks into a token (CommonMark flanking rules require non-whitespace/punctuation
+            // context to open/close). The caret at 2..2 therefore expands to the whole "****" run like any
+            // other word and gets wrapped, rather than being special-cased as "between empty tokens".
             var edit = MarkdownFormatter.Apply("****", 2, 2, MarkdownEditorCommands.Bold);
 
-            Assert.Equal(new MarkdownEdit(0, 4, "", 0, 0), edit);
+            Assert.Equal(new MarkdownEdit(0, 4, "**" + "****" + "**", 2, 6), edit);
         }
 
         [Fact]
         public void Wrap_DoesNotUnwrapDifferentToken()
         {
-            // italic applied to "**hi**" selected → wrap, not unwrap
+            // italic applied to "**hi**" selected → wrap (with the canonical "*" delimiter), not unwrap
             var edit = MarkdownFormatter.Apply("say **hi** now", 4, 10, MarkdownEditorCommands.Italic);
 
-            Assert.Equal(new MarkdownEdit(4, 10, "_**hi**_", 5, 11), edit);
+            Assert.Equal(new MarkdownEdit(4, 10, "*" + "**hi**" + "*", 5, 11), edit);
+        }
+
+        // enchev repro 1: trailing space in selection
+        [Fact]
+        public void Bold_TrimsTrailingWhitespace()
+        {
+            // "hello world", selection [0,6) = "hello "
+            var edit = MarkdownFormatter.Apply("hello world", 0, 6, MarkdownEditorCommands.Bold);
+            Assert.Equal(new MarkdownEdit(0, 5, "**hello**", 2, 7), edit);
+        }
+
+        // enchev repro 2: caret inside a word expands to the word
+        [Fact]
+        public void Bold_ExpandsCaretToWord()
+        {
+            var edit = MarkdownFormatter.Apply("hello world", 2, 2, MarkdownEditorCommands.Bold);
+            Assert.Equal(new MarkdownEdit(0, 5, "**hello**", 2, 7), edit);
+        }
+
+        [Fact]
+        public void Bold_CaretInWhitespace_InsertsEmptyDelimiters()
+        {
+            var edit = MarkdownFormatter.Apply("a  b", 2, 2, MarkdownEditorCommands.Bold);
+            Assert.Equal(new MarkdownEdit(2, 2, "****", 4, 4), edit);
+        }
+
+        // enchev repro 3: partial selection inside existing bold unwraps the whole token
+        [Fact]
+        public void Bold_PartialSelectionInsideBold_UnwrapsToken()
+        {
+            // "hello **world**", select "orl" [10,13)
+            var edit = MarkdownFormatter.Apply("hello **world**", 10, 13, MarkdownEditorCommands.Bold);
+            Assert.Equal(new MarkdownEdit(6, 15, "world", 6, 11), edit);
+        }
+
+        // enchev repro 4: star emphasis is recognized by the italic toggle
+        [Fact]
+        public void Italic_UnwrapsStarEmphasis()
+        {
+            var edit = MarkdownFormatter.Apply("*text*", 1, 5, MarkdownEditorCommands.Italic);
+            Assert.Equal(new MarkdownEdit(0, 6, "text", 0, 4), edit);
+        }
+
+        [Fact]
+        public void Italic_UnwrapsUnderscoreEmphasis()
+        {
+            var edit = MarkdownFormatter.Apply("_text_", 1, 5, MarkdownEditorCommands.Italic);
+            Assert.Equal(new MarkdownEdit(0, 6, "text", 0, 4), edit);
+        }
+
+        [Fact]
+        public void Italic_EmitsStar()
+        {
+            var edit = MarkdownFormatter.Apply("word", 0, 4, MarkdownEditorCommands.Italic);
+            Assert.Equal(new MarkdownEdit(0, 4, "*word*", 1, 5), edit);
+        }
+
+        // overlapping: selection extends past an existing token → strip inner, wrap whole
+        [Fact]
+        public void Bold_SelectionContainingBoldToken_StripsAndWrapsWhole()
+        {
+            // "**a** b", select all [0,7)
+            var edit = MarkdownFormatter.Apply("**a** b", 0, 7, MarkdownEditorCommands.Bold);
+            Assert.Equal(new MarkdownEdit(0, 7, "**a b**", 2, 5), edit);
+        }
+
+        [Fact]
+        public void Bold_DoesNotMatchTokensOnOtherLines()
+        {
+            // bold on line 2 must not affect detection for a selection on line 1
+            var edit = MarkdownFormatter.Apply("plain\n**bold**", 0, 5, MarkdownEditorCommands.Bold);
+            Assert.Equal(new MarkdownEdit(0, 5, "**plain**", 2, 7), edit);
+        }
+
+        [Fact]
+        public void Code_UnwrapsInlineCode()
+        {
+            var edit = MarkdownFormatter.Apply("`x`", 1, 2, MarkdownEditorCommands.Code);
+            Assert.Equal(new MarkdownEdit(0, 3, "x", 0, 1), edit);
+        }
+
+        [Fact]
+        public void Bold_LeadingWhitespaceOnLine_MapsSpanOffsetsBackToDocumentCoordinates()
+        {
+            // ScanSpans trims its input, so the span for "**bold**" is reported relative to the trimmed
+            // line ("**bold** x"), not the original line ("  **bold** x"). Selecting "ol" inside "bold"
+            // (document offsets 5..7) must still resolve to the correct outer token range (2..10) by
+            // compensating for the line's 2 leading spaces.
+            var edit = MarkdownFormatter.Apply("  **bold** x", 5, 7, MarkdownEditorCommands.Bold);
+            Assert.Equal(new MarkdownEdit(2, 10, "bold", 2, 6), edit);
         }
 
         [Theory]

--- a/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
@@ -1,0 +1,37 @@
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class MarkdownFormatterTests
+    {
+        [Fact]
+        public void Apply_ReturnsNull_ForUnknownCommand()
+        {
+            Assert.Null(MarkdownFormatter.Apply("hello", 0, 5, "insertToday"));
+        }
+
+        [Fact]
+        public void InsertText_ReplacesSelection_AndPlacesCaretAfter()
+        {
+            var edit = MarkdownFormatter.Apply("hello world", 6, 11, MarkdownEditorCommands.InsertText, "there");
+
+            Assert.Equal(new MarkdownEdit(6, 11, "there", 11, 11), edit);
+        }
+
+        [Fact]
+        public void InsertText_TreatsNullValueAsEmpty()
+        {
+            var edit = MarkdownFormatter.Apply("hello", 0, 5, MarkdownEditorCommands.InsertText, null);
+
+            Assert.Equal(new MarkdownEdit(0, 5, "", 0, 0), edit);
+        }
+
+        [Fact]
+        public void Apply_ClampsOutOfRangeSelection()
+        {
+            var edit = MarkdownFormatter.Apply("abc", -2, 99, MarkdownEditorCommands.InsertText, "x");
+
+            Assert.Equal(new MarkdownEdit(0, 3, "x", 1, 1), edit);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
@@ -179,5 +179,81 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal(new MarkdownEdit(0, 11, "1. a\n2. b\n3. c", 0, 14), edit);
         }
+
+        [Fact]
+        public void CodeBlock_FencesSelection_OnOwnLines()
+        {
+            // "ab" selected in the middle of a line
+            var edit = MarkdownFormatter.Apply("x ab y", 2, 4, MarkdownEditorCommands.CodeBlock);
+
+            Assert.Equal(new MarkdownEdit(2, 4, "\n```\nab\n```\n", 7, 9), edit);
+        }
+
+        [Fact]
+        public void CodeBlock_AtLineBoundaries_AddsNoExtraNewlines()
+        {
+            var edit = MarkdownFormatter.Apply("code\n", 0, 5, MarkdownEditorCommands.CodeBlock);
+
+            Assert.Equal(new MarkdownEdit(0, 5, "```\ncode\n```", 4, 9), edit);
+        }
+
+        [Fact]
+        public void CodeBlock_WithEmptySelection_PlacesCaretInsideFence()
+        {
+            var edit = MarkdownFormatter.Apply("", 0, 0, MarkdownEditorCommands.CodeBlock);
+
+            Assert.Equal(new MarkdownEdit(0, 0, "```\n\n```", 4, 4), edit);
+        }
+
+        [Fact]
+        public void HorizontalRule_AtLineStart_InsertsRuleAndNewline()
+        {
+            var edit = MarkdownFormatter.Apply("a\nb", 2, 2, MarkdownEditorCommands.HorizontalRule);
+
+            Assert.Equal(new MarkdownEdit(2, 2, "---\n", 6, 6), edit);
+        }
+
+        [Fact]
+        public void HorizontalRule_MidLine_AddsLeadingNewline()
+        {
+            var edit = MarkdownFormatter.Apply("ab", 1, 1, MarkdownEditorCommands.HorizontalRule);
+
+            Assert.Equal(new MarkdownEdit(1, 1, "\n---\n", 6, 6), edit);
+        }
+
+        [Fact]
+        public void HorizontalRule_BeforeExistingNewline_AddsNoTrailingNewline()
+        {
+            var edit = MarkdownFormatter.Apply("a\nb", 1, 1, MarkdownEditorCommands.HorizontalRule);
+
+            Assert.Equal(new MarkdownEdit(1, 1, "\n---", 5, 5), edit);
+        }
+
+        [Theory]
+        [InlineData("link", "[")]
+        [InlineData("image", "![")]
+        public void Link_WrapsSelection_AndPlacesCaretAfter(string command, string open)
+        {
+            var edit = MarkdownFormatter.Apply("see docs now", 4, 8, command, "https://x.y");
+
+            var replacement = open + "docs](https://x.y)";
+            Assert.Equal(new MarkdownEdit(4, 8, replacement, 4 + replacement.Length, 4 + replacement.Length), edit);
+        }
+
+        [Fact]
+        public void Link_WithEmptySelection_UsesLabel()
+        {
+            var edit = MarkdownFormatter.Apply("", 0, 0, MarkdownEditorCommands.Link, "https://x.y", "Docs");
+
+            Assert.Equal(new MarkdownEdit(0, 0, "[Docs](https://x.y)", 19, 19), edit);
+        }
+
+        [Fact]
+        public void Link_WithEmptySelectionAndNoLabel_PlacesCaretInsideBrackets()
+        {
+            var edit = MarkdownFormatter.Apply("", 0, 0, MarkdownEditorCommands.Image, "https://x.y/i.png");
+
+            Assert.Equal(new MarkdownEdit(0, 0, "![](https://x.y/i.png)", 2, 2), edit);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
@@ -79,6 +79,15 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Wrap_EmptyCaretBetweenTokens_Unwraps()
+        {
+            // "****" with the caret between the two pairs of tokens (2..2) unwraps rather than re-wrapping
+            var edit = MarkdownFormatter.Apply("****", 2, 2, MarkdownEditorCommands.Bold);
+
+            Assert.Equal(new MarkdownEdit(0, 4, "", 0, 0), edit);
+        }
+
+        [Fact]
         public void Wrap_DoesNotUnwrapDifferentToken()
         {
             // italic applied to "**hi**" selected → wrap, not unwrap
@@ -227,6 +236,14 @@ namespace Radzen.Blazor.Tests
             var edit = MarkdownFormatter.Apply("a\nb", 1, 1, MarkdownEditorCommands.HorizontalRule);
 
             Assert.Equal(new MarkdownEdit(1, 1, "\n---", 5, 5), edit);
+        }
+
+        [Fact]
+        public void HorizontalRule_WithSelection_InsertsAfterSelectionWithoutReplacing()
+        {
+            var edit = MarkdownFormatter.Apply("ab cd", 0, 2, MarkdownEditorCommands.HorizontalRule);
+
+            Assert.Equal(new MarkdownEdit(2, 2, "\n---\n", 7, 7), edit);
         }
 
         [Theory]

--- a/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
@@ -33,5 +33,58 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal(new MarkdownEdit(0, 3, "x", 1, 1), edit);
         }
+
+        [Theory]
+        [InlineData("bold", "**")]
+        [InlineData("italic", "_")]
+        [InlineData("strikethrough", "~~")]
+        [InlineData("code", "`")]
+        public void Wrap_WrapsSelection_AndSelectsInnerText(string command, string token)
+        {
+            var edit = MarkdownFormatter.Apply("hello world", 6, 11, command);
+
+            var t = token.Length;
+            Assert.Equal(new MarkdownEdit(6, 11, token + "world" + token, 6 + t, 11 + t), edit);
+        }
+
+        [Theory]
+        [InlineData("bold", "**")]
+        [InlineData("italic", "_")]
+        [InlineData("strikethrough", "~~")]
+        [InlineData("code", "`")]
+        public void Wrap_WithEmptySelection_InsertsTokens_AndPlacesCaretBetween(string command, string token)
+        {
+            var edit = MarkdownFormatter.Apply("hello", 5, 5, command);
+
+            var t = token.Length;
+            Assert.Equal(new MarkdownEdit(5, 5, token + token, 5 + t, 5 + t), edit);
+        }
+
+        [Fact]
+        public void Wrap_UnwrapsWhenSelectionIncludesTokens()
+        {
+            // "say **hi** now" — select "**hi**" (4..10)
+            var edit = MarkdownFormatter.Apply("say **hi** now", 4, 10, MarkdownEditorCommands.Bold);
+
+            Assert.Equal(new MarkdownEdit(4, 10, "hi", 4, 6), edit);
+        }
+
+        [Fact]
+        public void Wrap_UnwrapsWhenTokensSurroundSelection()
+        {
+            // "say **hi** now" — select "hi" (6..8)
+            var edit = MarkdownFormatter.Apply("say **hi** now", 6, 8, MarkdownEditorCommands.Bold);
+
+            Assert.Equal(new MarkdownEdit(4, 10, "hi", 4, 6), edit);
+        }
+
+        [Fact]
+        public void Wrap_DoesNotUnwrapDifferentToken()
+        {
+            // italic applied to "**hi**" selected → wrap, not unwrap
+            var edit = MarkdownFormatter.Apply("say **hi** now", 4, 10, MarkdownEditorCommands.Italic);
+
+            Assert.Equal(new MarkdownEdit(4, 10, "_**hi**_", 5, 11), edit);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
+++ b/Radzen.Blazor.Tests/MarkdownFormatterTests.cs
@@ -86,5 +86,82 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal(new MarkdownEdit(4, 10, "_**hi**_", 5, 11), edit);
         }
+
+        [Theory]
+        [InlineData("quote", "> ")]
+        [InlineData("unorderedList", "- ")]
+        [InlineData("taskList", "- [ ] ")]
+        public void PrefixLines_PrefixesEveryLineInSelection(string command, string prefix)
+        {
+            // caret in the middle of line 2 of three lines; only that line is affected
+            var text = "one\ntwo\nthree";
+            var edit = MarkdownFormatter.Apply(text, 5, 5, command);
+
+            var replacement = prefix + "two";
+            Assert.Equal(new MarkdownEdit(4, 7, replacement, 4, 4 + replacement.Length), edit);
+        }
+
+        [Fact]
+        public void PrefixLines_ExpandsPartialMultiLineSelection()
+        {
+            // select from inside "one" to inside "two"
+            var edit = MarkdownFormatter.Apply("one\ntwo\nthree", 1, 5, MarkdownEditorCommands.Quote);
+
+            Assert.Equal(new MarkdownEdit(0, 7, "> one\n> two", 0, 11), edit);
+        }
+
+        [Fact]
+        public void PrefixLines_StripsPrefixWhenAllLinesHaveIt()
+        {
+            var edit = MarkdownFormatter.Apply("- a\n- b", 0, 7, MarkdownEditorCommands.UnorderedList);
+
+            Assert.Equal(new MarkdownEdit(0, 7, "a\nb", 0, 3), edit);
+        }
+
+        [Fact]
+        public void PrefixLines_IgnoresTrailingNewlineInSelection()
+        {
+            // selecting "one\n" (0..4) must not drag line 2 in
+            var edit = MarkdownFormatter.Apply("one\ntwo", 0, 4, MarkdownEditorCommands.Quote);
+
+            Assert.Equal(new MarkdownEdit(0, 3, "> one", 0, 5), edit);
+        }
+
+        [Fact]
+        public void OrderedList_NumbersLines()
+        {
+            var edit = MarkdownFormatter.Apply("a\nb\nc", 0, 5, MarkdownEditorCommands.OrderedList);
+
+            Assert.Equal(new MarkdownEdit(0, 5, "1. a\n2. b\n3. c", 0, 14), edit);
+        }
+
+        [Fact]
+        public void OrderedList_StripsNumbersWhenAllLinesAreNumbered()
+        {
+            var edit = MarkdownFormatter.Apply("1. a\n12. b", 0, 10, MarkdownEditorCommands.OrderedList);
+
+            Assert.Equal(new MarkdownEdit(0, 10, "a\nb", 0, 3), edit);
+        }
+
+        [Theory]
+        [InlineData("title", "# title")]
+        [InlineData("# title", "## title")]
+        [InlineData("## title", "### title")]
+        [InlineData("### title", "title")]
+        [InlineData("###### title", "title")]
+        public void Heading_CyclesLevel(string line, string expected)
+        {
+            var edit = MarkdownFormatter.Apply(line, 0, 0, MarkdownEditorCommands.Heading);
+
+            Assert.Equal(new MarkdownEdit(0, line.Length, expected, 0, expected.Length), edit);
+        }
+
+        [Fact]
+        public void Heading_AppliesFirstLineLevelToAllSelectedLines()
+        {
+            var edit = MarkdownFormatter.Apply("# a\nb", 0, 5, MarkdownEditorCommands.Heading);
+
+            Assert.Equal(new MarkdownEdit(0, 5, "## a\n## b", 0, 9), edit);
+        }
     }
 }

--- a/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
+++ b/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Radzen.Documents.Markdown;
+
+/// <summary>
+/// Renders a markdown document as an HTML string. Used by RadzenMarkdownEditor's design mode.
+/// </summary>
+public class HtmlVisitor : NodeVisitorBase
+{
+    private readonly StringBuilder html = new();
+    private bool suppressParagraph;
+    private bool inHeaderRow;
+
+    /// <summary>Renders <paramref name="document" /> as HTML.</summary>
+    public static string ToHtml(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        var visitor = new HtmlVisitor();
+        document.Accept(visitor);
+        return visitor.html.ToString();
+    }
+
+    /// <summary>Parses <paramref name="markdown" /> and renders it as HTML.</summary>
+    public static string ToHtml(string markdown) => ToHtml(MarkdownParser.Parse(markdown ?? string.Empty));
+
+    private static string Escape(string? text) => (text ?? string.Empty)
+        .Replace("&", "&amp;", StringComparison.Ordinal)
+        .Replace("<", "&lt;", StringComparison.Ordinal)
+        .Replace(">", "&gt;", StringComparison.Ordinal)
+        .Replace("\"", "&quot;", StringComparison.Ordinal);
+
+    private void Wrap(string tag, Action visitChildren)
+    {
+        html.Append('<').Append(tag).Append('>');
+        visitChildren();
+        html.Append("</").Append(tag).Append('>');
+    }
+
+    /// <inheritdoc />
+    public override void VisitHeading(Heading heading)
+    {
+        ArgumentNullException.ThrowIfNull(heading);
+        Wrap($"h{heading.Level}", () => base.VisitHeading(heading));
+    }
+
+    /// <inheritdoc />
+    public override void VisitParagraph(Paragraph paragraph)
+    {
+        if (suppressParagraph)
+        {
+            suppressParagraph = false;
+            base.VisitParagraph(paragraph);
+        }
+        else
+        {
+            Wrap("p", () => base.VisitParagraph(paragraph));
+        }
+    }
+
+    /// <inheritdoc />
+    public override void VisitStrong(Strong strong) => Wrap("strong", () => base.VisitStrong(strong));
+
+    /// <inheritdoc />
+    public override void VisitEmphasis(Emphasis emphasis) => Wrap("em", () => base.VisitEmphasis(emphasis));
+
+    /// <inheritdoc />
+    public override void VisitStrikethrough(Strikethrough strikethrough) => Wrap("del", () => base.VisitStrikethrough(strikethrough));
+
+    /// <inheritdoc />
+    public override void VisitBlockQuote(BlockQuote blockQuote) => Wrap("blockquote", () => base.VisitBlockQuote(blockQuote));
+
+    /// <inheritdoc />
+    public override void VisitText(Text text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        html.Append(Escape(text.Value));
+    }
+
+    /// <inheritdoc />
+    public override void VisitCode(Code code)
+    {
+        ArgumentNullException.ThrowIfNull(code);
+        html.Append("<code>").Append(Escape(code.Value)).Append("</code>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitLineBreak(LineBreak lineBreak) => html.Append("<br>");
+
+    /// <inheritdoc />
+    public override void VisitSoftLineBreak(SoftLineBreak softLineBreak) => html.Append(' ');
+
+    /// <inheritdoc />
+    public override void VisitThematicBreak(ThematicBreak thematicBreak) => html.Append("<hr>");
+
+    /// <inheritdoc />
+    public override void VisitUnorderedList(UnorderedList unorderedList) => Wrap("ul", () => base.VisitUnorderedList(unorderedList));
+
+    /// <inheritdoc />
+    public override void VisitOrderedList(OrderedList orderedList)
+    {
+        ArgumentNullException.ThrowIfNull(orderedList);
+
+        html.Append("<ol");
+        if (orderedList.Start != 1)
+        {
+            html.Append(" start=\"").Append(orderedList.Start).Append('"');
+        }
+        html.Append('>');
+        base.VisitOrderedList(orderedList);
+        html.Append("</ol>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitListItem(ListItem listItem)
+    {
+        ArgumentNullException.ThrowIfNull(listItem);
+
+        html.Append("<li>");
+
+        if (listItem.Checked is bool isChecked)
+        {
+            html.Append("<input type=\"checkbox\"");
+            if (isChecked)
+            {
+                html.Append(" checked");
+            }
+            html.Append("> ");
+        }
+
+        var tight = listItem.Parent is List list && list.Tight
+            && listItem.Children.Count == 1 && listItem.Children[0] is Paragraph;
+
+        if (tight)
+        {
+            suppressParagraph = true;
+        }
+
+        base.VisitListItem(listItem);
+
+        html.Append("</li>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitLink(Link link)
+    {
+        ArgumentNullException.ThrowIfNull(link);
+
+        html.Append("<a href=\"").Append(Escape(link.Destination)).Append("\">");
+        base.VisitLink(link);
+        html.Append("</a>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitImage(Image image)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+
+        var alt = new StringBuilder();
+        AppendPlainText(alt, image.Children);
+
+        html.Append("<img src=\"").Append(Escape(image.Destination)).Append("\" alt=\"").Append(Escape(alt.ToString())).Append("\">");
+    }
+
+    private static void AppendPlainText(StringBuilder text, IReadOnlyList<Inline> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            switch (node)
+            {
+                case Text plain:
+                    text.Append(plain.Value);
+                    break;
+                case Code code:
+                    text.Append(code.Value);
+                    break;
+                case InlineContainer container:
+                    AppendPlainText(text, container.Children);
+                    break;
+                case SoftLineBreak or LineBreak:
+                    text.Append(' ');
+                    break;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override void VisitFencedCodeBlock(FencedCodeBlock fencedCodeBlock)
+    {
+        ArgumentNullException.ThrowIfNull(fencedCodeBlock);
+
+        html.Append("<pre><code");
+        if (!string.IsNullOrEmpty(fencedCodeBlock.Info))
+        {
+            html.Append(" class=\"language-").Append(Escape(fencedCodeBlock.Info)).Append('"');
+        }
+        html.Append('>').Append(Escape(fencedCodeBlock.Value)).Append("</code></pre>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitIndentedCodeBlock(IndentedCodeBlock codeBlock)
+    {
+        ArgumentNullException.ThrowIfNull(codeBlock);
+        html.Append("<pre><code>").Append(Escape(codeBlock.Value)).Append("</code></pre>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitHtmlBlock(HtmlBlock htmlBlock)
+    {
+        ArgumentNullException.ThrowIfNull(htmlBlock);
+        html.Append("<p>").Append(Escape(htmlBlock.Value)).Append("</p>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitHtmlInline(HtmlInline htmlInline)
+    {
+        ArgumentNullException.ThrowIfNull(htmlInline);
+        html.Append(Escape(htmlInline.Value));
+    }
+
+    /// <inheritdoc />
+    public override void VisitTable(Table table)
+    {
+        html.Append("<table>");
+        base.VisitTable(table);
+        html.Append("</tbody></table>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitTableHeaderRow(TableHeaderRow header)
+    {
+        html.Append("<thead>");
+        inHeaderRow = true;
+        Wrap("tr", () => base.VisitTableHeaderRow(header));
+        inHeaderRow = false;
+        html.Append("</thead><tbody>");
+    }
+
+    /// <inheritdoc />
+    public override void VisitTableRow(TableRow row) => Wrap("tr", () => base.VisitTableRow(row));
+
+    /// <inheritdoc />
+    public override void VisitTableCell(TableCell cell)
+    {
+        ArgumentNullException.ThrowIfNull(cell);
+
+        var tag = inHeaderRow ? "th" : "td";
+        html.Append('<').Append(tag);
+        AppendAlignment(cell.Alignment);
+        html.Append('>');
+        base.VisitTableCell(cell);
+        html.Append("</").Append(tag).Append('>');
+    }
+
+    private void AppendAlignment(TableCellAlignment alignment)
+    {
+        var value = alignment switch
+        {
+            TableCellAlignment.Left => "left",
+            TableCellAlignment.Center => "center",
+            TableCellAlignment.Right => "right",
+            _ => null
+        };
+
+        if (value != null)
+        {
+            html.Append(" style=\"text-align:").Append(value).Append('"');
+        }
+    }
+}

--- a/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
+++ b/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
@@ -147,7 +147,9 @@ public class HtmlVisitor : NodeVisitorBase
     {
         ArgumentNullException.ThrowIfNull(link);
 
-        html.Append("<a href=\"").Append(Escape(link.Destination)).Append("\">");
+        var destination = HtmlSanitizer.IsDangerousUrl(link.Destination ?? string.Empty) ? string.Empty : link.Destination;
+
+        html.Append("<a href=\"").Append(Escape(destination)).Append("\">");
         base.VisitLink(link);
         html.Append("</a>");
     }
@@ -160,7 +162,9 @@ public class HtmlVisitor : NodeVisitorBase
         var alt = new StringBuilder();
         AppendPlainText(alt, image.Children);
 
-        html.Append("<img src=\"").Append(Escape(image.Destination)).Append("\" alt=\"").Append(Escape(alt.ToString())).Append("\">");
+        var destination = HtmlSanitizer.IsDangerousUrl(image.Destination ?? string.Empty) ? string.Empty : image.Destination;
+
+        html.Append("<img src=\"").Append(Escape(destination)).Append("\" alt=\"").Append(Escape(alt.ToString())).Append("\">");
     }
 
     private static void AppendPlainText(StringBuilder text, IReadOnlyList<Inline> nodes)

--- a/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
+++ b/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
@@ -1,9 +1,8 @@
-using Radzen.Documents.Markdown;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Radzen.Blazor.Documents.Markdown;
+namespace Radzen.Documents.Markdown;
 
 /// <summary>
 /// Renders a Markdown document as an HTML string. Used by RadzenMarkdownEditor's design mode.

--- a/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
+++ b/Radzen.Blazor/Documents/Markdown/HtmlVisitor.cs
@@ -1,11 +1,12 @@
+using Radzen.Documents.Markdown;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Radzen.Documents.Markdown;
+namespace Radzen.Blazor.Documents.Markdown;
 
 /// <summary>
-/// Renders a markdown document as an HTML string. Used by RadzenMarkdownEditor's design mode.
+/// Renders a Markdown document as an HTML string. Used by RadzenMarkdownEditor's design mode.
 /// </summary>
 public class HtmlVisitor : NodeVisitorBase
 {
@@ -23,7 +24,7 @@ public class HtmlVisitor : NodeVisitorBase
     }
 
     /// <summary>Parses <paramref name="markdown" /> and renders it as HTML.</summary>
-    public static string ToHtml(string markdown) => ToHtml(MarkdownParser.Parse(markdown ?? string.Empty));
+    public static string ToHtml(string markdown) => ToHtml(MarkdownParser.Parse(markdown));
 
     private static string Escape(string? text) => (text ?? string.Empty)
         .Replace("&", "&amp;", StringComparison.Ordinal)
@@ -119,7 +120,7 @@ public class HtmlVisitor : NodeVisitorBase
 
         html.Append("<li>");
 
-        if (listItem.Checked is bool isChecked)
+        if (listItem.Checked is { } isChecked)
         {
             html.Append("<input type=\"checkbox\"");
             if (isChecked)
@@ -129,8 +130,7 @@ public class HtmlVisitor : NodeVisitorBase
             html.Append("> ");
         }
 
-        var tight = listItem.Parent is List list && list.Tight
-            && listItem.Children.Count == 1 && listItem.Children[0] is Paragraph;
+        bool tight = listItem is { Parent: List { Tight: true }, Children: [Paragraph] };
 
         if (tight)
         {

--- a/Radzen.Blazor/Documents/Markdown/INodeVisitor.cs
+++ b/Radzen.Blazor/Documents/Markdown/INodeVisitor.cs
@@ -57,6 +57,11 @@ public interface INodeVisitor
     void VisitStrong(Strong strong);
 
     /// <summary>
+    /// Visits a strikethrough node.
+    /// </summary>
+    void VisitStrikethrough(Strikethrough strikethrough);
+
+    /// <summary>
     /// Visits a code node.
     /// </summary>
     void VisitCode(Code code);

--- a/Radzen.Blazor/Documents/Markdown/InlineParser.cs
+++ b/Radzen.Blazor/Documents/Markdown/InlineParser.cs
@@ -5,12 +5,15 @@ using System;
 
 namespace Radzen.Documents.Markdown;
 
+internal readonly record struct InlineSpan(int Start, int End, int DelimiterLength, char Char);
+
 class InlineParser
 {
     class Delimiter
     {
         public char Char { get; set; }
         public int Length { get; set; }
+        public int OriginalLength { get; set; }
         public int Position { get; set; }
         public Text? Node { get; set; }
         public bool CanOpen { get; set; }
@@ -41,6 +44,7 @@ class InlineParser
     private readonly List<Inline> inlines = [];
     private readonly List<Delimiter> delimiters = [];
     private readonly StringBuilder buffer = new();
+    private List<InlineSpan>? spans;
 
     enum LinkState
     {
@@ -142,6 +146,8 @@ class InlineParser
 
             newIndex = bestMatch + openingCount;
 
+            spans?.Add(new InlineSpan(index, newIndex, openingCount, Backtick));
+
             return true;
         }
 
@@ -228,6 +234,7 @@ class InlineParser
                 Node = node,
                 Char = ch,
                 Length = buffer.Length,
+                OriginalLength = buffer.Length,
                 Position = index,
                 CanClose = canClose,
                 CanOpen = canOpen
@@ -266,7 +273,21 @@ class InlineParser
     {
         var parser = new InlineParser();
 
-        return parser.ParseInlines(text.Trim(), linkReferences);
+        return parser.ParseInto(text, linkReferences);
+    }
+
+    internal static List<InlineSpan> ScanSpans(string text)
+    {
+        var parser = new InlineParser { spans = [] };
+
+        parser.ParseInto(text, []);
+
+        return parser.spans!;
+    }
+
+    private List<Inline> ParseInto(string text, Dictionary<string, LinkReference> linkReferences)
+    {
+        return ParseInlines(text.Trim(), linkReferences);
     }
 
     private static readonly Regex EmailRegex = new(@"^([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)");
@@ -954,6 +975,12 @@ class InlineParser
                     {
                         parent.Add(child);
                     }
+
+                    spans?.Add(new InlineSpan(
+                        opener.Position + opener.Length - charsToConsume,
+                        closer.Position + (closer.OriginalLength - closer.Length) + charsToConsume,
+                        charsToConsume,
+                        closer.Char));
 
                     opener.Length -= charsToConsume;
 

--- a/Radzen.Blazor/Documents/Markdown/InlineParser.cs
+++ b/Radzen.Blazor/Documents/Markdown/InlineParser.cs
@@ -20,6 +20,7 @@ class InlineParser
 
     private const char Asterisk = '*';
     private const char Underscore = '_';
+    internal const char Tilde = '~';
     internal const char Backslash = '\\';
     private const char Null = '\0';
     private const char Backtick = '`';
@@ -176,7 +177,7 @@ class InlineParser
     {
         var ch = text[index];
 
-        if (ch is not (Asterisk or Underscore or OpenBracket) && (ch is not Exclamation || next is not OpenBracket))
+        if (ch is not (Asterisk or Underscore or Tilde or OpenBracket) && (ch is not Exclamation || next is not OpenBracket))
         {
             newIndex = index;
             return false;
@@ -210,7 +211,7 @@ class InlineParser
             var canOpen = false;
             var canClose = false;
 
-            if (ch is Asterisk)
+            if (ch is Asterisk or Tilde)
             {
                 canOpen = leftFlanking;
                 canClose = rightFlanking;
@@ -934,7 +935,20 @@ class InlineParser
 
                     var charsToConsume = closer.Length == opener.Length && closer.Length > 1 ? 2 : 1;
 
-                    InlineContainer parent = charsToConsume == 1 ? new Emphasis() : new Strong();
+                    if (closer.Char == Tilde)
+                    {
+                        if (opener.Length < 2 || closer.Length < 2)
+                        {
+                            // single tildes never pair — deactivate both as emphasis candidates
+                            delimiters.RemoveAt(closerIndex);
+                            continue;
+                        }
+                        charsToConsume = 2;
+                    }
+
+                    InlineContainer parent = closer.Char == Tilde
+                        ? new Strikethrough()
+                        : charsToConsume == 1 ? new Emphasis() : new Strong();
 
                     foreach (var child in innerInlines)
                     {
@@ -990,7 +1004,7 @@ class InlineParser
         {
             var delimiter = delimiters[index];
 
-            if (delimiter.CanClose && (delimiter.Char is Asterisk or Underscore))
+            if (delimiter.CanClose && (delimiter.Char is Asterisk or Underscore or Tilde))
             {
                 return index;
             }

--- a/Radzen.Blazor/Documents/Markdown/ListItem.cs
+++ b/Radzen.Blazor/Documents/Markdown/ListItem.cs
@@ -11,6 +11,11 @@ namespace Radzen.Documents.Markdown;
 /// </summary>
 public class ListItem : BlockContainer
 {
+    /// <summary>
+    /// For GFM task-list items: <c>true</c> for <c>[x]</c>, <c>false</c> for <c>[ ]</c>, <c>null</c> for a regular list item.
+    /// </summary>
+    public bool? Checked { get; set; }
+
     /// <inheritdoc />
     public override void Accept(INodeVisitor visitor)
     {
@@ -53,6 +58,18 @@ public class ListItem : BlockContainer
     internal override void Close(BlockParser parser)
     {
         base.Close(parser);
+
+        if (Children.Count > 0 && Children[0] is Paragraph paragraph)
+        {
+            var value = paragraph.Value;
+
+            if (value.Length >= 4 && value[0] == '[' && value[2] == ']' && value[3] == ' '
+                && (value[1] is ' ' or 'x' or 'X'))
+            {
+                Checked = value[1] != ' ';
+                paragraph.Value = value[4..];
+            }
+        }
 
         if (LastChild != null)
         {

--- a/Radzen.Blazor/Documents/Markdown/NodeVisitorBase.cs
+++ b/Radzen.Blazor/Documents/Markdown/NodeVisitorBase.cs
@@ -133,6 +133,15 @@ public abstract class NodeVisitorBase : INodeVisitor
     }
 
     /// <summary>
+    /// Visits a strikethrough by visiting its children.
+    /// </summary>
+    public virtual void VisitStrikethrough(Strikethrough strikethrough)
+    {
+        ArgumentNullException.ThrowIfNull(strikethrough);
+        VisitChildren(strikethrough.Children);
+    }
+
+    /// <summary>
     /// Visits a link by visiting its children.
     /// </summary>
     public virtual void VisitLink(Link link)

--- a/Radzen.Blazor/Documents/Markdown/Strikethrough.cs
+++ b/Radzen.Blazor/Documents/Markdown/Strikethrough.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Radzen.Documents.Markdown;
+
+/// <summary>
+/// Represents a strikethrough node: <c>~~strikethrough~~</c>.
+/// </summary>
+public class Strikethrough : InlineContainer
+{
+    /// <inheritdoc />
+    public override void Accept(INodeVisitor visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        visitor.VisitStrikethrough(this);
+    }
+}

--- a/Radzen.Blazor/MarkdownEditorCommands.cs
+++ b/Radzen.Blazor/MarkdownEditorCommands.cs
@@ -1,0 +1,37 @@
+namespace Radzen;
+
+/// <summary>
+/// Contains the names of the commands supported by <c>RadzenMarkdownEditor</c>.
+/// Pass them to <c>RadzenMarkdownEditor.ExecuteCommandAsync</c>.
+/// </summary>
+public static class MarkdownEditorCommands
+{
+    /// <summary>Wraps the selection in <c>**</c>.</summary>
+    public const string Bold = "bold";
+    /// <summary>Wraps the selection in <c>_</c>.</summary>
+    public const string Italic = "italic";
+    /// <summary>Wraps the selection in <c>~~</c>.</summary>
+    public const string Strikethrough = "strikethrough";
+    /// <summary>Cycles the heading level of the selected lines (# → ## → ### → none).</summary>
+    public const string Heading = "heading";
+    /// <summary>Wraps the selection in a markdown link. The command value is the URL.</summary>
+    public const string Link = "link";
+    /// <summary>Wraps the selection in a markdown image. The command value is the image URL.</summary>
+    public const string Image = "image";
+    /// <summary>Wraps the selection in backticks.</summary>
+    public const string Code = "code";
+    /// <summary>Wraps the selection in a fenced code block.</summary>
+    public const string CodeBlock = "codeBlock";
+    /// <summary>Prefixes the selected lines with <c>&gt; </c>.</summary>
+    public const string Quote = "quote";
+    /// <summary>Prefixes the selected lines with <c>- </c>.</summary>
+    public const string UnorderedList = "unorderedList";
+    /// <summary>Prefixes the selected lines with <c>1. </c>, <c>2. </c>, …</summary>
+    public const string OrderedList = "orderedList";
+    /// <summary>Prefixes the selected lines with <c>- [ ] </c>.</summary>
+    public const string TaskList = "taskList";
+    /// <summary>Inserts a horizontal rule (<c>---</c>) on its own line.</summary>
+    public const string HorizontalRule = "horizontalRule";
+    /// <summary>Replaces the selection with the command value.</summary>
+    public const string InsertText = "insertText";
+}

--- a/Radzen.Blazor/MarkdownEditorCommands.cs
+++ b/Radzen.Blazor/MarkdownEditorCommands.cs
@@ -34,4 +34,8 @@ public static class MarkdownEditorCommands
     public const string HorizontalRule = "horizontalRule";
     /// <summary>Replaces the selection with the command value.</summary>
     public const string InsertText = "insertText";
+    /// <summary>Restores the previous state from the editor's history.</summary>
+    public const string Undo = "undo";
+    /// <summary>Restores the next state from the editor's history.</summary>
+    public const string Redo = "redo";
 }

--- a/Radzen.Blazor/MarkdownEditorCommands.cs
+++ b/Radzen.Blazor/MarkdownEditorCommands.cs
@@ -8,7 +8,7 @@ public static class MarkdownEditorCommands
 {
     /// <summary>Wraps the selection in <c>**</c>.</summary>
     public const string Bold = "bold";
-    /// <summary>Wraps the selection in <c>_</c>.</summary>
+    /// <summary>Wraps the selection in <c>*</c>.</summary>
     public const string Italic = "italic";
     /// <summary>Wraps the selection in <c>~~</c>.</summary>
     public const string Strikethrough = "strikethrough";

--- a/Radzen.Blazor/MarkdownEditorCommands.cs
+++ b/Radzen.Blazor/MarkdownEditorCommands.cs
@@ -14,9 +14,9 @@ public static class MarkdownEditorCommands
     public const string Strikethrough = "strikethrough";
     /// <summary>Cycles the heading level of the selected lines (# → ## → ### → none).</summary>
     public const string Heading = "heading";
-    /// <summary>Wraps the selection in a markdown link. The command value is the URL.</summary>
+    /// <summary>Wraps the selection in a Markdown link. The command value is the URL.</summary>
     public const string Link = "link";
-    /// <summary>Wraps the selection in a markdown image. The command value is the image URL.</summary>
+    /// <summary>Wraps the selection in a Markdown image. The command value is the image URL.</summary>
     public const string Image = "image";
     /// <summary>Wraps the selection in backticks.</summary>
     public const string Code = "code";

--- a/Radzen.Blazor/MarkdownEditorExecuteEventArgs.cs
+++ b/Radzen.Blazor/MarkdownEditorExecuteEventArgs.cs
@@ -1,0 +1,24 @@
+using Radzen.Blazor;
+
+namespace Radzen;
+
+/// <summary>
+/// Supplies information about a <see cref="RadzenMarkdownEditor.Execute" /> event that is being raised.
+/// </summary>
+public class MarkdownEditorExecuteEventArgs
+{
+    /// <summary>
+    /// Gets the editor which raised the event.
+    /// </summary>
+    public RadzenMarkdownEditor Editor { get; }
+
+    internal MarkdownEditorExecuteEventArgs(RadzenMarkdownEditor editor)
+    {
+        Editor = editor;
+    }
+
+    /// <summary>
+    /// Gets the name of the command which was executed. Custom tools set this to their <c>CommandName</c>.
+    /// </summary>
+    public string? CommandName { get; set; }
+}

--- a/Radzen.Blazor/MarkdownEditorMode.cs
+++ b/Radzen.Blazor/MarkdownEditorMode.cs
@@ -1,0 +1,22 @@
+namespace Radzen;
+
+/// <summary>
+/// Specifies the mode of <c>RadzenMarkdownEditor</c>.
+/// </summary>
+public enum MarkdownEditorMode
+{
+    /// <summary>
+    /// Only the markdown source textarea is visible.
+    /// </summary>
+    Edit = 0,
+
+    /// <summary>
+    /// Only the rendered preview is visible.
+    /// </summary>
+    Preview = 1,
+
+    /// <summary>
+    /// The textarea and the rendered preview are shown side by side.
+    /// </summary>
+    Split = 2
+}

--- a/Radzen.Blazor/MarkdownEditorMode.cs
+++ b/Radzen.Blazor/MarkdownEditorMode.cs
@@ -1,22 +1,12 @@
-namespace Radzen;
+namespace Radzen.Blazor;
 
 /// <summary>
-/// Specifies the mode of <c>RadzenMarkdownEditor</c>.
+/// The mode of a <see cref="RadzenMarkdownEditor" />.
 /// </summary>
 public enum MarkdownEditorMode
 {
-    /// <summary>
-    /// Only the markdown source textarea is visible.
-    /// </summary>
-    Edit = 0,
-
-    /// <summary>
-    /// Only the rendered preview is visible.
-    /// </summary>
-    Preview = 1,
-
-    /// <summary>
-    /// The textarea and the rendered preview are shown side by side.
-    /// </summary>
-    Split = 2
+    /// <summary>WYSIWYG editing of the rendered markdown.</summary>
+    Design,
+    /// <summary>Editing the raw markdown source in a textarea.</summary>
+    Source
 }

--- a/Radzen.Blazor/MarkdownEditorMode.cs
+++ b/Radzen.Blazor/MarkdownEditorMode.cs
@@ -1,7 +1,7 @@
-namespace Radzen.Blazor;
+namespace Radzen;
 
 /// <summary>
-/// The mode of a <see cref="RadzenMarkdownEditor" />.
+/// The mode of a <see cref="Radzen.Blazor.RadzenMarkdownEditor" />.
 /// </summary>
 public enum MarkdownEditorMode
 {

--- a/Radzen.Blazor/MarkdownEditorToolState.cs
+++ b/Radzen.Blazor/MarkdownEditorToolState.cs
@@ -1,4 +1,4 @@
-namespace Radzen.Blazor;
+namespace Radzen;
 
 /// <summary>
 /// The active formats and history availability at the current design-surface selection, reported by JavaScript.

--- a/Radzen.Blazor/MarkdownEditorToolState.cs
+++ b/Radzen.Blazor/MarkdownEditorToolState.cs
@@ -1,0 +1,16 @@
+namespace Radzen.Blazor;
+
+/// <summary>
+/// The active formats and history availability at the current design-surface selection, reported by JavaScript.
+/// </summary>
+public class MarkdownEditorToolState
+{
+    /// <summary>The commands (see <see cref="MarkdownEditorCommands" />) active at the current selection.</summary>
+    public string[]? Formats { get; set; }
+
+    /// <summary>Whether the editor's history has a state to undo to.</summary>
+    public bool CanUndo { get; set; }
+
+    /// <summary>Whether the editor's history has a state to redo to.</summary>
+    public bool CanRedo { get; set; }
+}

--- a/Radzen.Blazor/MarkdownFormatter.cs
+++ b/Radzen.Blazor/MarkdownFormatter.cs
@@ -55,6 +55,14 @@ internal static class MarkdownFormatter
                 return PrefixLines(text, start, end, "- [ ] ");
             case MarkdownEditorCommands.OrderedList:
                 return OrderedList(text, start, end);
+            case MarkdownEditorCommands.CodeBlock:
+                return CodeBlock(text, start, end);
+            case MarkdownEditorCommands.HorizontalRule:
+                return HorizontalRule(text, start, end);
+            case MarkdownEditorCommands.Link:
+                return Link(text, start, end, value, label, "[");
+            case MarkdownEditorCommands.Image:
+                return Link(text, start, end, value, label, "![");
             default:
                 return null;
         }
@@ -135,5 +143,42 @@ internal static class MarkdownFormatter
             var prefix = next == 0 ? string.Empty : new string('#', next) + " ";
             return lines.Select(l => prefix + HeadingPrefix.Replace(l, string.Empty, 1)).ToArray();
         });
+    }
+
+    static bool AtLineStart(string text, int index) => index == 0 || text[index - 1] == '\n';
+    static bool AtLineEnd(string text, int index) => index == text.Length || text[index] == '\n';
+
+    static MarkdownEdit CodeBlock(string text, int start, int end)
+    {
+        var selected = text.Substring(start, end - start);
+        var before = AtLineStart(text, start) ? string.Empty : "\n";
+        var after = AtLineEnd(text, end) ? string.Empty : "\n";
+        var innerNewline = selected.EndsWith('\n') ? string.Empty : "\n";
+
+        var replacement = before + "```\n" + selected + innerNewline + "```" + after;
+        var innerStart = start + before.Length + 4;
+        return new MarkdownEdit(start, end, replacement, innerStart, innerStart + selected.Length);
+    }
+
+    static MarkdownEdit HorizontalRule(string text, int start, int end)
+    {
+        var before = AtLineStart(text, start) ? string.Empty : "\n";
+        var after = AtLineEnd(text, end) && end < text.Length ? string.Empty : "\n";
+        var replacement = before + "---" + after;
+        return new MarkdownEdit(start, end, replacement, start + replacement.Length, start + replacement.Length);
+    }
+
+    static MarkdownEdit Link(string text, int start, int end, string? url, string? label, string open)
+    {
+        var selected = text.Substring(start, end - start);
+        var linkText = selected.Length > 0 ? selected : label ?? string.Empty;
+        var replacement = open + linkText + "](" + (url ?? string.Empty) + ")";
+
+        if (linkText.Length == 0)
+        {
+            return new MarkdownEdit(start, end, replacement, start + open.Length, start + open.Length);
+        }
+
+        return new MarkdownEdit(start, end, replacement, start + replacement.Length, start + replacement.Length);
     }
 }

--- a/Radzen.Blazor/MarkdownFormatter.cs
+++ b/Radzen.Blazor/MarkdownFormatter.cs
@@ -162,10 +162,10 @@ internal static class MarkdownFormatter
 
     static MarkdownEdit HorizontalRule(string text, int start, int end)
     {
-        var before = AtLineStart(text, start) ? string.Empty : "\n";
+        var before = AtLineStart(text, end) ? string.Empty : "\n";
         var after = AtLineEnd(text, end) && end < text.Length ? string.Empty : "\n";
         var replacement = before + "---" + after;
-        return new MarkdownEdit(start, end, replacement, start + replacement.Length, start + replacement.Length);
+        return new MarkdownEdit(end, end, replacement, end + replacement.Length, end + replacement.Length);
     }
 
     static MarkdownEdit Link(string text, int start, int end, string? url, string? label, string open)

--- a/Radzen.Blazor/MarkdownFormatter.cs
+++ b/Radzen.Blazor/MarkdownFormatter.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A text edit produced by <see cref="MarkdownFormatter" />: replace <c>[Start, End)</c> with <see cref="Replacement" />
+/// and afterwards select <c>[SelectionStart, SelectionEnd)</c>.
+/// </summary>
+internal readonly record struct MarkdownEdit(int Start, int End, string Replacement, int SelectionStart, int SelectionEnd);
+
+/// <summary>
+/// Pure markdown formatting logic used by <c>RadzenMarkdownEditor</c>. Computes the minimal replacement
+/// for a command so the browser can apply it as a single undoable edit.
+/// </summary>
+internal static class MarkdownFormatter
+{
+    /// <summary>
+    /// Computes the edit for <paramref name="command" /> applied to the selection <c>[start, end)</c> of <paramref name="text" />.
+    /// Returns <c>null</c> for unknown commands.
+    /// </summary>
+    /// <param name="text">The current editor text.</param>
+    /// <param name="start">Selection start (clamped).</param>
+    /// <param name="end">Selection end (clamped).</param>
+    /// <param name="command">One of <see cref="MarkdownEditorCommands" />.</param>
+    /// <param name="value">Command value: the URL for link/image, the text for insertText.</param>
+    /// <param name="label">Optional link/image label used when the selection is empty.</param>
+    public static MarkdownEdit? Apply(string text, int start, int end, string command, string? value = null, string? label = null)
+    {
+        text ??= string.Empty;
+        start = Math.Clamp(start, 0, text.Length);
+        end = Math.Clamp(end, start, text.Length);
+
+        switch (command)
+        {
+            case MarkdownEditorCommands.InsertText:
+                var inserted = value ?? string.Empty;
+                return new MarkdownEdit(start, end, inserted, start + inserted.Length, start + inserted.Length);
+            default:
+                return null;
+        }
+    }
+}

--- a/Radzen.Blazor/MarkdownFormatter.cs
+++ b/Radzen.Blazor/MarkdownFormatter.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Radzen.Blazor;
 
@@ -43,6 +45,16 @@ internal static class MarkdownFormatter
                 return Wrap(text, start, end, "~~");
             case MarkdownEditorCommands.Code:
                 return Wrap(text, start, end, "`");
+            case MarkdownEditorCommands.Heading:
+                return Heading(text, start, end);
+            case MarkdownEditorCommands.Quote:
+                return PrefixLines(text, start, end, "> ");
+            case MarkdownEditorCommands.UnorderedList:
+                return PrefixLines(text, start, end, "- ");
+            case MarkdownEditorCommands.TaskList:
+                return PrefixLines(text, start, end, "- [ ] ");
+            case MarkdownEditorCommands.OrderedList:
+                return OrderedList(text, start, end);
             default:
                 return null;
         }
@@ -69,5 +81,59 @@ internal static class MarkdownFormatter
         }
 
         return new MarkdownEdit(start, end, token + selected + token, start + t, start + t + selected.Length);
+    }
+
+    static readonly Regex OrderedPrefix = new(@"^\d+\. ", RegexOptions.Compiled);
+    static readonly Regex HeadingPrefix = new(@"^(#{1,6}) ", RegexOptions.Compiled);
+
+    /// <summary>Expands [start, end) to whole lines. A selection ending right after a newline does not include the next line.</summary>
+    static (int LineStart, int LineEnd) ExpandToLines(string text, int start, int end)
+    {
+        var lineStart = start == 0 ? 0 : text.LastIndexOf('\n', start - 1) + 1;
+
+        var searchFrom = end > start && text[end - 1] == '\n' ? end - 1 : end;
+        var lineEnd = searchFrom < text.Length ? text.IndexOf('\n', searchFrom) : -1;
+        if (lineEnd == -1)
+        {
+            lineEnd = text.Length;
+        }
+
+        return (lineStart, lineEnd);
+    }
+
+    static MarkdownEdit ReplaceLines(string text, int start, int end, Func<string[], string[]> transform)
+    {
+        var (lineStart, lineEnd) = ExpandToLines(text, start, end);
+        var lines = text.Substring(lineStart, lineEnd - lineStart).Split('\n');
+        var replacement = string.Join("\n", transform(lines));
+        return new MarkdownEdit(lineStart, lineEnd, replacement, lineStart, lineStart + replacement.Length);
+    }
+
+    static MarkdownEdit PrefixLines(string text, int start, int end, string prefix)
+    {
+        return ReplaceLines(text, start, end, lines =>
+            lines.All(l => l.StartsWith(prefix, StringComparison.Ordinal))
+                ? lines.Select(l => l.Substring(prefix.Length)).ToArray()
+                : lines.Select(l => prefix + l).ToArray());
+    }
+
+    static MarkdownEdit OrderedList(string text, int start, int end)
+    {
+        return ReplaceLines(text, start, end, lines =>
+            lines.All(l => OrderedPrefix.IsMatch(l))
+                ? lines.Select(l => OrderedPrefix.Replace(l, string.Empty, 1)).ToArray()
+                : lines.Select((l, i) => $"{i + 1}. {l}").ToArray());
+    }
+
+    static MarkdownEdit Heading(string text, int start, int end)
+    {
+        return ReplaceLines(text, start, end, lines =>
+        {
+            var match = HeadingPrefix.Match(lines[0]);
+            var level = match.Success ? match.Groups[1].Value.Length : 0;
+            var next = level >= 3 ? 0 : level + 1;
+            var prefix = next == 0 ? string.Empty : new string('#', next) + " ";
+            return lines.Select(l => prefix + HeadingPrefix.Replace(l, string.Empty, 1)).ToArray();
+        });
     }
 }

--- a/Radzen.Blazor/MarkdownFormatter.cs
+++ b/Radzen.Blazor/MarkdownFormatter.cs
@@ -114,7 +114,7 @@ internal static class MarkdownFormatter
         return ReplaceLines(text, start, end, lines =>
             lines.All(l => l.StartsWith(prefix, StringComparison.Ordinal))
                 ? lines.Select(l => l.Substring(prefix.Length)).ToArray()
-                : lines.Select(l => prefix + l).ToArray());
+                : lines.Select(l => l.StartsWith(prefix, StringComparison.Ordinal) ? l : prefix + l).ToArray());
     }
 
     static MarkdownEdit OrderedList(string text, int start, int end)
@@ -122,7 +122,7 @@ internal static class MarkdownFormatter
         return ReplaceLines(text, start, end, lines =>
             lines.All(l => OrderedPrefix.IsMatch(l))
                 ? lines.Select(l => OrderedPrefix.Replace(l, string.Empty, 1)).ToArray()
-                : lines.Select((l, i) => $"{i + 1}. {l}").ToArray());
+                : lines.Select((l, i) => $"{i + 1}. {OrderedPrefix.Replace(l, string.Empty, 1)}").ToArray());
     }
 
     static MarkdownEdit Heading(string text, int start, int end)

--- a/Radzen.Blazor/MarkdownFormatter.cs
+++ b/Radzen.Blazor/MarkdownFormatter.cs
@@ -35,8 +35,39 @@ internal static class MarkdownFormatter
             case MarkdownEditorCommands.InsertText:
                 var inserted = value ?? string.Empty;
                 return new MarkdownEdit(start, end, inserted, start + inserted.Length, start + inserted.Length);
+            case MarkdownEditorCommands.Bold:
+                return Wrap(text, start, end, "**");
+            case MarkdownEditorCommands.Italic:
+                return Wrap(text, start, end, "_");
+            case MarkdownEditorCommands.Strikethrough:
+                return Wrap(text, start, end, "~~");
+            case MarkdownEditorCommands.Code:
+                return Wrap(text, start, end, "`");
             default:
                 return null;
         }
+    }
+
+    static MarkdownEdit Wrap(string text, int start, int end, string token)
+    {
+        var selected = text.Substring(start, end - start);
+        var t = token.Length;
+
+        // Selection contains the tokens: **hi** → hi
+        if (selected.Length >= 2 * t && selected.StartsWith(token, StringComparison.Ordinal) && selected.EndsWith(token, StringComparison.Ordinal))
+        {
+            var inner = selected.Substring(t, selected.Length - 2 * t);
+            return new MarkdownEdit(start, end, inner, start, start + inner.Length);
+        }
+
+        // Tokens immediately outside the selection: **[hi]** → hi
+        if (start >= t && end + t <= text.Length
+            && string.CompareOrdinal(text, start - t, token, 0, t) == 0
+            && string.CompareOrdinal(text, end, token, 0, t) == 0)
+        {
+            return new MarkdownEdit(start - t, end + t, selected, start - t, start - t + selected.Length);
+        }
+
+        return new MarkdownEdit(start, end, token + selected + token, start + t, start + t + selected.Length);
     }
 }

--- a/Radzen.Blazor/MarkdownFormatter.cs
+++ b/Radzen.Blazor/MarkdownFormatter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Radzen.Documents.Markdown;
 
 namespace Radzen.Blazor;
 
@@ -38,13 +39,13 @@ internal static class MarkdownFormatter
                 var inserted = value ?? string.Empty;
                 return new MarkdownEdit(start, end, inserted, start + inserted.Length, start + inserted.Length);
             case MarkdownEditorCommands.Bold:
-                return Wrap(text, start, end, "**");
+                return ToggleInline(text, start, end, "**", s => s.Char is '*' or '_' && s.DelimiterLength == 2);
             case MarkdownEditorCommands.Italic:
-                return Wrap(text, start, end, "_");
+                return ToggleInline(text, start, end, "*", s => s.Char is '*' or '_' && s.DelimiterLength == 1);
             case MarkdownEditorCommands.Strikethrough:
-                return Wrap(text, start, end, "~~");
+                return ToggleInline(text, start, end, "~~", s => s.Char == '~');
             case MarkdownEditorCommands.Code:
-                return Wrap(text, start, end, "`");
+                return ToggleInline(text, start, end, "`", s => s.Char == '`');
             case MarkdownEditorCommands.Heading:
                 return Heading(text, start, end);
             case MarkdownEditorCommands.Quote:
@@ -68,27 +69,80 @@ internal static class MarkdownFormatter
         }
     }
 
-    static MarkdownEdit Wrap(string text, int start, int end, string token)
+    /// <summary>
+    /// Toggles an inline markdown token (bold/italic/strikethrough/code) on the selection, normalizing it
+    /// GitHub-style: trims whitespace off the edges, expands a collapsed caret to the surrounding word,
+    /// unwraps a token that already contains the selection, and otherwise strips any fully-selected matching
+    /// tokens before wrapping once.
+    /// </summary>
+    static MarkdownEdit ToggleInline(string text, int start, int end, string emit, Func<InlineSpan, bool> matches)
     {
-        var selected = text.Substring(start, end - start);
-        var t = token.Length;
+        // 1. scan only the lines the selection touches — inline tokens never matter across paragraphs here
+        var (lineStart, lineEnd) = ExpandToLines(text, start, end);
+        var line = text.Substring(lineStart, lineEnd - lineStart);
+        var spans = InlineParser.ScanSpans(line);
 
-        // Selection contains the tokens: **hi** → hi
-        if (selected.Length >= 2 * t && selected.StartsWith(token, StringComparison.Ordinal) && selected.EndsWith(token, StringComparison.Ordinal))
+        // ScanSpans trims its input, so span offsets are relative to the trimmed line. Leading whitespace
+        // on the line shifts them; trailing whitespace does not affect start-relative offsets.
+        var leadingWhitespace = line.Length - line.TrimStart().Length;
+
+        // 2. trim whitespace off the selection edges
+        while (start < end && char.IsWhiteSpace(text[start]))
         {
-            var inner = selected.Substring(t, selected.Length - 2 * t);
-            return new MarkdownEdit(start, end, inner, start, start + inner.Length);
+            start++;
+        }
+        while (end > start && char.IsWhiteSpace(text[end - 1]))
+        {
+            end--;
         }
 
-        // Tokens immediately outside the selection: **[hi]** → hi
-        if (start >= t && end + t <= text.Length
-            && string.CompareOrdinal(text, start - t, token, 0, t) == 0
-            && string.CompareOrdinal(text, end, token, 0, t) == 0)
+        // 3. collapsed caret: expand to the surrounding non-whitespace run
+        if (start == end)
         {
-            return new MarkdownEdit(start - t, end + t, selected, start - t, start - t + selected.Length);
+            while (start > lineStart && !char.IsWhiteSpace(text[start - 1]))
+            {
+                start--;
+            }
+            while (end < lineEnd && !char.IsWhiteSpace(text[end]))
+            {
+                end++;
+            }
+            if (start == end)
+            {
+                // caret in whitespace: insert empty delimiters, caret between them
+                return new MarkdownEdit(start, end, emit + emit, start + emit.Length, start + emit.Length);
+            }
         }
 
-        return new MarkdownEdit(start, end, token + selected + token, start + t, start + t + selected.Length);
+        // 4a. a matching token whose outer range contains the selection → unwrap it
+        foreach (var s in spans)
+        {
+            if (!matches(s))
+            {
+                continue;
+            }
+            int outerStart = lineStart + leadingWhitespace + s.Start, outerEnd = lineStart + leadingWhitespace + s.End;
+            if (outerStart <= start && end <= outerEnd)
+            {
+                var inner = text.Substring(outerStart + s.DelimiterLength, outerEnd - outerStart - 2 * s.DelimiterLength);
+                return new MarkdownEdit(outerStart, outerEnd, inner, outerStart, outerStart + inner.Length);
+            }
+        }
+
+        // 4b. otherwise: strip matching tokens fully inside the selection, then wrap once
+        var content = text.Substring(start, end - start);
+        foreach (var s in spans.Where(s => matches(s)
+                     && lineStart + leadingWhitespace + s.Start >= start && lineStart + leadingWhitespace + s.End <= end)
+                 .OrderByDescending(s => s.Start))
+        {
+            int rs = lineStart + leadingWhitespace + s.Start - start, re = lineStart + leadingWhitespace + s.End - start;
+            content = content[..rs]
+                + content[(rs + s.DelimiterLength)..(re - s.DelimiterLength)]
+                + content[re..];
+        }
+
+        var replacement = emit + content + emit;
+        return new MarkdownEdit(start, end, replacement, start + emit.Length, start + emit.Length + content.Length);
     }
 
     static readonly Regex OrderedPrefix = new(@"^\d+\. ", RegexOptions.Compiled);

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -2,12 +2,23 @@
 
 @if (Visible)
 {
-    <div @ref=Element style=@Style @attributes=@Attributes class=@GetCssClass() id=@GetId()>
+    <div @ref="Element" style="@Style" @attributes="@Attributes" class="@GetCssClass()" id="@GetId()">
         @if (ShowToolbar)
         {
             <div class="rz-toolbar rz-markdown-editor-toolbar">
                 <div class="rz-markdown-editor-tools">
-                    <CascadingValue Value=@this>
+                    @if (ShowModeSwitch)
+                    {
+                        <div class="rz-markdown-editor-modes">
+                            <RadzenSelectBar TValue="MarkdownEditorMode" Value="@mode" ValueChanged="@SetModeAsync" Size="ButtonSize.Small" Disabled="@Disabled">
+                                <Items>
+                                    <RadzenSelectBarItem Value="MarkdownEditorMode.Source" Icon="markdown" AriaLabel="@SourceText" title="@SourceText"/>
+                                    <RadzenSelectBarItem Value="MarkdownEditorMode.Design" Icon="match_case" AriaLabel="@DesignText" title="@DesignText"/>
+                                </Items>
+                            </RadzenSelectBar>
+                        </div>
+                    }
+                    <CascadingValue Value="@this">
                         @if (ChildContent != null)
                         {
                             @ChildContent
@@ -36,25 +47,14 @@
                         }
                     </CascadingValue>
                 </div>
-                @if (ShowModeSwitch)
-                {
-                    <div class="rz-markdown-editor-modes">
-                        <RadzenSelectBar TValue="MarkdownEditorMode" Value=@mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
-                            <Items>
-                                <RadzenSelectBarItem Value="MarkdownEditorMode.Source" Icon="markdown" AriaLabel=@SourceText title=@SourceText/>
-                                <RadzenSelectBarItem Value="MarkdownEditorMode.Design" Icon="match_case" AriaLabel=@DesignText title=@DesignText/>
-                            </Items>
-                        </RadzenSelectBar>
-                    </div>
-                }
             </div>
         }
         <div class="rz-markdown-editor-content">
-            <div @ref=editable class="rz-markdown-editor-design" hidden=@(mode == MarkdownEditorMode.Source)
-                 contenteditable=@(Disabled ? "false" : "true")></div>
-            <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Design)
-                      name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
-                      @bind:get="@Value" @bind:set="@OnInputAsync" @bind:event="oninput" @onchange=@OnChange></textarea>
+            <div @ref="editable" class="rz-markdown-editor-design" hidden="@(mode == MarkdownEditorMode.Source)"
+                 contenteditable='@(Disabled ? "false" : "true")'></div>
+            <textarea @ref="textarea" class="rz-markdown-editor-textarea" hidden="@(mode == MarkdownEditorMode.Design)"
+                      name="@Name" rows="@Rows" placeholder="@CurrentPlaceholder" disabled="@Disabled"
+                      @bind:get="@Value" @bind:set="@OnInputAsync" @bind:event="oninput" @onchange="@OnChange"></textarea>
         </div>
     </div>
 }
@@ -65,19 +65,19 @@
         <RadzenTemplateForm TItem="LinkDialogModel" Data="@model" Submit="() => ds.Close(true)">
             <div class="rz-html-editor-dialog-item">
                 <label>@(image ? ImageUrlText : UrlText)</label>
-                <RadzenTextBox @bind-Value=@model.Url Style="width: 100%" Name="Url" />
+                <RadzenTextBox @bind-Value="@model.Url" Style="width: 100%" Name="Url" />
                 <RadzenRequiredValidator Component="Url" />
             </div>
             @if (!hasSelection)
             {
                 <div class="rz-html-editor-dialog-item">
                     <label>@(image ? ImageAltText : LinkText)</label>
-                    <RadzenTextBox @bind-Value=@model.Text Style="width: 100%" />
+                    <RadzenTextBox @bind-Value="@model.Text" Style="width: 100%" />
                 </div>
             }
             <div class="rz-html-editor-dialog-buttons">
-                <RadzenButton Text=@CancelText Click="() => ds.Close(false)" ButtonStyle="ButtonStyle.Base" Variant="Variant.Outlined" />
-                <RadzenButton Text=@OkText ButtonType="ButtonType.Submit" Variant="Variant.Flat" />
+                <RadzenButton Text="@CancelText" Click="() => ds.Close(false)" ButtonStyle="ButtonStyle.Base" Variant="Variant.Outlined" />
+                <RadzenButton Text="@OkText" ButtonType="ButtonType.Submit" Variant="Variant.Flat" />
             </div>
         </RadzenTemplateForm>
     </div>;

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -17,7 +17,6 @@
                         {
                             <RadzenMarkdownEditorBold />
                             <RadzenMarkdownEditorItalic />
-                            <RadzenMarkdownEditorStrikethrough />
                             <RadzenMarkdownEditorSeparator />
                             <RadzenMarkdownEditorHeading />
                             <RadzenMarkdownEditorQuote />
@@ -26,7 +25,6 @@
                             <RadzenMarkdownEditorSeparator />
                             <RadzenMarkdownEditorUnorderedList />
                             <RadzenMarkdownEditorOrderedList />
-                            <RadzenMarkdownEditorTaskList />
                             <RadzenMarkdownEditorSeparator />
                             <RadzenMarkdownEditorLink />
                             <RadzenMarkdownEditorImage />
@@ -35,7 +33,7 @@
                     </CascadingValue>
                 </div>
                 <div class="rz-markdown-editor-modes">
-                    <RadzenSelectBar TValue="MarkdownEditorMode" Value=@Mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
+                    <RadzenSelectBar TValue="MarkdownEditorMode" Value=@mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
                         <Items>
                             <RadzenSelectBarItem Value="MarkdownEditorMode.Edit" Text=@WriteText />
                             <RadzenSelectBarItem Value="MarkdownEditorMode.Preview" Text=@PreviewText />
@@ -46,10 +44,10 @@
             </div>
         }
         <div class=@ContentClass>
-            <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(Mode == MarkdownEditorMode.Preview)
-                      name=@Name rows=@Rows placeholder=@Placeholder disabled=@Disabled
+            <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Preview)
+                      name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
                       value=@Value @oninput=@OnInput @onchange=@OnChange></textarea>
-            @if (Mode != MarkdownEditorMode.Edit)
+            @if (mode != MarkdownEditorMode.Edit)
             {
                 <div class="rz-markdown-editor-preview">
                     @if (string.IsNullOrWhiteSpace(Value))

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -45,22 +45,25 @@
         }
         <RadzenSplitter Orientation="Orientation.Horizontal" class="rz-markdown-editor-content">
             <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" BarVisible=@(mode == MarkdownEditorMode.Split)
-                                class=@(mode == MarkdownEditorMode.Preview ? "rz-markdown-editor-pane rz-markdown-editor-pane-hidden" : "rz-markdown-editor-pane")>
+                                class=@TextareaPaneClass>
                 <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Preview)
                           name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
                           value=@Value @oninput=@OnInput @onchange=@OnChange></textarea>
             </RadzenSplitterPane>
-            <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" Visible=@(mode != MarkdownEditorMode.Edit) class="rz-markdown-editor-pane">
-                <div class="rz-markdown-editor-preview">
-                    @if (string.IsNullOrWhiteSpace(Value))
-                    {
-                        <span class="rz-markdown-editor-empty">@NothingToPreviewText</span>
-                    }
-                    else
-                    {
-                        <RadzenMarkdown Text=@Value AllowHtml=@AllowHtml AllowedHtmlTags=@AllowedHtmlTags AllowedHtmlAttributes=@AllowedHtmlAttributes />
-                    }
-                </div>
+            <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" class=@PreviewPaneClass>
+                @if (mode != MarkdownEditorMode.Edit)
+                {
+                    <div class="rz-markdown-editor-preview">
+                        @if (string.IsNullOrWhiteSpace(Value))
+                        {
+                            <span class="rz-markdown-editor-empty">@NothingToPreviewText</span>
+                        }
+                        else
+                        {
+                            <RadzenMarkdown Text=@Value AllowHtml=@AllowHtml AllowedHtmlTags=@AllowedHtmlTags AllowedHtmlAttributes=@AllowedHtmlAttributes />
+                        }
+                    </div>
+                }
             </RadzenSplitterPane>
         </RadzenSplitter>
     </div>

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -1,0 +1,76 @@
+@using Radzen.Blazor.Rendering
+@inherits FormComponent<string>
+
+@if (Visible)
+{
+    <div @ref=Element style=@Style @attributes=@Attributes class=@GetCssClass() id=@GetId()>
+        @if (ShowToolbar)
+        {
+            <div class="rz-toolbar rz-markdown-editor-toolbar">
+                <div class="rz-markdown-editor-tools">
+                    <CascadingValue Value=@this>
+                        @if (ChildContent != null)
+                        {
+                            @ChildContent
+                        }
+                        else
+                        {
+                            @* default tools added in Task 7 *@
+                        }
+                    </CascadingValue>
+                </div>
+                <div class="rz-markdown-editor-modes">
+                    <RadzenSelectBar TValue="MarkdownEditorMode" Value=@Mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
+                        <Items>
+                            <RadzenSelectBarItem Value="MarkdownEditorMode.Edit" Text=@WriteText />
+                            <RadzenSelectBarItem Value="MarkdownEditorMode.Preview" Text=@PreviewText />
+                            <RadzenSelectBarItem Value="MarkdownEditorMode.Split" Text=@SplitText />
+                        </Items>
+                    </RadzenSelectBar>
+                </div>
+            </div>
+        }
+        <div class=@ContentClass>
+            <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(Mode == MarkdownEditorMode.Preview)
+                      name=@Name rows=@Rows placeholder=@Placeholder disabled=@Disabled
+                      value=@Value @oninput=@OnInput @onchange=@OnChange></textarea>
+            @if (Mode != MarkdownEditorMode.Edit)
+            {
+                <div class="rz-markdown-editor-preview">
+                    @if (string.IsNullOrWhiteSpace(Value))
+                    {
+                        <span class="rz-markdown-editor-empty">@NothingToPreviewText</span>
+                    }
+                    else
+                    {
+                        <RadzenMarkdown Text=@Value AllowHtml=@AllowHtml AllowedHtmlTags=@AllowedHtmlTags AllowedHtmlAttributes=@AllowedHtmlAttributes />
+                    }
+                </div>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    RenderFragment<DialogService> LinkDialog(LinkDialogModel model, bool image, bool hasSelection) => ds =>
+    @<div class="rz-html-editor-dialog">
+        <RadzenTemplateForm TItem="LinkDialogModel" Data="@model" Submit="() => ds.Close(true)">
+            <div class="rz-html-editor-dialog-item">
+                <label>@(image ? ImageUrlText : UrlText)</label>
+                <RadzenTextBox @bind-Value=@model.Url Style="width: 100%" Name="Url" />
+                <RadzenRequiredValidator Component="Url" />
+            </div>
+            @if (!hasSelection)
+            {
+                <div class="rz-html-editor-dialog-item">
+                    <label>@(image ? ImageAltText : LinkText)</label>
+                    <RadzenTextBox @bind-Value=@model.Text Style="width: 100%" />
+                </div>
+            }
+            <div class="rz-html-editor-dialog-buttons">
+                <RadzenButton Text=@CancelText Click="() => ds.Close(false)" ButtonStyle="ButtonStyle.Base" Variant="Variant.Outlined" />
+                <RadzenButton Text=@OkText ButtonType="ButtonType.Submit" Variant="Variant.Flat" />
+            </div>
+        </RadzenTemplateForm>
+    </div>;
+}

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -43,12 +43,14 @@
                 </div>
             </div>
         }
-        <div class=@ContentClass>
-            <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Preview)
-                      name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
-                      value=@Value @oninput=@OnInput @onchange=@OnChange></textarea>
-            @if (mode != MarkdownEditorMode.Edit)
-            {
+        <RadzenSplitter Orientation="Orientation.Horizontal" class="rz-markdown-editor-content">
+            <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" BarVisible=@(mode == MarkdownEditorMode.Split)
+                                class=@(mode == MarkdownEditorMode.Preview ? "rz-markdown-editor-pane rz-markdown-editor-pane-hidden" : "rz-markdown-editor-pane")>
+                <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Preview)
+                          name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
+                          value=@Value @oninput=@OnInput @onchange=@OnChange></textarea>
+            </RadzenSplitterPane>
+            <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" Visible=@(mode != MarkdownEditorMode.Edit) class="rz-markdown-editor-pane">
                 <div class="rz-markdown-editor-preview">
                     @if (string.IsNullOrWhiteSpace(Value))
                     {
@@ -59,8 +61,8 @@
                         <RadzenMarkdown Text=@Value AllowHtml=@AllowHtml AllowedHtmlTags=@AllowedHtmlTags AllowedHtmlAttributes=@AllowedHtmlAttributes />
                     }
                 </div>
-            }
-        </div>
+            </RadzenSplitterPane>
+        </RadzenSplitter>
     </div>
 }
 

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -15,7 +15,22 @@
                         }
                         else
                         {
-                            @* default tools added in Task 7 *@
+                            <RadzenMarkdownEditorBold />
+                            <RadzenMarkdownEditorItalic />
+                            <RadzenMarkdownEditorStrikethrough />
+                            <RadzenMarkdownEditorSeparator />
+                            <RadzenMarkdownEditorHeading />
+                            <RadzenMarkdownEditorQuote />
+                            <RadzenMarkdownEditorCode />
+                            <RadzenMarkdownEditorCodeBlock />
+                            <RadzenMarkdownEditorSeparator />
+                            <RadzenMarkdownEditorUnorderedList />
+                            <RadzenMarkdownEditorOrderedList />
+                            <RadzenMarkdownEditorTaskList />
+                            <RadzenMarkdownEditorSeparator />
+                            <RadzenMarkdownEditorLink />
+                            <RadzenMarkdownEditorImage />
+                            <RadzenMarkdownEditorHorizontalRule />
                         }
                     </CascadingValue>
                 </div>

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -35,37 +35,20 @@
                 <div class="rz-markdown-editor-modes">
                     <RadzenSelectBar TValue="MarkdownEditorMode" Value=@mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
                         <Items>
-                            <RadzenSelectBarItem Value="MarkdownEditorMode.Edit" Text=@WriteText />
-                            <RadzenSelectBarItem Value="MarkdownEditorMode.Preview" Text=@PreviewText />
-                            <RadzenSelectBarItem Value="MarkdownEditorMode.Split" Text=@SplitText />
+                            <RadzenSelectBarItem Value="MarkdownEditorMode.Design" Text=@DesignText />
+                            <RadzenSelectBarItem Value="MarkdownEditorMode.Source" Text=@SourceText />
                         </Items>
                     </RadzenSelectBar>
                 </div>
             </div>
         }
-        <RadzenSplitter Orientation="Orientation.Horizontal" class="rz-markdown-editor-content">
-            <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" BarVisible=@(mode == MarkdownEditorMode.Split)
-                                class=@TextareaPaneClass>
-                <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Preview)
-                          name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
-                          @bind:get="@Value" @bind:set="@OnInputAsync" @bind:event="oninput" @onchange=@OnChange></textarea>
-            </RadzenSplitterPane>
-            <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" class=@PreviewPaneClass>
-                @if (mode != MarkdownEditorMode.Edit)
-                {
-                    <div class="rz-markdown-editor-preview">
-                        @if (string.IsNullOrWhiteSpace(Value))
-                        {
-                            <span class="rz-markdown-editor-empty">@NothingToPreviewText</span>
-                        }
-                        else
-                        {
-                            <RadzenMarkdown Text=@Value AllowHtml=@AllowHtml AllowedHtmlTags=@AllowedHtmlTags AllowedHtmlAttributes=@AllowedHtmlAttributes />
-                        }
-                    </div>
-                }
-            </RadzenSplitterPane>
-        </RadzenSplitter>
+        <div class="rz-markdown-editor-content">
+            <div @ref=editable class="rz-markdown-editor-design" hidden=@(mode == MarkdownEditorMode.Source)
+                 contenteditable=@(Disabled ? "false" : "true")></div>
+            <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Design)
+                      name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
+                      @bind:get="@Value" @bind:set="@OnInputAsync" @bind:event="oninput" @onchange=@OnChange></textarea>
+        </div>
     </div>
 }
 

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -41,8 +41,8 @@
                     <div class="rz-markdown-editor-modes">
                         <RadzenSelectBar TValue="MarkdownEditorMode" Value=@mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
                             <Items>
-                                <RadzenSelectBarItem Value="MarkdownEditorMode.Design" Text=@DesignText/>
-                                <RadzenSelectBarItem Value="MarkdownEditorMode.Source" Text=@SourceText/>
+                                <RadzenSelectBarItem Value="MarkdownEditorMode.Source" Icon="markdown" AriaLabel=@SourceText title=@SourceText/>
+                                <RadzenSelectBarItem Value="MarkdownEditorMode.Design" Icon="match_case" AriaLabel=@DesignText title=@DesignText/>
                             </Items>
                         </RadzenSelectBar>
                     </div>

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -51,7 +51,7 @@
         }
         <div class="rz-markdown-editor-content">
             <div @ref="editable" class="rz-markdown-editor-design" hidden="@(mode == MarkdownEditorMode.Source)"
-                 contenteditable='@(Disabled ? "false" : "true")'></div>
+                 contenteditable="@ContentEditable"></div>
             <textarea @ref="textarea" class="rz-markdown-editor-textarea" hidden="@(mode == MarkdownEditorMode.Design)"
                       name="@Name" rows="@Rows" placeholder="@CurrentPlaceholder" disabled="@Disabled"
                       @bind:get="@Value" @bind:set="@OnInputAsync" @bind:event="oninput" @onchange="@OnChange"></textarea>

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -15,8 +15,12 @@
                         }
                         else
                         {
+                            <RadzenMarkdownEditorUndo />
+                            <RadzenMarkdownEditorRedo />
+                            <RadzenMarkdownEditorSeparator />
                             <RadzenMarkdownEditorBold />
                             <RadzenMarkdownEditorItalic />
+                            <RadzenMarkdownEditorStrikethrough />
                             <RadzenMarkdownEditorSeparator />
                             <RadzenMarkdownEditorHeading />
                             <RadzenMarkdownEditorQuote />
@@ -25,6 +29,7 @@
                             <RadzenMarkdownEditorSeparator />
                             <RadzenMarkdownEditorUnorderedList />
                             <RadzenMarkdownEditorOrderedList />
+                            <RadzenMarkdownEditorTaskList />
                             <RadzenMarkdownEditorSeparator />
                             <RadzenMarkdownEditorLink />
                             <RadzenMarkdownEditorImage />

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -1,4 +1,3 @@
-@using Radzen.Blazor.Rendering
 @inherits FormComponent<string>
 
 @if (Visible)
@@ -37,14 +36,17 @@
                         }
                     </CascadingValue>
                 </div>
-                <div class="rz-markdown-editor-modes">
-                    <RadzenSelectBar TValue="MarkdownEditorMode" Value=@mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
-                        <Items>
-                            <RadzenSelectBarItem Value="MarkdownEditorMode.Design" Text=@DesignText />
-                            <RadzenSelectBarItem Value="MarkdownEditorMode.Source" Text=@SourceText />
-                        </Items>
-                    </RadzenSelectBar>
-                </div>
+                @if (ShowModeSwitch)
+                {
+                    <div class="rz-markdown-editor-modes">
+                        <RadzenSelectBar TValue="MarkdownEditorMode" Value=@mode ValueChanged=@SetModeAsync Size="ButtonSize.Small" Disabled=@Disabled>
+                            <Items>
+                                <RadzenSelectBarItem Value="MarkdownEditorMode.Design" Text=@DesignText/>
+                                <RadzenSelectBarItem Value="MarkdownEditorMode.Source" Text=@SourceText/>
+                            </Items>
+                        </RadzenSelectBar>
+                    </div>
+                }
             </div>
         }
         <div class="rz-markdown-editor-content">

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor
@@ -48,7 +48,7 @@
                                 class=@TextareaPaneClass>
                 <textarea @ref=textarea class="rz-markdown-editor-textarea" hidden=@(mode == MarkdownEditorMode.Preview)
                           name=@Name rows=@Rows placeholder=@CurrentPlaceholder disabled=@Disabled
-                          value=@Value @oninput=@OnInput @onchange=@OnChange></textarea>
+                          @bind:get="@Value" @bind:set="@OnInputAsync" @bind:event="oninput" @onchange=@OnChange></textarea>
             </RadzenSplitterPane>
             <RadzenSplitterPane Size="50%" Min="20%" Collapsible="false" class=@PreviewPaneClass>
                 @if (mode != MarkdownEditorMode.Edit)

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A markdown editor component with a toolbar, keyboard shortcuts and a live preview rendered by <see cref="RadzenMarkdown" />.
+/// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown @bind-Mode=@mode /&gt;
+/// @code {
+///   string markdown = "# Hello";
+///   MarkdownEditorMode mode = MarkdownEditorMode.Split;
+/// }
+/// </code>
+/// </example>
+public partial class RadzenMarkdownEditor : FormComponent<string>
+{
+    [Inject]
+    DialogService DialogService { get; set; } = default!;
+
+    ElementReference textarea;
+    IJSObjectReference? jsRef;
+    readonly Dictionary<string, Func<Task>> shortcuts = new();
+
+    /// <summary>
+    /// Gets or sets the mode of the editor. Two-way bindable.
+    /// </summary>
+    [Parameter]
+    public MarkdownEditorMode Mode { get; set; } = MarkdownEditorMode.Edit;
+
+    /// <summary>
+    /// A callback invoked when the user switches the mode.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MarkdownEditorMode> ModeChanged { get; set; }
+
+    /// <summary>
+    /// Specifies whether the toolbar is shown. Set to <c>true</c> by default.
+    /// </summary>
+    [Parameter]
+    public bool ShowToolbar { get; set; } = true;
+
+    /// <summary>
+    /// Custom toolbar content. When set it replaces the default toolbar tools.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Specifies whether <see cref="Input" /> is raised on every keystroke. Set to <c>false</c> by default.
+    /// </summary>
+    [Parameter]
+    public bool Immediate { get; set; }
+
+    /// <summary>
+    /// A callback invoked on every keystroke when <see cref="Immediate" /> is <c>true</c>.
+    /// </summary>
+    [Parameter]
+    public EventCallback<string> Input { get; set; }
+
+    /// <summary>
+    /// A callback invoked after a command is executed, either by a built-in tool, a shortcut, <see cref="ExecuteCommandAsync" /> or a <c>RadzenMarkdownEditorCustomTool</c>.
+    /// </summary>
+    [Parameter]
+    public EventCallback<MarkdownEditorExecuteEventArgs> Execute { get; set; }
+
+    /// <summary>
+    /// The number of visible text rows of the textarea. Set to <c>10</c> by default.
+    /// </summary>
+    [Parameter]
+    public int Rows { get; set; } = 10;
+
+    /// <summary>
+    /// Specifies whether HTML in the markdown is rendered in the preview. Forwarded to <see cref="RadzenMarkdown.AllowHtml" />.
+    /// </summary>
+    [Parameter]
+    public bool AllowHtml { get; set; } = true;
+
+    /// <summary>
+    /// Forwarded to <see cref="RadzenMarkdown.AllowedHtmlTags" />.
+    /// </summary>
+    [Parameter]
+    public IEnumerable<string>? AllowedHtmlTags { get; set; }
+
+    /// <summary>
+    /// Forwarded to <see cref="RadzenMarkdown.AllowedHtmlAttributes" />.
+    /// </summary>
+    [Parameter]
+    public IEnumerable<string>? AllowedHtmlAttributes { get; set; }
+
+    string WriteText => Localize(nameof(RadzenStrings.MarkdownEditor_WriteText));
+    string PreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_PreviewText));
+    string SplitText => Localize(nameof(RadzenStrings.MarkdownEditor_SplitText));
+    string NothingToPreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_NothingToPreviewText));
+    string UrlText => Localize(nameof(RadzenStrings.MarkdownEditorLink_UrlText));
+    string LinkText => Localize(nameof(RadzenStrings.MarkdownEditorLink_LinkText));
+    string ImageUrlText => Localize(nameof(RadzenStrings.MarkdownEditorImage_UrlText));
+    string ImageAltText => Localize(nameof(RadzenStrings.MarkdownEditorImage_AltText));
+    string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
+    string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
+
+    string ContentClass => Mode == MarkdownEditorMode.Split
+        ? "rz-markdown-editor-content rz-markdown-editor-content-split"
+        : "rz-markdown-editor-content";
+
+    /// <inheritdoc />
+    protected override string GetComponentCssClass() => GetClassList("rz-markdown-editor").ToString();
+
+    async Task SetModeAsync(MarkdownEditorMode mode)
+    {
+        Mode = mode;
+        await ModeChanged.InvokeAsync(mode);
+    }
+
+    async Task OnInput(ChangeEventArgs args)
+    {
+        var newValue = $"{args.Value}";
+        Value = newValue;
+        await ValueChanged.InvokeAsync(newValue);
+        NotifyFieldChanged(newValue);
+
+        if (Immediate)
+        {
+            await Input.InvokeAsync(newValue);
+        }
+    }
+
+    async Task OnChange(ChangeEventArgs args)
+    {
+        await Change.InvokeAsync($"{args.Value}");
+    }
+
+    /// <summary>
+    /// Registers a keyboard shortcut. Used by toolbar tools.
+    /// </summary>
+    public void RegisterShortcut(string key, Func<Task> action) => shortcuts[key] = action;
+
+    /// <summary>
+    /// Unregisters a keyboard shortcut. Used by toolbar tools.
+    /// </summary>
+    public void UnregisterShortcut(string key) => shortcuts.Remove(key);
+
+    /// <summary>
+    /// Invoked from JavaScript when a registered shortcut is pressed.
+    /// </summary>
+    [JSInvokable("ExecuteShortcutAsync")]
+    public async Task ExecuteShortcutAsync(string shortcut)
+    {
+        if (shortcuts.TryGetValue(shortcut, out var action))
+        {
+            await action();
+        }
+    }
+
+    /// <summary>
+    /// Focuses the textarea.
+    /// </summary>
+    public override ValueTask FocusAsync() => textarea.FocusAsync();
+
+    /// <summary>
+    /// Executes a command. Built-in commands (see <see cref="MarkdownEditorCommands" />) modify the text; unknown command names only raise <see cref="Execute" />.
+    /// </summary>
+    /// <param name="name">The command name.</param>
+    /// <param name="value">The command value: the URL for <see cref="MarkdownEditorCommands.Link" /> and <see cref="MarkdownEditorCommands.Image" /> (a dialog is opened when <c>null</c>), the text for <see cref="MarkdownEditorCommands.InsertText" />.</param>
+    public async Task ExecuteCommandAsync(string name, string? value = null)
+    {
+        var (start, end) = await GetSelectionAsync();
+        string? label = null;
+
+        if (value == null && name is MarkdownEditorCommands.Link or MarkdownEditorCommands.Image)
+        {
+            var model = new LinkDialogModel();
+            var title = Localize(name == MarkdownEditorCommands.Image ? nameof(RadzenStrings.MarkdownEditorImage_Title) : nameof(RadzenStrings.MarkdownEditorLink_Title));
+            var result = await DialogService.OpenAsync(title, LinkDialog(model, name == MarkdownEditorCommands.Image, end > start));
+
+            if (result is not true || string.IsNullOrWhiteSpace(model.Url))
+            {
+                return;
+            }
+
+            value = model.Url;
+            label = model.Text;
+        }
+
+        var edit = MarkdownFormatter.Apply(Value ?? string.Empty, start, end, name, value, label);
+
+        if (edit is { } e && JSRuntime != null)
+        {
+            await JSRuntime.InvokeVoidAsync("Radzen.markdownEditorApply", textarea, e.Start, e.End, e.Replacement, e.SelectionStart, e.SelectionEnd);
+        }
+
+        await Execute.InvokeAsync(new MarkdownEditorExecuteEventArgs(this) { CommandName = name });
+    }
+
+    async Task<(int Start, int End)> GetSelectionAsync()
+    {
+        var length = Value?.Length ?? 0;
+
+        if (JSRuntime == null)
+        {
+            return (length, length);
+        }
+
+        var range = await JSRuntime.InvokeAsync<int[]?>("Radzen.getSelectionRange", textarea);
+
+        return range is { Length: 2 }
+            ? (Math.Clamp(range[0], 0, length), Math.Clamp(range[1], 0, length))
+            : (length, length);
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender && Visible && JSRuntime != null)
+        {
+            jsRef = await JSRuntime.InvokeAsync<IJSObjectReference>("Radzen.createMarkdownEditor", textarea, Reference, shortcuts.Keys);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        if (jsRef != null)
+        {
+            jsRef.InvokeVoid("dispose");
+            jsRef.DisposeFireAndForget();
+            jsRef = null;
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    class LinkDialogModel
+    {
+        public string? Url { get; set; }
+        public string? Text { get; set; }
+    }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -134,9 +134,9 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
         await ModeChanged.InvokeAsync(value);
     }
 
-    private async Task OnInput(ChangeEventArgs args)
+    private async Task OnInputAsync(string? value)
     {
-        string newValue = $"{args.Value}";
+        string newValue = value ?? string.Empty;
         Value = newValue;
         await ValueChanged.InvokeAsync(newValue);
         NotifyFieldChanged(newValue);

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Radzen.Documents.Markdown;
 
 namespace Radzen.Blazor;
 
@@ -101,7 +102,55 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     {
         mode = value;
         await ModeChanged.InvokeAsync(value);
+
+        if (value == MarkdownEditorMode.Design)
+        {
+            await SyncDesignContentAsync();
+        }
     }
+
+    private string? lastSurfaceValue;
+    private bool valueChangedExternally;
+
+    /// <summary>
+    /// Invoked from JavaScript when the design surface content changes.
+    /// </summary>
+    [JSInvokable("OnDesignInputAsync")]
+    public async Task OnDesignInputAsync(string markdown)
+    {
+        lastSurfaceValue = markdown;
+        Value = markdown;
+        await ValueChanged.InvokeAsync(markdown);
+        NotifyFieldChanged(markdown);
+
+        if (Immediate)
+        {
+            await Input.InvokeAsync(markdown);
+        }
+    }
+
+    /// <summary>
+    /// Invoked from JavaScript when the design surface loses focus.
+    /// </summary>
+    [JSInvokable("OnDesignChangeAsync")]
+    public async Task OnDesignChangeAsync(string markdown)
+    {
+        await Change.InvokeAsync(markdown);
+    }
+
+    private async Task SyncDesignContentAsync()
+    {
+        if (jsRef != null && mode == MarkdownEditorMode.Design)
+        {
+            await jsRef.InvokeVoidAsync("setContent", HtmlVisitor.ToHtml(NormalizedValue));
+        }
+    }
+
+    /// <summary>
+    /// Invoked from JavaScript to render markdown as design-surface HTML (paste laundering, undo/redo cross-mode restore).
+    /// </summary>
+    [JSInvokable("RenderMarkdownAsync")]
+    public Task<string> RenderMarkdownAsync(string markdown) => Task.FromResult(HtmlVisitor.ToHtml(markdown ?? string.Empty));
 
     private async Task OnInputAsync(string? value)
     {
@@ -222,6 +271,12 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
             mode = parameters.GetValueOrDefault<MarkdownEditorMode>(nameof(Mode));
         }
 
+        if (parameters.DidParameterChange(nameof(Value), Value))
+        {
+            var incoming = parameters.GetValueOrDefault<string?>(nameof(Value));
+            valueChangedExternally = incoming != lastSurfaceValue;
+        }
+
         visibleChanged = parameters.DidParameterChange(nameof(Visible), Visible);
 
         await base.SetParametersAsync(parameters);
@@ -255,7 +310,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 
             if (version == jsRefVersion)
             {
-                IJSObjectReference created = await JSRuntime.InvokeAsync<IJSObjectReference>("Radzen.createMarkdownEditor", textarea, Reference, shortcuts.Keys);
+                IJSObjectReference created = await JSRuntime.InvokeAsync<IJSObjectReference>("Radzen.createMarkdownEditor", editable, textarea, Reference, shortcuts.Keys);
 
                 if (version == jsRefVersion)
                 {
@@ -267,6 +322,14 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
                     await created.DisposeAsync();
                 }
             }
+
+            await SyncDesignContentAsync();
+        }
+
+        if (valueChangedExternally)
+        {
+            valueChangedExternally = false;
+            await SyncDesignContentAsync();
         }
 
         visibleChanged = false;

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Radzen.Blazor.Documents.Markdown;
 using Radzen.Documents.Markdown;
 
 namespace Radzen.Blazor;
@@ -36,7 +37,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// Gets or sets the mode of the editor. Two-way bindable.
     /// </summary>
     [Parameter]
-    public MarkdownEditorMode Mode { get; set; } = MarkdownEditorMode.Design;
+    public MarkdownEditorMode Mode { get; set; }
 
     /// <summary>
     /// A callback invoked when the user switches the mode.
@@ -49,6 +50,12 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// </summary>
     [Parameter]
     public bool ShowToolbar { get; set; } = true;
+    
+    /// <summary>
+    /// Specifies whether the mode selector is shown. Set to <c>true</c> by default.
+    /// </summary>
+    [Parameter]
+    public bool ShowModeSwitch { get; set; } = true;
 
     /// <summary>
     /// Custom toolbar content. When set, it replaces the default toolbar tools.
@@ -104,7 +111,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     [JSInvokable("OnToolStateAsync")]
     public Task OnToolStateAsync(MarkdownEditorToolState state)
     {
-        toolState = state ?? new();
+        toolState = state;
         StateHasChanged();
         return Task.CompletedTask;
     }
@@ -120,11 +127,6 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 
     /// <inheritdoc />
     protected override string GetComponentCssClass() => GetClassList("rz-markdown-editor").ToString();
-
-    /// <summary>
-    /// Returns the current mode of the editor.
-    /// </summary>
-    public MarkdownEditorMode GetMode() => mode;
 
     private async Task SetModeAsync(MarkdownEditorMode value)
     {
@@ -189,10 +191,10 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     }
 
     /// <summary>
-    /// Invoked from JavaScript to render markdown as design-surface HTML (paste laundering, undo/redo cross-mode restore).
+    /// Invoked from JavaScript to render Markdown as design-surface HTML (paste laundering, undo/redo cross-mode restore).
     /// </summary>
     [JSInvokable("RenderMarkdownAsync")]
-    public Task<string> RenderMarkdownAsync(string markdown) => Task.FromResult(HtmlVisitor.ToHtml(markdown ?? string.Empty));
+    public Task<string> RenderMarkdownAsync(string markdown) => Task.FromResult(HtmlVisitor.ToHtml(markdown));
 
     private async Task OnInputAsync(string? value)
     {
@@ -243,7 +245,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// Executes a command. Built-in commands (see <see cref="MarkdownEditorCommands" />) modify the text; unknown command names only raise <see cref="Execute" />.
     /// </summary>
     /// <param name="name">The command name.</param>
-    /// <param name="value">The command value: the URL for <see cref="MarkdownEditorCommands.Link" /> and <see cref="MarkdownEditorCommands.Image" /> (a dialog is opened when <c>null</c>), the text for <see cref="MarkdownEditorCommands.InsertText" />.</param>
+    /// <param name="value">The command value: the URL for <see cref="MarkdownEditorCommands.Link" /> and <see cref="MarkdownEditorCommands.Image" /> (a dialogue is opened when <c>null</c>), the text for <see cref="MarkdownEditorCommands.InsertText" />.</param>
     public async Task ExecuteCommandAsync(string name, string? value = null)
     {
         string? label = null;

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -81,15 +81,33 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     [Parameter]
     public int Rows { get; set; } = 10;
 
+    private MarkdownEditorToolState toolState = new();
+
     /// <summary>
     /// Whether the editor's history has a state to undo to.
     /// </summary>
-    public bool CanUndo { get; private set; }
+    public bool CanUndo => toolState.CanUndo;
 
     /// <summary>
     /// Whether the editor's history has a state to redo to.
     /// </summary>
-    public bool CanRedo { get; private set; }
+    public bool CanRedo => toolState.CanRedo;
+
+    /// <summary>
+    /// Returns whether the current design-mode selection has the format of <paramref name="commandName" /> applied.
+    /// </summary>
+    public bool IsActive(string commandName) => Array.IndexOf(toolState.Formats ?? [], commandName) >= 0;
+
+    /// <summary>
+    /// Invoked from JavaScript when the selection or history state changes.
+    /// </summary>
+    [JSInvokable("OnToolStateAsync")]
+    public Task OnToolStateAsync(MarkdownEditorToolState state)
+    {
+        toolState = state ?? new();
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
 
     private string DesignText => Localize(nameof(RadzenStrings.MarkdownEditor_DesignText));
     private string SourceText => Localize(nameof(RadzenStrings.MarkdownEditor_SourceText));

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -81,6 +81,16 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     [Parameter]
     public int Rows { get; set; } = 10;
 
+    /// <summary>
+    /// Whether the editor's history has a state to undo to.
+    /// </summary>
+    public bool CanUndo { get; private set; }
+
+    /// <summary>
+    /// Whether the editor's history has a state to redo to.
+    /// </summary>
+    public bool CanRedo { get; private set; }
+
     private string DesignText => Localize(nameof(RadzenStrings.MarkdownEditor_DesignText));
     private string SourceText => Localize(nameof(RadzenStrings.MarkdownEditor_SourceText));
     private string UrlText => Localize(nameof(RadzenStrings.MarkdownEditorLink_UrlText));
@@ -241,6 +251,17 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 
             value = model.Url;
             label = model.Text;
+        }
+
+        if (name is MarkdownEditorCommands.Undo or MarkdownEditorCommands.Redo)
+        {
+            if (jsRef != null)
+            {
+                await jsRef.InvokeVoidAsync("execute", name, null, null);
+            }
+
+            await Execute.InvokeAsync(new MarkdownEditorExecuteEventArgs(this) { CommandName = name });
+            return;
         }
 
         if (jsRef != null)

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -139,6 +139,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 
     private string? lastSurfaceValue;
     private bool valueChangedExternally;
+    private bool modeChangedExternally;
 
     /// <summary>
     /// Invoked from JavaScript when the design surface content changes.
@@ -339,6 +340,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
         if (parameters.DidParameterChange(nameof(Mode), Mode))
         {
             mode = parameters.GetValueOrDefault<MarkdownEditorMode>(nameof(Mode));
+            modeChangedExternally = mode == MarkdownEditorMode.Design;
         }
 
         if (parameters.DidParameterChange(nameof(Value), Value))
@@ -399,6 +401,12 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
         if (valueChangedExternally)
         {
             valueChangedExternally = false;
+            await SyncDesignContentAsync();
+        }
+
+        if (modeChangedExternally)
+        {
+            modeChangedExternally = false;
             await SyncDesignContentAsync();
         }
 

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -7,15 +7,14 @@ using Microsoft.JSInterop;
 namespace Radzen.Blazor;
 
 /// <summary>
-/// A Markdown editor component with a toolbar, keyboard shortcuts, and a live preview rendered by <see cref="RadzenMarkdown" />.
-/// In <see cref="MarkdownEditorMode.Split" /> mode the editor and preview are separated by a <see cref="RadzenSplitter" /> so their ratio can be adjusted.
+/// A Markdown editor component with a toolbar, keyboard shortcuts, and a Design/Source mode switcher.
 /// </summary>
 /// <example>
 /// <code>
 /// &lt;RadzenMarkdownEditor @bind-Value=@markdown @bind-Mode=@mode /&gt;
 /// @code {
 ///   string markdown = "# Hello";
-///   MarkdownEditorMode mode = MarkdownEditorMode.Split;
+///   MarkdownEditorMode mode = MarkdownEditorMode.Design;
 /// }
 /// </code>
 /// </example>
@@ -23,6 +22,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 {
     [Inject] private DialogService DialogService { get; set; } = null!;
 
+    private ElementReference editable;
     private ElementReference textarea;
     private IJSObjectReference? jsRef;
     private readonly Dictionary<string, Func<Task>> shortcuts = new();
@@ -35,7 +35,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// Gets or sets the mode of the editor. Two-way bindable.
     /// </summary>
     [Parameter]
-    public MarkdownEditorMode Mode { get; set; } = MarkdownEditorMode.Edit;
+    public MarkdownEditorMode Mode { get; set; } = MarkdownEditorMode.Design;
 
     /// <summary>
     /// A callback invoked when the user switches the mode.
@@ -80,45 +80,14 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     [Parameter]
     public int Rows { get; set; } = 10;
 
-    /// <summary>
-    /// Specifies whether HTML in the markdown is rendered in the preview. Forwarded to <see cref="RadzenMarkdown.AllowHtml" />.
-    /// </summary>
-    [Parameter]
-    public bool AllowHtml { get; set; } = true;
-
-    /// <summary>
-    /// Forwarded to <see cref="RadzenMarkdown.AllowedHtmlTags" />.
-    /// </summary>
-    [Parameter]
-    public IEnumerable<string>? AllowedHtmlTags { get; set; }
-
-    /// <summary>
-    /// Forwarded to <see cref="RadzenMarkdown.AllowedHtmlAttributes" />.
-    /// </summary>
-    [Parameter]
-    public IEnumerable<string>? AllowedHtmlAttributes { get; set; }
-
-    private string WriteText => Localize(nameof(RadzenStrings.MarkdownEditor_WriteText));
-    private string PreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_PreviewText));
-    private string SplitText => Localize(nameof(RadzenStrings.MarkdownEditor_SplitText));
-    private string NothingToPreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_NothingToPreviewText));
+    private string DesignText => Localize(nameof(RadzenStrings.MarkdownEditor_DesignText));
+    private string SourceText => Localize(nameof(RadzenStrings.MarkdownEditor_SourceText));
     private string UrlText => Localize(nameof(RadzenStrings.MarkdownEditorLink_UrlText));
     private string LinkText => Localize(nameof(RadzenStrings.MarkdownEditorLink_LinkText));
     private string ImageUrlText => Localize(nameof(RadzenStrings.MarkdownEditorImage_UrlText));
     private string ImageAltText => Localize(nameof(RadzenStrings.MarkdownEditorImage_AltText));
     private string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
     private string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
-
-    private string TextareaPaneClass => mode switch
-    {
-        MarkdownEditorMode.Edit => "rz-markdown-editor-pane rz-markdown-editor-pane-full",
-        MarkdownEditorMode.Preview => "rz-markdown-editor-pane rz-markdown-editor-pane-hidden",
-        _ => "rz-markdown-editor-pane"
-    };
-
-    private string PreviewPaneClass => mode == MarkdownEditorMode.Edit
-        ? "rz-markdown-editor-pane rz-markdown-editor-pane-hidden"
-        : "rz-markdown-editor-pane rz-markdown-editor-pane-fill";
 
     /// <inheritdoc />
     protected override string GetComponentCssClass() => GetClassList("rz-markdown-editor").ToString();
@@ -175,9 +144,9 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     }
 
     /// <summary>
-    /// Focuses the textarea.
+    /// Focuses the editable surface in Design mode, or the textarea in Source mode.
     /// </summary>
-    public override ValueTask FocusAsync() => textarea.FocusAsync();
+    public override ValueTask FocusAsync() => mode == MarkdownEditorMode.Design ? editable.FocusAsync() : textarea.FocusAsync();
 
     /// <summary>
     /// Executes a command. Built-in commands (see <see cref="MarkdownEditorCommands" />) modify the text; unknown command names only raise <see cref="Execute" />.

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using Radzen.Blazor.Documents.Markdown;
 using Radzen.Documents.Markdown;
 
 namespace Radzen.Blazor;
@@ -124,6 +123,8 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     private string ImageAltText => Localize(nameof(RadzenStrings.MarkdownEditorImage_AltText));
     private string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
     private string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
+    
+    private string ContentEditable => Disabled ? "false" : "true";
 
     /// <inheritdoc />
     protected override string GetComponentCssClass() => GetClassList("rz-markdown-editor").ToString();

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -27,6 +27,10 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     IJSObjectReference? jsRef;
     readonly Dictionary<string, Func<Task>> shortcuts = new();
 
+    MarkdownEditorMode mode;
+    bool visibleChanged;
+    int jsRefVersion;
+
     /// <summary>
     /// Gets or sets the mode of the editor. Two-way bindable.
     /// </summary>
@@ -53,6 +57,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 
     /// <summary>
     /// Specifies whether <see cref="Input" /> is raised on every keystroke. Set to <c>false</c> by default.
+    /// Unlike <see cref="RadzenTextArea.Immediate" />, <see cref="FormComponent{T}.Value" /> is always updated on input; this only controls whether <see cref="Input" /> is raised per keystroke.
     /// </summary>
     [Parameter]
     public bool Immediate { get; set; }
@@ -104,17 +109,22 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
     string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
 
-    string ContentClass => Mode == MarkdownEditorMode.Split
+    string ContentClass => mode == MarkdownEditorMode.Split
         ? "rz-markdown-editor-content rz-markdown-editor-content-split"
         : "rz-markdown-editor-content";
 
     /// <inheritdoc />
     protected override string GetComponentCssClass() => GetClassList("rz-markdown-editor").ToString();
 
-    async Task SetModeAsync(MarkdownEditorMode mode)
+    /// <summary>
+    /// Returns the current mode of the editor.
+    /// </summary>
+    public MarkdownEditorMode GetMode() => mode;
+
+    async Task SetModeAsync(MarkdownEditorMode value)
     {
-        Mode = mode;
-        await ModeChanged.InvokeAsync(mode);
+        mode = value;
+        await ModeChanged.InvokeAsync(value);
     }
 
     async Task OnInput(ChangeEventArgs args)
@@ -187,7 +197,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
             label = model.Text;
         }
 
-        var edit = MarkdownFormatter.Apply(Value ?? string.Empty, start, end, name, value, label);
+        var edit = MarkdownFormatter.Apply(NormalizedValue, start, end, name, value, label);
 
         if (edit is { } e && JSRuntime != null)
         {
@@ -197,9 +207,16 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
         await Execute.InvokeAsync(new MarkdownEditorExecuteEventArgs(this) { CommandName = name });
     }
 
+    /// <summary>
+    /// <see cref="FormComponent{T}.Value" /> with line endings normalised to <c>\n</c>, matching the offsets
+    /// <c>Radzen.getSelectionRange</c> returns for the textarea (the HTML spec normalises the API value to LF).
+    /// </summary>
+    string NormalizedValue => (Value ?? string.Empty).Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+
     async Task<(int Start, int End)> GetSelectionAsync()
     {
-        var length = Value?.Length ?? 0;
+        var text = NormalizedValue;
+        var length = text.Length;
 
         if (JSRuntime == null)
         {
@@ -214,14 +231,69 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     }
 
     /// <inheritdoc />
+    protected override void OnInitialized()
+    {
+        mode = Mode;
+
+        base.OnInitialized();
+    }
+
+    /// <inheritdoc />
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        if (parameters.DidParameterChange(nameof(Mode), Mode))
+        {
+            mode = parameters.GetValueOrDefault<MarkdownEditorMode>(nameof(Mode));
+        }
+
+        visibleChanged = parameters.DidParameterChange(nameof(Visible), Visible);
+
+        await base.SetParametersAsync(parameters);
+
+        if (visibleChanged && !Visible && jsRef != null)
+        {
+            jsRefVersion++;
+            var stale = jsRef;
+            jsRef = null;
+            await stale.InvokeVoidAsync("dispose");
+            await stale.DisposeAsync();
+        }
+    }
+
+    /// <inheritdoc />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (firstRender && Visible && JSRuntime != null)
+        if ((firstRender || visibleChanged) && Visible && JSRuntime != null)
         {
-            jsRef = await JSRuntime.InvokeAsync<IJSObjectReference>("Radzen.createMarkdownEditor", textarea, Reference, shortcuts.Keys);
+            var version = ++jsRefVersion;
+            var stale = jsRef;
+            jsRef = null;
+
+            if (stale != null)
+            {
+                await stale.InvokeVoidAsync("dispose");
+                await stale.DisposeAsync();
+            }
+
+            if (version == jsRefVersion)
+            {
+                var created = await JSRuntime.InvokeAsync<IJSObjectReference>("Radzen.createMarkdownEditor", textarea, Reference, shortcuts.Keys);
+
+                if (version == jsRefVersion)
+                {
+                    jsRef = created;
+                }
+                else
+                {
+                    await created.InvokeVoidAsync("dispose");
+                    await created.DisposeAsync();
+                }
+            }
         }
+
+        visibleChanged = false;
     }
 
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -110,6 +110,17 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
     string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
 
+    string TextareaPaneClass => mode switch
+    {
+        MarkdownEditorMode.Edit => "rz-markdown-editor-pane rz-markdown-editor-pane-full",
+        MarkdownEditorMode.Preview => "rz-markdown-editor-pane rz-markdown-editor-pane-hidden",
+        _ => "rz-markdown-editor-pane"
+    };
+
+    string PreviewPaneClass => mode == MarkdownEditorMode.Edit
+        ? "rz-markdown-editor-pane rz-markdown-editor-pane-hidden"
+        : "rz-markdown-editor-pane rz-markdown-editor-pane-fill";
+
     /// <inheritdoc />
     protected override string GetComponentCssClass() => GetClassList("rz-markdown-editor").ToString();
 

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -8,6 +8,7 @@ namespace Radzen.Blazor;
 
 /// <summary>
 /// A markdown editor component with a toolbar, keyboard shortcuts and a live preview rendered by <see cref="RadzenMarkdown" />.
+/// In <see cref="MarkdownEditorMode.Split" /> mode the editor and preview are separated by a <see cref="RadzenSplitter" /> so their ratio can be adjusted.
 /// </summary>
 /// <example>
 /// <code>
@@ -108,10 +109,6 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     string ImageAltText => Localize(nameof(RadzenStrings.MarkdownEditorImage_AltText));
     string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
     string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
-
-    string ContentClass => mode == MarkdownEditorMode.Split
-        ? "rz-markdown-editor-content rz-markdown-editor-content-split"
-        : "rz-markdown-editor-content";
 
     /// <inheritdoc />
     protected override string GetComponentCssClass() => GetClassList("rz-markdown-editor").ToString();

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.JSInterop;
 namespace Radzen.Blazor;
 
 /// <summary>
-/// A markdown editor component with a toolbar, keyboard shortcuts and a live preview rendered by <see cref="RadzenMarkdown" />.
+/// A Markdown editor component with a toolbar, keyboard shortcuts, and a live preview rendered by <see cref="RadzenMarkdown" />.
 /// In <see cref="MarkdownEditorMode.Split" /> mode the editor and preview are separated by a <see cref="RadzenSplitter" /> so their ratio can be adjusted.
 /// </summary>
 /// <example>
@@ -21,16 +21,15 @@ namespace Radzen.Blazor;
 /// </example>
 public partial class RadzenMarkdownEditor : FormComponent<string>
 {
-    [Inject]
-    DialogService DialogService { get; set; } = default!;
+    [Inject] private DialogService DialogService { get; set; } = null!;
 
-    ElementReference textarea;
-    IJSObjectReference? jsRef;
-    readonly Dictionary<string, Func<Task>> shortcuts = new();
+    private ElementReference textarea;
+    private IJSObjectReference? jsRef;
+    private readonly Dictionary<string, Func<Task>> shortcuts = new();
 
-    MarkdownEditorMode mode;
-    bool visibleChanged;
-    int jsRefVersion;
+    private MarkdownEditorMode mode;
+    private bool visibleChanged;
+    private int jsRefVersion;
 
     /// <summary>
     /// Gets or sets the mode of the editor. Two-way bindable.
@@ -51,7 +50,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     public bool ShowToolbar { get; set; } = true;
 
     /// <summary>
-    /// Custom toolbar content. When set it replaces the default toolbar tools.
+    /// Custom toolbar content. When set, it replaces the default toolbar tools.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -99,25 +98,25 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     [Parameter]
     public IEnumerable<string>? AllowedHtmlAttributes { get; set; }
 
-    string WriteText => Localize(nameof(RadzenStrings.MarkdownEditor_WriteText));
-    string PreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_PreviewText));
-    string SplitText => Localize(nameof(RadzenStrings.MarkdownEditor_SplitText));
-    string NothingToPreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_NothingToPreviewText));
-    string UrlText => Localize(nameof(RadzenStrings.MarkdownEditorLink_UrlText));
-    string LinkText => Localize(nameof(RadzenStrings.MarkdownEditorLink_LinkText));
-    string ImageUrlText => Localize(nameof(RadzenStrings.MarkdownEditorImage_UrlText));
-    string ImageAltText => Localize(nameof(RadzenStrings.MarkdownEditorImage_AltText));
-    string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
-    string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
+    private string WriteText => Localize(nameof(RadzenStrings.MarkdownEditor_WriteText));
+    private string PreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_PreviewText));
+    private string SplitText => Localize(nameof(RadzenStrings.MarkdownEditor_SplitText));
+    private string NothingToPreviewText => Localize(nameof(RadzenStrings.MarkdownEditor_NothingToPreviewText));
+    private string UrlText => Localize(nameof(RadzenStrings.MarkdownEditorLink_UrlText));
+    private string LinkText => Localize(nameof(RadzenStrings.MarkdownEditorLink_LinkText));
+    private string ImageUrlText => Localize(nameof(RadzenStrings.MarkdownEditorImage_UrlText));
+    private string ImageAltText => Localize(nameof(RadzenStrings.MarkdownEditorImage_AltText));
+    private string OkText => Localize(nameof(RadzenStrings.HtmlEditorLink_OkText));
+    private string CancelText => Localize(nameof(RadzenStrings.HtmlEditorLink_CancelText));
 
-    string TextareaPaneClass => mode switch
+    private string TextareaPaneClass => mode switch
     {
         MarkdownEditorMode.Edit => "rz-markdown-editor-pane rz-markdown-editor-pane-full",
         MarkdownEditorMode.Preview => "rz-markdown-editor-pane rz-markdown-editor-pane-hidden",
         _ => "rz-markdown-editor-pane"
     };
 
-    string PreviewPaneClass => mode == MarkdownEditorMode.Edit
+    private string PreviewPaneClass => mode == MarkdownEditorMode.Edit
         ? "rz-markdown-editor-pane rz-markdown-editor-pane-hidden"
         : "rz-markdown-editor-pane rz-markdown-editor-pane-fill";
 
@@ -129,15 +128,15 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// </summary>
     public MarkdownEditorMode GetMode() => mode;
 
-    async Task SetModeAsync(MarkdownEditorMode value)
+    private async Task SetModeAsync(MarkdownEditorMode value)
     {
         mode = value;
         await ModeChanged.InvokeAsync(value);
     }
 
-    async Task OnInput(ChangeEventArgs args)
+    private async Task OnInput(ChangeEventArgs args)
     {
-        var newValue = $"{args.Value}";
+        string newValue = $"{args.Value}";
         Value = newValue;
         await ValueChanged.InvokeAsync(newValue);
         NotifyFieldChanged(newValue);
@@ -148,7 +147,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
         }
     }
 
-    async Task OnChange(ChangeEventArgs args)
+    private async Task OnChange(ChangeEventArgs args)
     {
         await Change.InvokeAsync($"{args.Value}");
     }
@@ -187,14 +186,14 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// <param name="value">The command value: the URL for <see cref="MarkdownEditorCommands.Link" /> and <see cref="MarkdownEditorCommands.Image" /> (a dialog is opened when <c>null</c>), the text for <see cref="MarkdownEditorCommands.InsertText" />.</param>
     public async Task ExecuteCommandAsync(string name, string? value = null)
     {
-        var (start, end) = await GetSelectionAsync();
+        (int start, int end) = await GetSelectionAsync();
         string? label = null;
 
         if (value == null && name is MarkdownEditorCommands.Link or MarkdownEditorCommands.Image)
         {
-            var model = new LinkDialogModel();
-            var title = Localize(name == MarkdownEditorCommands.Image ? nameof(RadzenStrings.MarkdownEditorImage_Title) : nameof(RadzenStrings.MarkdownEditorLink_Title));
-            var result = await DialogService.OpenAsync(title, LinkDialog(model, name == MarkdownEditorCommands.Image, end > start));
+            LinkDialogModel model = new();
+            string title = Localize(name == MarkdownEditorCommands.Image ? nameof(RadzenStrings.MarkdownEditorImage_Title) : nameof(RadzenStrings.MarkdownEditorLink_Title));
+            dynamic? result = await DialogService.OpenAsync(title, LinkDialog(model, name == MarkdownEditorCommands.Image, end > start));
 
             if (result is not true || string.IsNullOrWhiteSpace(model.Url))
             {
@@ -205,7 +204,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
             label = model.Text;
         }
 
-        var edit = MarkdownFormatter.Apply(NormalizedValue, start, end, name, value, label);
+        MarkdownEdit? edit = MarkdownFormatter.Apply(NormalizedValue, start, end, name, value, label);
 
         if (edit is { } e && JSRuntime != null)
         {
@@ -219,19 +218,19 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// <see cref="FormComponent{T}.Value" /> with line endings normalised to <c>\n</c>, matching the offsets
     /// <c>Radzen.getSelectionRange</c> returns for the textarea (the HTML spec normalises the API value to LF).
     /// </summary>
-    string NormalizedValue => (Value ?? string.Empty).Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    private string NormalizedValue => (Value ?? string.Empty).Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
 
-    async Task<(int Start, int End)> GetSelectionAsync()
+    private async Task<(int Start, int End)> GetSelectionAsync()
     {
-        var text = NormalizedValue;
-        var length = text.Length;
+        string text = NormalizedValue;
+        int length = text.Length;
 
         if (JSRuntime == null)
         {
             return (length, length);
         }
 
-        var range = await JSRuntime.InvokeAsync<int[]?>("Radzen.getSelectionRange", textarea);
+        int[]? range = await JSRuntime.InvokeAsync<int[]?>("Radzen.getSelectionRange", textarea);
 
         return range is { Length: 2 }
             ? (Math.Clamp(range[0], 0, length), Math.Clamp(range[1], 0, length))
@@ -261,7 +260,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
         if (visibleChanged && !Visible && jsRef != null)
         {
             jsRefVersion++;
-            var stale = jsRef;
+            IJSObjectReference stale = jsRef;
             jsRef = null;
             await stale.InvokeVoidAsync("dispose");
             await stale.DisposeAsync();
@@ -275,8 +274,8 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 
         if ((firstRender || visibleChanged) && Visible && JSRuntime != null)
         {
-            var version = ++jsRefVersion;
-            var stale = jsRef;
+            int version = ++jsRefVersion;
+            IJSObjectReference? stale = jsRef;
             jsRef = null;
 
             if (stale != null)
@@ -287,7 +286,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
 
             if (version == jsRefVersion)
             {
-                var created = await JSRuntime.InvokeAsync<IJSObjectReference>("Radzen.createMarkdownEditor", textarea, Reference, shortcuts.Keys);
+                IJSObjectReference created = await JSRuntime.InvokeAsync<IJSObjectReference>("Radzen.createMarkdownEditor", textarea, Reference, shortcuts.Keys);
 
                 if (version == jsRefVersion)
                 {
@@ -319,7 +318,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
         GC.SuppressFinalize(this);
     }
 
-    class LinkDialogModel
+    private class LinkDialogModel
     {
         public string? Url { get; set; }
         public string? Text { get; set; }

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -196,6 +196,14 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     [JSInvokable("RenderMarkdownAsync")]
     public Task<string> RenderMarkdownAsync(string markdown) => Task.FromResult(HtmlVisitor.ToHtml(markdown));
 
+    /// <summary>
+    /// Invoked from JavaScript when a <c>:shortcode:</c> is typed in the design surface. Returns the
+    /// emoji for the shortcode, or <c>null</c> when it is not a known emoji shortcode.
+    /// </summary>
+    [JSInvokable("LookupEmojiAsync")]
+    public Task<string?> LookupEmojiAsync(string shortcode) =>
+        Task.FromResult(EmojiMapping.Emojis.TryGetValue(shortcode ?? string.Empty, out var emoji) ? emoji : null);
+
     private async Task OnInputAsync(string? value)
     {
         string newValue = value ?? string.Empty;

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -217,14 +217,22 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     /// <param name="value">The command value: the URL for <see cref="MarkdownEditorCommands.Link" /> and <see cref="MarkdownEditorCommands.Image" /> (a dialog is opened when <c>null</c>), the text for <see cref="MarkdownEditorCommands.InsertText" />.</param>
     public async Task ExecuteCommandAsync(string name, string? value = null)
     {
-        (int start, int end) = await GetSelectionAsync();
         string? label = null;
 
         if (value == null && name is MarkdownEditorCommands.Link or MarkdownEditorCommands.Image)
         {
+            if (mode == MarkdownEditorMode.Design && jsRef != null)
+            {
+                await jsRef.InvokeVoidAsync("saveSelection");
+            }
+
+            bool hasSelection = mode == MarkdownEditorMode.Design
+                ? jsRef != null && await jsRef.InvokeAsync<bool>("hasSelection")
+                : await GetSelectionAsync() is var (s, e) && e > s;
+
             LinkDialogModel model = new();
             string title = Localize(name == MarkdownEditorCommands.Image ? nameof(RadzenStrings.MarkdownEditorImage_Title) : nameof(RadzenStrings.MarkdownEditorLink_Title));
-            dynamic? result = await DialogService.OpenAsync(title, LinkDialog(model, name == MarkdownEditorCommands.Image, end > start));
+            dynamic? result = await DialogService.OpenAsync(title, LinkDialog(model, name == MarkdownEditorCommands.Image, hasSelection));
 
             if (result is not true || string.IsNullOrWhiteSpace(model.Url))
             {
@@ -235,11 +243,21 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
             label = model.Text;
         }
 
-        MarkdownEdit? edit = MarkdownFormatter.Apply(NormalizedValue, start, end, name, value, label);
-
-        if (edit is { } e && JSRuntime != null)
+        if (jsRef != null)
         {
-            await JSRuntime.InvokeVoidAsync("Radzen.markdownEditorApply", textarea, e.Start, e.End, e.Replacement, e.SelectionStart, e.SelectionEnd);
+            if (mode == MarkdownEditorMode.Design)
+            {
+                await jsRef.InvokeVoidAsync("execute", name, value, label);
+            }
+            else
+            {
+                (int start, int end) = await GetSelectionAsync();
+
+                if (MarkdownFormatter.Apply(NormalizedValue, start, end, name, value, label) is { } edit)
+                {
+                    await jsRef.InvokeVoidAsync("apply", edit.Start, edit.End, edit.Replacement, edit.SelectionStart, edit.SelectionEnd);
+                }
+            }
         }
 
         await Execute.InvokeAsync(new MarkdownEditorExecuteEventArgs(this) { CommandName = name });

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -118,10 +118,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     [JSInvokable("OnDesignInputAsync")]
     public async Task OnDesignInputAsync(string markdown)
     {
-        lastSurfaceValue = markdown;
-        Value = markdown;
-        await ValueChanged.InvokeAsync(markdown);
-        NotifyFieldChanged(markdown);
+        await UpdateValueFromSurfaceAsync(markdown);
 
         if (Immediate)
         {
@@ -130,12 +127,28 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     }
 
     /// <summary>
-    /// Invoked from JavaScript when the design surface loses focus.
+    /// Invoked from JavaScript when the design surface loses focus. Flushes any edit still
+    /// pending inside the debounce window (JS clears the debounce timer on blur and reports
+    /// the surface's current content here) before raising <see cref="FormComponent{T}.Change" />, so a
+    /// keystroke immediately before blur is never lost.
     /// </summary>
     [JSInvokable("OnDesignChangeAsync")]
     public async Task OnDesignChangeAsync(string markdown)
     {
+        if (markdown != lastSurfaceValue)
+        {
+            await UpdateValueFromSurfaceAsync(markdown);
+        }
+
         await Change.InvokeAsync(markdown);
+    }
+
+    private async Task UpdateValueFromSurfaceAsync(string markdown)
+    {
+        lastSurfaceValue = markdown;
+        Value = markdown;
+        await ValueChanged.InvokeAsync(markdown);
+        NotifyFieldChanged(markdown);
     }
 
     private async Task SyncDesignContentAsync()

--- a/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditor.razor.cs
@@ -64,7 +64,7 @@ public partial class RadzenMarkdownEditor : FormComponent<string>
     public EventCallback<string> Input { get; set; }
 
     /// <summary>
-    /// A callback invoked after a command is executed, either by a built-in tool, a shortcut, <see cref="ExecuteCommandAsync" /> or a <c>RadzenMarkdownEditorCustomTool</c>.
+    /// A callback invoked after a command is executed, either by a built-in tool, a shortcut, <see cref="ExecuteCommandAsync" /> or a <see cref="RadzenMarkdownEditorCustomTool" />.
     /// </summary>
     [Parameter]
     public EventCallback<MarkdownEditorExecuteEventArgs> Execute { get; set; }

--- a/Radzen.Blazor/RadzenMarkdownEditorBold.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorBold.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_bold" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Bold) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="format_bold" Selected="@(Editor?.IsActive(MarkdownEditorCommands.Bold) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorBold.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorBold.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_bold" />

--- a/Radzen.Blazor/RadzenMarkdownEditorBold.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorBold.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_bold" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_bold" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Bold) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorBold.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorBold.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which makes the selection bold.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorBold /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorBold : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorBold.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorBold.razor.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which makes the selection bold.
+/// </summary>
+public partial class RadzenMarkdownEditorBold : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Bold;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorBold_Title)); set => title = value; }
+
+    /// <inheritdoc />
+    [Parameter]
+    public override string? Shortcut { get; set; } = "Ctrl+B";
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorButtonBase.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorButtonBase.cs
@@ -35,7 +35,7 @@ public abstract class RadzenMarkdownEditorButtonBase : ComponentBase, IDisposabl
     protected virtual string? CommandName { get; }
 
     /// <summary>
-    /// The keyboard shortcut of this tool, e.g. <c>Ctrl+B</c>.
+    /// The keyboard shortcut of this tool, e.g. <c>Ctrl+B</c>. Only Ctrl/Cmd combinations are supported, e.g. <c>Ctrl+B</c> (Cmd on macOS).
     /// </summary>
     [Parameter]
     public virtual string? Shortcut { get; set; }

--- a/Radzen.Blazor/RadzenMarkdownEditorButtonBase.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorButtonBase.cs
@@ -16,12 +16,12 @@ public abstract class RadzenMarkdownEditorButtonBase : ComponentBase, IDisposabl
 
     private Localizer? localizer;
 
-    internal Localizer Localizer => localizer ??= Services.GetService<Localizer>() ?? Localizer.Default;
+    private Localizer Localizer => localizer ??= Services.GetService<Localizer>() ?? Localizer.Default;
 
     /// <summary>
     /// Returns the localized string for <paramref name="key" /> using the editor's UI culture.
     /// </summary>
-    public string Localize(string key) => Localizer.Get(key, Editor?.UICulture ?? CultureInfo.CurrentUICulture);
+    protected string Localize(string key) => Localizer.Get(key, Editor?.UICulture ?? CultureInfo.CurrentUICulture);
 
     /// <summary>
     /// The <see cref="RadzenMarkdownEditor" /> this tool belongs to.

--- a/Radzen.Blazor/RadzenMarkdownEditorButtonBase.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorButtonBase.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// Base class for <see cref="RadzenMarkdownEditor" /> toolbar tools.
+/// </summary>
+public abstract class RadzenMarkdownEditorButtonBase : ComponentBase, IDisposable
+{
+    [Inject]
+    private IServiceProvider Services { get; set; } = default!;
+
+    private Localizer? localizer;
+
+    internal Localizer Localizer => localizer ??= Services.GetService<Localizer>() ?? Localizer.Default;
+
+    /// <summary>
+    /// Returns the localized string for <paramref name="key" /> using the editor's UI culture.
+    /// </summary>
+    public string Localize(string key) => Localizer.Get(key, Editor?.UICulture ?? CultureInfo.CurrentUICulture);
+
+    /// <summary>
+    /// The <see cref="RadzenMarkdownEditor" /> this tool belongs to.
+    /// </summary>
+    [CascadingParameter]
+    public RadzenMarkdownEditor? Editor { get; set; }
+
+    /// <summary>
+    /// The command this tool executes. One of <see cref="MarkdownEditorCommands" />.
+    /// </summary>
+    protected virtual string? CommandName { get; }
+
+    /// <summary>
+    /// The keyboard shortcut of this tool, e.g. <c>Ctrl+B</c>.
+    /// </summary>
+    [Parameter]
+    public virtual string? Shortcut { get; set; }
+
+    /// <summary>
+    /// Executes <see cref="CommandName" /> on the editor.
+    /// </summary>
+    protected virtual async Task OnClick()
+    {
+        if (Editor != null && CommandName != null)
+        {
+            await Editor.ExecuteCommandAsync(CommandName);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnInitialized()
+    {
+        if (!string.IsNullOrEmpty(Shortcut))
+        {
+            Editor?.RegisterShortcut(Shortcut, OnClick);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!string.IsNullOrEmpty(Shortcut))
+        {
+            Editor?.UnregisterShortcut(Shortcut);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorCode.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorCode.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="code" />

--- a/Radzen.Blazor/RadzenMarkdownEditorCode.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorCode.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="code" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="code" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Code) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorCode.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorCode.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="code" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Code) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="code" Selected="@(Editor?.IsActive(MarkdownEditorCommands.Code) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorCode.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorCode.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which wraps the selection in inline code.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorCode /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorCode : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorCode.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorCode.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which wraps the selection in inline code.
+/// </summary>
+public partial class RadzenMarkdownEditorCode : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Code;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorCode_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="code_blocks" />

--- a/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="code_blocks" />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="code_blocks" />

--- a/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which wraps the selection in a fenced code block.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorCodeBlock /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorCodeBlock : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorCodeBlock.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which wraps the selection in a fenced code block.
+/// </summary>
+public partial class RadzenMarkdownEditorCodeBlock : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.CodeBlock;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorCodeBlock_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorCustomTool.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorCustomTool.razor
@@ -1,0 +1,13 @@
+@using Radzen.Blazor.Rendering
+
+@if (Visible)
+{
+    @if (Template == null)
+    {
+        <MarkdownEditorButton Title=@Title Click=@OnClick Icon=@Icon IconColor=@IconColor Selected=@Selected Disabled=@Disabled />
+    }
+    else if (Editor != null)
+    {
+        <div class="rz-markdown-editor-custom-tool">@Template(Editor)</div>
+    }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorCustomTool.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorCustomTool.razor
@@ -4,7 +4,7 @@
 {
     @if (Template == null)
     {
-        <MarkdownEditorButton Title=@Title Click=@OnClick Icon=@Icon IconColor=@IconColor Selected=@Selected Disabled=@Disabled />
+        <MarkdownEditorButton Title="@Title" Click="@OnClick" Icon="@Icon" IconColor="@IconColor" Selected="@Selected" Disabled="@Disabled" />
     }
     else if (Editor != null)
     {

--- a/Radzen.Blazor/RadzenMarkdownEditorCustomTool.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorCustomTool.razor.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A custom tool in <see cref="RadzenMarkdownEditor" />. Either renders a button which raises <see cref="RadzenMarkdownEditor.Execute" />
+/// with <see cref="CommandName" />, or arbitrary content via <see cref="Template" />.
+/// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown Execute=@OnExecute&gt;
+///   &lt;RadzenMarkdownEditorCustomTool CommandName="InsertToday" Icon="today" Title="Insert today" /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// @code {
+///   async Task OnExecute(MarkdownEditorExecuteEventArgs args)
+///   {
+///     if (args.CommandName == "InsertToday")
+///     {
+///       await args.Editor.ExecuteCommandAsync(MarkdownEditorCommands.InsertText, DateTime.Today.ToLongDateString());
+///     }
+///   }
+/// }
+/// </code>
+/// </example>
+public partial class RadzenMarkdownEditorCustomTool
+{
+    /// <summary>Determines if the tool is visible.</summary>
+    [Parameter]
+    public bool Visible { get; set; } = true;
+
+    /// <summary>The icon of the tool. Set to <c>"settings"</c> by default.</summary>
+    [Parameter]
+    public string Icon { get; set; } = "settings";
+
+    /// <summary>The icon color.</summary>
+    [Parameter]
+    public string? IconColor { get; set; }
+
+    /// <summary>Custom content rendered instead of the button. Receives the editor.</summary>
+    [Parameter]
+    public RenderFragment<RadzenMarkdownEditor>? Template { get; set; }
+
+    /// <summary>Specifies whether the tool is rendered as selected.</summary>
+    [Parameter]
+    public bool Selected { get; set; }
+
+    /// <summary>Specifies whether the tool is disabled.</summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>The command name passed to <see cref="RadzenMarkdownEditor.Execute" /> when the tool is clicked.</summary>
+    [Parameter]
+    public string? CommandName { get; set; }
+
+    /// <summary>The editor this tool belongs to.</summary>
+    [CascadingParameter]
+    public RadzenMarkdownEditor? Editor { get; set; }
+
+    /// <summary>The tooltip of the tool.</summary>
+    [Parameter]
+    public string? Title { get; set; }
+
+    async Task OnClick()
+    {
+        if (Editor != null && CommandName != null)
+        {
+            await Editor.ExecuteCommandAsync(CommandName);
+        }
+    }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorHeading.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorHeading.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="title" />

--- a/Radzen.Blazor/RadzenMarkdownEditorHeading.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorHeading.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="title" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Heading) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="title" Selected="@(Editor?.IsActive(MarkdownEditorCommands.Heading) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorHeading.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorHeading.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="title" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="title" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Heading) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorHeading.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorHeading.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which cycles the heading level of the selected lines.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorHeading /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorHeading : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorHeading.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorHeading.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which cycles the heading level of the selected lines.
+/// </summary>
+public partial class RadzenMarkdownEditorHeading : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Heading;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorHeading_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="horizontal_rule" />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="horizontal_rule" />

--- a/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="horizontal_rule" />

--- a/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which inserts a horizontal rule.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorHorizontalRule /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorHorizontalRule : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorHorizontalRule.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which inserts a horizontal rule.
+/// </summary>
+public partial class RadzenMarkdownEditorHorizontalRule : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.HorizontalRule;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorHorizontalRule_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorImage.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorImage.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="image" />

--- a/Radzen.Blazor/RadzenMarkdownEditorImage.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorImage.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="image" />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="image" />

--- a/Radzen.Blazor/RadzenMarkdownEditorImage.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorImage.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which inserts an image.
+/// </summary>
+public partial class RadzenMarkdownEditorImage : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Image;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorImage_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorImage.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorImage.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which inserts an image.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorImage /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorImage : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorItalic.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorItalic.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_italic" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_italic" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Italic) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorItalic.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorItalic.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_italic" />

--- a/Radzen.Blazor/RadzenMarkdownEditorItalic.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorItalic.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_italic" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Italic) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="format_italic" Selected="@(Editor?.IsActive(MarkdownEditorCommands.Italic) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorItalic.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorItalic.razor.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which makes the selection italic.
+/// </summary>
+public partial class RadzenMarkdownEditorItalic : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Italic;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorItalic_Title)); set => title = value; }
+
+    /// <inheritdoc />
+    [Parameter]
+    public override string? Shortcut { get; set; } = "Ctrl+I";
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorItalic.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorItalic.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which makes the selection italic.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorItalic /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorItalic : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorLink.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorLink.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="link" />

--- a/Radzen.Blazor/RadzenMarkdownEditorLink.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorLink.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="link" />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="link" />

--- a/Radzen.Blazor/RadzenMarkdownEditorLink.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorLink.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which inserts a link.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorLink /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorLink : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorLink.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorLink.razor.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which inserts a link.
+/// </summary>
+public partial class RadzenMarkdownEditorLink : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Link;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorLink_Title)); set => title = value; }
+
+    /// <inheritdoc />
+    [Parameter]
+    public override string? Shortcut { get; set; } = "Ctrl+K";
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_numbered" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_numbered" Selected=@(Editor?.IsActive(MarkdownEditorCommands.OrderedList) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_numbered" Selected=@(Editor?.IsActive(MarkdownEditorCommands.OrderedList) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="format_list_numbered" Selected="@(Editor?.IsActive(MarkdownEditorCommands.OrderedList) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_numbered" />

--- a/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which converts the selected lines to a numbered list.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorOrderedList /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorOrderedList : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorOrderedList.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which converts the selected lines to a numbered list.
+/// </summary>
+public partial class RadzenMarkdownEditorOrderedList : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.OrderedList;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorOrderedList_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorQuote.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorQuote.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_quote" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Quote) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="format_quote" Selected="@(Editor?.IsActive(MarkdownEditorCommands.Quote) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorQuote.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorQuote.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_quote" />

--- a/Radzen.Blazor/RadzenMarkdownEditorQuote.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorQuote.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_quote" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_quote" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Quote) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorQuote.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorQuote.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which quotes the selected lines.
+/// </summary>
+public partial class RadzenMarkdownEditorQuote : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Quote;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorQuote_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorQuote.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorQuote.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which quotes the selected lines.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorQuote /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorQuote : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorRedo.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorRedo.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Click=@OnClick Icon="redo" Disabled=@(Editor?.CanRedo != true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorRedo.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorRedo.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Click=@OnClick Icon="redo" Disabled=@(Editor?.CanRedo != true) />
+<MarkdownEditorButton Title="@Title" Click="@OnClick" Icon="redo" Disabled="@(Editor?.CanRedo != true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorRedo.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorRedo.razor.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which restores the next state from the editor's history.
+/// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorRedo /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
+public partial class RadzenMarkdownEditorRedo : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Redo;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorRedo_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorSeparator.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorSeparator.razor
@@ -1,0 +1,1 @@
+<div class="rz-toolbar-separator"></div>

--- a/Radzen.Blazor/RadzenMarkdownEditorSeparator.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorSeparator.razor.cs
@@ -1,0 +1,8 @@
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A visual separator between <see cref="RadzenMarkdownEditor" /> toolbar tools.
+/// </summary>
+public partial class RadzenMarkdownEditorSeparator
+{
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="strikethrough_s" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Strikethrough) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="strikethrough_s" Selected="@(Editor?.IsActive(MarkdownEditorCommands.Strikethrough) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="strikethrough_s" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="strikethrough_s" Selected=@(Editor?.IsActive(MarkdownEditorCommands.Strikethrough) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="strikethrough_s" />

--- a/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor.cs
@@ -4,7 +4,15 @@ namespace Radzen.Blazor;
 
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which strikes through the selection.
+/// Not rendered by <see cref="RadzenMarkdown" />, which does not support GitHub-flavoured strikethrough/task lists; therefore not part of the default toolbar.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorStrikethrough /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorStrikethrough : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorStrikethrough.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which strikes through the selection.
+/// </summary>
+public partial class RadzenMarkdownEditorStrikethrough : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Strikethrough;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorStrikethrough_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="checklist" />

--- a/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="checklist" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="checklist" Selected=@(Editor?.IsActive(MarkdownEditorCommands.TaskList) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="checklist" Selected=@(Editor?.IsActive(MarkdownEditorCommands.TaskList) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="checklist" Selected="@(Editor?.IsActive(MarkdownEditorCommands.TaskList) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which converts the selected lines to a task list.
+/// </summary>
+public partial class RadzenMarkdownEditorTaskList : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.TaskList;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorTaskList_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorTaskList.razor.cs
@@ -4,7 +4,15 @@ namespace Radzen.Blazor;
 
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which converts the selected lines to a task list.
+/// Not rendered by <see cref="RadzenMarkdown" />, which does not support GitHub-flavoured strikethrough/task lists; therefore not part of the default toolbar.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorTaskList /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorTaskList : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorUndo.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorUndo.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Click=@OnClick Icon="undo" Disabled=@(Editor?.CanUndo != true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorUndo.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorUndo.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Click=@OnClick Icon="undo" Disabled=@(Editor?.CanUndo != true) />
+<MarkdownEditorButton Title="@Title" Click="@OnClick" Icon="undo" Disabled="@(Editor?.CanUndo != true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorUndo.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorUndo.razor.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which restores the previous state from the editor's history.
+/// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorUndo /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
+public partial class RadzenMarkdownEditorUndo : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.Undo;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorUndo_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor
@@ -1,0 +1,4 @@
+@using Radzen.Blazor.Rendering
+@inherits RadzenMarkdownEditorButtonBase
+
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_bulleted" />

--- a/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_bulleted" Selected=@(Editor?.IsActive(MarkdownEditorCommands.UnorderedList) == true) />
+<MarkdownEditorButton Title="@Title" Shortcut="@Shortcut" Click="@OnClick" Icon="format_list_bulleted" Selected="@(Editor?.IsActive(MarkdownEditorCommands.UnorderedList) == true)" />

--- a/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor
+++ b/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor
@@ -1,4 +1,4 @@
 @using Radzen.Blazor.Rendering
 @inherits RadzenMarkdownEditorButtonBase
 
-<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_bulleted" />
+<MarkdownEditorButton Title=@Title Shortcut=@Shortcut Click=@OnClick Icon="format_list_bulleted" Selected=@(Editor?.IsActive(MarkdownEditorCommands.UnorderedList) == true) />

--- a/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor.cs
@@ -5,6 +5,13 @@ namespace Radzen.Blazor;
 /// <summary>
 /// A <see cref="RadzenMarkdownEditor" /> tool which converts the selected lines to a bulleted list.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;RadzenMarkdownEditor @bind-Value=@markdown&gt;
+///   &lt;RadzenMarkdownEditorUnorderedList /&gt;
+/// &lt;/RadzenMarkdownEditor&gt;
+/// </code>
+/// </example>
 public partial class RadzenMarkdownEditorUnorderedList : RadzenMarkdownEditorButtonBase
 {
     /// <inheritdoc />

--- a/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor.cs
+++ b/Radzen.Blazor/RadzenMarkdownEditorUnorderedList.razor.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Radzen.Blazor;
+
+/// <summary>
+/// A <see cref="RadzenMarkdownEditor" /> tool which converts the selected lines to a bulleted list.
+/// </summary>
+public partial class RadzenMarkdownEditorUnorderedList : RadzenMarkdownEditorButtonBase
+{
+    /// <inheritdoc />
+    protected override string CommandName => MarkdownEditorCommands.UnorderedList;
+
+    private string? title;
+
+    /// <summary>
+    /// The tooltip of the tool. Localized by default.
+    /// </summary>
+    [Parameter]
+    public string Title { get => title ?? Localize(nameof(RadzenStrings.MarkdownEditorUnorderedList_Title)); set => title = value; }
+}

--- a/Radzen.Blazor/RadzenStrings.Designer.cs
+++ b/Radzen.Blazor/RadzenStrings.Designer.cs
@@ -809,10 +809,8 @@ namespace Radzen.Blazor {
         public static string Spreadsheet_PieChartText { get { return ResourceManager.GetString("Spreadsheet_PieChartText", resourceCulture); } }
         public static string Spreadsheet_DonutChartText { get { return ResourceManager.GetString("Spreadsheet_DonutChartText", resourceCulture); } }
         public static string Spreadsheet_ScatterChartText { get { return ResourceManager.GetString("Spreadsheet_ScatterChartText", resourceCulture); } }
-        public static string MarkdownEditor_WriteText { get { return ResourceManager.GetString("MarkdownEditor_WriteText", resourceCulture); } }
-        public static string MarkdownEditor_PreviewText { get { return ResourceManager.GetString("MarkdownEditor_PreviewText", resourceCulture); } }
-        public static string MarkdownEditor_SplitText { get { return ResourceManager.GetString("MarkdownEditor_SplitText", resourceCulture); } }
-        public static string MarkdownEditor_NothingToPreviewText { get { return ResourceManager.GetString("MarkdownEditor_NothingToPreviewText", resourceCulture); } }
+        public static string MarkdownEditor_DesignText { get { return ResourceManager.GetString("MarkdownEditor_DesignText", resourceCulture); } }
+        public static string MarkdownEditor_SourceText { get { return ResourceManager.GetString("MarkdownEditor_SourceText", resourceCulture); } }
         public static string MarkdownEditorBold_Title { get { return ResourceManager.GetString("MarkdownEditorBold_Title", resourceCulture); } }
         public static string MarkdownEditorItalic_Title { get { return ResourceManager.GetString("MarkdownEditorItalic_Title", resourceCulture); } }
         public static string MarkdownEditorStrikethrough_Title { get { return ResourceManager.GetString("MarkdownEditorStrikethrough_Title", resourceCulture); } }

--- a/Radzen.Blazor/RadzenStrings.Designer.cs
+++ b/Radzen.Blazor/RadzenStrings.Designer.cs
@@ -809,5 +809,15 @@ namespace Radzen.Blazor {
         public static string Spreadsheet_PieChartText { get { return ResourceManager.GetString("Spreadsheet_PieChartText", resourceCulture); } }
         public static string Spreadsheet_DonutChartText { get { return ResourceManager.GetString("Spreadsheet_DonutChartText", resourceCulture); } }
         public static string Spreadsheet_ScatterChartText { get { return ResourceManager.GetString("Spreadsheet_ScatterChartText", resourceCulture); } }
+        public static string MarkdownEditor_WriteText { get { return ResourceManager.GetString("MarkdownEditor_WriteText", resourceCulture); } }
+        public static string MarkdownEditor_PreviewText { get { return ResourceManager.GetString("MarkdownEditor_PreviewText", resourceCulture); } }
+        public static string MarkdownEditor_SplitText { get { return ResourceManager.GetString("MarkdownEditor_SplitText", resourceCulture); } }
+        public static string MarkdownEditor_NothingToPreviewText { get { return ResourceManager.GetString("MarkdownEditor_NothingToPreviewText", resourceCulture); } }
+        public static string MarkdownEditorLink_Title { get { return ResourceManager.GetString("MarkdownEditorLink_Title", resourceCulture); } }
+        public static string MarkdownEditorLink_UrlText { get { return ResourceManager.GetString("MarkdownEditorLink_UrlText", resourceCulture); } }
+        public static string MarkdownEditorLink_LinkText { get { return ResourceManager.GetString("MarkdownEditorLink_LinkText", resourceCulture); } }
+        public static string MarkdownEditorImage_Title { get { return ResourceManager.GetString("MarkdownEditorImage_Title", resourceCulture); } }
+        public static string MarkdownEditorImage_UrlText { get { return ResourceManager.GetString("MarkdownEditorImage_UrlText", resourceCulture); } }
+        public static string MarkdownEditorImage_AltText { get { return ResourceManager.GetString("MarkdownEditorImage_AltText", resourceCulture); } }
     }
 }

--- a/Radzen.Blazor/RadzenStrings.Designer.cs
+++ b/Radzen.Blazor/RadzenStrings.Designer.cs
@@ -811,6 +811,8 @@ namespace Radzen.Blazor {
         public static string Spreadsheet_ScatterChartText { get { return ResourceManager.GetString("Spreadsheet_ScatterChartText", resourceCulture); } }
         public static string MarkdownEditor_DesignText { get { return ResourceManager.GetString("MarkdownEditor_DesignText", resourceCulture); } }
         public static string MarkdownEditor_SourceText { get { return ResourceManager.GetString("MarkdownEditor_SourceText", resourceCulture); } }
+        public static string MarkdownEditorUndo_Title { get { return ResourceManager.GetString("MarkdownEditorUndo_Title", resourceCulture); } }
+        public static string MarkdownEditorRedo_Title { get { return ResourceManager.GetString("MarkdownEditorRedo_Title", resourceCulture); } }
         public static string MarkdownEditorBold_Title { get { return ResourceManager.GetString("MarkdownEditorBold_Title", resourceCulture); } }
         public static string MarkdownEditorItalic_Title { get { return ResourceManager.GetString("MarkdownEditorItalic_Title", resourceCulture); } }
         public static string MarkdownEditorStrikethrough_Title { get { return ResourceManager.GetString("MarkdownEditorStrikethrough_Title", resourceCulture); } }

--- a/Radzen.Blazor/RadzenStrings.Designer.cs
+++ b/Radzen.Blazor/RadzenStrings.Designer.cs
@@ -813,11 +813,22 @@ namespace Radzen.Blazor {
         public static string MarkdownEditor_PreviewText { get { return ResourceManager.GetString("MarkdownEditor_PreviewText", resourceCulture); } }
         public static string MarkdownEditor_SplitText { get { return ResourceManager.GetString("MarkdownEditor_SplitText", resourceCulture); } }
         public static string MarkdownEditor_NothingToPreviewText { get { return ResourceManager.GetString("MarkdownEditor_NothingToPreviewText", resourceCulture); } }
+        public static string MarkdownEditorBold_Title { get { return ResourceManager.GetString("MarkdownEditorBold_Title", resourceCulture); } }
+        public static string MarkdownEditorItalic_Title { get { return ResourceManager.GetString("MarkdownEditorItalic_Title", resourceCulture); } }
+        public static string MarkdownEditorStrikethrough_Title { get { return ResourceManager.GetString("MarkdownEditorStrikethrough_Title", resourceCulture); } }
+        public static string MarkdownEditorHeading_Title { get { return ResourceManager.GetString("MarkdownEditorHeading_Title", resourceCulture); } }
+        public static string MarkdownEditorQuote_Title { get { return ResourceManager.GetString("MarkdownEditorQuote_Title", resourceCulture); } }
+        public static string MarkdownEditorCode_Title { get { return ResourceManager.GetString("MarkdownEditorCode_Title", resourceCulture); } }
+        public static string MarkdownEditorCodeBlock_Title { get { return ResourceManager.GetString("MarkdownEditorCodeBlock_Title", resourceCulture); } }
+        public static string MarkdownEditorUnorderedList_Title { get { return ResourceManager.GetString("MarkdownEditorUnorderedList_Title", resourceCulture); } }
+        public static string MarkdownEditorOrderedList_Title { get { return ResourceManager.GetString("MarkdownEditorOrderedList_Title", resourceCulture); } }
+        public static string MarkdownEditorTaskList_Title { get { return ResourceManager.GetString("MarkdownEditorTaskList_Title", resourceCulture); } }
         public static string MarkdownEditorLink_Title { get { return ResourceManager.GetString("MarkdownEditorLink_Title", resourceCulture); } }
         public static string MarkdownEditorLink_UrlText { get { return ResourceManager.GetString("MarkdownEditorLink_UrlText", resourceCulture); } }
         public static string MarkdownEditorLink_LinkText { get { return ResourceManager.GetString("MarkdownEditorLink_LinkText", resourceCulture); } }
         public static string MarkdownEditorImage_Title { get { return ResourceManager.GetString("MarkdownEditorImage_Title", resourceCulture); } }
         public static string MarkdownEditorImage_UrlText { get { return ResourceManager.GetString("MarkdownEditorImage_UrlText", resourceCulture); } }
         public static string MarkdownEditorImage_AltText { get { return ResourceManager.GetString("MarkdownEditorImage_AltText", resourceCulture); } }
+        public static string MarkdownEditorHorizontalRule_Title { get { return ResourceManager.GetString("MarkdownEditorHorizontalRule_Title", resourceCulture); } }
     }
 }

--- a/Radzen.Blazor/RadzenStrings.de.resx
+++ b/Radzen.Blazor/RadzenStrings.de.resx
@@ -2387,4 +2387,35 @@
   <data name="Spreadsheet_ScatterChartText" xml:space="preserve">
     <value>Punktdiagramm</value>
   </data>
+  <!-- MarkdownEditor -->
+  <data name="MarkdownEditor_WriteText" xml:space="preserve">
+    <value>Schreiben</value>
+  </data>
+  <data name="MarkdownEditor_PreviewText" xml:space="preserve">
+    <value>Vorschau</value>
+  </data>
+  <data name="MarkdownEditor_SplitText" xml:space="preserve">
+    <value>Geteilt</value>
+  </data>
+  <data name="MarkdownEditor_NothingToPreviewText" xml:space="preserve">
+    <value>Keine Vorschau verfügbar</value>
+  </data>
+  <data name="MarkdownEditorLink_Title" xml:space="preserve">
+    <value>Link einfügen</value>
+  </data>
+  <data name="MarkdownEditorLink_UrlText" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="MarkdownEditorLink_LinkText" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="MarkdownEditorImage_Title" xml:space="preserve">
+    <value>Bild einfügen</value>
+  </data>
+  <data name="MarkdownEditorImage_UrlText" xml:space="preserve">
+    <value>Bild-URL</value>
+  </data>
+  <data name="MarkdownEditorImage_AltText" xml:space="preserve">
+    <value>Alternativtext</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.de.resx
+++ b/Radzen.Blazor/RadzenStrings.de.resx
@@ -2394,6 +2394,12 @@
   <data name="MarkdownEditor_SourceText" xml:space="preserve">
     <value>Quelltext</value>
   </data>
+  <data name="MarkdownEditorUndo_Title" xml:space="preserve">
+    <value>Rückgängig</value>
+  </data>
+  <data name="MarkdownEditorRedo_Title" xml:space="preserve">
+    <value>Wiederholen</value>
+  </data>
   <data name="MarkdownEditorBold_Title" xml:space="preserve">
     <value>Fett</value>
   </data>

--- a/Radzen.Blazor/RadzenStrings.de.resx
+++ b/Radzen.Blazor/RadzenStrings.de.resx
@@ -2388,17 +2388,11 @@
     <value>Punktdiagramm</value>
   </data>
   <!-- MarkdownEditor -->
-  <data name="MarkdownEditor_WriteText" xml:space="preserve">
-    <value>Schreiben</value>
+  <data name="MarkdownEditor_DesignText" xml:space="preserve">
+    <value>Design</value>
   </data>
-  <data name="MarkdownEditor_PreviewText" xml:space="preserve">
-    <value>Vorschau</value>
-  </data>
-  <data name="MarkdownEditor_SplitText" xml:space="preserve">
-    <value>Geteilt</value>
-  </data>
-  <data name="MarkdownEditor_NothingToPreviewText" xml:space="preserve">
-    <value>Keine Vorschau verfügbar</value>
+  <data name="MarkdownEditor_SourceText" xml:space="preserve">
+    <value>Quelltext</value>
   </data>
   <data name="MarkdownEditorBold_Title" xml:space="preserve">
     <value>Fett</value>

--- a/Radzen.Blazor/RadzenStrings.de.resx
+++ b/Radzen.Blazor/RadzenStrings.de.resx
@@ -2400,6 +2400,36 @@
   <data name="MarkdownEditor_NothingToPreviewText" xml:space="preserve">
     <value>Keine Vorschau verfügbar</value>
   </data>
+  <data name="MarkdownEditorBold_Title" xml:space="preserve">
+    <value>Fett</value>
+  </data>
+  <data name="MarkdownEditorItalic_Title" xml:space="preserve">
+    <value>Kursiv</value>
+  </data>
+  <data name="MarkdownEditorStrikethrough_Title" xml:space="preserve">
+    <value>Durchgestrichen</value>
+  </data>
+  <data name="MarkdownEditorHeading_Title" xml:space="preserve">
+    <value>Überschrift</value>
+  </data>
+  <data name="MarkdownEditorQuote_Title" xml:space="preserve">
+    <value>Zitat</value>
+  </data>
+  <data name="MarkdownEditorCode_Title" xml:space="preserve">
+    <value>Code</value>
+  </data>
+  <data name="MarkdownEditorCodeBlock_Title" xml:space="preserve">
+    <value>Codeblock</value>
+  </data>
+  <data name="MarkdownEditorUnorderedList_Title" xml:space="preserve">
+    <value>Aufzählung</value>
+  </data>
+  <data name="MarkdownEditorOrderedList_Title" xml:space="preserve">
+    <value>Nummerierte Liste</value>
+  </data>
+  <data name="MarkdownEditorTaskList_Title" xml:space="preserve">
+    <value>Aufgabenliste</value>
+  </data>
   <data name="MarkdownEditorLink_Title" xml:space="preserve">
     <value>Link einfügen</value>
   </data>
@@ -2417,5 +2447,8 @@
   </data>
   <data name="MarkdownEditorImage_AltText" xml:space="preserve">
     <value>Alternativtext</value>
+  </data>
+  <data name="MarkdownEditorHorizontalRule_Title" xml:space="preserve">
+    <value>Trennlinie</value>
   </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.es.resx
+++ b/Radzen.Blazor/RadzenStrings.es.resx
@@ -2394,4 +2394,10 @@
   <data name="MarkdownEditor_SourceText" xml:space="preserve">
     <value>Código</value>
   </data>
+  <data name="MarkdownEditorUndo_Title" xml:space="preserve">
+    <value>Deshacer</value>
+  </data>
+  <data name="MarkdownEditorRedo_Title" xml:space="preserve">
+    <value>Rehacer</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.es.resx
+++ b/Radzen.Blazor/RadzenStrings.es.resx
@@ -2387,4 +2387,11 @@
   <data name="Spreadsheet_ScatterChartText" xml:space="preserve">
     <value>Gráfico de dispersión</value>
   </data>
+  <!-- MarkdownEditor -->
+  <data name="MarkdownEditor_DesignText" xml:space="preserve">
+    <value>Diseño</value>
+  </data>
+  <data name="MarkdownEditor_SourceText" xml:space="preserve">
+    <value>Código</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.fr.resx
+++ b/Radzen.Blazor/RadzenStrings.fr.resx
@@ -2394,4 +2394,10 @@
   <data name="MarkdownEditor_SourceText" xml:space="preserve">
     <value>Source</value>
   </data>
+  <data name="MarkdownEditorUndo_Title" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="MarkdownEditorRedo_Title" xml:space="preserve">
+    <value>Rétablir</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.fr.resx
+++ b/Radzen.Blazor/RadzenStrings.fr.resx
@@ -2387,4 +2387,11 @@
   <data name="Spreadsheet_ScatterChartText" xml:space="preserve">
     <value>Graphique en nuage de points</value>
   </data>
+  <!-- MarkdownEditor -->
+  <data name="MarkdownEditor_DesignText" xml:space="preserve">
+    <value>Création</value>
+  </data>
+  <data name="MarkdownEditor_SourceText" xml:space="preserve">
+    <value>Source</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.it.resx
+++ b/Radzen.Blazor/RadzenStrings.it.resx
@@ -2387,4 +2387,11 @@
   <data name="Spreadsheet_ScatterChartText" xml:space="preserve">
     <value>Grafico a dispersione</value>
   </data>
+  <!-- MarkdownEditor -->
+  <data name="MarkdownEditor_DesignText" xml:space="preserve">
+    <value>Design</value>
+  </data>
+  <data name="MarkdownEditor_SourceText" xml:space="preserve">
+    <value>Sorgente</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.it.resx
+++ b/Radzen.Blazor/RadzenStrings.it.resx
@@ -2394,4 +2394,10 @@
   <data name="MarkdownEditor_SourceText" xml:space="preserve">
     <value>Sorgente</value>
   </data>
+  <data name="MarkdownEditorUndo_Title" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="MarkdownEditorRedo_Title" xml:space="preserve">
+    <value>Ripeti</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.ja.resx
+++ b/Radzen.Blazor/RadzenStrings.ja.resx
@@ -2394,4 +2394,10 @@
   <data name="MarkdownEditor_SourceText" xml:space="preserve">
     <value>ソース</value>
   </data>
+  <data name="MarkdownEditorUndo_Title" xml:space="preserve">
+    <value>元に戻す</value>
+  </data>
+  <data name="MarkdownEditorRedo_Title" xml:space="preserve">
+    <value>やり直し</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.ja.resx
+++ b/Radzen.Blazor/RadzenStrings.ja.resx
@@ -2387,4 +2387,11 @@
   <data name="Spreadsheet_ScatterChartText" xml:space="preserve">
     <value>散布図</value>
   </data>
+  <!-- MarkdownEditor -->
+  <data name="MarkdownEditor_DesignText" xml:space="preserve">
+    <value>デザイン</value>
+  </data>
+  <data name="MarkdownEditor_SourceText" xml:space="preserve">
+    <value>ソース</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.resx
+++ b/Radzen.Blazor/RadzenStrings.resx
@@ -2397,4 +2397,35 @@
   <data name="Spreadsheet_ScatterChartText" xml:space="preserve">
     <value>Scatter Chart</value>
   </data>
+  <!-- MarkdownEditor -->
+  <data name="MarkdownEditor_WriteText" xml:space="preserve">
+    <value>Write</value>
+  </data>
+  <data name="MarkdownEditor_PreviewText" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="MarkdownEditor_SplitText" xml:space="preserve">
+    <value>Split</value>
+  </data>
+  <data name="MarkdownEditor_NothingToPreviewText" xml:space="preserve">
+    <value>Nothing to preview</value>
+  </data>
+  <data name="MarkdownEditorLink_Title" xml:space="preserve">
+    <value>Insert link</value>
+  </data>
+  <data name="MarkdownEditorLink_UrlText" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="MarkdownEditorLink_LinkText" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="MarkdownEditorImage_Title" xml:space="preserve">
+    <value>Insert image</value>
+  </data>
+  <data name="MarkdownEditorImage_UrlText" xml:space="preserve">
+    <value>Image URL</value>
+  </data>
+  <data name="MarkdownEditorImage_AltText" xml:space="preserve">
+    <value>Alternative text</value>
+  </data>
 </root>

--- a/Radzen.Blazor/RadzenStrings.resx
+++ b/Radzen.Blazor/RadzenStrings.resx
@@ -2398,17 +2398,11 @@
     <value>Scatter Chart</value>
   </data>
   <!-- MarkdownEditor -->
-  <data name="MarkdownEditor_WriteText" xml:space="preserve">
-    <value>Write</value>
+  <data name="MarkdownEditor_DesignText" xml:space="preserve">
+    <value>Design</value>
   </data>
-  <data name="MarkdownEditor_PreviewText" xml:space="preserve">
-    <value>Preview</value>
-  </data>
-  <data name="MarkdownEditor_SplitText" xml:space="preserve">
-    <value>Split</value>
-  </data>
-  <data name="MarkdownEditor_NothingToPreviewText" xml:space="preserve">
-    <value>Nothing to preview</value>
+  <data name="MarkdownEditor_SourceText" xml:space="preserve">
+    <value>Source</value>
   </data>
   <data name="MarkdownEditorBold_Title" xml:space="preserve">
     <value>Bold</value>

--- a/Radzen.Blazor/RadzenStrings.resx
+++ b/Radzen.Blazor/RadzenStrings.resx
@@ -2404,6 +2404,12 @@
   <data name="MarkdownEditor_SourceText" xml:space="preserve">
     <value>Source</value>
   </data>
+  <data name="MarkdownEditorUndo_Title" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="MarkdownEditorRedo_Title" xml:space="preserve">
+    <value>Redo</value>
+  </data>
   <data name="MarkdownEditorBold_Title" xml:space="preserve">
     <value>Bold</value>
   </data>

--- a/Radzen.Blazor/RadzenStrings.resx
+++ b/Radzen.Blazor/RadzenStrings.resx
@@ -2410,6 +2410,36 @@
   <data name="MarkdownEditor_NothingToPreviewText" xml:space="preserve">
     <value>Nothing to preview</value>
   </data>
+  <data name="MarkdownEditorBold_Title" xml:space="preserve">
+    <value>Bold</value>
+  </data>
+  <data name="MarkdownEditorItalic_Title" xml:space="preserve">
+    <value>Italic</value>
+  </data>
+  <data name="MarkdownEditorStrikethrough_Title" xml:space="preserve">
+    <value>Strikethrough</value>
+  </data>
+  <data name="MarkdownEditorHeading_Title" xml:space="preserve">
+    <value>Heading</value>
+  </data>
+  <data name="MarkdownEditorQuote_Title" xml:space="preserve">
+    <value>Quote</value>
+  </data>
+  <data name="MarkdownEditorCode_Title" xml:space="preserve">
+    <value>Code</value>
+  </data>
+  <data name="MarkdownEditorCodeBlock_Title" xml:space="preserve">
+    <value>Code block</value>
+  </data>
+  <data name="MarkdownEditorUnorderedList_Title" xml:space="preserve">
+    <value>Bulleted list</value>
+  </data>
+  <data name="MarkdownEditorOrderedList_Title" xml:space="preserve">
+    <value>Numbered list</value>
+  </data>
+  <data name="MarkdownEditorTaskList_Title" xml:space="preserve">
+    <value>Task list</value>
+  </data>
   <data name="MarkdownEditorLink_Title" xml:space="preserve">
     <value>Insert link</value>
   </data>
@@ -2427,5 +2457,8 @@
   </data>
   <data name="MarkdownEditorImage_AltText" xml:space="preserve">
     <value>Alternative text</value>
+  </data>
+  <data name="MarkdownEditorHorizontalRule_Title" xml:space="preserve">
+    <value>Horizontal rule</value>
   </data>
 </root>

--- a/Radzen.Blazor/Rendering/BlazorMarkdownRenderer.cs
+++ b/Radzen.Blazor/Rendering/BlazorMarkdownRenderer.cs
@@ -186,6 +186,14 @@ internal class BlazorMarkdownRenderer(BlazorMarkdownRendererOptions options, Ren
     }
 
     /// <inheritdoc />
+    public override void VisitStrikethrough(Strikethrough strikethrough)
+    {
+        builder.OpenElement(0, "del");
+        VisitChildren(strikethrough.Children);
+        builder.CloseElement();
+    }
+
+    /// <inheritdoc />
     public override void VisitEmphasis(Emphasis emphasis)
     {
         builder.OpenElement(0, "em");

--- a/Radzen.Blazor/Rendering/BlazorMarkdownRenderer.cs
+++ b/Radzen.Blazor/Rendering/BlazorMarkdownRenderer.cs
@@ -278,6 +278,17 @@ internal class BlazorMarkdownRenderer(BlazorMarkdownRendererOptions options, Ren
     public override void VisitListItem(ListItem listItem)
     {
         builder.OpenElement(0, "li");
+        if (listItem.Checked is bool isChecked)
+        {
+            builder.OpenElement(1, "input");
+            builder.AddAttribute(2, "type", "checkbox");
+            builder.AddAttribute(3, "disabled", true);
+            if (isChecked)
+            {
+                builder.AddAttribute(4, "checked", true);
+            }
+            builder.CloseElement();
+        }
         VisitChildren(listItem.Children);
         builder.CloseElement();
     }

--- a/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
+++ b/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
@@ -1,0 +1,54 @@
+<button type="button" tabindex="-1" @onclick=@OnClick class=@Class disabled=@IsDisabled @onmousedown=@Empty @onmousedown:preventDefault @onclick:preventDefault title=@GetTitle()>
+    <span class="rz-button-box">
+        <i class="notranslate rzi" aria-hidden="true" style="@(!string.IsNullOrEmpty(IconColor) ? $"color:{IconColor}" : null)">@Icon</i>
+    </span>
+</button>
+@code {
+    [CascadingParameter]
+    public RadzenMarkdownEditor? Editor { get; set; }
+
+    [Parameter]
+    public string? Title { get; set; }
+
+    [Parameter]
+    public string? Shortcut { get; set; }
+
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    [Parameter]
+    public bool Selected { get; set; }
+
+    [Parameter]
+    public string? Icon { get; set; }
+
+    [Parameter]
+    public string? IconColor { get; set; }
+
+    [Parameter]
+    public EventCallback Click { get; set; }
+
+    async Task OnClick()
+    {
+        await Click.InvokeAsync(null);
+    }
+
+    string? GetTitle() => !string.IsNullOrEmpty(Shortcut) ? $"{Title} ({Shortcut})" : Title;
+
+    bool IsDisabled => Editor?.Disabled == true || Disabled || Editor?.Mode == MarkdownEditorMode.Preview;
+
+    string Class
+    {
+        get
+        {
+            var baseClasses = Selected && !IsDisabled
+                ? "rz-button rz-toggle-button rz-button-icon-only rz-button-sm rz-variant-flat rz-primary rz-shade-lighter rz-state-active"
+                : "rz-button rz-button-icon-only rz-button-sm rz-variant-text rz-base rz-shade-default";
+            return IsDisabled ? $"{baseClasses} rz-state-disabled" : baseClasses;
+        }
+    }
+
+    void Empty()
+    {
+    }
+}

--- a/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
+++ b/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
@@ -35,7 +35,7 @@
 
     string? GetTitle() => !string.IsNullOrEmpty(Shortcut) ? $"{Title} ({Shortcut})" : Title;
 
-    bool IsDisabled => Editor?.Disabled == true || Disabled || Editor?.GetMode() == MarkdownEditorMode.Preview;
+    bool IsDisabled => Editor?.Disabled == true || Disabled;
 
     string Class
     {

--- a/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
+++ b/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
@@ -35,7 +35,7 @@
 
     string? GetTitle() => !string.IsNullOrEmpty(Shortcut) ? $"{Title} ({Shortcut})" : Title;
 
-    bool IsDisabled => Editor?.Disabled == true || Disabled || Editor?.Mode == MarkdownEditorMode.Preview;
+    bool IsDisabled => Editor?.Disabled == true || Disabled || Editor?.GetMode() == MarkdownEditorMode.Preview;
 
     string Class
     {

--- a/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
+++ b/Radzen.Blazor/Rendering/MarkdownEditorButton.razor
@@ -1,4 +1,4 @@
-<button type="button" tabindex="-1" @onclick=@OnClick class=@Class disabled=@IsDisabled @onmousedown=@Empty @onmousedown:preventDefault @onclick:preventDefault title=@GetTitle()>
+<button type="button" tabindex="-1" @onclick="@OnClick" class="@Class" disabled="@IsDisabled" @onmousedown="@Empty" @onmousedown:preventDefault @onclick:preventDefault title="@GetTitle()">
     <span class="rz-button-box">
         <i class="notranslate rzi" aria-hidden="true" style="@(!string.IsNullOrEmpty(IconColor) ? $"color:{IconColor}" : null)">@Icon</i>
     </span>

--- a/Radzen.Blazor/themes/_components.scss
+++ b/Radzen.Blazor/themes/_components.scss
@@ -70,6 +70,7 @@
 @import 'components/blazor/gantt';
 @import 'components/blazor/link';
 @import 'components/blazor/editor';
+@import 'components/blazor/markdown-editor';
 @import 'components/blazor/colorpicker';
 @import 'components/blazor/splitter';
 @import 'components/blazor/tile-layout';

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -16,7 +16,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
   flex-wrap: wrap;
   border-bottom: var(--rz-editor-border);
   background-color: var(--rz-editor-toolbar-background-color);

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -15,7 +15,6 @@
 .rz-markdown-editor-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   flex-wrap: wrap;
   border-bottom: var(--rz-editor-border);
   background-color: var(--rz-editor-toolbar-background-color);

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -29,7 +29,7 @@
 }
 
 .rz-markdown-editor-modes {
-  margin-inline-start: auto;
+  margin-inline-end: 0.25rem;
 }
 
 .rz-markdown-editor-content {
@@ -107,4 +107,18 @@
 .rz-markdown-editor-custom-tool {
   display: inline-flex;
   align-items: center;
+}
+
+// GitHub-style task lists: no list marker, checkbox in the marker position
+.rz-markdown-editor-design,
+.rz-markdown {
+  li:has(> input[type='checkbox']:first-child) {
+    list-style: none;
+
+    > input[type='checkbox'] {
+      margin-inline-start: -1.4em;
+      margin-inline-end: 0.2em;
+      vertical-align: middle;
+    }
+  }
 }

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -1,0 +1,88 @@
+.rz-markdown-editor {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--rz-editor-border-radius);
+  border: var(--rz-editor-border);
+  overflow: hidden;
+
+  &:focus-within {
+    outline: var(--rz-editor-focus-outline);
+    outline-offset: var(--rz-editor-focus-outline-offset);
+  }
+}
+
+.rz-markdown-editor-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  border-bottom: var(--rz-editor-border);
+  background-color: var(--rz-editor-toolbar-background-color);
+  padding: 0.25rem;
+}
+
+.rz-markdown-editor-tools {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.125rem;
+}
+
+.rz-markdown-editor-modes {
+  margin-inline-start: auto;
+}
+
+.rz-markdown-editor-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  background-color: var(--rz-editor-content-background-color);
+}
+
+.rz-markdown-editor-content-split {
+  > .rz-markdown-editor-textarea,
+  > .rz-markdown-editor-preview {
+    flex: 1 1 50%;
+    min-width: 0;
+  }
+
+  > .rz-markdown-editor-preview {
+    border-inline-start: var(--rz-editor-border);
+  }
+}
+
+.rz-markdown-editor-textarea {
+  flex: 1;
+  width: 100%;
+  border: none;
+  outline: none;
+  resize: vertical;
+  padding: 0.5rem;
+  font-family: inherit;
+  font-size: var(--rz-input-font-size);
+  line-height: var(--rz-input-line-height);
+  color: var(--rz-input-value-color);
+  background-color: transparent;
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.rz-markdown-editor-preview {
+  flex: 1;
+  overflow: auto;
+  padding: 0.5rem;
+}
+
+.rz-markdown-editor-empty {
+  color: var(--rz-text-disabled-color);
+  font-style: italic;
+}
+
+.rz-markdown-editor-custom-tool {
+  display: inline-flex;
+  align-items: center;
+}

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -33,24 +33,10 @@
 }
 
 .rz-markdown-editor-content {
+  display: flex;
   flex: 1;
   min-height: 0;
   background-color: var(--rz-editor-content-background-color);
-}
-
-.rz-markdown-editor-pane {
-  display: flex;
-  min-width: 0;
-  min-height: 0;
-
-  &.rz-markdown-editor-pane-hidden {
-    display: none !important;
-  }
-
-  &.rz-markdown-editor-pane-full,
-  &.rz-markdown-editor-pane-fill {
-    flex: 1 1 auto !important;
-  }
 }
 
 .rz-markdown-editor-textarea {
@@ -71,15 +57,51 @@
   }
 }
 
-.rz-markdown-editor-preview {
+.rz-markdown-editor-design {
   flex: 1;
   overflow: auto;
   padding: 0.5rem;
-}
+  outline: none;
+  color: var(--rz-input-value-color);
 
-.rz-markdown-editor-empty {
-  color: var(--rz-text-disabled-color);
-  font-style: italic;
+  &[hidden] {
+    display: none;
+  }
+
+  > :first-child {
+    margin-block-start: 0;
+  }
+
+  > :last-child {
+    margin-block-end: 0;
+  }
+
+  pre {
+    background-color: var(--rz-base-100);
+    border-radius: var(--rz-border-radius);
+    padding: 0.5rem;
+    overflow-x: auto;
+  }
+
+  blockquote {
+    border-inline-start: 3px solid var(--rz-base-300);
+    margin-inline-start: 0;
+    padding-inline-start: 0.75rem;
+    color: var(--rz-text-secondary-color);
+  }
+
+  table {
+    border-collapse: collapse;
+
+    th, td {
+      border: 1px solid var(--rz-base-300);
+      padding: 0.25rem 0.5rem;
+    }
+  }
+
+  img {
+    max-width: 100%;
+  }
 }
 
 .rz-markdown-editor-custom-tool {

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -33,21 +33,18 @@
 }
 
 .rz-markdown-editor-content {
-  display: flex;
   flex: 1;
   min-height: 0;
   background-color: var(--rz-editor-content-background-color);
 }
 
-.rz-markdown-editor-content-split {
-  > .rz-markdown-editor-textarea,
-  > .rz-markdown-editor-preview {
-    flex: 1 1 50%;
-    min-width: 0;
-  }
+.rz-markdown-editor-pane {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
 
-  > .rz-markdown-editor-preview {
-    border-inline-start: var(--rz-editor-border);
+  &.rz-markdown-editor-pane-hidden {
+    display: none !important;
   }
 }
 

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -53,7 +53,7 @@
   width: 100%;
   border: none;
   outline: none;
-  resize: vertical;
+  resize: none;
   padding: 0.5rem;
   font-family: inherit;
   font-size: var(--rz-input-font-size);

--- a/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_markdown-editor.scss
@@ -46,6 +46,11 @@
   &.rz-markdown-editor-pane-hidden {
     display: none !important;
   }
+
+  &.rz-markdown-editor-pane-full,
+  &.rz-markdown-editor-pane-fill {
+    flex: 1 1 auto !important;
+  }
 }
 
 .rz-markdown-editor-textarea {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7123,39 +7123,6 @@ Radzen.datePickerKeydown = function (e) {
 };
 document.addEventListener('keydown', Radzen.datePickerKeydown);
 
-Radzen.markdownEditorApply = function (textarea, start, end, replacement, selectionStart, selectionEnd) {
-  if (!textarea) {
-    return;
-  }
-
-  var before = textarea.value;
-  var expected = before.substring(0, start) + replacement + before.substring(end);
-
-  textarea.focus();
-  textarea.setSelectionRange(start, end);
-
-  try {
-    // execCommand keeps the browser's native undo stack intact.
-    if (document.execCommand) {
-      if (replacement.length > 0) {
-        document.execCommand('insertText', false, replacement);
-      } else if (start !== end) {
-        document.execCommand('delete', false);
-      }
-    }
-  } catch (e) {
-    // fall through to the verification below
-  }
-
-  if (textarea.value !== expected) {
-    // execCommand unsupported or applied incorrectly: set the exact result (native undo is lost only on this path).
-    textarea.value = expected;
-    textarea.dispatchEvent(new Event('input', { bubbles: true }));
-  }
-
-  textarea.setSelectionRange(selectionStart, selectionEnd);
-};
-
 Radzen.markdownSerialize = function (root) {
   var escapeText = function (text) {
     return text.replace(/[\\`*_~\[\]]/g, function (c) { return '\\' + c; });
@@ -7353,6 +7320,218 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     suppressInput = true;
     editable.innerHTML = html;
     suppressInput = false;
+  };
+
+  editor.apply = function (start, end, replacement, selectionStart, selectionEnd) {
+    var before = textarea.value;
+    textarea.focus();
+    textarea.value = before.substring(0, start) + replacement + before.substring(end);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.setSelectionRange(selectionStart, selectionEnd);
+  };
+
+  var savedRange = null;
+
+  var currentRange = function () {
+    // savedRange is only ever set by saveSelection(), called right before an async interruption
+    // (the link/image dialog) that leaves the live selection stale/collapsed; prefer it when present.
+    if (savedRange) return savedRange;
+    var sel = window.getSelection();
+    if (sel.rangeCount && editable.contains(sel.anchorNode)) return sel.getRangeAt(0);
+    return null;
+  };
+  var setRange = function (range) {
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  };
+  var blockOf = function (node) {
+    while (node && node.parentNode !== editable) node = node.parentNode;
+    return node;
+  };
+  var blocksInRange = function (range) {
+    var first = blockOf(range.startContainer), last = blockOf(range.endContainer);
+    var result = [];
+    for (var el = first; el; el = el.nextSibling) {
+      result.push(el);
+      if (el === last) break;
+    }
+    return result;
+  };
+  var replaceTag = function (el, tag) {
+    var next = document.createElement(tag);
+    // insert next before moving children into it, so they stay attached to the document
+    // throughout the move (detaching them, even briefly, collapses the live selection)
+    el.parentNode.insertBefore(next, el);
+    while (el.firstChild) next.appendChild(el.firstChild);
+    el.parentNode.removeChild(el);
+    return next;
+  };
+  // reparenting a node (even between two attached positions) can silently collapse the
+  // live selection in Chromium, so block-restructuring commands must explicitly set a
+  // fresh, valid selection into the mutated result afterward.
+  var selectStart = function (el) {
+    if (!el) return;
+    var range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(true);
+    setRange(range);
+  };
+  var expandCollapsedToWord = function (range) {
+    if (!range.collapsed || range.startContainer.nodeType !== Node.TEXT_NODE) return;
+    var text = range.startContainer.data, start = range.startOffset, end = range.endOffset;
+    while (start > 0 && !/\s/.test(text[start - 1])) start--;
+    while (end < text.length && !/\s/.test(text[end])) end++;
+    range.setStart(range.startContainer, start);
+    range.setEnd(range.startContainer, end);
+  };
+  var toggleInline = function (range, tag, alternates) {
+    // unwrap when an enclosing element of the type exists
+    for (var node = range.startContainer; node && node !== editable; node = node.parentNode) {
+      if (node.nodeType === Node.ELEMENT_NODE && alternates.includes(node.tagName)) {
+        var parent = node.parentNode;
+        while (node.firstChild) parent.insertBefore(node.firstChild, node);
+        parent.removeChild(node);
+        return;
+      }
+    }
+    expandCollapsedToWord(range);
+    if (range.collapsed) return;
+    var wrapper = document.createElement(tag);
+    wrapper.appendChild(range.extractContents());
+    // strip nested same-type elements inside the wrapper
+    wrapper.querySelectorAll(alternates.join(',')).forEach(function (el) {
+      while (el.firstChild) el.parentNode.insertBefore(el.firstChild, el);
+      el.parentNode.removeChild(el);
+    });
+    range.insertNode(wrapper);
+    range.selectNodeContents(wrapper);
+    setRange(range);
+  };
+
+  editor.saveSelection = function () {
+    var sel = window.getSelection();
+    if (sel.rangeCount && editable.contains(sel.anchorNode)) savedRange = sel.getRangeAt(0).cloneRange();
+  };
+  editor.hasSelection = function () {
+    var range = currentRange();
+    return !!range && !range.collapsed;
+  };
+
+  editor.execute = function (name, value, label) {
+    var range = currentRange();
+    if (!range) { editable.focus(); range = currentRange(); if (!range) return; }
+    editable.focus();
+    setRange(range);
+    if (editor.snapshot) editor.snapshot(true); // Task 10 provides this
+
+    switch (name) {
+      case 'bold': toggleInline(range, 'strong', ['STRONG', 'B']); break;
+      case 'italic': toggleInline(range, 'em', ['EM', 'I']); break;
+      case 'strikethrough': toggleInline(range, 'del', ['DEL', 'S', 'STRIKE']); break;
+      case 'code': toggleInline(range, 'code', ['CODE']); break;
+      case 'heading': {
+        var headed = blocksInRange(range).map(function (el) {
+          var level = /^H([1-6])$/.test(el.tagName) ? +RegExp.$1 : 0;
+          return replaceTag(el, level >= 3 ? 'p' : 'h' + (level + 1));
+        });
+        selectStart(headed[0]);
+        break;
+      }
+      case 'quote': {
+        var inside = range.startContainer.parentNode.closest && range.startContainer.parentNode.closest('blockquote');
+        if (inside && editable.contains(inside)) {
+          var unwrapped = inside.firstChild;
+          while (inside.firstChild) inside.parentNode.insertBefore(inside.firstChild, inside);
+          inside.parentNode.removeChild(inside);
+          selectStart(unwrapped);
+        } else {
+          var bq = document.createElement('blockquote');
+          var els = blocksInRange(range);
+          els[0].parentNode.insertBefore(bq, els[0]);
+          els.forEach(function (el) { bq.appendChild(el); });
+          selectStart(bq);
+        }
+        break;
+      }
+      case 'unorderedList': case 'orderedList': case 'taskList': {
+        var listTag = name === 'orderedList' ? 'ol' : 'ul';
+        var existing = range.startContainer.parentNode.closest && range.startContainer.parentNode.closest('ul,ol');
+        if (existing && editable.contains(existing) && existing.tagName.toLowerCase() === listTag && name !== 'taskList') {
+          var firstP = null;
+          Array.prototype.slice.call(existing.children).forEach(function (li) {
+            var p = document.createElement('p');
+            while (li.firstChild) p.appendChild(li.firstChild);
+            existing.parentNode.insertBefore(p, existing);
+            firstP = firstP || p;
+          });
+          existing.parentNode.removeChild(existing);
+          selectStart(firstP);
+        } else if (!existing || !editable.contains(existing)) {
+          var list = document.createElement(listTag);
+          var items = blocksInRange(range);
+          items[0].parentNode.insertBefore(list, items[0]);
+          items.forEach(function (el) {
+            var li = document.createElement('li');
+            if (name === 'taskList') {
+              var cb = document.createElement('input');
+              cb.type = 'checkbox';
+              li.appendChild(cb);
+              li.appendChild(document.createTextNode(' '));
+            }
+            while (el.firstChild) li.appendChild(el.firstChild);
+            el.parentNode.removeChild(el);
+            list.appendChild(li);
+          });
+          selectStart(list);
+        }
+        break;
+      }
+      case 'codeBlock': {
+        var target = blockOf(range.startContainer);
+        if (target) {
+          var pre = document.createElement('pre');
+          var codeChild = document.createElement('code');
+          codeChild.textContent = target.textContent;
+          pre.appendChild(codeChild);
+          target.parentNode.replaceChild(pre, target);
+          selectStart(codeChild);
+        }
+        break;
+      }
+      case 'horizontalRule': {
+        var after = blockOf(range.startContainer);
+        var hr = document.createElement('hr');
+        if (after && after.nextSibling) after.parentNode.insertBefore(hr, after.nextSibling);
+        else editable.appendChild(hr);
+        break;
+      }
+      case 'link': case 'image': {
+        if (name === 'image') {
+          var img = document.createElement('img');
+          img.src = value || '';
+          img.alt = label || '';
+          range.deleteContents();
+          range.insertNode(img);
+        } else {
+          var a = document.createElement('a');
+          a.href = value || '';
+          if (range.collapsed) a.textContent = label || value || '';
+          else a.appendChild(range.extractContents());
+          range.insertNode(a);
+        }
+        break;
+      }
+      case 'insertText':
+        range.deleteContents();
+        range.insertNode(document.createTextNode(value || ''));
+        break;
+    }
+
+    savedRange = null;
+    dirty = true;
+    clearTimeout(inputTimeout);
+    notifyValue();
   };
 
   editable.addEventListener('paste', onPaste);

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7283,38 +7283,84 @@ Radzen.markdownSerialize = function (root) {
   return root ? blocks(root) : '';
 };
 
-Radzen.createMarkdownEditor = function (textarea, instance, shortcuts) {
-  if (!textarea) {
-    return { dispose: function () {} };
+Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts) {
+  if (!editable || !textarea) {
+    return { setContent: function () {}, dispose: function () {} };
   }
 
   shortcuts = shortcuts || [];
+  var editor = { editable: editable, textarea: textarea, instance: instance };
+  var inputTimeout = null;
+  var suppressInput = false;
 
-  var listener = function (e) {
-    if (!(e.ctrlKey || e.metaKey) || !e.code) {
-      return;
-    }
+  var notifyValue = function () {
+    try { suppressDisposed(instance.invokeMethodAsync('OnDesignInputAsync', Radzen.markdownSerialize(editable))); } catch { }
+  };
 
+  var onInput = function () {
+    if (suppressInput) return;
+    clearTimeout(inputTimeout);
+    inputTimeout = setTimeout(notifyValue, 250);
+  };
+
+  var onBlur = function () {
+    clearTimeout(inputTimeout);
+    try { suppressDisposed(instance.invokeMethodAsync('OnDesignChangeAsync', Radzen.markdownSerialize(editable))); } catch { }
+  };
+
+  var onKeyDown = function (e) {
+    if (!(e.ctrlKey || e.metaKey) || !e.code) return;
     var key = 'Ctrl+';
-    if (e.altKey) {
-      key += 'Alt+';
-    }
-    if (e.shiftKey) {
-      key += 'Shift+';
-    }
+    if (e.altKey) key += 'Alt+';
+    if (e.shiftKey) key += 'Shift+';
     key += e.code.replace('Key', '').replace('Digit', '').replace('Numpad', '');
-
     if (shortcuts.includes(key)) {
       e.preventDefault();
       try { suppressDisposed(instance.invokeMethodAsync('ExecuteShortcutAsync', key)); } catch { }
     }
   };
 
-  textarea.addEventListener('keydown', listener);
-
-  return {
-    dispose: function () {
-      textarea.removeEventListener('keydown', listener);
-    }
+  var onPaste = function (e) {
+    var html = e.clipboardData && e.clipboardData.getData('text/html');
+    if (!html) return; // plain-text paste: native behavior is fine
+    e.preventDefault();
+    // launder rich content: pasted HTML → markdown → canonical HTML via .NET
+    var scratch = document.createElement('div');
+    scratch.innerHTML = html;
+    var markdown = Radzen.markdownSerialize(scratch);
+    instance.invokeMethodAsync('RenderMarkdownAsync', markdown).then(function (canonical) {
+      var sel = window.getSelection();
+      if (!sel.rangeCount || !editable.contains(sel.anchorNode)) return;
+      var range = sel.getRangeAt(0);
+      range.deleteContents();
+      var fragment = document.createRange().createContextualFragment(canonical);
+      var last = fragment.lastChild;
+      range.insertNode(fragment);
+      if (last) { range.setStartAfter(last); range.collapse(true); sel.removeAllRanges(); sel.addRange(range); }
+      onInput();
+    });
   };
+
+  editor.setContent = function (html) {
+    suppressInput = true;
+    editable.innerHTML = html;
+    suppressInput = false;
+  };
+
+  editable.addEventListener('paste', onPaste);
+  editable.addEventListener('input', onInput);
+  editable.addEventListener('blur', onBlur);
+  editable.addEventListener('keydown', onKeyDown);
+  textarea.addEventListener('keydown', onKeyDown);
+
+  editor.dispose = function () {
+    clearTimeout(inputTimeout);
+    editable.removeEventListener('paste', onPaste);
+    editable.removeEventListener('input', onInput);
+    editable.removeEventListener('blur', onBlur);
+    editable.removeEventListener('keydown', onKeyDown);
+    textarea.removeEventListener('keydown', onKeyDown);
+  };
+
+  return editor;
 };

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7139,7 +7139,7 @@ Radzen.markdownEditorApply = function (textarea, start, end, replacement, select
     if (document.execCommand) {
       if (replacement.length > 0) {
         document.execCommand('insertText', false, replacement);
-      } else {
+      } else if (start !== end) {
         document.execCommand('delete', false);
       }
     }
@@ -7157,6 +7157,10 @@ Radzen.markdownEditorApply = function (textarea, start, end, replacement, select
 };
 
 Radzen.createMarkdownEditor = function (textarea, instance, shortcuts) {
+  if (!textarea) {
+    return { dispose: function () {} };
+  }
+
   shortcuts = shortcuts || [];
 
   var listener = function (e) {
@@ -7175,7 +7179,7 @@ Radzen.createMarkdownEditor = function (textarea, instance, shortcuts) {
 
     if (shortcuts.includes(key)) {
       e.preventDefault();
-      instance.invokeMethodAsync('ExecuteShortcutAsync', key);
+      try { suppressDisposed(instance.invokeMethodAsync('ExecuteShortcutAsync', key)); } catch { }
     }
   };
 

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7338,6 +7338,42 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     } catch { }
   };
 
+  var onEmojiInput = function (e) {
+    if (!e || e.inputType !== 'insertText' || e.data !== ':') return;
+    var sel = window.getSelection();
+    if (!sel.rangeCount || !sel.isCollapsed) return;
+    var node = sel.anchorNode;
+    if (!node || node.nodeType !== Node.TEXT_NODE || !editable.contains(node)) return;
+    for (var el = node.parentNode; el && el !== editable; el = el.parentNode) {
+      if (el.tagName === 'CODE' || el.tagName === 'PRE') return; // parser skips shortcodes in code
+    }
+    var match = node.data.substring(0, sel.anchorOffset).match(/:([A-Za-z0-9_+-]+):$/);
+    if (!match) return;
+    var start = sel.anchorOffset - match[0].length;
+    var shortcode = match[0];
+    try {
+      suppressDisposed(instance.invokeMethodAsync('LookupEmojiAsync', match[1]).then(function (emoji) {
+        // the lookup is async: bail out if the surface changed underneath it
+        if (!emoji || node.data.substring(start, start + shortcode.length) !== shortcode) return;
+        editor.snapshot(true); // its own history entry, so undo restores the shortcode text
+        var caret = window.getSelection();
+        var caretNode = caret.rangeCount ? caret.anchorNode : null;
+        var caretOffset = caret.rangeCount ? caret.anchorOffset : 0;
+        node.replaceData(start, shortcode.length, emoji);
+        if (caretNode === node) {
+          var end = start + shortcode.length;
+          var offset = caretOffset >= end ? caretOffset - shortcode.length + emoji.length
+            : caretOffset > start ? start + emoji.length : caretOffset;
+          var range = document.createRange();
+          range.setStart(node, Math.min(offset, node.length));
+          range.collapse(true);
+          setRange(range);
+        }
+        onInput();
+      }));
+    } catch { }
+  };
+
   editor.setContent = function (html) {
     clearTimeout(inputTimeout);
     dirty = false;
@@ -7704,6 +7740,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
 
   editable.addEventListener('paste', onPaste);
   editable.addEventListener('input', onInput);
+  editable.addEventListener('input', onEmojiInput);
   editable.addEventListener('blur', onBlur);
   editable.addEventListener('keydown', onKeyDown);
   textarea.addEventListener('keydown', onKeyDown);
@@ -7715,6 +7752,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     clearTimeout(stateTimeout);
     editable.removeEventListener('paste', onPaste);
     editable.removeEventListener('input', onInput);
+    editable.removeEventListener('input', onEmojiInput);
     editable.removeEventListener('blur', onBlur);
     editable.removeEventListener('keydown', onKeyDown);
     textarea.removeEventListener('keydown', onKeyDown);

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7263,6 +7263,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
 
   var notifyValue = function () {
     try { suppressDisposed(instance.invokeMethodAsync('OnDesignInputAsync', Radzen.markdownSerialize(editable))); } catch { }
+    reportState();
   };
 
   var onInput = function () {
@@ -7345,6 +7346,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     textarea.value = before.substring(0, start) + replacement + before.substring(end);
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
     textarea.setSelectionRange(selectionStart, selectionEnd);
+    reportState();
   };
 
   var savedRange = null;
@@ -7521,13 +7523,45 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     history.redo.push(captureState());
     restoreState(history.undo.pop());
     dirty = true;
+    reportState();
   };
   editor.redo = function () {
     if (!history.redo.length) return;
     history.undo.push(captureState());
     restoreState(history.redo.pop());
     dirty = true;
+    reportState();
   };
+
+  var stateTimeout = null;
+  var reportState = function () {
+    clearTimeout(stateTimeout);
+    stateTimeout = setTimeout(function () {
+      var formats = [];
+      var sel = window.getSelection();
+      if (sel.rangeCount && editable.contains(sel.anchorNode)) {
+        for (var node = sel.anchorNode; node && node !== editable; node = node.parentNode) {
+          if (node.nodeType !== Node.ELEMENT_NODE) continue;
+          switch (node.tagName) {
+            case 'STRONG': case 'B': formats.push('bold'); break;
+            case 'EM': case 'I': formats.push('italic'); break;
+            case 'DEL': case 'S': formats.push('strikethrough'); break;
+            case 'CODE': formats.push('code'); break;
+            case 'BLOCKQUOTE': formats.push('quote'); break;
+            case 'UL': formats.push('unorderedList'); break;
+            case 'OL': formats.push('orderedList'); break;
+          }
+          if (/^H[1-6]$/.test(node.tagName)) formats.push('heading');
+        }
+      }
+      try {
+        suppressDisposed(instance.invokeMethodAsync('OnToolStateAsync', {
+          formats: formats, canUndo: history.undo.length > 0, canRedo: history.redo.length > 0
+        }));
+      } catch { }
+    }, 100);
+  };
+  document.addEventListener('selectionchange', reportState);
 
   var onBeforeInput = function (e) {
     var type = e.inputType || '';
@@ -7659,6 +7693,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     dirty = true;
     clearTimeout(inputTimeout);
     notifyValue();
+    reportState();
   };
 
   editable.addEventListener('paste', onPaste);
@@ -7671,6 +7706,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
 
   editor.dispose = function () {
     clearTimeout(inputTimeout);
+    clearTimeout(stateTimeout);
     editable.removeEventListener('paste', onPaste);
     editable.removeEventListener('input', onInput);
     editable.removeEventListener('blur', onBlur);
@@ -7678,6 +7714,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     textarea.removeEventListener('keydown', onKeyDown);
     editable.removeEventListener('beforeinput', onBeforeInput);
     textarea.removeEventListener('beforeinput', onBeforeInput);
+    document.removeEventListener('selectionchange', reportState);
   };
 
   return editor;

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7128,7 +7128,8 @@ Radzen.markdownSerialize = function (root) {
     return text.replace(/[\\`*_~\[\]]/g, function (c) { return '\\' + c; });
   };
   var escapeBlockStart = function (line) {
-    return line.replace(/^(\s*)([#>+-]|\d+[.)])(\s)/, '$1\\$2$3');
+    return line.replace(/^(\s*)([#>+-])(\s)/, '$1\\$2$3')
+               .replace(/^(\s*)(\d+)([.)])(\s)/, '$1$2\\$3$4');
   };
   var styleWraps = function (el) {
     var wraps = [];

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7292,6 +7292,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
   var editor = { editable: editable, textarea: textarea, instance: instance };
   var inputTimeout = null;
   var suppressInput = false;
+  var dirty = false; // true once the surface has genuinely been edited since the last setContent/blur flush
 
   var notifyValue = function () {
     try { suppressDisposed(instance.invokeMethodAsync('OnDesignInputAsync', Radzen.markdownSerialize(editable))); } catch { }
@@ -7299,12 +7300,15 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
 
   var onInput = function () {
     if (suppressInput) return;
+    dirty = true;
     clearTimeout(inputTimeout);
     inputTimeout = setTimeout(notifyValue, 250);
   };
 
   var onBlur = function () {
     clearTimeout(inputTimeout);
+    if (!dirty) return; // matches RadzenTextArea semantics: no edit, no Change
+    dirty = false;
     try { suppressDisposed(instance.invokeMethodAsync('OnDesignChangeAsync', Radzen.markdownSerialize(editable))); } catch { }
   };
 
@@ -7345,6 +7349,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
 
   editor.setContent = function (html) {
     clearTimeout(inputTimeout);
+    dirty = false;
     suppressInput = true;
     editable.innerHTML = html;
     suppressInput = false;

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7122,3 +7122,63 @@ Radzen.datePickerKeydown = function (e) {
   }
 };
 document.addEventListener('keydown', Radzen.datePickerKeydown);
+
+Radzen.markdownEditorApply = function (textarea, start, end, replacement, selectionStart, selectionEnd) {
+  if (!textarea) {
+    return;
+  }
+
+  textarea.focus();
+  textarea.setSelectionRange(start, end);
+
+  var applied = false;
+  try {
+    // execCommand keeps the browser's native undo stack intact.
+    if (document.execCommand) {
+      applied = replacement.length > 0
+        ? document.execCommand('insertText', false, replacement)
+        : document.execCommand('delete', false);
+    }
+  } catch (e) {
+    applied = false;
+  }
+
+  if (!applied || textarea.value.substring(start, start + replacement.length) !== replacement) {
+    textarea.setRangeText(replacement, start, end, 'end');
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  textarea.setSelectionRange(selectionStart, selectionEnd);
+};
+
+Radzen.createMarkdownEditor = function (textarea, instance, shortcuts) {
+  shortcuts = shortcuts || [];
+
+  var listener = function (e) {
+    if (!(e.ctrlKey || e.metaKey) || !e.code) {
+      return;
+    }
+
+    var key = 'Ctrl+';
+    if (e.altKey) {
+      key += 'Alt+';
+    }
+    if (e.shiftKey) {
+      key += 'Shift+';
+    }
+    key += e.code.replace('Key', '').replace('Digit', '').replace('Numpad', '');
+
+    if (shortcuts.includes(key)) {
+      e.preventDefault();
+      instance.invokeMethodAsync('ExecuteShortcutAsync', key);
+    }
+  };
+
+  textarea.addEventListener('keydown', listener);
+
+  return {
+    dispose: function () {
+      textarea.removeEventListener('keydown', listener);
+    }
+  };
+};

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7156,6 +7156,133 @@ Radzen.markdownEditorApply = function (textarea, start, end, replacement, select
   textarea.setSelectionRange(selectionStart, selectionEnd);
 };
 
+Radzen.markdownSerialize = function (root) {
+  var escapeText = function (text) {
+    return text.replace(/[\\`*_~\[\]]/g, function (c) { return '\\' + c; });
+  };
+  var escapeBlockStart = function (line) {
+    return line.replace(/^(\s*)([#>+-]|\d+[.)])(\s)/, '$1\\$2$3');
+  };
+  var styleWraps = function (el) {
+    var wraps = [];
+    var s = el.style;
+    if (s.fontWeight === 'bold' || parseInt(s.fontWeight, 10) >= 600) wraps.push('**');
+    if (s.fontStyle === 'italic') wraps.push('*');
+    if ((s.textDecoration || '').indexOf('line-through') >= 0) wraps.push('~~');
+    return wraps;
+  };
+  var wrap = function (token, inner) {
+    var m = inner.match(/^(\s*)([\s\S]*?)(\s*)$/); // keep edge whitespace outside tokens
+    return m[2] ? m[1] + token + m[2] + token + m[3] : inner;
+  };
+  var inline = function (node) {
+    var out = '';
+    node.childNodes.forEach(function (child) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        out += escapeText(child.data.replace(/\s+/g, ' '));
+        return;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) return;
+      switch (child.tagName) {
+        case 'STRONG': case 'B': out += wrap('**', inline(child)); break;
+        case 'EM': case 'I': out += wrap('*', inline(child)); break;
+        case 'DEL': case 'S': case 'STRIKE': out += wrap('~~', inline(child)); break;
+        case 'CODE': {
+          var code = child.textContent;
+          out += code.indexOf('`') >= 0 ? '`` ' + code + ' ``' : '`' + code + '`';
+          break;
+        }
+        case 'A': out += '[' + inline(child) + '](' + (child.getAttribute('href') || '') + ')'; break;
+        case 'IMG': out += '![' + (child.getAttribute('alt') || '') + '](' + (child.getAttribute('src') || '') + ')'; break;
+        case 'BR': out += '  \n'; break;
+        case 'INPUT': break; // task checkboxes are handled by the list item
+        default: {
+          var text = inline(child);
+          styleWraps(child).forEach(function (token) { text = wrap(token, text); });
+          out += text;
+        }
+      }
+    });
+    return out;
+  };
+  var paragraph = function (el) {
+    var text = inline(el).replace(/^[ ]+|[ ]+$/g, '');
+    return text ? text.split('\n').map(escapeBlockStart).join('\n') : '';
+  };
+  var indent = function (text, first, rest) {
+    return text.split('\n').map(function (line, i) {
+      return (i === 0 ? first : rest) + line;
+    }).join('\n').replace(/[ ]+$/gm, '');
+  };
+  var listItem = function (li, marker) {
+    var checkbox = li.querySelector(':scope > input[type=checkbox], :scope > p:first-child > input[type=checkbox]:first-child');
+    if (checkbox) marker += checkbox.checked ? '[x] ' : '[ ] ';
+    var content = blocks(li) || '';
+    return indent(content, marker, ' '.repeat(marker.length));
+  };
+  var tableCell = function (cell) { return inline(cell).trim().replace(/\|/g, '\\|'); };
+  var block = function (el) {
+    switch (el.tagName) {
+      case 'H1': case 'H2': case 'H3': case 'H4': case 'H5': case 'H6':
+        return '#'.repeat(+el.tagName[1]) + ' ' + paragraph(el);
+      case 'P': case 'DIV': return paragraph(el);
+      case 'BLOCKQUOTE':
+        return (blocks(el) || '').split('\n').map(function (l) { return ('> ' + l).replace(/[ ]+$/, ''); }).join('\n');
+      case 'UL':
+        return Array.prototype.map.call(el.children, function (li) { return listItem(li, '- '); }).join('\n');
+      case 'OL': {
+        var start = parseInt(el.getAttribute('start'), 10) || 1;
+        return Array.prototype.map.call(el.children, function (li, i) { return listItem(li, (start + i) + '. '); }).join('\n');
+      }
+      case 'PRE': {
+        var codeEl = el.querySelector('code');
+        var lang = ((codeEl && codeEl.className || '').match(/language-(\S+)/) || [])[1] || '';
+        var code = (codeEl || el).textContent.replace(/\n$/, '');
+        var fence = /```/.test(code) ? '````' : '```';
+        return fence + lang + '\n' + code + '\n' + fence;
+      }
+      case 'HR': return '---';
+      case 'TABLE': {
+        var rows = Array.prototype.slice.call(el.querySelectorAll('tr'));
+        if (!rows.length) return '';
+        var line = function (cells) { return '| ' + cells.join(' | ') + ' |'; };
+        var header = Array.prototype.map.call(rows[0].cells, tableCell);
+        var aligns = Array.prototype.map.call(rows[0].cells, function (cell) {
+          var a = cell.style.textAlign;
+          return a === 'center' ? ':---:' : a === 'right' ? '---:' : '---';
+        });
+        var body = rows.slice(1).map(function (row) {
+          return line(Array.prototype.map.call(row.cells, tableCell));
+        });
+        return [line(header), line(aligns)].concat(body).join('\n');
+      }
+      default: return paragraph(el);
+    }
+  };
+  var blocks = function (parent) {
+    var out = [], pending = null;
+    var flush = function () {
+      if (pending) { var text = paragraph(pending); if (text) out.push(text); pending = null; }
+    };
+    parent.childNodes.forEach(function (child) {
+      var isBlock = child.nodeType === Node.ELEMENT_NODE &&
+        /^(H[1-6]|P|DIV|BLOCKQUOTE|UL|OL|PRE|HR|TABLE)$/.test(child.tagName);
+      if (isBlock) {
+        flush();
+        var text = block(child);
+        if (text) out.push(text);
+      } else {
+        // stray inline content at block level accumulates into an implicit paragraph
+        if (!pending) { pending = document.createElement('p'); }
+        pending.appendChild(child.cloneNode(true));
+      }
+    });
+    flush();
+    return out.join('\n\n');
+  };
+  return root ? blocks(root) : '';
+};
+
 Radzen.createMarkdownEditor = function (textarea, instance, shortcuts) {
   if (!textarea) {
     return { dispose: function () {} };

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7267,6 +7267,11 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     reportState();
   };
 
+  // mirrors HtmlSanitizer.IsDangerousUrl (Radzen.Blazor/Documents/Markdown/HtmlSanitizer.cs)
+  var isDangerousUrl = function (url) {
+    return /^\s*(javascript|vbscript|data:text\/html)/i.test(url || '');
+  };
+
   var onInput = function () {
     if (suppressInput) return;
     dirty = true;
@@ -7314,8 +7319,9 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     lastInputType = 'insertFromPaste';
     lastInputTime = Date.now();
     // launder rich content: pasted HTML → markdown → canonical HTML via .NET
-    var scratch = document.createElement('div');
-    scratch.innerHTML = html;
+    // parsed via DOMParser (not a live-document div) so clipboard HTML like
+    // <img src=x onerror=...> can't execute while markdownSerialize reads it
+    var scratch = new DOMParser().parseFromString(html, 'text/html').body;
     var markdown = Radzen.markdownSerialize(scratch);
     try {
       suppressDisposed(instance.invokeMethodAsync('RenderMarkdownAsync', markdown).then(function (canonical) {
@@ -7671,13 +7677,13 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
       case 'link': case 'image': {
         if (name === 'image') {
           var img = document.createElement('img');
-          img.src = value || '';
+          img.src = isDangerousUrl(value) ? '' : (value || '');
           img.alt = label || '';
           range.deleteContents();
           range.insertNode(img);
         } else {
           var a = document.createElement('a');
-          a.href = value || '';
+          a.href = isDangerousUrl(value) ? '' : (value || '');
           if (range.collapsed) a.textContent = label || value || '';
           else a.appendChild(range.extractContents());
           range.insertNode(a);
@@ -7694,7 +7700,6 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     dirty = true;
     clearTimeout(inputTimeout);
     notifyValue();
-    reportState();
   };
 
   editable.addEventListener('paste', onPaste);

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7128,23 +7128,28 @@ Radzen.markdownEditorApply = function (textarea, start, end, replacement, select
     return;
   }
 
+  var before = textarea.value;
+  var expected = before.substring(0, start) + replacement + before.substring(end);
+
   textarea.focus();
   textarea.setSelectionRange(start, end);
 
-  var applied = false;
   try {
     // execCommand keeps the browser's native undo stack intact.
     if (document.execCommand) {
-      applied = replacement.length > 0
-        ? document.execCommand('insertText', false, replacement)
-        : document.execCommand('delete', false);
+      if (replacement.length > 0) {
+        document.execCommand('insertText', false, replacement);
+      } else {
+        document.execCommand('delete', false);
+      }
     }
   } catch (e) {
-    applied = false;
+    // fall through to the verification below
   }
 
-  if (!applied || textarea.value.substring(start, start + replacement.length) !== replacement) {
-    textarea.setRangeText(replacement, start, end, 'end');
+  if (textarea.value !== expected) {
+    // execCommand unsupported or applied incorrectly: set the exact result (native undo is lost only on this path).
+    textarea.value = expected;
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
   }
 

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7281,6 +7281,17 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
 
   var onKeyDown = function (e) {
     if (!(e.ctrlKey || e.metaKey) || !e.code) return;
+    var codeKey = e.code;
+    if (codeKey === 'KeyZ' && !e.altKey) {
+      e.preventDefault();
+      if (e.shiftKey) editor.redo(); else editor.undo();
+      return;
+    }
+    if (codeKey === 'KeyY' && !e.altKey && !e.shiftKey) {
+      e.preventDefault();
+      editor.redo();
+      return;
+    }
     var key = 'Ctrl+';
     if (e.altKey) key += 'Alt+';
     if (e.shiftKey) key += 'Shift+';
@@ -7323,6 +7334,7 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
   };
 
   editor.apply = function (start, end, replacement, selectionStart, selectionEnd) {
+    editor.snapshot(true);
     var before = textarea.value;
     textarea.focus();
     textarea.value = before.substring(0, start) + replacement + before.substring(end);
@@ -7424,12 +7436,109 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     return !!range && !range.collapsed;
   };
 
+  var history = { undo: [], redo: [] };
+  var lastInputTime = 0, lastInputType = null;
+  var HISTORY_LIMIT = 100;
+
+  var nodePath = function (node) {
+    var path = [];
+    while (node && node !== editable) {
+      var parent = node.parentNode;
+      path.unshift(Array.prototype.indexOf.call(parent.childNodes, node));
+      node = parent;
+    }
+    return path;
+  };
+  var resolvePath = function (path) {
+    var node = editable;
+    for (var i = 0; i < path.length && node; i++) node = node.childNodes[path[i]];
+    return node;
+  };
+  var captureState = function () {
+    var mode = textarea.hidden ? 'design' : 'source';
+    var state = { mode: mode, markdown: Radzen.markdownSerialize(editable) };
+    if (mode === 'design') {
+      state.html = editable.innerHTML;
+      var sel = window.getSelection();
+      if (sel.rangeCount && editable.contains(sel.anchorNode)) {
+        var range = sel.getRangeAt(0);
+        state.sel = {
+          sp: nodePath(range.startContainer), so: range.startOffset,
+          ep: nodePath(range.endContainer), eo: range.endOffset
+        };
+      }
+    } else {
+      state.markdown = textarea.value;
+      state.sel = { start: textarea.selectionStart, end: textarea.selectionEnd };
+    }
+    return state;
+  };
+  var restoreState = function (state) {
+    var mode = textarea.hidden ? 'design' : 'source';
+    if (mode === 'design') {
+      if (state.mode === 'design' && state.html !== undefined) {
+        editor.setContent(state.html);
+        if (state.sel) {
+          var start = resolvePath(state.sel.sp), end = resolvePath(state.sel.ep);
+          if (start && end) {
+            var range = document.createRange();
+            range.setStart(start, Math.min(state.sel.so, (start.length !== undefined ? start.length : start.childNodes.length)));
+            range.setEnd(end, Math.min(state.sel.eo, (end.length !== undefined ? end.length : end.childNodes.length)));
+            setRange(range);
+          }
+        }
+      } else {
+        // cross-mode entry: re-render markdown via .NET
+        instance.invokeMethodAsync('RenderMarkdownAsync', state.markdown).then(function (html) {
+          editor.setContent(html);
+        });
+      }
+    } else {
+      textarea.value = state.markdown;
+      if (state.sel && state.sel.start !== undefined) {
+        textarea.setSelectionRange(state.sel.start, state.sel.end);
+      }
+    }
+    try { suppressDisposed(instance.invokeMethodAsync('OnDesignInputAsync', state.markdown)); } catch { }
+  };
+
+  editor.snapshot = function (force) {
+    var now = Date.now();
+    if (!force && now - lastInputTime < 1000) return;
+    history.undo.push(captureState());
+    if (history.undo.length > HISTORY_LIMIT) history.undo.shift();
+    history.redo = [];
+    lastInputTime = now;
+  };
+  editor.undo = function () {
+    if (!history.undo.length) return;
+    history.redo.push(captureState());
+    restoreState(history.undo.pop());
+  };
+  editor.redo = function () {
+    if (!history.redo.length) return;
+    history.undo.push(captureState());
+    restoreState(history.redo.pop());
+  };
+
+  var onBeforeInput = function (e) {
+    var type = e.inputType || '';
+    var boundary = (type.indexOf('delete') === 0) !== ((lastInputType || '').indexOf('delete') === 0)
+      || type === 'insertParagraph' || type === 'insertFromPaste';
+    editor.snapshot(boundary);
+    lastInputType = type;
+    lastInputTime = Date.now();
+  };
+
   editor.execute = function (name, value, label) {
+    if (name === 'undo') { editor.undo(); return; }
+    if (name === 'redo') { editor.redo(); return; }
+
     var range = currentRange();
     if (!range) { editable.focus(); range = currentRange(); if (!range) return; }
     editable.focus();
     setRange(range);
-    if (editor.snapshot) editor.snapshot(true); // Task 10 provides this
+    editor.snapshot(true);
 
     switch (name) {
       case 'bold': toggleInline(range, 'strong', ['STRONG', 'B']); break;
@@ -7549,6 +7658,8 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
   editable.addEventListener('blur', onBlur);
   editable.addEventListener('keydown', onKeyDown);
   textarea.addEventListener('keydown', onKeyDown);
+  editable.addEventListener('beforeinput', onBeforeInput);
+  textarea.addEventListener('beforeinput', onBeforeInput);
 
   editor.dispose = function () {
     clearTimeout(inputTimeout);
@@ -7557,6 +7668,8 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     editable.removeEventListener('blur', onBlur);
     editable.removeEventListener('keydown', onKeyDown);
     textarea.removeEventListener('keydown', onKeyDown);
+    editable.removeEventListener('beforeinput', onBeforeInput);
+    textarea.removeEventListener('beforeinput', onBeforeInput);
   };
 
   return editor;

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7249,7 +7249,7 @@ Radzen.markdownSerialize = function (root) {
         var header = Array.prototype.map.call(rows[0].cells, tableCell);
         var aligns = Array.prototype.map.call(rows[0].cells, function (cell) {
           var a = cell.style.textAlign;
-          return a === 'center' ? ':---:' : a === 'right' ? '---:' : '---';
+          return a === 'center' ? ':---:' : a === 'right' ? '---:' : a === 'left' ? ':---' : '---';
         });
         var body = rows.slice(1).map(function (row) {
           return line(Array.prototype.map.call(row.cells, tableCell));

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7351,6 +7351,12 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
   };
   var blocksInRange = function (range) {
     var first = blockOf(range.startContainer), last = blockOf(range.endContainer);
+    if (!first || !last) {
+      // empty editable: blockOf climbed out without finding a block. Give the command
+      // something to operate on instead of an empty list.
+      first = last = document.createElement('p');
+      editable.appendChild(first);
+    }
     var result = [];
     for (var el = first; el; el = el.nextSibling) {
       result.push(el);
@@ -7489,14 +7495,18 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
       }
       case 'codeBlock': {
         var target = blockOf(range.startContainer);
-        if (target) {
-          var pre = document.createElement('pre');
-          var codeChild = document.createElement('code');
-          codeChild.textContent = target.textContent;
-          pre.appendChild(codeChild);
-          target.parentNode.replaceChild(pre, target);
-          selectStart(codeChild);
+        if (!target) {
+          // empty editable: give the command an empty block to convert, consistent with
+          // heading/quote/list via blocksInRange above.
+          target = document.createElement('p');
+          editable.appendChild(target);
         }
+        var pre = document.createElement('pre');
+        var codeChild = document.createElement('code');
+        codeChild.textContent = target.textContent;
+        pre.appendChild(codeChild);
+        target.parentNode.replaceChild(pre, target);
+        selectStart(codeChild);
         break;
       }
       case 'horizontalRule': {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7306,6 +7306,11 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     var html = e.clipboardData && e.clipboardData.getData('text/html');
     if (!html) return; // plain-text paste: native behavior is fine
     e.preventDefault();
+    // preventDefault suppresses the native beforeinput/insertFromPaste that onBeforeInput
+    // would otherwise snapshot on, so checkpoint here before laundering mutates the DOM.
+    editor.snapshot(true);
+    lastInputType = 'insertFromPaste';
+    lastInputTime = Date.now();
     // launder rich content: pasted HTML → markdown → canonical HTML via .NET
     var scratch = document.createElement('div');
     scratch.innerHTML = html;
@@ -7456,8 +7461,9 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
   };
   var captureState = function () {
     var mode = textarea.hidden ? 'design' : 'source';
-    var state = { mode: mode, markdown: Radzen.markdownSerialize(editable) };
+    var state = { mode: mode };
     if (mode === 'design') {
+      state.markdown = Radzen.markdownSerialize(editable);
       state.html = editable.innerHTML;
       var sel = window.getSelection();
       if (sel.rangeCount && editable.contains(sel.anchorNode)) {
@@ -7514,11 +7520,13 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     if (!history.undo.length) return;
     history.redo.push(captureState());
     restoreState(history.undo.pop());
+    dirty = true;
   };
   editor.redo = function () {
     if (!history.redo.length) return;
     history.undo.push(captureState());
     restoreState(history.redo.pop());
+    dirty = true;
   };
 
   var onBeforeInput = function (e) {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -7328,20 +7328,23 @@ Radzen.createMarkdownEditor = function (editable, textarea, instance, shortcuts)
     var scratch = document.createElement('div');
     scratch.innerHTML = html;
     var markdown = Radzen.markdownSerialize(scratch);
-    instance.invokeMethodAsync('RenderMarkdownAsync', markdown).then(function (canonical) {
-      var sel = window.getSelection();
-      if (!sel.rangeCount || !editable.contains(sel.anchorNode)) return;
-      var range = sel.getRangeAt(0);
-      range.deleteContents();
-      var fragment = document.createRange().createContextualFragment(canonical);
-      var last = fragment.lastChild;
-      range.insertNode(fragment);
-      if (last) { range.setStartAfter(last); range.collapse(true); sel.removeAllRanges(); sel.addRange(range); }
-      onInput();
-    });
+    try {
+      suppressDisposed(instance.invokeMethodAsync('RenderMarkdownAsync', markdown).then(function (canonical) {
+        var sel = window.getSelection();
+        if (!sel.rangeCount || !editable.contains(sel.anchorNode)) return;
+        var range = sel.getRangeAt(0);
+        range.deleteContents();
+        var fragment = document.createRange().createContextualFragment(canonical);
+        var last = fragment.lastChild;
+        range.insertNode(fragment);
+        if (last) { range.setStartAfter(last); range.collapse(true); sel.removeAllRanges(); sel.addRange(range); }
+        onInput();
+      }));
+    } catch { }
   };
 
   editor.setContent = function (html) {
+    clearTimeout(inputTimeout);
     suppressInput = true;
     editable.innerHTML = html;
     suppressInput = false;

--- a/RadzenBlazorDemos/Pages/MarkdownEditor.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditor.razor
@@ -5,11 +5,21 @@
 </RadzenStack>
 
 @code {
-    MarkdownEditorMode mode = MarkdownEditorMode.Source;
-    string markdown = @"# Hello, Markdown :wave:
+    MarkdownEditorMode mode = MarkdownEditorMode.Design;
+    string markdown = @"# Hello, Markdown
 
-- Select text and use the **toolbar** or `Ctrl+B` / `Ctrl+I` / `Ctrl+K`.
-- Switch between *Write*, *Preview* and *Split*.
+Edit this text **directly** — it round-trips to *markdown*. Toggle ~~WYSIWYG~~ **Design** and **Source** mode in the toolbar.
+
+- [x] A task list item
+- [ ] Bold, italic and `code` via the toolbar or Ctrl+B / Ctrl+I / Ctrl+K
+- Undo and redo with Ctrl+Z / Ctrl+Shift+Z
+
+> Blockquotes, [links](https://blazor.radzen.com) and tables work too:
+
+| Feature | Mode |
+| --- | --- |
+| WYSIWYG | Design |
+| Raw markdown | Source |
 
 ```csharp
 var editor = new RadzenMarkdownEditor();

--- a/RadzenBlazorDemos/Pages/MarkdownEditor.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditor.razor
@@ -1,0 +1,17 @@
+<RadzenStack Gap="1rem">
+    <RadzenMarkdownEditor @bind-Value=@markdown @bind-Mode=@mode Style="min-height: 300px" />
+    <RadzenText TextStyle="TextStyle.Caption">Mode: @mode</RadzenText>
+    <RadzenTextArea Value=@markdown ReadOnly="true" Style="width: 100%; height: 120px" />
+</RadzenStack>
+
+@code {
+    MarkdownEditorMode mode = MarkdownEditorMode.Split;
+    string markdown = @"# Hello, Markdown :wave:
+
+- Select text and use the **toolbar** or `Ctrl+B` / `Ctrl+I` / `Ctrl+K`.
+- Switch between *Write*, *Preview* and *Split*.
+
+```csharp
+var editor = new RadzenMarkdownEditor();
+```";
+}

--- a/RadzenBlazorDemos/Pages/MarkdownEditor.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditor.razor
@@ -5,7 +5,7 @@
 </RadzenStack>
 
 @code {
-    MarkdownEditorMode mode = MarkdownEditorMode.Split;
+    MarkdownEditorMode mode = MarkdownEditorMode.Source;
     string markdown = @"# Hello, Markdown :wave:
 
 - Select text and use the **toolbar** or `Ctrl+B` / `Ctrl+I` / `Ctrl+K`.

--- a/RadzenBlazorDemos/Pages/MarkdownEditorCustomTools.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditorCustomTools.razor
@@ -1,0 +1,23 @@
+<RadzenMarkdownEditor @bind-Value=@markdown Execute=@OnExecute Style="min-height: 200px">
+    <RadzenMarkdownEditorBold />
+    <RadzenMarkdownEditorItalic />
+    <RadzenMarkdownEditorSeparator />
+    <RadzenMarkdownEditorCustomTool CommandName="InsertToday" Icon="today" Title="Insert today's date" />
+    <RadzenMarkdownEditorCustomTool>
+        <Template Context="editor">
+            <RadzenButton Size="ButtonSize.Small" Variant="Variant.Text" Text="Clear" Click="@(() => editor.ExecuteCommandAsync(MarkdownEditorCommands.InsertText, string.Empty))" />
+        </Template>
+    </RadzenMarkdownEditorCustomTool>
+</RadzenMarkdownEditor>
+
+@code {
+    string markdown = "Click the calendar tool to insert today's date.";
+
+    async Task OnExecute(MarkdownEditorExecuteEventArgs args)
+    {
+        if (args.CommandName == "InsertToday")
+        {
+            await args.Editor.ExecuteCommandAsync(MarkdownEditorCommands.InsertText, DateTime.Today.ToLongDateString());
+        }
+    }
+}

--- a/RadzenBlazorDemos/Pages/MarkdownEditorCustomTools.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditorCustomTools.razor
@@ -5,7 +5,7 @@
     <RadzenMarkdownEditorCustomTool CommandName="InsertToday" Icon="today" Title="Insert today's date" />
     <RadzenMarkdownEditorCustomTool>
         <Template Context="editor">
-            <RadzenButton Size="ButtonSize.Small" Variant="Variant.Text" Text="Clear" Click="@(() => editor.ExecuteCommandAsync(MarkdownEditorCommands.InsertText, string.Empty))" />
+            <RadzenButton Size="ButtonSize.Small" Variant="Variant.Text" Text="Delete selection" Click="@(() => editor.ExecuteCommandAsync(MarkdownEditorCommands.InsertText, string.Empty))" />
         </Template>
     </RadzenMarkdownEditorCustomTool>
 </RadzenMarkdownEditor>

--- a/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
@@ -1,0 +1,22 @@
+@page "/markdown-editor"
+
+<RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
+    Blazor Markdown Editor
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    The Blazor Markdown Editor component (RadzenMarkdownEditor) edits Markdown with a toolbar, keyboard shortcuts and a live preview rendered by RadzenMarkdown. Switch between Write, Preview and Split mode.
+</RadzenText>
+
+<RadzenExample ComponentName="MarkdownEditor" Example="MarkdownEditor">
+    <MarkdownEditor />
+</RadzenExample>
+
+<RadzenText Anchor="markdown-editor#custom-tools" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    Custom tools
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Provide your own toolbar by placing tools inside <strong>RadzenMarkdownEditor</strong>. Use <code>RadzenMarkdownEditorCustomTool</code> to add buttons that run your own commands via the <code>Execute</code> event, or render arbitrary content with its <code>Template</code>.
+</RadzenText>
+<RadzenExample ComponentName="MarkdownEditor" Example="MarkdownEditorCustomTools">
+    <MarkdownEditorCustomTools />
+</RadzenExample>

--- a/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
@@ -4,7 +4,7 @@
     Blazor Markdown Editor
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
-    The Blazor Markdown Editor component (RadzenMarkdownEditor) edits Markdown with a toolbar, keyboard shortcuts and a live preview rendered by RadzenMarkdown. Switch between Write, Preview and Split mode.
+    The Blazor Markdown Editor component (RadzenMarkdownEditor) edits Markdown with a toolbar and keyboard shortcuts. It defaults to a WYSIWYG Design mode rendered by RadzenMarkdown, with a Source mode to edit the raw Markdown text.
 </RadzenText>
 
 <RadzenExample ComponentName="MarkdownEditor" Example="MarkdownEditor">
@@ -29,17 +29,19 @@ The Radzen MarkdownEditor supports the following tools. Place them inside <stron
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Body1">
     <ul style="line-height: 2rem">
+        <li>RadzenMarkdownEditorUndo - undoes the last change.</li>
+        <li>RadzenMarkdownEditorRedo - redoes the last undone change.</li>
         <li>RadzenMarkdownEditorSeparator - displays a vertical separator used to delimit groups of similar tools.</li>
         <li>RadzenMarkdownEditorBold - toggles <code>**bold**</code> on the selected text.</li>
         <li>RadzenMarkdownEditorItalic - toggles <code>_italic_</code> on the selected text.</li>
-        <li>RadzenMarkdownEditorStrikethrough - toggles <code>~~strikethrough~~</code> on the selected text. Not rendered by RadzenMarkdown, therefore not part of the default toolbar.</li>
+        <li>RadzenMarkdownEditorStrikethrough - toggles <code>~~strikethrough~~</code> on the selected text.</li>
         <li>RadzenMarkdownEditorHeading - cycles the heading level of the selected lines (<code>#</code>, <code>##</code>, <code>###</code>, none).</li>
         <li>RadzenMarkdownEditorQuote - toggles <code>&gt; </code> block quotes on the selected lines.</li>
         <li>RadzenMarkdownEditorCode - toggles inline <code>`code`</code> on the selected text.</li>
         <li>RadzenMarkdownEditorCodeBlock - wraps the selection in a fenced <code>```</code> code block.</li>
         <li>RadzenMarkdownEditorUnorderedList - toggles a bullet list (<code>- </code>) on the selected lines.</li>
         <li>RadzenMarkdownEditorOrderedList - toggles a numbered list (<code>1. </code>) on the selected lines.</li>
-        <li>RadzenMarkdownEditorTaskList - toggles a task list (<code>- [ ] </code>) on the selected lines. Not rendered by RadzenMarkdown, therefore not part of the default toolbar.</li>
+        <li>RadzenMarkdownEditorTaskList - toggles a task list (<code>- [ ] </code>) on the selected lines.</li>
         <li>RadzenMarkdownEditorLink - inserts a link; opens a dialog for the URL (and text when nothing is selected).</li>
         <li>RadzenMarkdownEditorImage - inserts an image by URL; opens a dialog for the URL (and alternative text when nothing is selected).</li>
         <li>RadzenMarkdownEditorHorizontalRule - inserts a horizontal rule (<code>---</code>) on its own line.</li>
@@ -51,7 +53,7 @@ The Radzen MarkdownEditor supports the following tools. Place them inside <stron
     Keyboard Navigation
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
-    The following keys or key combinations provide a way for users to navigate and interact with Radzen Blazor MarkdownEditor component.
+    The following keys or key combinations provide a way for users to navigate and interact with Radzen Blazor MarkdownEditor component. Shortcuts work the same in Design and Source mode.
 </RadzenText>
 
 <RadzenTable>
@@ -97,14 +99,9 @@ The Radzen MarkdownEditor supports the following tools. Place them inside <stron
             <RadzenTableCell>Redo the last undone change.</RadzenTableCell>
         </RadzenTableRow>
         <RadzenTableRow>
-            <RadzenTableCell><RadzenBadge Text="←" /> / <RadzenBadge Text="→" /></RadzenTableCell>
-            <RadzenTableCell><RadzenBadge Text="←" /> / <RadzenBadge Text="→" /></RadzenTableCell>
-            <RadzenTableCell>In Split mode, with the splitter handle focused (reach it with Tab): resize the editor and preview panes.</RadzenTableCell>
-        </RadzenTableRow>
-        <RadzenTableRow>
-            <RadzenTableCell><RadzenBadge Text="Home" /> / <RadzenBadge Text="End" /></RadzenTableCell>
-            <RadzenTableCell><RadzenBadge Text="Home" /> / <RadzenBadge Text="End" /></RadzenTableCell>
-            <RadzenTableCell>With the splitter handle focused: move the split to its minimum / maximum position.</RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="Y" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="⌘" /> + <RadzenBadge Text="Y" /></RadzenTableCell>
+            <RadzenTableCell>Redo the last undone change (alternative to Ctrl+Shift+Z).</RadzenTableCell>
         </RadzenTableRow>
     </RadzenTableBody>
 </RadzenTable>

--- a/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
@@ -20,3 +20,86 @@
 <RadzenExample ComponentName="MarkdownEditor" Example="MarkdownEditorCustomTools">
     <MarkdownEditorCustomTools />
 </RadzenExample>
+
+<RadzenText Anchor="markdown-editor#all-tools" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    All tools
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+The Radzen MarkdownEditor supports the following tools. Place them inside <strong>RadzenMarkdownEditor</strong> to compose your own toolbar; without child content the default toolbar is used.
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1">
+    <ul style="line-height: 2rem">
+        <li>RadzenMarkdownEditorSeparator - displays a vertical separator used to delimit groups of similar tools.</li>
+        <li>RadzenMarkdownEditorBold - toggles <code>**bold**</code> on the selected text.</li>
+        <li>RadzenMarkdownEditorItalic - toggles <code>_italic_</code> on the selected text.</li>
+        <li>RadzenMarkdownEditorStrikethrough - toggles <code>~~strikethrough~~</code> on the selected text. Not rendered by RadzenMarkdown yet, therefore not part of the default toolbar.</li>
+        <li>RadzenMarkdownEditorHeading - cycles the heading level of the selected lines (<code>#</code>, <code>##</code>, <code>###</code>, none).</li>
+        <li>RadzenMarkdownEditorQuote - toggles <code>&gt; </code> block quotes on the selected lines.</li>
+        <li>RadzenMarkdownEditorCode - toggles inline <code>`code`</code> on the selected text.</li>
+        <li>RadzenMarkdownEditorCodeBlock - wraps the selection in a fenced <code>```</code> code block.</li>
+        <li>RadzenMarkdownEditorUnorderedList - toggles a bullet list (<code>- </code>) on the selected lines.</li>
+        <li>RadzenMarkdownEditorOrderedList - toggles a numbered list (<code>1. </code>) on the selected lines.</li>
+        <li>RadzenMarkdownEditorTaskList - toggles a task list (<code>- [ ] </code>) on the selected lines. Not rendered by RadzenMarkdown yet, therefore not part of the default toolbar.</li>
+        <li>RadzenMarkdownEditorLink - inserts a link; opens a dialog for the URL (and text when nothing is selected).</li>
+        <li>RadzenMarkdownEditorImage - inserts an image by URL; opens a dialog for the URL and alternative text.</li>
+        <li>RadzenMarkdownEditorHorizontalRule - inserts a horizontal rule (<code>---</code>) on its own line.</li>
+        <li>RadzenMarkdownEditorCustomTool - allows the developer to implement a custom tool (see Custom tools above).</li>
+    </ul>
+</RadzenText>
+
+<RadzenText Anchor="markdown-editor#keyboard-navigation" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    Keyboard Navigation
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    The following keys or key combinations provide a way for users to navigate and interact with Radzen Blazor MarkdownEditor component.
+</RadzenText>
+
+<RadzenTable>
+    <RadzenTableHeader>
+        <RadzenTableHeaderRow>
+            <RadzenTableHeaderCell colspan="2">Press this key</RadzenTableHeaderCell>
+            <RadzenTableHeaderCell rowspan="2">To do this</RadzenTableHeaderCell>
+        </RadzenTableHeaderRow>
+        <RadzenTableHeaderRow>
+            <RadzenTableHeaderCell>Windows, Chrome OS</RadzenTableHeaderCell>
+            <RadzenTableHeaderCell>Mac</RadzenTableHeaderCell>
+        </RadzenTableHeaderRow>
+    </RadzenTableHeader>
+    <RadzenTableBody>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="Tab" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="Tab" /></RadzenTableCell>
+            <RadzenTableCell>Navigate to a MarkdownEditor component.</RadzenTableCell>
+        </RadzenTableRow>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="B" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="⌘" /> + <RadzenBadge Text="B" /></RadzenTableCell>
+            <RadzenTableCell>Toggle bold on the selected text.</RadzenTableCell>
+        </RadzenTableRow>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="I" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="⌘" /> + <RadzenBadge Text="I" /></RadzenTableCell>
+            <RadzenTableCell>Toggle italic on the selected text.</RadzenTableCell>
+        </RadzenTableRow>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="K" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="⌘" /> + <RadzenBadge Text="K" /></RadzenTableCell>
+            <RadzenTableCell>Insert a link (opens the link dialog).</RadzenTableCell>
+        </RadzenTableRow>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="Z" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="⌘" /> + <RadzenBadge Text="Z" /></RadzenTableCell>
+            <RadzenTableCell>Undo the last change, including toolbar actions.</RadzenTableCell>
+        </RadzenTableRow>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="Y" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="⌘" /> + <RadzenBadge Text="Shift" /> + <RadzenBadge Text="Z" /></RadzenTableCell>
+            <RadzenTableCell>Redo the last undone change.</RadzenTableCell>
+        </RadzenTableRow>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="←" /> / <RadzenBadge Text="→" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="←" /> / <RadzenBadge Text="→" /></RadzenTableCell>
+            <RadzenTableCell>In Split mode, with the splitter handle focused (reach it with Tab): resize the editor and preview panes.</RadzenTableCell>
+        </RadzenTableRow>
+    </RadzenTableBody>
+</RadzenTable>

--- a/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
@@ -4,7 +4,7 @@
     Blazor Markdown Editor
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
-    The Blazor Markdown Editor component (RadzenMarkdownEditor) edits Markdown with a toolbar and keyboard shortcuts. It defaults to a WYSIWYG Design mode rendered by RadzenMarkdown, with a Source mode to edit the raw Markdown text.
+    The Blazor Markdown Editor component (RadzenMarkdownEditor) edits Markdown with a toolbar and keyboard shortcuts. It defaults to a WYSIWYG Design mode - a contenteditable surface synced with the Markdown - with a Source mode to edit the raw Markdown text.
 </RadzenText>
 
 <RadzenExample ComponentName="MarkdownEditor" Example="MarkdownEditor">
@@ -33,7 +33,7 @@ The Radzen MarkdownEditor supports the following tools. Place them inside <stron
         <li>RadzenMarkdownEditorRedo - redoes the last undone change.</li>
         <li>RadzenMarkdownEditorSeparator - displays a vertical separator used to delimit groups of similar tools.</li>
         <li>RadzenMarkdownEditorBold - toggles <code>**bold**</code> on the selected text.</li>
-        <li>RadzenMarkdownEditorItalic - toggles <code>_italic_</code> on the selected text.</li>
+        <li>RadzenMarkdownEditorItalic - toggles <code>*italic*</code> on the selected text.</li>
         <li>RadzenMarkdownEditorStrikethrough - toggles <code>~~strikethrough~~</code> on the selected text.</li>
         <li>RadzenMarkdownEditorHeading - cycles the heading level of the selected lines (<code>#</code>, <code>##</code>, <code>###</code>, none).</li>
         <li>RadzenMarkdownEditorQuote - toggles <code>&gt; </code> block quotes on the selected lines.</li>

--- a/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
+++ b/RadzenBlazorDemos/Pages/MarkdownEditorPage.razor
@@ -32,16 +32,16 @@ The Radzen MarkdownEditor supports the following tools. Place them inside <stron
         <li>RadzenMarkdownEditorSeparator - displays a vertical separator used to delimit groups of similar tools.</li>
         <li>RadzenMarkdownEditorBold - toggles <code>**bold**</code> on the selected text.</li>
         <li>RadzenMarkdownEditorItalic - toggles <code>_italic_</code> on the selected text.</li>
-        <li>RadzenMarkdownEditorStrikethrough - toggles <code>~~strikethrough~~</code> on the selected text. Not rendered by RadzenMarkdown yet, therefore not part of the default toolbar.</li>
+        <li>RadzenMarkdownEditorStrikethrough - toggles <code>~~strikethrough~~</code> on the selected text. Not rendered by RadzenMarkdown, therefore not part of the default toolbar.</li>
         <li>RadzenMarkdownEditorHeading - cycles the heading level of the selected lines (<code>#</code>, <code>##</code>, <code>###</code>, none).</li>
         <li>RadzenMarkdownEditorQuote - toggles <code>&gt; </code> block quotes on the selected lines.</li>
         <li>RadzenMarkdownEditorCode - toggles inline <code>`code`</code> on the selected text.</li>
         <li>RadzenMarkdownEditorCodeBlock - wraps the selection in a fenced <code>```</code> code block.</li>
         <li>RadzenMarkdownEditorUnorderedList - toggles a bullet list (<code>- </code>) on the selected lines.</li>
         <li>RadzenMarkdownEditorOrderedList - toggles a numbered list (<code>1. </code>) on the selected lines.</li>
-        <li>RadzenMarkdownEditorTaskList - toggles a task list (<code>- [ ] </code>) on the selected lines. Not rendered by RadzenMarkdown yet, therefore not part of the default toolbar.</li>
+        <li>RadzenMarkdownEditorTaskList - toggles a task list (<code>- [ ] </code>) on the selected lines. Not rendered by RadzenMarkdown, therefore not part of the default toolbar.</li>
         <li>RadzenMarkdownEditorLink - inserts a link; opens a dialog for the URL (and text when nothing is selected).</li>
-        <li>RadzenMarkdownEditorImage - inserts an image by URL; opens a dialog for the URL and alternative text.</li>
+        <li>RadzenMarkdownEditorImage - inserts an image by URL; opens a dialog for the URL (and alternative text when nothing is selected).</li>
         <li>RadzenMarkdownEditorHorizontalRule - inserts a horizontal rule (<code>---</code>) on its own line.</li>
         <li>RadzenMarkdownEditorCustomTool - allows the developer to implement a custom tool (see Custom tools above).</li>
     </ul>
@@ -92,7 +92,7 @@ The Radzen MarkdownEditor supports the following tools. Place them inside <stron
             <RadzenTableCell>Undo the last change, including toolbar actions.</RadzenTableCell>
         </RadzenTableRow>
         <RadzenTableRow>
-            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="Y" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="Ctrl" /> + <RadzenBadge Text="Shift" /> + <RadzenBadge Text="Z" /></RadzenTableCell>
             <RadzenTableCell><RadzenBadge Text="⌘" /> + <RadzenBadge Text="Shift" /> + <RadzenBadge Text="Z" /></RadzenTableCell>
             <RadzenTableCell>Redo the last undone change.</RadzenTableCell>
         </RadzenTableRow>
@@ -100,6 +100,11 @@ The Radzen MarkdownEditor supports the following tools. Place them inside <stron
             <RadzenTableCell><RadzenBadge Text="←" /> / <RadzenBadge Text="→" /></RadzenTableCell>
             <RadzenTableCell><RadzenBadge Text="←" /> / <RadzenBadge Text="→" /></RadzenTableCell>
             <RadzenTableCell>In Split mode, with the splitter handle focused (reach it with Tab): resize the editor and preview panes.</RadzenTableCell>
+        </RadzenTableRow>
+        <RadzenTableRow>
+            <RadzenTableCell><RadzenBadge Text="Home" /> / <RadzenBadge Text="End" /></RadzenTableCell>
+            <RadzenTableCell><RadzenBadge Text="Home" /> / <RadzenBadge Text="End" /></RadzenTableCell>
+            <RadzenTableCell>With the splitter handle focused: move the split to its minimum / maximum position.</RadzenTableCell>
         </RadzenTableRow>
     </RadzenTableBody>
 </RadzenTable>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -3261,7 +3261,7 @@ namespace RadzenBlazorDemos
         {
             Toc = [ new () { Text = "Custom tools", Anchor = "#custom-tools" } ],
             Name = "MarkdownEditor",
-            Icon = "",
+            Icon = "\uf552",
             Path = "markdown-editor",
             Title = "Blazor Markdown Editor | Free UI Components by Radzen",
             Description = "Edit Markdown in Blazor with RadzenMarkdownEditor - toolbar, keyboard shortcuts, custom tools and a live preview with Write, Preview and Split modes.",

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -3259,7 +3259,7 @@ namespace RadzenBlazorDemos
         },
         new Example
         {
-            Toc = [ new () { Text = "Custom tools", Anchor = "#custom-tools" } ],
+            Toc = [ new () { Text = "Custom tools", Anchor = "#custom-tools" }, new () { Text = "All tools", Anchor = "#all-tools" }, new () { Text = "Keyboard Navigation", Anchor = "#keyboard-navigation" } ],
             Name = "MarkdownEditor",
             Icon = "\uf552",
             Path = "markdown-editor",

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -3264,13 +3264,13 @@ namespace RadzenBlazorDemos
             Icon = "\uf552",
             Path = "markdown-editor",
             Title = "Blazor Markdown Editor | Free UI Components by Radzen",
-            Description = "Edit Markdown in Blazor with RadzenMarkdownEditor - toolbar, keyboard shortcuts, custom tools and a live preview with Write, Preview and Split modes.",
+            Description = "Edit Markdown in Blazor with RadzenMarkdownEditor - toolbar, keyboard shortcuts, custom tools and a WYSIWYG Design mode with a Source mode for raw Markdown.",
             Tags = new[] { "markdown", "editor", "text", "preview", "toolbar" },
             Related = new [] { "markdown", "html-editor", "textarea" },
             Faq = new []
             {
-                new FaqItem { Question = "How do I edit Markdown in Blazor?", Answer = "Add RadzenMarkdownEditor and bind its Value property; the toolbar and keyboard shortcuts insert Markdown syntax and the preview renders it with RadzenMarkdown." },
-                new FaqItem { Question = "Can I show the editor and preview side by side?", Answer = "Yes. Bind the Mode property to MarkdownEditorMode.Split, or let users switch between Write, Preview and Split with the built-in mode switcher." },
+                new FaqItem { Question = "How do I edit Markdown in Blazor?", Answer = "Add RadzenMarkdownEditor and bind its Value property; it opens in a WYSIWYG Design mode rendered by RadzenMarkdown, with the toolbar and keyboard shortcuts editing the content directly." },
+                new FaqItem { Question = "Can I edit the raw Markdown instead of the WYSIWYG view?", Answer = "Yes. Bind the Mode property to MarkdownEditorMode.Source, or let users switch between Design and Source with the built-in mode switcher." },
                 new FaqItem { Question = "How do I add custom buttons to the Markdown Editor?", Answer = "Declare RadzenMarkdownEditorCustomTool inside the editor and handle the Execute callback, or use its Template to render any content." }
             }
         },

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -3259,6 +3259,23 @@ namespace RadzenBlazorDemos
         },
         new Example
         {
+            Toc = [ new () { Text = "Custom tools", Anchor = "#custom-tools" } ],
+            Name = "MarkdownEditor",
+            Icon = "",
+            Path = "markdown-editor",
+            Title = "Blazor Markdown Editor | Free UI Components by Radzen",
+            Description = "Edit Markdown in Blazor with RadzenMarkdownEditor - toolbar, keyboard shortcuts, custom tools and a live preview with Write, Preview and Split modes.",
+            Tags = new[] { "markdown", "editor", "text", "preview", "toolbar" },
+            Related = new [] { "markdown", "html-editor", "textarea" },
+            Faq = new []
+            {
+                new FaqItem { Question = "How do I edit Markdown in Blazor?", Answer = "Add RadzenMarkdownEditor and bind its Value property; the toolbar and keyboard shortcuts insert Markdown syntax and the preview renders it with RadzenMarkdown." },
+                new FaqItem { Question = "Can I show the editor and preview side by side?", Answer = "Yes. Bind the Mode property to MarkdownEditorMode.Split, or let users switch between Write, Preview and Split with the built-in mode switcher." },
+                new FaqItem { Question = "How do I add custom buttons to the Markdown Editor?", Answer = "Declare RadzenMarkdownEditorCustomTool inside the editor and handle the Execute callback, or use its Template to render any content." }
+            }
+        },
+        new Example
+        {
             Name = "Data",
             Icon = "\ue99c",
             Children = new [] {

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -3269,7 +3269,7 @@ namespace RadzenBlazorDemos
             Related = new [] { "markdown", "html-editor", "textarea" },
             Faq = new []
             {
-                new FaqItem { Question = "How do I edit Markdown in Blazor?", Answer = "Add RadzenMarkdownEditor and bind its Value property; it opens in a WYSIWYG Design mode rendered by RadzenMarkdown, with the toolbar and keyboard shortcuts editing the content directly." },
+                new FaqItem { Question = "How do I edit Markdown in Blazor?", Answer = "Add RadzenMarkdownEditor and bind its Value property; it opens in a WYSIWYG Design mode - a contenteditable surface kept in sync with the Markdown - with the toolbar and keyboard shortcuts editing the content directly." },
                 new FaqItem { Question = "Can I edit the raw Markdown instead of the WYSIWYG view?", Answer = "Yes. Bind the Mode property to MarkdownEditorMode.Source, or let users switch between Design and Source with the built-in mode switcher." },
                 new FaqItem { Question = "How do I add custom buttons to the Markdown Editor?", Answer = "Declare RadzenMarkdownEditorCustomTool inside the editor and handle the Execute callback, or use its Template to render any content." }
             }


### PR DESCRIPTION
## RadzenMarkdownEditor

Implements #2665.

Adds `RadzenMarkdownEditor`, a Markdown editor with a WYSIWYG **Design** mode and a raw-text **Source** mode, built on the existing `RadzenMarkdown` parser.

- **Modes**: `Design` (default) edits the rendered document in a `contenteditable` surface and round-trips it to Markdown; `Source` edits the Markdown text in a textarea. `Mode` is bindable and a built-in switcher toggles between the two (`ShowModeSwitch`).
- **Toolbar** following the `RadzenHtmlEditor` pattern: default tool set when no child content, fully composable otherwise (`RadzenMarkdownEditorUndo`, `…Redo`, `…Bold`, `…Italic`, `…Strikethrough`, `…FormatBlock`, `…Quote`, `…Code`, `…CodeBlock`, `…UnorderedList`, `…OrderedList`, `…TaskList`, `…Link`, `…Image`, `…HorizontalRule`, `…Separator`, `…CustomTool`). `…FormatBlock` is a level picker (Normal, Heading 1 to 6) modelled on `RadzenHtmlEditorFormatBlock`; it follows the caret and is disabled while the selection holds no paragraph or heading. Tools reflect the selection state (active format, undo/redo availability).
- **Commands** are applied to the DOM in Design mode and computed in C# (`MarkdownFormatter`, unit-tested) in Source mode, with the same normalization in both: whitespace is trimmed off the selection, a caret expands to its word, a selection that is already formatted has the format removed from its words (splitting the token when it contains more), otherwise it is wrapped once per block/line.
- **Undo/redo** is a component-owned history with toolbar tools and Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z, Ctrl/Cmd+Y.
- **Parser additions**: GFM strikethrough (`~~text~~`, `Strikethrough` node, `INodeVisitor.VisitStrikethrough` with a default implementation) and task lists (`ListItem.Checked`), rendered by `RadzenMarkdown` as well.
- **Paste** of rich content is laundered through Markdown so only supported constructs survive; `:shortcode:` emoji are expanded while typing.
- `Execute` event + `ExecuteCommandAsync` for custom tools, shortcuts via the same key-string scheme as `RadzenHtmlEditor`, `Immediate`/`Input`/`Change` semantics matching `RadzenTextArea`.
- Localized strings (en, de, es, fr, it, ja), styles for all themes via the existing `--rz-editor-*` tokens, demos and docs entry.

**Note:** Design-mode edits reserialize the whole value to canonical Markdown (`__bold__` becomes `**bold**`, `snake_case` becomes `snake\_case`); the rendered result is unchanged. This is documented on the component and the demo page.

Out of scope for now (happy to follow up): image upload, Tab-indent / list continuation.

**Theme notes:** styles use the existing `--rz-editor-*` tokens; the premium theme CSS under `RadzenBlazorDemos/wwwroot/css` is not regenerated by this PR (maintainer process), so the demo shows the new styles under the non-premium themes until the next "Update premium themes".
