### PR TITLE
RadzenPivotDataGrid: reload when a bound filter value changes

### DIFF
--- a/Radzen.Blazor.Tests/PivotDataGridTests.cs
+++ b/Radzen.Blazor.Tests/PivotDataGridTests.cs
@@ -935,6 +935,83 @@ namespace Radzen.Blazor.Tests
             });
         }
 
+        // A pivot field's filter parameters are applied after the pivot has already run its own
+        // OnParametersSetAsync reload, so that reload composed the filters as they were before the
+        // change. The field reloaded the pivot only when it had a filter template, which left a plain
+        // bound FilterValue holding a new value that nothing ever asked for: the pivot went on rendering
+        // the previous filter's rows. RadzenDataGridColumn reloads its grid on the same change.
+        static void BuildFilteredPivot(ComponentParameterCollectionBuilder<RadzenPivotDataGrid<SalesData>> p,
+            string region, FilterOperator filterOperator = FilterOperator.Equals)
+        {
+            p.Add(g => g.Data, AggregationData);
+            p.Add(g => g.AllowDrillDown, false);
+            p.Add(g => g.AllowFieldsPicking, false);
+
+            p.Add<RenderFragment>(g => g.Rows, b =>
+            {
+                b.OpenComponent<RadzenPivotRow<SalesData>>(0);
+                b.AddAttribute(1, nameof(RadzenPivotRow<SalesData>.Property), nameof(SalesData.Region));
+                b.AddAttribute(2, nameof(RadzenPivotRow<SalesData>.FilterValue), region);
+                b.AddAttribute(3, nameof(RadzenPivotRow<SalesData>.FilterOperator), filterOperator);
+                b.CloseComponent();
+            });
+
+            p.Add<RenderFragment>(g => g.Columns, b =>
+            {
+                b.OpenComponent<RadzenPivotColumn<SalesData>>(0);
+                b.AddAttribute(1, nameof(RadzenPivotColumn<SalesData>.Property), nameof(SalesData.Year));
+                b.CloseComponent();
+            });
+
+            p.Add<RenderFragment>(g => g.Aggregates, b =>
+            {
+                b.OpenComponent<RadzenPivotAggregate<SalesData>>(0);
+                b.AddAttribute(1, nameof(RadzenPivotAggregate<SalesData>.Property), nameof(SalesData.Amount));
+                b.AddAttribute(2, nameof(RadzenPivotAggregate<SalesData>.Aggregate), AggregateFunction.Sum);
+                b.CloseComponent();
+            });
+        }
+
+        static List<string> RowHeaders(IRenderedComponent<RadzenPivotDataGrid<SalesData>> component) =>
+            component.FindAll("tbody.rz-pivot-body td.rz-pivot-row-header")
+                .Select(c => c.TextContent.Trim()).ToList();
+
+        [Fact]
+        public void PivotDataGrid_ChangingABoundFilterValue_RefiltersTheRows()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenPivotDataGrid<SalesData>>(p => BuildFilteredPivot(p, "North"));
+
+            Assert.Contains("North", RowHeaders(component));
+            Assert.DoesNotContain("South", RowHeaders(component));
+
+            component.SetParametersAndRender(p => BuildFilteredPivot(p, "South"));
+
+            Assert.Contains("South", RowHeaders(component));
+            Assert.DoesNotContain("North", RowHeaders(component));
+        }
+
+        [Fact]
+        public void PivotDataGrid_ClearingABoundFilterValue_RestoresEveryRow()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenPivotDataGrid<SalesData>>(p => BuildFilteredPivot(p, "North"));
+
+            Assert.DoesNotContain("South", RowHeaders(component));
+
+            // Back to no filter at all, which is the same change in the other direction.
+            component.SetParametersAndRender(p => BuildFilteredPivot(p, null));
+
+            Assert.Contains("North", RowHeaders(component));
+            Assert.Contains("South", RowHeaders(component));
+        }
+
         [Fact]
         public void PivotDataGrid_Sort_OrdersRows()
         {

--- a/Radzen.Blazor.Tests/PivotDataGridTests.cs
+++ b/Radzen.Blazor.Tests/PivotDataGridTests.cs
@@ -941,7 +941,7 @@ namespace Radzen.Blazor.Tests
         // bound FilterValue holding a new value that nothing ever asked for: the pivot went on rendering
         // the previous filter's rows. RadzenDataGridColumn reloads its grid on the same change.
         static void BuildFilteredPivot(ComponentParameterCollectionBuilder<RadzenPivotDataGrid<SalesData>> p,
-            string region, FilterOperator filterOperator = FilterOperator.Equals)
+            string region, string secondRegion = null)
         {
             p.Add(g => g.Data, AggregationData);
             p.Add(g => g.AllowDrillDown, false);
@@ -952,7 +952,10 @@ namespace Radzen.Blazor.Tests
                 b.OpenComponent<RadzenPivotRow<SalesData>>(0);
                 b.AddAttribute(1, nameof(RadzenPivotRow<SalesData>.Property), nameof(SalesData.Region));
                 b.AddAttribute(2, nameof(RadzenPivotRow<SalesData>.FilterValue), region);
-                b.AddAttribute(3, nameof(RadzenPivotRow<SalesData>.FilterOperator), filterOperator);
+                b.AddAttribute(3, nameof(RadzenPivotRow<SalesData>.FilterOperator), FilterOperator.Equals);
+                b.AddAttribute(4, nameof(RadzenPivotRow<SalesData>.SecondFilterValue), secondRegion);
+                b.AddAttribute(5, nameof(RadzenPivotRow<SalesData>.SecondFilterOperator), FilterOperator.Equals);
+                b.AddAttribute(6, nameof(RadzenPivotRow<SalesData>.LogicalFilterOperator), LogicalFilterOperator.Or);
                 b.CloseComponent();
             });
 
