### PR TITLE
RadzenDatePicker: O(1) selected-day membership in Multiple-mode calendar

### DIFF
--- a/Radzen.Blazor.Tests/DatePickerTests.cs
+++ b/Radzen.Blazor.Tests/DatePickerTests.cs
@@ -897,6 +897,54 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void DatePicker_Multiple_SelectedState_ReflectsToggleAndReassignment()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var initial = new DateTime(2024, 1, 1);
+
+            var component = ctx.RenderComponent<RadzenDatePicker<IEnumerable<DateTime>>>(parameters =>
+            {
+                parameters.Add(p => p.Multiple, true);
+                parameters.Add(p => p.InitialViewDate, initial);
+            });
+
+            AngleSharp.Dom.IElement cell(string day) =>
+                component.FindAll("td:not(.rz-calendar-other-month)")
+                         .First(td => td.QuerySelector("span")?.TextContent == day);
+
+            bool isActive(string day) => cell(day).QuerySelector("span")!.ClassList.Contains("rz-state-active");
+
+            // In-place edits: select two days (Add), then deselect the first (RemoveAt). aria-selected and
+            // the rz-state-active highlight must both track the current selection each render.
+            cell("10").Click();
+            cell("12").Click();
+
+            Assert.Equal("true", cell("10").GetAttribute("aria-selected"));
+            Assert.Equal("true", cell("12").GetAttribute("aria-selected"));
+            Assert.True(isActive("10"));
+            Assert.True(isActive("12"));
+
+            cell("10").Click();
+
+            Assert.Equal("false", cell("10").GetAttribute("aria-selected"));
+            Assert.Equal("true", cell("12").GetAttribute("aria-selected"));
+            Assert.False(isActive("10"));
+
+            // Reference invalidation: reassign Value to a different selection and confirm the memo rebuilds.
+            component.SetParametersAndRender(parameters =>
+            {
+                parameters.Add(p => p.Value, new List<DateTime> { new DateTime(2024, 1, 20) });
+            });
+
+            Assert.Equal("true", cell("20").GetAttribute("aria-selected"));
+            Assert.Equal("false", cell("12").GetAttribute("aria-selected"));
+            Assert.True(isActive("20"));
+        }
+
+        [Fact]
         public void DatePicker_Multiple_Selects_IEnumerableNullableDateTime()
         {
             using var ctx = new TestContext();

--- a/Radzen.Blazor/RadzenDatePicker.razor.cs
+++ b/Radzen.Blazor/RadzenDatePicker.razor.cs
@@ -66,6 +66,35 @@ namespace Radzen.Blazor
         // Holds selected dates when Multiple is true
         List<DateTime> selectedDates = new List<DateTime>();
 
+        List<DateTime>? selectedDatesSetSource;
+        int selectedDatesSetCount = -1;
+        HashSet<DateTime>? selectedDatesSet;
+
+        // Membership test for the Multiple-mode calendar. Rendering a month calls this ~2x per day cell
+        // (aria-selected and the day css class); memoizing the selected days as a set keeps that O(1) per
+        // cell instead of a selectedDates.Any() scan. The cache is dropped on reassignment (reference
+        // check) and on any count-changing in-place edit (an automatic backstop); InvalidateSelectedDates
+        // also drops it explicitly at each mutation site to cover a hypothetical net-zero-count edit.
+        bool IsSelectedDate(DateTime date)
+        {
+            if (selectedDatesSet == null || !ReferenceEquals(selectedDatesSetSource, selectedDates) || selectedDatesSetCount != selectedDates.Count)
+            {
+                selectedDatesSetSource = selectedDates;
+                selectedDatesSetCount = selectedDates.Count;
+                selectedDatesSet = new HashSet<DateTime>(selectedDates.Count);
+                foreach (var d in selectedDates)
+                {
+                    selectedDatesSet.Add(d.Date);
+                }
+            }
+
+            return selectedDatesSet.Contains(date.Date);
+        }
+
+        // Invalidate the memoized set after an in-place edit of selectedDates (reassignments and
+        // count changes are already caught in IsSelectedDate; this also covers a net-zero-count edit).
+        void InvalidateSelectedDates() => selectedDatesSet = null;
+
         private string? calendarWeekTitle;
 
         /// <summary>
@@ -211,7 +240,7 @@ namespace Radzen.Blazor
         {
             if (Multiple)
             {
-                return selectedDates.Any(d => d.Date == date.Date);
+                return IsSelectedDate(date);
             }
 
             return DateTimeValue.HasValue && DateTimeValue.Value.Date.CompareTo(date.Date) == 0;
@@ -864,6 +893,7 @@ namespace Radzen.Blazor
                         if (value == null)
                         {
                             selectedDates.Clear();
+                            InvalidateSelectedDates();
                             _value = null;
                             _dateTimeValue = null;
                         }
@@ -952,6 +982,7 @@ namespace Radzen.Blazor
                         else
                         {
                             selectedDates.Clear();
+                            InvalidateSelectedDates();
                             _value = null;
                             _dateTimeValue = null;
                         }
@@ -1217,6 +1248,7 @@ namespace Radzen.Blazor
                 else if (nullable)
                 {
                     selectedDates.Clear();
+                    InvalidateSelectedDates();
                     await UpdateValueFromSelectedDates(null);
                 }
             }
@@ -1345,6 +1377,7 @@ namespace Radzen.Blazor
             if (Multiple)
             {
                 selectedDates.Clear();
+                InvalidateSelectedDates();
                 _value = null;
                 _dateTimeValue = null;
 
@@ -1770,6 +1803,7 @@ namespace Radzen.Blazor
             {
                 selectedDates.Add(DateTime.SpecifyKind(date, Kind));
             }
+            InvalidateSelectedDates();
         }
 
         async Task UpdateValueFromSelectedDates(DateTime? lastSelected)
@@ -2038,7 +2072,7 @@ namespace Radzen.Blazor
             var list = ClassList.Create()
                                .Add("rz-state-default", !forCell)
                                .Add("rz-calendar-other-month", GetCalendarMonth(CurrentDate) != GetCalendarMonth(date))
-                               .Add("rz-state-active", !forCell && (Multiple ? selectedDates.Any(d => d.Date == date.Date) : (DateTimeValue.HasValue && DateTimeValue.Value.Date.CompareTo(date.Date) == 0)))
+                               .Add("rz-state-active", !forCell && (Multiple ? IsSelectedDate(date) : (DateTimeValue.HasValue && DateTimeValue.Value.Date.CompareTo(date.Date) == 0)))
                                .Add("rz-calendar-today", !forCell && DateTime.Now.Date.CompareTo(date.Date) == 0)
                                .Add("rz-state-focused", !forCell && FocusedDate.Date.CompareTo(date.Date) == 0)
                                .Add("rz-state-disabled", !forCell && dateArgs.Disabled);


### PR DESCRIPTION
### RadzenDatePicker — Multiple-mode calendar selection scan
When `Multiple` is set, rendering a month calendar tested each of the 42 day cells against the selected dates with `selectedDates.Any(d => d.Date == date.Date)` — called **~2× per cell** (`aria-selected` and the day CSS class), i.e. O(cells × selected) per calendar render plus a closure allocation per cell.

The selected days are now memoized as a `HashSet<DateTime>` (by `.Date`) and tested in O(1). `selectedDates` is either rebuilt or edited in place (only single `Add`/`Remove`/`Clear`) on value changes, so a **reference + count** check rebuilds the set exactly when it changes — robust to the in-place toggle path.