### PR TITLE
RadzenDataGrid: avoid per row and per cell allocations for unused features

### DIFF
--- a/Radzen.Blazor.Tests/DataGridCellAttributePrecedenceTests.cs
+++ b/Radzen.Blazor.Tests/DataGridCellAttributePrecedenceTests.cs
@@ -1,0 +1,87 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    // Preserve CellRender class/style precedence while allocating cell attributes lazily.
+    public class DataGridCellAttributePrecedenceTests
+    {
+        public class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        static List<Person> People(int n) =>
+            Enumerable.Range(1, n).Select(i => new Person { Id = i, Name = "Person " + i }).ToList();
+
+        static IRenderedComponent<RadzenDataGrid<Person>> Render(TestContext ctx,
+            System.Action<DataGridCellRenderEventArgs<Person>> cellRender, TextAlign align = TextAlign.Right)
+        {
+            return ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(2));
+
+                if (cellRender != null)
+                {
+                    p.Add(g => g.CellRender, cellRender);
+                }
+
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.TextAlign), align);
+                    builder.CloseComponent();
+                });
+            });
+        }
+
+        [Fact]
+        public void ColumnStyle_WinsOverCellRenderStyle()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = Render(ctx, args => args.Attributes["style"] = "text-align:left");
+
+            var style = component.FindAll("td").First().GetAttribute("style");
+            Assert.Contains("text-align:left", style);
+            Assert.Contains("text-align:right", style);
+            Assert.True(style.IndexOf("text-align:right") > style.IndexOf("text-align:left"),
+                $"the column style should land last and win, got '{style}'");
+        }
+
+        [Fact]
+        public void CellRenderClass_IsMergedWithTheColumnClass()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = Render(ctx, args => args.Attributes["class"] = "my-cell");
+
+            var css = component.FindAll("td").First().GetAttribute("class");
+            Assert.NotNull(css);
+            Assert.Contains("my-cell", css);
+        }
+
+        [Fact]
+        public void WithoutCellRender_ClassAndStyleStillLandOnTheCell()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = Render(ctx, cellRender: null);
+
+            var cell = component.FindAll("td").First();
+            Assert.Contains("text-align:right", cell.GetAttribute("style"));
+            Assert.Contains("Person 1", component.Markup);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridCellContextMenuTests.cs
+++ b/Radzen.Blazor.Tests/DataGridCellContextMenuTests.cs
@@ -1,0 +1,191 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridCellContextMenuTests
+    {
+        class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        static List<Person> People(int n) =>
+            Enumerable.Range(1, n).Select(i => new Person { Id = i, Name = "Person " + i }).ToList();
+
+        static IRenderedComponent<RadzenDataGrid<Person>> RenderGrid(TestContext ctx,
+            EventCallback<DataGridCellMouseEventArgs<Person>>? contextMenu)
+        {
+            return ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(3));
+
+                if (contextMenu.HasValue)
+                {
+                    p.Add(g => g.CellContextMenu, contextMenu.Value);
+                }
+
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Id));
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(2);
+                    builder.AddAttribute(3, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                    builder.CloseComponent();
+                });
+            });
+        }
+
+        // Detects subtree replacement rather than an ordinary re-render.
+        class StatefulCell : ComponentBase
+        {
+            [Parameter]
+            public string Text { get; set; }
+
+            [Parameter]
+            public Action OnInit { get; set; }
+
+            protected override void OnInitialized() => OnInit?.Invoke();
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder) => builder.AddContent(0, Text);
+        }
+
+        [Fact]
+        public void DataGrid_AddingCellContextMenu_DoesNotRebuildTheCellSubtree()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var initializations = 0;
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(1));
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.Template),
+                        (RenderFragment<Person>)(item => cell =>
+                        {
+                            cell.OpenComponent<StatefulCell>(0);
+                            cell.AddAttribute(1, nameof(StatefulCell.Text), item.Name);
+                            cell.AddAttribute(2, nameof(StatefulCell.OnInit), (Action)(() => initializations++));
+                            cell.CloseComponent();
+                        }));
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.Equal(1, initializations);
+
+            component.SetParametersAndRender(p => p.Add(g => g.CellContextMenu,
+                EventCallback.Factory.Create<DataGridCellMouseEventArgs<Person>>(this, _ => { })));
+
+            Assert.Equal(1, initializations);
+
+            DataGridCellMouseEventArgs<Person> received = null;
+
+            component.SetParametersAndRender(p => p.Add(g => g.CellContextMenu,
+                EventCallback.Factory.Create<DataGridCellMouseEventArgs<Person>>(this, args => received = args)));
+
+            component.Find("td").ContextMenu();
+
+            Assert.NotNull(received);
+            Assert.Equal(1, initializations);
+
+            component.SetParametersAndRender(p => p.Add(g => g.CellContextMenu,
+                default(EventCallback<DataGridCellMouseEventArgs<Person>>)));
+
+            Assert.Equal(1, initializations);
+        }
+
+        [Fact]
+        public void DataGrid_CellContextMenu_FiresWithCellAndItem()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            DataGridCellMouseEventArgs<Person> received = null;
+            var component = RenderGrid(ctx, EventCallback.Factory.Create<DataGridCellMouseEventArgs<Person>>(
+                this, args => received = args));
+
+            var cells = component.FindAll("td");
+            Assert.NotEmpty(cells);
+
+            cells[0].ContextMenu();
+
+            Assert.NotNull(received);
+            Assert.Equal(1, received.Data.Id);
+            Assert.Equal(nameof(Person.Id), received.Column.Property);
+        }
+
+        [Fact]
+        public void DataGrid_WithoutCellContextMenu_RendersTheSameCells()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var withHandler = RenderGrid(ctx, EventCallback.Factory.Create<DataGridCellMouseEventArgs<Person>>(
+                this, _ => { }));
+            var withoutHandler = RenderGrid(ctx, null);
+
+            // Handler presence must not change cell content.
+            string CellText(IRenderedComponent<RadzenDataGrid<Person>> c) =>
+                string.Join("|", c.FindAll("td").Select(td => td.TextContent.Trim()));
+
+            Assert.Equal(CellText(withHandler), CellText(withoutHandler));
+            Assert.Contains("Person 1", withoutHandler.Markup);
+            Assert.Contains("Person 3", withoutHandler.Markup);
+        }
+
+        // A misspelled modifier still lets the handler fire but no longer suppresses the browser menu.
+        [Fact]
+        public void TheContextMenuModifiersAreTheOnesBlazorActuallyLooksFor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var cell = RenderGrid(ctx, EventCallback.Factory.Create<DataGridCellMouseEventArgs<Person>>(
+                this, _ => { })).Find("tbody td");
+
+            var names = cell.Attributes.Select(a => a.Name).ToArray();
+
+            // bUnit normalizes recognized modifiers, so compare complete attribute names.
+            Assert.Contains(names, n =>
+                string.Equals(n, "blazor:oncontextmenu:preventDefault", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(names, n =>
+                string.Equals(n, "blazor:oncontextmenu:stopPropagation", StringComparison.OrdinalIgnoreCase));
+
+            Assert.DoesNotContain(names, n =>
+                n.StartsWith("oncontextmenu:", StringComparison.OrdinalIgnoreCase) ||
+                n.StartsWith("__internal", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void AGridWithNoContextMenuHandlerEmitsNoModifiersAtAll()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var cells = RenderGrid(ctx, null).FindAll("td");
+
+            // The grid root has its own unrelated context-menu handler.
+            Assert.NotEmpty(cells);
+            Assert.All(cells, cell =>
+                Assert.DoesNotContain("oncontextmenu", cell.OuterHtml, StringComparison.Ordinal));
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridCellTooltipTests.cs
+++ b/Radzen.Blazor.Tests/DataGridCellTooltipTests.cs
@@ -1,0 +1,242 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridCellTooltipTests
+    {
+        class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public decimal Salary { get; set; }
+        }
+
+        static readonly List<Person> People = new()
+        {
+            new Person { Id = 1, Name = "Alice", Salary = 50000m },
+            new Person { Id = 2, Name = null, Salary = 61234.5m },
+        };
+
+        static IRenderedComponent<RadzenDataGrid<Person>> Render(TestContext ctx,
+            Action<ComponentParameterCollectionBuilder<RadzenDataGrid<Person>>> extra = null,
+            RenderFragment columns = null)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            return ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People);
+                p.Add(g => g.Columns, columns ?? NameColumn);
+                extra?.Invoke(p);
+            });
+        }
+
+        static readonly RenderFragment NameColumn = builder =>
+        {
+            builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+            builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+            builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.Title), "Name");
+            builder.CloseComponent();
+        };
+
+        static IReadOnlyList<AngleSharp.Dom.IElement> Cells(IRenderedComponent<RadzenDataGrid<Person>> cut) =>
+            cut.FindAll("tbody td span.rz-cell-data").ToArray();
+
+        [Fact]
+        public void TheCellCarriesItsOwnValueAsATitle()
+        {
+            using var ctx = new TestContext();
+
+            var cells = Cells(Render(ctx));
+
+            Assert.Equal("Alice", cells[0].GetAttribute("title"));
+        }
+
+        // Empty values omit the attribute rather than emitting title="".
+        [Fact]
+        public void ACellWithNoValueCarriesNoTitleAttributeAtAll()
+        {
+            using var ctx = new TestContext();
+
+            var cells = Cells(Render(ctx));
+
+            Assert.False(cells[1].HasAttribute("title"),
+                "a null value must leave the attribute off entirely, not emit title=\"\"");
+        }
+
+        [Fact]
+        public void TurningItOffLeavesNoTitleOnAnyCell()
+        {
+            using var ctx = new TestContext();
+
+            var cells = Cells(Render(ctx, p => p.Add(g => g.ShowCellDataAsTooltip, false)));
+
+            Assert.All(cells, cell => Assert.False(cell.HasAttribute("title")));
+        }
+
+        [Fact]
+        public void ATemplateColumnGetsNoTitleFromTheGridWideDefault()
+        {
+            using var ctx = new TestContext();
+
+            var cells = Cells(Render(ctx, columns: builder =>
+            {
+                builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.Template),
+                    (RenderFragment<Person>)(person => inner => inner.AddContent(0, "[" + person.Name + "]")));
+                builder.CloseComponent();
+            }));
+
+            Assert.All(cells, cell => Assert.False(cell.HasAttribute("title")));
+        }
+
+        // An opted-in template column uses the underlying value, not its rendered content.
+        [Fact]
+        public void ATemplateColumnThatAsksForATitleGetsTheUnderlyingValue()
+        {
+            using var ctx = new TestContext();
+
+            var cells = Cells(Render(ctx, columns: builder =>
+            {
+                builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.ShowCellDataAsTooltip), true);
+                builder.AddAttribute(3, nameof(RadzenDataGridColumn<Person>.Template),
+                    (RenderFragment<Person>)(person => inner => inner.AddContent(0, "[" + person.Name + "]")));
+                builder.CloseComponent();
+            }));
+
+            Assert.Equal("Alice", cells[0].GetAttribute("title"));
+            Assert.Equal("[Alice]", cells[0].TextContent);
+        }
+
+        // The title and body share the formatted value.
+        [Fact]
+        public void TheTitleIsTheFormattedValueAndMatchesWhatTheCellShows()
+        {
+            using var ctx = new TestContext();
+
+            var cells = Cells(Render(ctx, columns: builder =>
+            {
+                builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Salary");
+                builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.FormatString), "{0:0.00}");
+                builder.CloseComponent();
+            }));
+
+            Assert.Equal("50000.00", cells[0].GetAttribute("title"));
+            Assert.Equal(cells[0].TextContent, cells[0].GetAttribute("title"));
+        }
+
+        class CountingColumn : RadzenDataGridColumn<Person>
+        {
+            public int Calls { get; private set; }
+
+            public override object GetValue(Person item)
+            {
+                Calls++;
+
+                return base.GetValue(item);
+            }
+        }
+
+        class NullReturningColumn : CountingColumn
+        {
+            public override object GetValue(Person item)
+            {
+                base.GetValue(item);
+
+                return null;
+            }
+        }
+
+        static IRenderedComponent<RadzenDataGrid<Person>> RenderCounting(TestContext ctx,
+            bool tooltip, int rows, out CountingColumn column, bool returnsNull = false)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            CountingColumn captured = null;
+
+            var cut = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People.Take(rows).ToList());
+                p.Add(g => g.ShowCellDataAsTooltip, tooltip);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, returnsNull ? typeof(NullReturningColumn) : typeof(CountingColumn));
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), "Name");
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.EditTemplate),
+                        (RenderFragment<Person>)(person => inner => inner.AddContent(0, "editing")));
+                    builder.AddComponentReferenceCapture(3, c => captured = (CountingColumn)c);
+                    builder.CloseComponent();
+                });
+            });
+
+            column = captured;
+
+            return cut;
+        }
+
+        // Call frequency is observable because GetValue is virtual; compare deltas across render passes.
+        [Fact]
+        public void EnteringEditModeAsksForNoValueWhenTheTooltipIsOff()
+        {
+            using var ctx = new TestContext();
+
+            var cut = RenderCounting(ctx, tooltip: false, rows: 1, out var column);
+            var before = column.Calls;
+
+            cut.InvokeAsync(() => cut.Instance.EditRow(People[0])).Wait();
+
+            Assert.Contains("editing", cut.Markup);
+            Assert.Equal(before, column.Calls);
+        }
+
+        // Enabling the tooltip must not add a second lookup.
+        [Fact]
+        public void TheTooltipDoesNotCostASecondLookup()
+        {
+            using var withTooltipCtx = new TestContext();
+            using var withoutTooltipCtx = new TestContext();
+
+            RenderCounting(withTooltipCtx, tooltip: true, rows: 2, out var withTooltip);
+            RenderCounting(withoutTooltipCtx, tooltip: false, rows: 2, out var withoutTooltip);
+
+            Assert.True(withoutTooltip.Calls > 0, "the read-only body has to ask for its value");
+            Assert.Equal(withoutTooltip.Calls, withTooltip.Calls);
+        }
+
+        // A legitimate null result must still count as derived.
+        [Fact]
+        public void AnOverrideThatReturnsNullIsStillOnlyAskedOnce()
+        {
+            using var nullCtx = new TestContext();
+            using var valueCtx = new TestContext();
+
+            RenderCounting(nullCtx, tooltip: true, rows: 2, out var returnsNull, returnsNull: true);
+            RenderCounting(valueCtx, tooltip: true, rows: 2, out var returnsValue);
+
+            Assert.True(returnsValue.Calls > 0, "the tooltip has to ask for its value");
+            Assert.Equal(returnsValue.Calls, returnsNull.Calls);
+        }
+
+        [Fact]
+        public void TheResponsiveBranchCarriesTheTitleToo()
+        {
+            using var ctx = new TestContext();
+
+            var cells = Cells(Render(ctx, p => p.Add(g => g.Responsive, true)));
+
+            Assert.Equal("Alice", cells[0].GetAttribute("title"));
+            Assert.False(cells[1].HasAttribute("title"));
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridRowCascadeBehaviourTests.cs
+++ b/Radzen.Blazor.Tests/DataGridRowCascadeBehaviourTests.cs
@@ -1,0 +1,213 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    // Pins the compatibility effects of omitting edit cascades from read-only rows.
+    public class DataGridRowCascadeBehaviourTests
+    {
+        public class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        static List<Person> People(int n) =>
+            Enumerable.Range(1, n).Select(i => new Person { Id = i, Name = "Person " + i }).ToList();
+
+        // Distinguishes subtree replacement from an in-place render.
+        public class InitCounter : ComponentBase
+        {
+            public static int Initialised;
+            protected override void OnInitialized() => Initialised++;
+            protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder b)
+                => b.AddContent(0, "probe");
+        }
+
+        static IRenderedComponent<RadzenDataGrid<Person>> EditableGrid(TestContext ctx, List<Person> data) =>
+            ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, data);
+                p.Add<RenderFragment>(g => g.Columns, cb =>
+                {
+                    cb.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    cb.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                    cb.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.EditTemplate),
+                        (RenderFragment<Person>)(item => eb => eb.AddContent(0, "editing " + item.Name)));
+                    cb.CloseComponent();
+                });
+            });
+
+        // Blazor retains omitted component parameters, so leaving edit mode must supply null explicitly.
+        [Fact]
+        public async Task CancellingAnEdit_ClearsTheRowEditContext()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(2);
+            var component = EditableGrid(ctx, data);
+
+            RadzenDataGridRow<Person> Row() => component.FindComponents<RadzenDataGridRow<Person>>()
+                .Single(r => ReferenceEquals(r.Instance.Item, data[0])).Instance;
+
+            Assert.Null(Row().EditContext);
+
+            await component.InvokeAsync(() => component.Instance.EditRow(data[0]));
+
+            Assert.NotNull(Row().EditContext);
+
+            await component.InvokeAsync(() => component.Instance.CancelEditRow(data[0]));
+
+            Assert.Null(Row().EditContext);
+        }
+
+        [Fact]
+        public async Task UpdatingARow_ClearsTheRowEditContext()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(2);
+            var component = EditableGrid(ctx, data);
+
+            RadzenDataGridRow<Person> Row() => component.FindComponents<RadzenDataGridRow<Person>>()
+                .Single(r => ReferenceEquals(r.Instance.Item, data[0])).Instance;
+
+            await component.InvokeAsync(() => component.Instance.EditRow(data[0]));
+
+            Assert.NotNull(Row().EditContext);
+
+            await component.InvokeAsync(() => component.Instance.UpdateRow(data[0]));
+
+            Assert.Null(Row().EditContext);
+        }
+
+        [Fact]
+        public void ReadOnlyRow_NoLongerShadowsAnEnclosingForm()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(2);
+            var model = new Person { Id = 99, Name = "Outer" };
+
+            var form = ctx.RenderComponent<RadzenTemplateForm<Person>>(p =>
+            {
+                p.Add(f => f.Data, model);
+                p.Add<RenderFragment<EditContext>>(f => f.ChildContent, _ => builder =>
+                {
+                    builder.OpenComponent<RadzenDataGrid<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGrid<Person>.Data), data);
+                    builder.AddAttribute(2, nameof(RadzenDataGrid<Person>.Columns), (RenderFragment)(cb =>
+                    {
+                        cb.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                        cb.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                        cb.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.Template),
+                            (RenderFragment<Person>)(person => tb =>
+                            {
+                                tb.OpenComponent<RadzenTextBox>(0);
+                                tb.AddAttribute(1, nameof(RadzenTextBox.Name), "RowBox");
+                                tb.CloseComponent();
+                            }));
+                        cb.CloseComponent();
+                    }));
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.NotNull(form.Instance.FindComponent("RowBox"));
+        }
+
+        [Fact]
+        public void TogglingEditMode_RebuildsTheRowSubtree()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(2);
+            InitCounter.Initialised = 0;
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, data);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Id));
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.Template),
+                        (RenderFragment<Person>)(_ => tb =>
+                        {
+                            tb.OpenComponent<InitCounter>(0);
+                            tb.CloseComponent();
+                        }));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(3);
+                    builder.AddAttribute(4, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                    builder.AddAttribute(5, nameof(RadzenDataGridColumn<Person>.EditTemplate),
+                        (RenderFragment<Person>)(person => eb => eb.AddContent(0, "editing")));
+                    builder.CloseComponent();
+                });
+            });
+
+            var afterFirstRender = InitCounter.Initialised;
+            Assert.Equal(2, afterFirstRender);   // one probe per row
+
+            component.InvokeAsync(() => component.Instance.EditRow(data[0])).GetAwaiter().GetResult();
+
+            // Switching cascade branches rebuilds stateful components in otherwise unchanged columns.
+            Assert.True(InitCounter.Initialised > afterFirstRender,
+                "entering edit mode is expected to rebuild the row subtree");
+        }
+
+        [Fact]
+        public void WhileEditing_ReRendersDoNotRebuildTheRow()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(2);
+            InitCounter.Initialised = 0;
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, data);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Id));
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.EditTemplate),
+                        (RenderFragment<Person>)(_ => tb =>
+                        {
+                            tb.OpenComponent<InitCounter>(0);
+                            tb.CloseComponent();
+                        }));
+                    builder.CloseComponent();
+                });
+            });
+
+            component.InvokeAsync(() => component.Instance.EditRow(data[0])).GetAwaiter().GetResult();
+
+            var afterEnteringEdit = InitCounter.Initialised;
+
+            // Remaining in the same branch must preserve the editor subtree.
+            for (var i = 0; i < 3; i++)
+            {
+                component.InvokeAsync(() => component.Instance.Reload()).GetAwaiter().GetResult();
+            }
+
+            Assert.Equal(afterEnteringEdit, InitCounter.Initialised);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/DataGridRowCascadeTests.cs
+++ b/Radzen.Blazor.Tests/DataGridRowCascadeTests.cs
@@ -1,0 +1,131 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    // Covers editing and validation behavior that depends on the row cascades.
+    public class DataGridRowCascadeTests
+    {
+        public class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        static List<Person> People(int n) =>
+            Enumerable.Range(1, n).Select(i => new Person { Id = i, Name = "Person " + i }).ToList();
+
+        static IRenderedComponent<RadzenDataGrid<Person>> RenderEditableGrid(TestContext ctx, List<Person> data,
+            bool withValidator)
+        {
+            return ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, data);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.EditTemplate),
+                        (RenderFragment<Person>)(person => eb =>
+                        {
+                            eb.OpenComponent<RadzenTextBox>(0);
+                            eb.AddAttribute(1, nameof(RadzenTextBox.Name), "PersonName");
+                            eb.AddAttribute(2, nameof(RadzenTextBox.Value), person.Name);
+                            eb.AddAttribute(3, nameof(RadzenTextBox.ValueChanged),
+                                EventCallback.Factory.Create<string>(person, v => person.Name = v));
+                            eb.AddAttribute(4, "ValueExpression",
+                                (System.Linq.Expressions.Expression<System.Func<string>>)(() => person.Name));
+                            eb.CloseComponent();
+
+                            if (withValidator)
+                            {
+                                eb.OpenComponent<RadzenRequiredValidator>(5);
+                                eb.AddAttribute(6, nameof(RadzenRequiredValidator.Component), "PersonName");
+                                eb.AddAttribute(7, nameof(RadzenRequiredValidator.Text), "Name is required");
+                                eb.CloseComponent();
+                            }
+                        }));
+                    builder.CloseComponent();
+                });
+            });
+        }
+
+        [Fact]
+        public void EditRow_CascadesEditContextToEditors()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(3);
+            var component = RenderEditableGrid(ctx, data, withValidator: false);
+
+            component.InvokeAsync(() => component.Instance.EditRow(data[0])).GetAwaiter().GetResult();
+
+            Assert.True(component.Instance.IsRowInEditMode(data[0]));
+
+            // FormComponent gets its validation-state class from the cascaded EditContext.
+            var input = component.FindAll("input.rz-textbox").Single();
+            var css = input.GetAttribute("class");
+            Assert.True(css.Contains("valid") || css.Contains("invalid"),
+                $"editor should carry an EditContext validation-state class, got '{css}'");
+        }
+
+        [Fact]
+        public void EditRow_CascadesFormSoValidatorsResolveTheirComponent()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(3);
+            data[0].Name = null;   // required field left empty
+
+            var component = RenderEditableGrid(ctx, data, withValidator: true);
+
+            component.InvokeAsync(() => component.Instance.EditRow(data[0])).GetAwaiter().GetResult();
+            component.InvokeAsync(() => component.Instance.UpdateRow(data[0])).GetAwaiter().GetResult();
+
+            // The validator resolves its target through the cascaded row form.
+            Assert.True(component.Instance.IsRowInEditMode(data[0]),
+                "a failing required validator should have kept the row in edit mode");
+        }
+
+        [Fact]
+        public void ReadOnlyRow_WithInputInPlainTemplate_StillRenders()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var data = People(3);
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, data);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenDataGridColumn<Person>.Property), nameof(Person.Name));
+                    builder.AddAttribute(2, nameof(RadzenDataGridColumn<Person>.Template),
+                        (RenderFragment<Person>)(person => tb =>
+                        {
+                            tb.OpenComponent<RadzenCheckBox<bool>>(0);
+                            tb.AddAttribute(1, nameof(RadzenCheckBox<bool>.Value), true);
+                            tb.CloseComponent();
+                            tb.AddContent(2, person.Name);
+                        }));
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.False(component.Instance.IsRowInEditMode(data[0]));
+            Assert.Contains("Person 1", component.Markup);
+            Assert.Contains("Person 3", component.Markup);
+            Assert.Equal(3, component.FindAll("tbody.rz-datatable-data > tr, tbody > tr.rz-data-row").Count);
+        }
+    }
+}