@@ -995,6 +998,23 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void PivotDataGrid_ChangingABoundFilterValue_ReplacesTheInteractiveValue()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenPivotDataGrid<SalesData>>(p => BuildFilteredPivot(p, "North"));
+            var row = component.FindComponent<RadzenPivotRow<SalesData>>().Instance;
+            row.SetFilterValueInternal("North");
+
+            component.SetParametersAndRender(p => BuildFilteredPivot(p, "South"));
+
+            Assert.Contains("South", RowHeaders(component));
+            Assert.DoesNotContain("North", RowHeaders(component));
+        }
+
+        [Fact]
         public void PivotDataGrid_ClearingABoundFilterValue_RestoresEveryRow()
         {
             using var ctx = new TestContext();
@@ -1010,6 +1030,23 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains("North", RowHeaders(component));
             Assert.Contains("South", RowHeaders(component));
+        }
+
+        [Fact]
+        public void PivotDataGrid_ClearingABoundSecondFilterValue_ReplacesTheInteractiveValue()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = ctx.RenderComponent<RadzenPivotDataGrid<SalesData>>(p => BuildFilteredPivot(p, "North", "South"));
+            var row = component.FindComponent<RadzenPivotRow<SalesData>>().Instance;
+            row.SetSecondFilterValueInternal("South");
+
+            component.SetParametersAndRender(p => BuildFilteredPivot(p, "North"));
+
+            Assert.Contains("North", RowHeaders(component));
+            Assert.DoesNotContain("South", RowHeaders(component));
         }
 
         [Fact]
@@ -2162,4 +2199,3 @@ namespace Radzen.Blazor.Tests
         }
     }
 }
-

--- a/Radzen.Blazor.Tests/PivotDataGridTests.cs
+++ b/Radzen.Blazor.Tests/PivotDataGridTests.cs
@@ -935,11 +935,6 @@ namespace Radzen.Blazor.Tests
             });
         }
 
-        // A pivot field's filter parameters are applied after the pivot has already run its own
-        // OnParametersSetAsync reload, so that reload composed the filters as they were before the
-        // change. The field reloaded the pivot only when it had a filter template, which left a plain
-        // bound FilterValue holding a new value that nothing ever asked for: the pivot went on rendering
-        // the previous filter's rows. RadzenDataGridColumn reloads its grid on the same change.
         static void BuildFilteredPivot(ComponentParameterCollectionBuilder<RadzenPivotDataGrid<SalesData>> p,
             string region, string secondRegion = null)
         {

--- a/Radzen.Blazor/RadzenPivotField.razor.cs
+++ b/Radzen.Blazor/RadzenPivotField.razor.cs
@@ -469,6 +469,11 @@ namespace Radzen.Blazor
         /// <returns>A Task representing the asynchronous operation.</returns>
         public override async Task SetParametersAsync(ParameterView parameters)
         {
+            // Whether this parameter set changes what the pivot's View composes, and so needs a reload
+            // once the new values have been applied. The template branches below reload and return before
+            // reaching that, exactly as they did.
+            var filterChanged = false;
+
             if (parameters.DidParameterChange(nameof(FilterValue), FilterValue))
             {
                 filterValue = parameters.GetValueOrDefault<object>(nameof(FilterValue));
@@ -483,6 +488,8 @@ namespace Radzen.Blazor
 
                     return;
                 }
+
+                filterChanged = true;
             }
 
             if (parameters.DidParameterChange(nameof(SecondFilterValue), SecondFilterValue))
@@ -499,6 +506,8 @@ namespace Radzen.Blazor
 
                     return;
                 }