--- a/Radzen.Blazor/RadzenDataGrid.razor
+++ b/Radzen.Blazor/RadzenDataGrid.razor
@@ -603,37 +603,44 @@
 
     internal RenderFragment RenderCell(RadzenDataGridColumn<TItem> column, TItem Item, IReadOnlyDictionary<string, object> Attributes, Tuple<Radzen.RowRenderEventArgs<TItem>, IReadOnlyDictionary<string, object>> rowArgs, int RowIndex)
     {
-            var cellAttributes = new Dictionary<string, object>(Attributes);
+            // Keep class/style in the splat so SetAttribute preserves CellRender precedence. Allocate the
+            // dictionary on first use; AddMultipleAttributes ignores null without enumerating it.
+            var cellStyle = GetCellStyle(column, Attributes);
+            var cellClass = GetCellCssClass(column, Item, Attributes);
 
             var rowspan = column.GetRowSpan(true);
-            if(rowspan > 1)
-            {
-                SetAttribute(cellAttributes, "rowspan", rowspan);
-            }
-
             var colspan = column.GetColSpan(true);
-            if(colspan > 1)
+
+            // A non-chainable row onclick occupies the <tr>, so raise the built-in click from the cell.
+            var rowClickFromCell = RowClickActive
+                && rowArgs.Item2.TryGetValue("onclick", out var rowOnclick)
+                && !IsChainableClickHandler(rowOnclick);
+
+            Dictionary<string, object>? cellAttributes = null;
+
+            if (Attributes.Count > 0)
             {
-                SetAttribute(cellAttributes, "colspan", colspan);
+                cellAttributes = new Dictionary<string, object>(Attributes.Count);
+
+                foreach (var attribute in Attributes)
+                {
+                    cellAttributes[attribute.Key] = attribute.Value;
+                }
             }
 
-            var cellStyle = GetCellStyle(column, Attributes);
-            if(!string.IsNullOrEmpty(cellStyle))
+            if (rowspan > 1)
             {
-                SetAttribute(cellAttributes, "style", cellStyle);
+                SetAttribute(cellAttributes ??= new(), "rowspan", rowspan);
             }
 
-            var cellClass = GetCellCssClass(column, Item, Attributes);
-            if (!string.IsNullOrEmpty(cellClass))
+            if (colspan > 1)
             {
-                SetAttribute(cellAttributes, "class", cellClass);
+                SetAttribute(cellAttributes ??= new(), "colspan", colspan);
             }
 
-            // A non-chainable consumer onclick (e.g. a string) occupies the <tr>, so the built-in row click
-            // can't ride it - raise it from the cell for that row instead, alongside any cell click.
-            if (RowClickActive && rowArgs.Item2.TryGetValue("onclick", out var rowOnclick) && !IsChainableClickHandler(rowOnclick))
+            if (rowClickFromCell)
             {
-                SetAttribute(cellAttributes, "onclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: async (eventArgs) =>
+                SetAttribute(cellAttributes ??= new(), "onclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: async (eventArgs) =>
                 {
                     if (CellClick.HasDelegate) { await OnCellClickHandler(column, Item, eventArgs); }
                     await OnRowClickHandler(Item, eventArgs);
@@ -641,34 +648,55 @@
             }
             else if (CellClick.HasDelegate)
             {
-                SetAttribute(cellAttributes, "onclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnCellClickHandler(column, Item, eventArgs)));
+                SetAttribute(cellAttributes ??= new(), "onclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnCellClickHandler(column, Item, eventArgs)));
             }
 
             if (CellDoubleClick.HasDelegate || RowDoubleClick.HasDelegate)
             {
-                SetAttribute(cellAttributes, "ondblclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnDblClick(column, Item, eventArgs)));
+                SetAttribute(cellAttributes ??= new(), "ondblclick", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnDblClick(column, Item, eventArgs)));
+            }
+
+            if (!string.IsNullOrEmpty(cellStyle))
+            {
+                SetAttribute(cellAttributes ??= new(), "style", cellStyle);
+            }
+
+            if (!string.IsNullOrEmpty(cellClass))
+            {
+                SetAttribute(cellAttributes ??= new(), "class", cellClass);
             }
 
             if (CellContextMenu.HasDelegate)
             {
-                SetAttribute(cellAttributes, "oncontextmenu", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnContextMenu(column, Item, eventArgs)));
+                SetAttribute(cellAttributes ??= new(), "oncontextmenu", EventCallback.Factory.Create<MouseEventArgs>(receiver: this, callback: (eventArgs) => OnContextMenu(column, Item, eventArgs)));
             }
 
-            var title = column.Template == null && this.ShowCellDataAsTooltip || column.ShowCellDataAsTooltip ? $"{column.GetValue(Item)}" : "";
-            IReadOnlyDictionary<string, object> spanAttributes = EmptyAttributes;
-            if(!string.IsNullOrEmpty(title))
+            var hasTemplate = column.Template != null;
+
+            // Reuse the tooltip's formatted value in the body without hoisting GetValue into paths that
+            // do not need it. Track derivation separately because a GetValue override may return null.
+            object? cellValue = null;
+            var cellValueDerived = false;
+
+            string? title = null;
+
+            if (!hasTemplate && this.ShowCellDataAsTooltip || column.ShowCellDataAsTooltip)
             {
-                var titleAttrs = new Dictionary<string, object>();
-                SetAttribute(titleAttrs, "title", title);
-                spanAttributes = titleAttrs;
+                cellValue = column.GetValue(Item);
+                cellValueDerived = true;
+
+                var text = cellValue?.ToString();
+
+                // A null attribute is omitted; preserve that behavior for empty formatted values.
+                title = string.IsNullOrEmpty(text) ? null : text;
             }
 
             return __builder => {
             <text>
             @if (this.AllowCompositeDataCells ? RowIndex == column.GetLevel() : (column.Parent != null && RowIndex == column.GetLevel() || column.Columns == null))
             {
-                <td role="gridcell" @attributes="@cellAttributes" @oncontextmenu:preventDefault="@this.CellContextMenu.HasDelegate" @oncontextmenu:stopPropagation="@this.CellContextMenu.HasDelegate" @onkeydown:stopPropagation>
-                    @if (this.Responsive)
+                // The builder omits inactive modifier frames while keeping one stable <td> sequence.
+                RenderFragment cellContent = @<text>                    @if (this.Responsive)
                     {
                         <span class="rz-column-title">
                             @if (column.HeaderTemplate != null)
@@ -691,7 +719,7 @@
                                     @onclick="_ => this.ExpandItem(Item)" @onclick:stopPropagation="true">
                                 <span class="@(getExpandIconCssClass(this, Item)) @(this.ExpandedItemStyle(Item))"></span>
                             </button>
-                            <span class="@column.GetCellClass()" @attributes="@spanAttributes">
+                            <span class="@column.GetCellClass()" title="@title">
                                 @if (Item != null)
                                 {
                                     @if (this.IsRowInEditMode(Item) && column.EditTemplate != null)
@@ -712,7 +740,7 @@
                                         }
                                         else
                                         {
-                                            @column.GetValue(Item)
+                                            @(cellValueDerived ? cellValue : column.GetValue(Item))
                                         }
                                     }
                                     else if (column.Template != null)
@@ -721,7 +749,7 @@
                                     }
                                     else
                                     {
-                                        @column.GetValue(Item)
+                                        @(cellValueDerived ? cellValue : column.GetValue(Item))
                                     }
                                 }
                             </span>
@@ -729,7 +757,7 @@
                     }
                     else
                     {
-                            <span class="@column.GetCellClass()" @attributes="@spanAttributes">
+                            <span class="@column.GetCellClass()" title="@title">
                             @if (Item != null)
                             {
                                 @if (this.IsRowInEditMode(Item) && column.EditTemplate != null)
@@ -750,7 +778,7 @@
                                     }
                                     else
                                     {
-                                        @column.GetValue(Item)
+                                        @(cellValueDerived ? cellValue : column.GetValue(Item))
                                     }
                                 }
                                 else if (column.Template != null)
@@ -759,12 +787,13 @@
                                 }
                                 else
                                 {
-                                    @column.GetValue(Item)
+                                    @(cellValueDerived ? cellValue : column.GetValue(Item))
                                 }
                             }
                         </span>
-                    }
-                </td>
+                    }</text>;
+
+                @RenderCellElement(cellAttributes, cellContent)
             }
             else
             {
@@ -776,6 +805,24 @@
             </text>
         };
     }
+
+    // Keep one element frame so toggling context-menu modifiers preserves the cell subtree.
+    RenderFragment RenderCellElement(Dictionary<string, object>? cellAttributes, RenderFragment cellContent) => builder =>
+    {
+        builder.OpenElement(0, "td");
+        builder.AddAttribute(1, "role", "gridcell");
+        builder.AddMultipleAttributes(2, cellAttributes);
+
+        if (this.CellContextMenu.HasDelegate)
+        {
+            builder.AddEventPreventDefaultAttribute(3, "oncontextmenu", true);
+            builder.AddEventStopPropagationAttribute(4, "oncontextmenu", true);
+        }
+
+        builder.AddEventStopPropagationAttribute(5, "onkeydown", true);
+        builder.AddContent(6, cellContent);
+        builder.CloseElement();
+    };
 
     string GetCellStyle(RadzenDataGridColumn<TItem> column, IReadOnlyDictionary<string, object> Attributes)
     {

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -313,11 +313,10 @@ namespace Radzen.Blazor
                                 b.AddAttribute(8, "InEditMode", IsRowInEditMode(context));
                                 b.AddAttribute(9, "Index", virtualDataItems.IndexOf(context));
 
-                                // O(1) lookup instead of scanning editContexts.Keys per rendered row.
-                                if (editContexts.TryGetValue(context, out var editContext))
-                                {
-                                    b.AddAttribute(10, nameof(RadzenDataGridRow<TItem>.EditContext), editContext);
-                                }
+                                // Always supply the value because omitted parameters retain their previous value.
+                                editContexts.TryGetValue(context, out EditContext? editContext);
+
+                                b.AddAttribute(10, nameof(RadzenDataGridRow<TItem>.EditContext), editContext);
 
                                 b.SetKey(context);
                                 b.CloseComponent();
@@ -369,10 +368,10 @@ namespace Radzen.Blazor
                     builder.AddAttribute(5, "Item", item);
                     builder.AddAttribute(6, "InEditMode", IsRowInEditMode(item));
 
-                    if (editContexts.TryGetValue(item, out var editContext))
-                    {
-                        builder.AddAttribute(7, nameof(RadzenDataGridRow<TItem>.EditContext), editContext);
-                    }
+                    // Always supply the value because omitted parameters retain their previous value.
+                    editContexts.TryGetValue(item, out EditContext? editContext);
+
+                    builder.AddAttribute(7, nameof(RadzenDataGridRow<TItem>.EditContext), editContext);
 
                     builder.SetKey(item);
 

--- a/Radzen.Blazor/RadzenDataGridGroupRow.razor
+++ b/Radzen.Blazor/RadzenDataGridGroupRow.razor
@@ -181,10 +181,12 @@
                             builder.AddAttribute(5, "Item", item);
                             builder.AddAttribute(6, "InEditMode", Grid != null ? Grid.IsRowInEditMode((TItem)item) : false);
 
-                            if (Grid != null && Grid.editContexts.ContainsKey((TItem)item))
-                            {
-                                builder.AddAttribute(7, nameof(RadzenDataGridRow<TItem>.EditContext), Grid.editContexts[(TItem)item]);
-                            }
+                            // Always supply the value because omitted parameters retain their previous value.
+                            Microsoft.AspNetCore.Components.Forms.EditContext? editContext = null;
+
+                            Grid?.editContexts.TryGetValue((TItem)item, out editContext);
+
+                            builder.AddAttribute(7, nameof(RadzenDataGridRow<TItem>.EditContext), (object?)editContext);
 
                             builder.CloseComponent();
                             i++;

--- a/Radzen.Blazor/RadzenDataGridRow.razor
+++ b/Radzen.Blazor/RadzenDataGridRow.razor
@@ -1,9 +1,11 @@
 @using Microsoft.AspNetCore.Components.Forms
 @typeparam TItem
 @implements IRadzenForm
- <CascadingValue Value=@EditContext>
-    <CascadingValue Value=this>
-@{var rowArgs = Grid?.RowAttributes(Item, Index); }
+@{
+    // The cached fragment reads current parameters through this, so it is reusable across renders.
+    rowContent ??= @<text>@{
+        var rowArgs = Grid?.RowAttributes(Item, Index);
+    }
 @{var firstLevel = Grid?.AllowCompositeDataCells == true ? 0 : (Grid?.deepestChildColumnLevel ?? 0); }
 @for(var i = firstLevel; (Grid?.AllowCompositeDataCells == true ? i <= (Grid?.deepestChildColumnLevel ?? 0) + 1 : i < (Grid?.deepestChildColumnLevel ?? 0) + 1); i++)
 {
@@ -113,8 +115,23 @@
         </tr>
     }
 }
+</text>;
+}
+@* Cascades are needed only by edit templates; the EditContext check also supports direct parameter use.
+   Read-only templates now inherit an outer form. Switching branches rebuilds the row and resets state
+   held by non-edited templates. *@
+@if (InEditMode || EditContext != null)
+{
+    <CascadingValue Value=@EditContext>
+        <CascadingValue Value=this>
+            @rowContent
+        </CascadingValue>
     </CascadingValue>
-</CascadingValue>
+}
+else
+{
+    @rowContent
+}
 @code {
         [Parameter]
         public IList<RadzenDataGridColumn<TItem>> Columns { get; set; } = new List<RadzenDataGridColumn<TItem>>();
@@ -142,6 +159,8 @@
 
         [Parameter]
         public EditContext? EditContext { get; set; }
+
+        RenderFragment? rowContent;
 
         List<IRadzenFormComponent> components = new();
 


### PR DESCRIPTION
## Summary

Reduces allocations when rendering 1,000 rows × 5 columns from **28,708 KB** to **13,333 KB (−53.6%)**, with render time reduced by about one third.

## Allocation progression

| Stage | Allocated |
| --- | ---: |
| Pre-change `master` | 28,708 KB |
| Lazy cell attributes | 27,286 KB |
| Conditional context-menu modifiers | 25,294 KB |
| Edit-only row cascades | 18,728 KB |
| All non-tooltip changes combined | 18,189 KB |
| Tooltip value reuse | **13,333 KB** |

## Changes

- Allocates the per-cell attribute dictionary only when a cell needs attributes, while preserving `CellRender` class and style precedence.
- Emits context-menu modifiers only when `CellContextMenu` has a handler. A single stable `<td>` frame ensures adding or removing the handler does not rebuild cell subtrees.
- Cascades the row `EditContext` and `IRadzenForm` only while editing. The grid supplies `null` explicitly when editing ends so rows cannot retain a stale context.
- Writes cell tooltips without a per-cell dictionary and reuses the formatted `GetValue` result in the cell body. Lazy lookup behavior and legitimate `null` overrides are preserved.

## Compatibility notes

The row-cascade optimization has two intentional behavior changes:

- Controls in a read-only column template now inherit and register with an enclosing form instead of being isolated by a null row context.
- Entering or leaving edit mode rebuilds that row subtree, so state held by components in non-edited column templates does not survive the transition. Re-renders while remaining in edit mode preserve the subtree.

The cascade optimization is isolated in the second commit and can be dropped without affecting the per-cell changes.

## Validation

- Full suite: **5,037 tests passed**
- **26 new regression tests** across five files
- Clean build on **net8.0, net9.0, and net10.0**
- GitHub Actions passing

<details>
  <summary>AI Toolchain</summary>

  VSCode, Claude Code CLI - [Opus 4.8 - high], reviews from Codex - [5.6 Sol - High]
</details>