+
+                filterChanged = true;
             }
 
             if (filterOperator == null && (parameters.DidParameterChange(nameof(FilterOperator), FilterOperator) || _filterOperator != null))
@@ -522,6 +531,17 @@ namespace Radzen.Blazor
             }
 
             await base.SetParametersAsync(parameters);
+
+            // After the base call, so GetFilterValue() reads the value this parameter set carried. The
+            // pivot has already run its own OnParametersSetAsync reload by the time a field's parameters
+            // are applied, and that reload composed the filters as they were before this change - so
+            // without this the new filter is held but never asked for. RadzenDataGridColumn reloads its
+            // grid on the same change; the template check here only decides whether the work above has
+            // already been done, not whether a reload is owed.
+            if (filterChanged && PivotGrid != null)
+            {
+                await PivotGrid.Reload();
+            }
         }
     }
 } 

--- a/Radzen.Blazor/RadzenPivotField.razor.cs
+++ b/Radzen.Blazor/RadzenPivotField.razor.cs
@@ -469,9 +469,6 @@ namespace Radzen.Blazor
         /// <returns>A Task representing the asynchronous operation.</returns>
         public override async Task SetParametersAsync(ParameterView parameters)
         {
-            // Whether this parameter set changes what the pivot's View composes, and so needs a reload
-            // once the new values have been applied. The template branches below reload and return before
-            // reaching that, exactly as they did.
             var filterChanged = false;
 
             if (parameters.DidParameterChange(nameof(FilterValue), FilterValue))
@@ -534,12 +531,7 @@ namespace Radzen.Blazor
 
             await base.SetParametersAsync(parameters);
 
-            // After the base call, so GetFilterValue() reads the value this parameter set carried. The
-            // pivot has already run its own OnParametersSetAsync reload by the time a field's parameters
-            // are applied, and that reload composed the filters as they were before this change - so
-            // without this the new filter is held but never asked for. RadzenDataGridColumn reloads its
-            // grid on the same change; the template check here only decides whether the work above has
-            // already been done, not whether a reload is owed.
+            // Reload after applying parameters so the pivot uses the new filter values.
             if (filterChanged && PivotGrid != null)
             {
                 await PivotGrid.Reload();

--- a/Radzen.Blazor/RadzenPivotField.razor.cs
+++ b/Radzen.Blazor/RadzenPivotField.razor.cs
@@ -476,6 +476,7 @@ namespace Radzen.Blazor
 
             if (parameters.DidParameterChange(nameof(FilterValue), FilterValue))
             {
+                internalFilterValue = null;
                 filterValue = parameters.GetValueOrDefault<object>(nameof(FilterValue));
 
                 if (FilterTemplate != null || FilterValueTemplate != null)
@@ -494,6 +495,7 @@ namespace Radzen.Blazor
 
             if (parameters.DidParameterChange(nameof(SecondFilterValue), SecondFilterValue))
             {
+                internalSecondFilterValue = null;
                 secondFilterValue = parameters.GetValueOrDefault<object>(nameof(SecondFilterValue));
 
                 if (FilterTemplate != null || SecondFilterValueTemplate != null)
@@ -544,4 +546,4 @@ namespace Radzen.Blazor
             }
         }
     }
-} 
+}


### PR DESCRIPTION
Fixes #2685.

- Reload the pivot after changed bound filter parameters are applied.
- Let bound values replace older values held by the interactive filter UI.
- Cover changing and clearing both primary and secondary filter values.

<details>
  <summary>AI Toolchain</summary>

  VSCode, Claude Code CLI - [Opus 4.8 - high], reviews from Codex - [5.6 Sol - High]
</details>
