### PR TITLE
RadzenDataGrid: async IQueryable execution for EF Core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,7 @@ jobs:
     
     - name: Build
       run: dotnet build Radzen.Blazor/Radzen.Blazor.csproj
+    - name: Build Entity Framework adapter
+      run: dotnet build Radzen.Blazor.EntityFrameworkAdapter/Radzen.Blazor.EntityFrameworkAdapter.csproj
     - name: Test
       run: dotnet test Radzen.Blazor.Tests/Radzen.Blazor.Tests.csproj

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Test
         run: dotnet test Radzen.Blazor.Tests/Radzen.Blazor.Tests.csproj -c Release
 
+      - name: Pack Entity Framework adapter
+        run: dotnet pack Radzen.Blazor.EntityFrameworkAdapter/Radzen.Blazor.EntityFrameworkAdapter.csproj -c Release
+
       - name: Upload package artifact
         if: ${{ !inputs.publish }}
         uses: actions/upload-artifact@v4
@@ -89,7 +92,13 @@ jobs:
           path: |
             Radzen.Blazor/bin/Release/*.nupkg
             Radzen.Blazor/bin/Release/*.snupkg
+            Radzen.Blazor.EntityFrameworkAdapter/bin/Release/*.nupkg
+            Radzen.Blazor.EntityFrameworkAdapter/bin/Release/*.snupkg
 
       - name: Push to NuGet
         if: ${{ inputs.publish }}
         run: dotnet nuget push "Radzen.Blazor/bin/Release/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Push Entity Framework adapter to NuGet
+        if: ${{ inputs.publish }}
+        run: dotnet nuget push "Radzen.Blazor.EntityFrameworkAdapter/bin/Release/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Radzen.Blazor.EntityFrameworkAdapter/README.md
+++ b/Radzen.Blazor.EntityFrameworkAdapter/README.md
@@ -1,0 +1,62 @@
+# Radzen.Blazor.EntityFrameworkAdapter
+
+Execute Entity Framework Core queries from Radzen data-bound components asynchronously.
+
+Radzen components compose filtering, sorting, paging, and virtualization over a bound `IQueryable`. This adapter lets supported Entity Framework queries use `CountAsync` and `ToListAsync` without requiring a custom `LoadData` handler. `Radzen.Blazor` remains provider-agnostic; this package supplies the EF Core implementation of `IAsyncQueryExecutor`.
+
+## Install
+
+Install the adapter version that matches your `Radzen.Blazor` version:
+
+```shell
+dotnet add package Radzen.Blazor.EntityFrameworkAdapter
+```
+
+The package targets .NET 8, .NET 9, and .NET 10.
+
+## Configure
+
+Register the adapter once in `Program.cs`:
+
+```csharp
+builder.Services.AddRadzenQueryableEntityFrameworkAdapter();
+```
+
+## Use
+
+Bind an EF Core `IQueryable` or `DbSet` normally:
+
+```razor
+<RadzenDataGrid Data="@db.Orders"
+                TItem="Order"
+                AllowPaging="true"
+                AllowSorting="true"
+                AllowFiltering="true">
+    <Columns>
+        <RadzenDataGridColumn TItem="Order" Property="Number" Title="Number" />
+        <RadzenDataGridColumn TItem="Order" Property="Customer.Name" Title="Customer" />
+    </Columns>
+</RadzenDataGrid>
+```
+
+The component continues to compose the query. Count and materialization operations are awaited through EF Core when the query provider supports asynchronous execution.
+
+## Supported components
+
+- `RadzenDataGrid`, including paging, grouping, and virtualization
+- `RadzenDataList`, including virtualization
+- `RadzenPivotDataGrid`
+- `RadzenDropDown` and `RadzenListBox` virtualization
+- `RadzenDropDownDataGrid` search and paging
+
+Existing synchronous behavior is preserved when the adapter is not registered or a query provider does not support asynchronous execution. Application-provided `LoadData` handlers continue to own their query execution.
+
+`RadzenGantt` retains its existing synchronous internal loader because it performs hierarchy-wide traversal in addition to paging. Materialize its data asynchronously before binding when the source requires asynchronous database access.
+
+## Cancellation and concurrency
+
+Each component serializes its provider operations. A newer load requests cancellation of a superseded load and waits for that load to exit before using the same provider again. Virtualized requests link the component lifetime with the request cancellation token.
+
+Coordination is per component. If multiple components or application services share one `DbContext`, they can still issue concurrent operations against that context. Follow EF Core lifetime guidance: avoid concurrent use of a `DbContext`, scope it to the appropriate unit of work, or create contexts with `IDbContextFactory<TContext>`.
+
+Provider-originated failures and cancellations continue to propagate. The adapter permits synchronous fallback only for query shapes EF Core cannot execute asynchronously; it does not retry against a busy `DbContext`.

--- a/Radzen.Blazor.EntityFrameworkAdapter/Radzen.Blazor.EntityFrameworkAdapter.csproj
+++ b/Radzen.Blazor.EntityFrameworkAdapter/Radzen.Blazor.EntityFrameworkAdapter.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Radzen.Blazor.EntityFrameworkAdapter</PackageId>
+    <Description>Entity Framework Core adapter that lets data-bound Radzen.Blazor components execute their count and paging queries asynchronously.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>blazor;radzen;entityframework;efcore;async</PackageTags>
+    <Version>11.2.8</Version>
+    <Copyright>Radzen Ltd.</Copyright>
+    <Authors>Radzen Ltd.</Authors>
+    <PackageProjectUrl>https://www.radzen.com</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/radzenhq/radzen-blazor</RepositoryUrl>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.*-*" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <ProjectReference Include="..\Radzen.Blazor\Radzen.Blazor.csproj" />
+  </ItemGroup>
+</Project>

--- a/Radzen.Blazor.EntityFrameworkAdapter/RadzenEntityFrameworkAdapterServiceCollectionExtensions.cs
+++ b/Radzen.Blazor.EntityFrameworkAdapter/RadzenEntityFrameworkAdapterServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+using Radzen.EntityFrameworkCore;
+
+namespace Radzen
+{
+    /// <summary>
+    /// Extension methods that register the Entity Framework Core adapter for data-bound Radzen components.
+    /// </summary>
+    public static class RadzenEntityFrameworkAdapterServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers an <see cref="IAsyncQueryExecutor" /> so that Radzen components bound to an Entity
+        /// Framework Core <see cref="System.Linq.IQueryable{T}" /> count and page their data with awaited
+        /// asynchronous queries instead of blocking the calling thread on <c>Count()</c> / <c>ToList()</c>.
+        /// </summary>
+        /// <param name="services">The service collection to add the adapter to.</param>
+        /// <returns>The same service collection, for chaining.</returns>
+        public static IServiceCollection AddRadzenQueryableEntityFrameworkAdapter(this IServiceCollection services)
+        {
+            services.AddSingleton<IAsyncQueryExecutor, RadzenEntityFrameworkQueryExecutor>();
+            return services;
+        }
+    }
+}

--- a/Radzen.Blazor.EntityFrameworkAdapter/RadzenEntityFrameworkQueryExecutor.cs
+++ b/Radzen.Blazor.EntityFrameworkAdapter/RadzenEntityFrameworkQueryExecutor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Radzen.EntityFrameworkCore
+{
+    /// <summary>
+    /// An <see cref="IAsyncQueryExecutor" /> that runs the count and page-materialization queries of a
+    /// data-bound Radzen component through Entity Framework Core's asynchronous operators.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instantiated by the dependency injection container through AddRadzenQueryableEntityFrameworkAdapter.")]
+    internal sealed class RadzenEntityFrameworkQueryExecutor : IAsyncQueryExecutor
+    {
+        /// <summary>
+        /// Returns <c>true</c> when the queryable is provided by Entity Framework Core, i.e. its provider
+        /// implements <see cref="IAsyncQueryProvider" />.
+        /// </summary>
+        public bool IsSupported<T>(IQueryable<T> queryable) => queryable.Provider is IAsyncQueryProvider;
+
+        /// <inheritdoc />
+        public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            => queryable.CountAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            => queryable.ToListAsync(cancellationToken);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// A busy <c>DbContext</c> cannot safely retry the same query synchronously.
+        /// </remarks>
+        public bool CanFallBackToSynchronous(Exception exception) =>
+            (exception is InvalidOperationException or NotSupportedException) && !IsContextBusy(exception);
+
+        static bool IsContextBusy(Exception exception) =>
+#pragma warning disable EF1001
+            exception.TargetSite?.DeclaringType == typeof(ConcurrencyDetector);
+#pragma warning restore EF1001
+    }
+}

--- a/Radzen.Blazor.Tests/AsyncQueryCoordinatorTests.cs
+++ b/Radzen.Blazor.Tests/AsyncQueryCoordinatorTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class AsyncQueryCoordinatorTests
+    {
+        sealed class CoordinatorOwner : RadzenComponent
+        {
+            public int Notifications { get; private set; }
+
+            internal override void NotifyAsyncQueryCompleted()
+            {
+                Notifications++;
+            }
+        }
+
+        sealed class Executor : IAsyncQueryExecutor
+        {
+            public Func<IQueryable<int>, CancellationToken, Task<int>> Count { get; set; } =
+                (query, token) => Task.FromResult(query.Count());
+
+            public Func<IQueryable<int>, CancellationToken, Task<List<int>>> ToList { get; set; } =
+                (query, token) => Task.FromResult(query.ToList());
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default) =>
+                Count((IQueryable<int>)(object)queryable, cancellationToken);
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable,
+                CancellationToken cancellationToken = default) =>
+                (Task<List<T>>)(object)ToList((IQueryable<int>)(object)queryable, cancellationToken);
+        }
+
+        static AsyncQueryCoordinator Coordinator(Executor executor, out CoordinatorOwner owner)
+        {
+            owner = new CoordinatorOwner();
+
+            return new AsyncQueryCoordinator(owner, executor);
+        }
+
+        static AsyncQueryCoordinator Coordinator(out CoordinatorOwner owner) => Coordinator(new(), out owner);
+
+        static IQueryable<int> Query(params int[] items) => items.AsQueryable();
+
+        [Fact]
+        public async Task AnUncontendedQueryStartsAndCompletesInline()
+        {
+            bool invoked = false;
+            Executor executor = new()
+            {
+                Count = (query, token) =>
+                {
+                    invoked = true;
+                    return Task.FromResult(3);
+                }
+            };
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+
+            Task<int> result = coordinator.CountAsync(Query(1, 2, 3), default);
+
+            Assert.True(invoked);
+            Assert.True(result.IsCompletedSuccessfully);
+            Assert.Equal(3, await result);
+        }
+
+        [Fact]
+        public async Task ContendedQueriesRunInFifoOrder()
+        {
+            TaskCompletionSource<int> first = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            List<string> calls = new();
+            int countCalls = 0;
+            Executor executor = new()
+            {
+                Count = (query, token) =>
+                {
+                    calls.Add($"count-{++countCalls}");
+                    return countCalls == 1 ? first.Task : Task.FromResult(query.Count());
+                },
+                ToList = (query, token) =>
+                {
+                    calls.Add("list");
+                    return Task.FromResult(query.ToList());
+                }
+            };
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+
+            Task<int> firstQuery = coordinator.CountAsync(Query(1), default);
+            Task<List<int>> secondQuery = coordinator.ToListAsync(Query(2), default);
+            Task<int> thirdQuery = coordinator.CountAsync(Query(3), default);
+
+            Assert.Equal(new[] { "count-1" }, calls);
+
+            first.SetResult(1);
+            await Task.WhenAll(firstQuery, secondQuery, thirdQuery);
+
+            Assert.Equal(new[] { "count-1", "list", "count-2" }, calls);
+        }
+
+        [Fact]
+        public async Task AFaultDoesNotPoisonTheQueueTail()
+        {
+            TaskCompletionSource<int> first = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            bool secondStarted = false;
+            Executor executor = new()
+            {
+                Count = (query, token) => first.Task,
+                ToList = (query, token) =>
+                {
+                    secondStarted = true;
+                    return Task.FromResult(query.ToList());
+                }
+            };
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+
+            Task<int> failed = coordinator.CountAsync(Query(1), default);
+            Task<List<int>> next = coordinator.ToListAsync(Query(2), default);
+
+            first.SetException(new InvalidOperationException("first failed"));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => failed);
+            Assert.Equal(new[] { 2 }, await next);
+            Assert.True(secondStarted);
+        }
+
+        [Fact]
+        public async Task ASynchronousExecutorThrowBecomesAFaultedTask()
+        {
+            Executor executor = new()
+            {
+                Count = (query, token) => throw new InvalidOperationException("synchronous"),
+                ToList = (query, token) => Task.FromResult(query.ToList())
+            };
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+
+            Task<int> failed = coordinator.CountAsync(Query(1), default);
+
+            Assert.True(failed.IsFaulted);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => failed);
+            Assert.Equal(new[] { 2 }, await coordinator.ToListAsync(Query(2), default));
+        }
+
+        [Fact]
+        public async Task CountAndPageKeepsItsRoundTripsInOneTurn()
+        {
+            TaskCompletionSource<int> count = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            List<string> calls = new();
+            Executor executor = new()
+            {
+                ToList = (query, token) =>
+                {
+                    calls.Add(query.Count() == 1 ? "other" : "page");
+                    return Task.FromResult(query.ToList());
+                },
+                Count = (query, token) =>
+                {
+                    calls.Add("count");
+                    return count.Task;
+                }
+            };
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+
+            Task<(int Count, List<int> Items)> pair = coordinator.CountAndPageAsync(
+                Query(1, 2, 3), Query(1, 2), true, default);
+            Task<List<int>> other = coordinator.ToListAsync(Query(9), default);
+
+            Assert.Equal(new[] { "count" }, calls);
+
+            count.SetResult(3);
+
+            (int total, List<int> items) = await pair;
+            Assert.Equal(3, total);
+            Assert.Equal(new[] { 1, 2 }, items);
+            Assert.Equal(new[] { 9 }, await other);
+            Assert.Equal(new[] { "count", "page", "other" }, calls);
+        }
+
+        [Fact]
+        public async Task WholeSourceCountComesFromTheMaterializedItems()
+        {
+            int countCalls = 0;
+            Executor executor = new()
+            {
+                Count = (query, token) =>
+                {
+                    countCalls++;
+                    return Task.FromResult(query.Count());
+                }
+            };
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+
+            (int count, List<int> items) = await coordinator.CountAndPageAsync(
+                Query(1, 2, 3), Query(1, 2, 3), false, default);
+
+            Assert.Equal(3, count);
+            Assert.Equal(new[] { 1, 2, 3 }, items);
+            Assert.Equal(0, countCalls);
+        }
+
+        [Fact]
+        public async Task VirtualCountAndPageAppliesApprovedSynchronousFallback()
+        {
+            Executor executor = new()
+            {
+                ToList = (query, token) => Task.FromException<List<int>>(
+                    new InvalidOperationException("cannot be translated"))
+            };
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+            using var request = coordinator.TrackVirtualRequest(default);
+
+            var result = await request.CountAndPageAsync(Query(1, 2, 3), Query(2, 3), true);
+
+            Assert.True(result.HasValue);
+            Assert.Equal(3, result.Value.Count);
+            Assert.Equal(new[] { 2, 3 }, result.Value.Items);
+        }
+
+        [Fact]
+        public async Task SupersedeWaitsForTheWholeLoadWhenCancellationIsAdvisory()
+        {
+            Executor executor = new();
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+            TaskCompletionSource first = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource continueLoad = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource second = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            int calls = 0;
+
+            executor.ToList = async (query, token) =>
+            {
+                if (++calls == 1)
+                {
+                    await first.Task;
+                }
+                else
+                {
+                    await second.Task;
+                }
+
+                return query.ToList();
+            };
+
+            Task<bool> load = coordinator.RunLoadAsync(async lease =>
+            {
+                await coordinator.ToListAsync(Query(1), lease.Token);
+                await continueLoad.Task;
+                await coordinator.ToListAsync(Query(2), lease.Token);
+            });
+
+            Task supersede = coordinator.SupersedeAsyncLoad();
+
+            Assert.True(coordinator.LoadPending);
+
+            first.SetResult();
+            continueLoad.SetResult();
+
+            while (Volatile.Read(ref calls) < 2)
+            {
+                await Task.Yield();
+            }
+
+            Assert.False(supersede.IsCompleted);
+
+            second.SetResult();
+
+            Assert.False(await load);
+            await supersede;
+            Assert.False(coordinator.LoadPending);
+        }
+
+        [Fact]
+        public async Task SimultaneousSupersedingWaitsKeepPendingSuppressed()
+        {
+            Executor executor = new();
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+            TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            Task<bool> load = coordinator.RunLoadAsync(async lease => await gate.Task);
+
+            Task first = coordinator.SupersedeAsyncLoad();
+            Task second = coordinator.SupersedeAsyncLoad();
+
+            Assert.True(coordinator.LoadPending);
+            Assert.False(first.IsCompleted);
+            Assert.False(second.IsCompleted);
+
+            gate.SetResult();
+
+            await Task.WhenAll(load, first, second);
+            Assert.False(coordinator.LoadPending);
+        }
+
+        [Fact]
+        public async Task ReplacingAVirtualLeaseDoesNotLetTheOldLeaseClearTheNewOne()
+        {
+            AsyncQueryCoordinator coordinator = Coordinator(out _);
+            AsyncQueryCoordinator.VirtualRequestLease first = coordinator.TrackVirtualRequest(default);
+            AsyncQueryCoordinator.VirtualRequestLease second = coordinator.TrackVirtualRequest(default);
+
+            Assert.True(first.Token.IsCancellationRequested);
+            Assert.False(second.Token.IsCancellationRequested);
+
+            first.Dispose();
+            await coordinator.SupersedeAsyncLoad();
+
+            Assert.True(second.Token.IsCancellationRequested);
+            second.Dispose();
+        }
+
+        [Fact]
+        public async Task CancellationCallbackReentrancyDoesNotTransferLoadOwnership()
+        {
+            AsyncQueryCoordinator coordinator = Coordinator(out CoordinatorOwner owner);
+            TaskCompletionSource firstGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource callbackGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            Task<bool> callbackLoad = null!;
+
+            Task<bool> first = coordinator.RunLoadAsync(async lease =>
+            {
+                using CancellationTokenRegistration registration = lease.Token.Register(() =>
+                    callbackLoad = coordinator.RunLoadAsync(async callbackLease => await callbackGate.Task));
+                await firstGate.Task;
+            });
+
+            Task<bool> superseded = coordinator.RunLoadAsync(lease =>
+            {
+                lease.ThrowIfSuperseded();
+                return Task.CompletedTask;
+            });
+
+            Assert.NotNull(callbackLoad);
+            Assert.False(await superseded);
+
+            callbackGate.SetResult();
+            Assert.True(await callbackLoad);
+
+            firstGate.SetResult();
+            Assert.False(await first);
+            Assert.Equal(1, owner.Notifications);
+        }
+
+        [Fact]
+        public async Task VirtualRequestDisposalIsDeferredUntilTheLeaseExits()
+        {
+            AsyncQueryCoordinator coordinator = Coordinator(out _);
+            AsyncQueryCoordinator.VirtualRequestLease lease = coordinator.TrackVirtualRequest(default);
+
+            coordinator.Dispose();
+
+            Assert.True(lease.Token.IsCancellationRequested);
+            Assert.NotNull(lease.Token.WaitHandle);
+
+            lease.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { _ = lease.Token.WaitHandle; });
+            await coordinator.SupersedeAsyncLoad();
+        }
+
+        [Fact]
+        public async Task ComponentDisposalDoesNotDisposeALoadTokenStillInUse()
+        {
+            Executor executor = new();
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out _);
+            TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            bool waitHandleWasSafe = false;
+
+            Task<bool> load = coordinator.RunLoadAsync(async lease =>
+            {
+                await gate.Task;
+                waitHandleWasSafe = lease.Token.WaitHandle != null;
+            });
+
+            coordinator.Dispose();
+            gate.SetResult();
+
+            Assert.True(await load);
+            Assert.True(waitHandleWasSafe);
+        }
+
+        [Fact]
+        public async Task OnlyTheOwningLeaseNotifiesItsComponentWhenItEnds()
+        {
+            Executor executor = new();
+            AsyncQueryCoordinator coordinator = Coordinator(executor, out CoordinatorOwner owner);
+            TaskCompletionSource firstGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource secondGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            Task<bool> first = coordinator.RunLoadAsync(async lease => await firstGate.Task);
+            Task<bool> second = coordinator.RunLoadAsync(async lease => await secondGate.Task);
+
+            firstGate.SetResult();
+
+            Assert.False(await first);
+            Assert.Equal(0, owner.Notifications);
+
+            secondGate.SetResult();
+
+            Assert.True(await second);
+            Assert.Equal(1, owner.Notifications);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/AsyncQueryExecutorTests.cs
+++ b/Radzen.Blazor.Tests/AsyncQueryExecutorTests.cs
@@ -1,0 +1,757 @@
+using System;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class AsyncQueryExecutorTests
+    {
+        public class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Team { get; set; }
+        }
+
+        sealed class RecordingExecutor : IAsyncQueryExecutor
+        {
+            public int CountCalls;
+            public int ToListCalls;
+            public int LargestToList;
+            public bool Supported = true;
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => Supported;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            {
+                CountCalls++;
+                return Task.FromResult(queryable.Count());
+            }
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            {
+                ToListCalls++;
+
+                var items = queryable.ToList();
+
+                LargestToList = Math.Max(LargestToList, items.Count);
+
+                return Task.FromResult(items);
+            }
+        }
+
+        static List<Person> People(int n) =>
+            Enumerable.Range(1, n).Select(i => new Person { Id = i, Name = "Person " + i, Team = "Team " + (i % 3) }).ToList();
+
+        static object CoordinatorFor(RadzenComponent component) =>
+            typeof(RadzenComponent).GetField("asyncQueryCoordinator",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(component);
+
+        static IRenderedComponent<RadzenDataGrid<Person>> RenderGrid(TestContext ctx, IEnumerable<Person> data, int pageSize) =>
+            ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, data);
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, pageSize);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(1, "Property", "Id");
+                    builder.CloseComponent();
+                    builder.OpenComponent(2, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(3, "Property", "Name");
+                    builder.CloseComponent();
+                });
+            });
+
+        [Fact]
+        public void DataGrid_VirtualizationWithPaging_UsesAsyncExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(60).AsQueryable());
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.PageSize, 10);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(1, "Property", "Id");
+                    builder.CloseComponent();
+                    builder.OpenComponent(2, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(3, "Property", "Name");
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.True(executor.CountCalls > 0, "the count should have gone through the executor");
+            Assert.True(executor.ToListCalls > 0, "the page should have been materialized through the executor");
+
+            Assert.Equal(10, executor.LargestToList);
+
+            Assert.Equal(60, component.Instance.Count);
+            Assert.Contains("Person 1", component.Markup);
+        }
+
+        [Fact]
+        public void DataGrid_UsesAsyncExecutor_ForCountAndPage_WhenRegistered()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = RenderGrid(ctx, People(23).AsQueryable(), pageSize: 10);
+
+            Assert.True(executor.CountCalls > 0, "CountAsync should have been called");
+            Assert.True(executor.ToListCalls > 0, "ToListAsync should have been called");
+            Assert.NotNull(CoordinatorFor(component.Instance));
+
+            Assert.Equal(23, component.Instance.Count);
+            Assert.Contains(">Person 1<", component.Markup);
+            Assert.Contains(">Person 10<", component.Markup);
+            Assert.DoesNotContain(">Person 11<", component.Markup);
+        }
+
+        [Fact]
+        public void DataGrid_FallsBackToSync_WhenExecutorDoesNotSupportQueryable()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor { Supported = false };
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = RenderGrid(ctx, People(23).AsQueryable(), pageSize: 10);
+
+            Assert.Equal(0, executor.CountCalls);
+            Assert.Equal(0, executor.ToListCalls);
+            Assert.Null(CoordinatorFor(component.Instance));
+            Assert.Equal(23, component.Instance.Count);
+            Assert.Contains(">Person 10<", component.Markup);
+            Assert.DoesNotContain(">Person 11<", component.Markup);
+        }
+
+        [Fact]
+        public void DataGrid_Virtualization_UsesAsyncExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(500).AsQueryable());
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(1, "Property", "Id");
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.True(executor.CountCalls > 0, "CountAsync should have been called by LoadItems");
+            Assert.True(executor.ToListCalls > 0, "ToListAsync should have been called by LoadItems");
+        }
+
+        sealed class GatedExecutor : IAsyncQueryExecutor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            int calls;
+            public readonly List<CancellationToken> CountTokens = new();
+
+            public void Release() => release.TrySetResult();
+
+            public bool Supported = true;
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => Supported;
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            {
+                CountTokens.Add(cancellationToken);
+                if (Interlocked.Increment(ref calls) > 1)
+                {
+                    await release.Task;
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+                return queryable.Count();
+            }
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+                => Task.FromResult(queryable.ToList());
+        }
+
+        [Fact]
+        public async Task DataGrid_CancelsSupersededLoad()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new GatedExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = RenderGrid(ctx, People(30).AsQueryable(), pageSize: 10);
+
+            var loadA = component.InvokeAsync(() => component.Instance.Reload());
+            var loadB = component.InvokeAsync(() => component.Instance.Reload());
+            executor.Release();
+            await Task.WhenAll(loadA, loadB);
+
+            Assert.True(executor.CountTokens.Count >= 3);
+            Assert.True(executor.CountTokens[1].IsCancellationRequested, "the superseded load's token must be cancelled");
+            Assert.False(executor.CountTokens[^1].IsCancellationRequested, "the latest load's token must remain active");
+            Assert.Equal(30, component.Instance.Count);
+        }
+
+        [Fact]
+        public async Task DataGrid_CancelsSupersededLoad_WhenTheReplacementIsSynchronous()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new GatedExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = RenderGrid(ctx, People(30).AsQueryable(), pageSize: 10);
+
+            var parked = component.InvokeAsync(() => component.Instance.Reload());
+
+            executor.Supported = false;
+            var replacement = component.InvokeAsync(() => component.Instance.Reload());
+
+            executor.Release();
+            await Task.WhenAll(parked, replacement);
+
+            Assert.True(executor.CountTokens[1].IsCancellationRequested,
+                "the superseded load's token must be cancelled even though the replacement is synchronous");
+            Assert.Equal(30, component.Instance.Count);
+        }
+
+        sealed class AdvisoryGatedExecutor : IAsyncQueryExecutor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            int calls;
+
+            public void Release() => release.TrySetResult();
+
+            public bool Supported = true;
+
+            public const int StaleCount = 4242;
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => Supported;
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            {
+                if (Interlocked.Increment(ref calls) > 1)
+                {
+                    await release.Task;
+
+                    return StaleCount;
+                }
+
+                return queryable.Count();
+            }
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+                => Task.FromResult(queryable.ToList());
+        }
+
+        [Fact]
+        public async Task DataGrid_SupersededLoad_PublishesNothing_WhenTheReplacementIsSynchronous()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new AdvisoryGatedExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = RenderGrid(ctx, People(30).AsQueryable(), pageSize: 10);
+
+            var parked = component.InvokeAsync(() => component.Instance.Reload());
+
+            executor.Supported = false;
+
+            var replacement = component.InvokeAsync(() => component.Instance.Reload());
+
+            await component.InvokeAsync(() => { });
+
+            Assert.Empty(await component.InvokeAsync(() => component.Instance.PagedView.Cast<object>().ToList()));
+
+            executor.Release();
+
+            await parked;
+            await replacement;
+
+            Assert.NotEqual(AdvisoryGatedExecutor.StaleCount, component.Instance.Count);
+            Assert.Equal(30, component.Instance.Count);
+            Assert.Equal(10, await component.InvokeAsync(() => component.Instance.PagedView.Count()));
+        }
+
+        sealed class IgnoresCancellationExecutor : IAsyncQueryExecutor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            readonly TaskCompletionSource hold = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            int calls;
+
+            public bool Parked { get; private set; }
+
+            public bool Held { get; private set; }
+
+            public void Release() => release.TrySetResult();
+
+            public void Continue() => hold.TrySetResult();
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            {
+                var call = Interlocked.Increment(ref calls);
+
+                if (call == 2)
+                {
+                    Parked = true;
+
+                    await release.Task;
+
+                    Parked = false;
+                }
+                else if (call == 3)
+                {
+                    Held = true;
+
+                    await hold.Task;
+
+                    Held = false;
+                }
+
+                return queryable.Count();
+            }
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+                => Task.FromResult(queryable.ToList());
+        }
+
+        class SearchableDropDownDataGrid<T> : RadzenDropDownDataGrid<T>
+        {
+            public Task Search() =>
+                OnFilter(new Microsoft.AspNetCore.Components.ChangeEventArgs());
+        }
+
+        [Fact]
+        public async Task DropDownDataGrid_ASupersededLoadDoesNotReplaceTheView_WhenTheExecutorIgnoresCancellation()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new IgnoresCancellationExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var searchBox = ctx.JSInterop.Setup<string>("Radzen.getInputValue", _ => true);
+            searchBox.SetResult(string.Empty);
+
+            var people = People(30).AsQueryable();
+
+            var component = ctx.RenderComponent<SearchableDropDownDataGrid<Person>>(p =>
+            {
+                p.Add(d => d.Data, people);
+                p.Add(d => d.TextProperty, nameof(Person.Name));
+                p.Add(d => d.AllowFiltering, true);
+                p.Add(d => d.PageSize, 10);
+            });
+
+            string[] Names() => component.Instance.View.Cast<Person>().Select(x => x.Name).ToArray();
+
+            var unsearched = Names();
+
+            searchBox.SetResult("Person 1");
+
+            var parked = component.InvokeAsync(() => component.Instance.Search());
+
+            component.WaitForState(() => executor.Parked);
+
+            searchBox.SetResult("Person 25");
+
+            var replacement = component.InvokeAsync(() => component.Instance.Search());
+
+            executor.Release();
+
+            await parked;
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Held, TimeSpan.FromSeconds(5)));
+
+            Assert.Equal(unsearched, Names());
+
+            executor.Continue();
+
+            await replacement;
+
+            Assert.Equal(new[] { "Person 25" }, Names());
+        }
+
+        [Fact]
+        public void DataGrid_GroupedVirtualization_UsesAsyncExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(500).AsQueryable());
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.AllowGrouping, true);
+                p.Add(g => g.Groups, new System.Collections.ObjectModel.ObservableCollection<GroupDescriptor>
+                {
+                    new GroupDescriptor { Property = nameof(Person.Team) }
+                });
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                    builder.OpenComponent(2, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(3, "Property", "Team");
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.True(executor.ToListCalls > 0, "ToListAsync should have been called by LoadGroups");
+            Assert.Contains("Team 0", component.Markup);
+        }
+
+        [Fact]
+        public void DataGrid_Grouped_UsesAsyncExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(30).AsQueryable());
+                p.Add(g => g.Groups, new System.Collections.ObjectModel.ObservableCollection<GroupDescriptor>
+                {
+                    new GroupDescriptor { Property = nameof(Person.Team) }
+                });
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                    builder.OpenComponent(2, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(3, "Property", "Team");
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.True(executor.ToListCalls > 0, "ToListAsync should have been called for the grouped view");
+            Assert.Contains("Team 0", component.Markup);
+
+            Assert.Equal(0, executor.CountCalls);
+            Assert.Equal(30, component.Instance.Count);
+        }
+
+        [Fact]
+        public void DataGrid_ObjectTyped_Sorted_UsesAsyncExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataGrid<object>>(p =>
+            {
+                p.Add<IEnumerable<object>>(g => g.Data, People(30).Cast<object>().ToList().AsQueryable());
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.AllowSorting, true);
+                p.Add(g => g.PageSize, 10);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<object>));
+                    builder.AddAttribute(1, "Property", "Id");
+                    builder.CloseComponent();
+                    builder.OpenComponent(2, typeof(RadzenDataGridColumn<object>));
+                    builder.AddAttribute(3, "Property", "Name");
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.True(executor.CountCalls > 0, "CountAsync should have been called");
+            Assert.True(executor.ToListCalls > 0, "ToListAsync should have materialized the page");
+
+            var countBefore = executor.CountCalls;
+            var toListBefore = executor.ToListCalls;
+            component.InvokeAsync(() => component.Instance.OrderBy("Id")).GetAwaiter().GetResult();
+
+            Assert.True(executor.CountCalls > countBefore, "sorting should have counted through the async seam");
+            Assert.True(executor.ToListCalls - toListBefore >= 2, "sorting should have run the type probe and the page");
+            Assert.Equal(30, component.Instance.Count);
+            Assert.Contains(">Person 1<", component.Markup);
+            Assert.DoesNotContain(">Person 11<", component.Markup);
+        }
+
+        [Fact]
+        public void DropDownDataGrid_UsesAsyncExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDropDownDataGrid<int>>(p =>
+            {
+                p.Add(d => d.Data, People(30).Cast<object>());
+                p.Add(d => d.TextProperty, nameof(Person.Name));
+                p.Add(d => d.ValueProperty, nameof(Person.Id));
+            });
+
+            Assert.True(executor.CountCalls > 0, "CountAsync should have been called by OnLoadData");
+            Assert.True(executor.ToListCalls > 0, "ToListAsync should have been called by OnLoadData");
+        }
+
+
+        sealed class MarkerProvider : IQueryProvider
+        {
+            readonly IQueryProvider inner;
+
+            public MarkerProvider(IQueryProvider inner) => this.inner = inner;
+
+            public IQueryable CreateQuery(Expression expression) => inner.CreateQuery(expression);
+
+            public IQueryable<TElement> CreateQuery<TElement>(Expression expression) =>
+                new MarkerQueryable<TElement>(inner.CreateQuery<TElement>(expression));
+
+            public object? Execute(Expression expression) => inner.Execute(expression);
+
+            public TResult Execute<TResult>(Expression expression) => inner.Execute<TResult>(expression);
+        }
+
+        sealed class MarkerQueryable<T> : IQueryable<T>
+        {
+            readonly IQueryable<T> inner;
+
+            public MarkerQueryable(IQueryable<T> inner)
+            {
+                this.inner = inner;
+                Provider = new MarkerProvider(inner.Provider);
+            }
+
+            public Type ElementType => inner.ElementType;
+            public Expression Expression => inner.Expression;
+            public IQueryProvider Provider { get; }
+            public IEnumerator<T> GetEnumerator() => inner.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => inner.GetEnumerator();
+        }
+
+        sealed class ProviderSniffingExecutor : IAsyncQueryExecutor
+        {
+            public int CountCalls;
+            public int ToListCalls;
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => queryable.Provider is MarkerProvider;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            {
+                CountCalls++;
+                return Task.FromResult(queryable.Count());
+            }
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+            {
+                ToListCalls++;
+                return Task.FromResult(queryable.ToList());
+            }
+        }
+
+        [Fact]
+        public void DropDownBase_Virtualization_PreservesQueryProvider()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new ProviderSniffingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            ctx.RenderComponent<RadzenDropDown<int>>(p =>
+            {
+                p.Add(d => d.Data, new MarkerQueryable<Person>(People(500).AsQueryable()));
+                p.Add(d => d.TextProperty, nameof(Person.Name));
+                p.Add(d => d.ValueProperty, nameof(Person.Id));
+                p.Add(d => d.AllowVirtualization, true);
+            });
+
+            Assert.True(executor.ToListCalls > 0,
+                "DropDownBase.LoadItems should have reached the executor with the provider intact");
+        }
+
+        [Fact]
+        public void DataGrid_PreservesQueryProvider()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new ProviderSniffingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataGrid<Person>>(p =>
+            {
+                p.Add<IEnumerable<Person>>(g => g.Data, new MarkerQueryable<Person>(People(30).AsQueryable()));
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 10);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Person>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.True(executor.ToListCalls > 0, "the grid should have reached the executor");
+            Assert.Equal(30, component.Instance.Count);
+            Assert.Contains(">Person 1<", component.Markup);
+            Assert.DoesNotContain(">Person 11<", component.Markup);
+        }
+
+        [Fact]
+        public void DataList_UnpagedVirtualized_CountsWithoutMaterializingWholeQueryable()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataList<Person>>(p =>
+            {
+                p.Add(d => d.Data, People(500).AsQueryable());
+                p.Add(d => d.AllowVirtualization, true);
+                p.Add<RenderFragment<Person>>(d => d.Template, item => builder => builder.AddContent(0, item.Name));
+            });
+
+            Assert.True(executor.CountCalls > 0, "the count should still have gone through the seam");
+            Assert.True(executor.ToListCalls > 0, "the windows should have come through the seam too");
+            Assert.True(executor.LargestToList < 500,
+                $"nothing should have materialized the whole queryable; largest was {executor.LargestToList}");
+            Assert.Equal(500, component.Instance.Count);
+        }
+
+[Fact]
+        public void DataList_UnpagedNotVirtualized_MaterializesThroughTheSeam()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenDataList<Person>>(p =>
+            {
+                p.Add(d => d.Data, People(120).AsQueryable());
+                p.Add(d => d.AllowPaging, false);
+                p.Add(d => d.AllowVirtualization, false);
+                p.Add<RenderFragment<Person>>(d => d.Template, item => builder => builder.AddContent(0, item.Name));
+            });
+
+            Assert.True(executor.ToListCalls > 0, "the rows should have come through the seam");
+            Assert.Equal(0, executor.CountCalls);
+            Assert.Equal(120, component.Instance.Count);
+        }
+
+        [Fact]
+        public void PivotDataGrid_UsesAsyncExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var executor = new RecordingExecutor();
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var component = ctx.RenderComponent<RadzenPivotDataGrid<Person>>(p =>
+            {
+                p.Add(g => g.Data, People(30).AsQueryable());
+                p.Add<RenderFragment>(g => g.Rows, builder =>
+                {
+                    builder.OpenComponent<RadzenPivotRow<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenPivotRow<Person>.Property), nameof(Person.Name));
+                    builder.AddAttribute(2, nameof(RadzenPivotRow<Person>.Title), "Name");
+                    builder.CloseComponent();
+                });
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenPivotColumn<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenPivotColumn<Person>.Property), nameof(Person.Team));
+                    builder.AddAttribute(2, nameof(RadzenPivotColumn<Person>.Title), "Team");
+                    builder.CloseComponent();
+                });
+                p.Add<RenderFragment>(g => g.Aggregates, builder =>
+                {
+                    builder.OpenComponent<RadzenPivotAggregate<Person>>(0);
+                    builder.AddAttribute(1, nameof(RadzenPivotAggregate<Person>.Property), nameof(Person.Id));
+                    builder.AddAttribute(2, nameof(RadzenPivotAggregate<Person>.Title), "Id");
+                    builder.AddAttribute(3, nameof(RadzenPivotAggregate<Person>.Aggregate), AggregateFunction.Sum);
+                    builder.CloseComponent();
+                });
+            });
+
+            Assert.True(executor.ToListCalls > 0, "the pivot grid should have materialized through the seam");
+            Assert.Equal(30, component.Instance.Count);
+        }
+
+        [Fact]
+        public void DataGrid_WorksWithoutAnyExecutorRegistered()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = RenderGrid(ctx, People(23).AsQueryable(), pageSize: 10);
+
+            Assert.Null(CoordinatorFor(component.Instance));
+            Assert.Equal(23, component.Instance.Count);
+            Assert.Contains(">Person 10<", component.Markup);
+            Assert.DoesNotContain(">Person 11<", component.Markup);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/AsyncSeamProviderConcurrencyTests.cs
+++ b/Radzen.Blazor.Tests/AsyncSeamProviderConcurrencyTests.cs
@@ -1,0 +1,450 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class AsyncSeamProviderConcurrencyTests : IDisposable
+    {
+        readonly SqliteConnection connection = new("DataSource=:memory:");
+        readonly Parking parking = new();
+        readonly EntityFrameworkAdapterTests.Ctx context;
+
+        public AsyncSeamProviderConcurrencyTests()
+        {
+            connection.Open();
+
+            context = new EntityFrameworkAdapterTests.Ctx(
+                new DbContextOptionsBuilder<EntityFrameworkAdapterTests.Ctx>()
+                    .UseSqlite(connection)
+                    .AddInterceptors(parking)
+                    .Options);
+
+            context.Database.EnsureCreated();
+
+            context.People.AddRange(Enumerable.Range(1, 500).Select(i => new EntityFrameworkAdapterTests.Employee
+            {
+                Id = i,
+                Name = "Name" + i,
+                Department = "Engineering",
+                Salary = 1000 + i,
+            }));
+
+            context.SaveChanges();
+        }
+
+        public void Dispose()
+        {
+            parking.Release();
+
+            context.Dispose();
+            connection.Dispose();
+
+            GC.SuppressFinalize(this);
+        }
+
+        sealed class Parking : DbCommandInterceptor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            int armed;
+
+            public int Started;
+
+            public void Arm() => Volatile.Write(ref armed, 1);
+
+            public void Release() => release.TrySetResult();
+
+            public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+                DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+                CancellationToken cancellationToken = default)
+            {
+                if (Interlocked.CompareExchange(ref armed, 0, 1) == 1)
+                {
+                    Interlocked.Increment(ref Started);
+
+                    await release.Task;
+                }
+                else
+                {
+                    Interlocked.Increment(ref Started);
+                }
+
+                return result;
+            }
+        }
+
+        IRenderedComponent<RadzenListBox<EntityFrameworkAdapterTests.Employee>> VirtualListBox(TestContext ctx,
+            IAsyncQueryExecutor? instead = null)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.Services.AddRadzenQueryableEntityFrameworkAdapter();
+
+            if (instead != null)
+            {
+                ctx.Services.AddSingleton(instead);
+            }
+
+            var cut = ctx.RenderComponent<RadzenListBox<EntityFrameworkAdapterTests.Employee>>(p =>
+            {
+                p.Add(d => d.Data, context.People);
+                p.Add(d => d.TextProperty, "Name");
+                p.Add(d => d.AllowVirtualization, true);
+                p.Add(d => d.PageSize, 5);
+            });
+
+            cut.WaitForAssertion(() => Assert.Contains("Name1", cut.Markup));
+
+            return cut;
+        }
+
+        [Fact]
+        public async Task ASecondLookupWaitsForTheFirstRatherThanRacingItAtTheProvider()
+        {
+            using var ctx = new TestContext();
+
+            var cut = VirtualListBox(ctx);
+
+            parking.Arm();
+
+            var before = parking.Started;
+
+            var end = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(499));
+
+            Assert.True(SpinWait.SpinUntil(() => parking.Started == before + 1, TimeSpan.FromSeconds(5)));
+
+            var home = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(200));
+
+            await cut.InvokeAsync(() => { });
+
+            Assert.Equal(before + 1, parking.Started);
+
+            parking.Release();
+
+            Assert.Null(await end);
+
+            var row = await home as EntityFrameworkAdapterTests.Employee;
+
+            Assert.Equal("Name201", row?.Name);
+        }
+
+        IRenderedComponent<RadzenDataGrid<EntityFrameworkAdapterTests.Employee>> PagedGrid(TestContext ctx,
+            IAsyncQueryExecutor? instead = null)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+            ctx.Services.AddRadzenQueryableEntityFrameworkAdapter();
+
+            if (instead != null)
+            {
+                ctx.Services.AddSingleton(instead);
+            }
+
+            var cut = ctx.RenderComponent<RadzenDataGrid<EntityFrameworkAdapterTests.Employee>>(p =>
+            {
+                p.Add(g => g.Data, context.People);
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 5);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent<RadzenDataGridColumn<EntityFrameworkAdapterTests.Employee>>(0);
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                });
+            });
+
+            cut.WaitForAssertion(() => Assert.Contains("Name1", cut.Markup));
+
+            return cut;
+        }
+
+        [Fact]
+        public async Task ASecondLoadWaitsForTheFirstRatherThanRacingItAtTheProvider()
+        {
+            using var ctx = new TestContext();
+
+            var cut = PagedGrid(ctx);
+
+            parking.Arm();
+
+            var before = parking.Started;
+
+            var first = cut.InvokeAsync(() => cut.Instance.Reload());
+
+            Assert.True(SpinWait.SpinUntil(() => parking.Started > before, TimeSpan.FromSeconds(5)));
+
+            var second = cut.InvokeAsync(() => cut.Instance.Reload());
+
+            await cut.InvokeAsync(() => { });
+
+            Assert.Equal(before + 1, parking.Started);
+
+            parking.Release();
+
+            await second;
+            await first;
+
+            Assert.Contains("Name1", cut.Markup);
+        }
+
+        sealed class Switchable : IAsyncQueryExecutor
+        {
+            readonly IAsyncQueryExecutor inner;
+
+            public Switchable(IAsyncQueryExecutor inner) => this.inner = inner;
+
+            public bool Supported = true;
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => Supported && inner.IsSupported(queryable);
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                inner.CountAsync(queryable, token);
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                inner.ToListAsync(queryable, token);
+
+            public bool CanFallBackToSynchronous(Exception exception) =>
+                inner.CanFallBackToSynchronous(exception);
+        }
+
+        [Fact]
+        public async Task ASynchronousReplacementWaitsForTheQueryItSuperseded()
+        {
+            using var ctx = new TestContext();
+
+            var executor = new Switchable(RealExecutor(ctx));
+
+            var cut = PagedGrid(ctx, executor);
+
+            parking.Arm();
+
+            var before = parking.Started;
+
+            var superseded = cut.InvokeAsync(() => cut.Instance.Reload());
+
+            Assert.True(SpinWait.SpinUntil(() => parking.Started > before, TimeSpan.FromSeconds(5)));
+
+            executor.Supported = false;
+
+            var replacement = cut.InvokeAsync(async () =>
+            {
+                await cut.Instance.Reload();
+
+                return cut.Instance.PagedView.Count();
+            });
+
+            parking.Release();
+
+            await superseded;
+
+            Assert.Equal(5, await replacement);
+        }
+
+        IRenderedComponent<RadzenDataList<EntityFrameworkAdapterTests.Employee>> PagedList(TestContext ctx,
+            IAsyncQueryExecutor instead)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.Services.AddRadzenQueryableEntityFrameworkAdapter();
+            ctx.Services.AddSingleton(instead);
+
+            var cut = ctx.RenderComponent<RadzenDataList<EntityFrameworkAdapterTests.Employee>>(p =>
+            {
+                p.Add(l => l.Data, context.People);
+                p.Add(l => l.AllowPaging, true);
+                p.Add(l => l.PageSize, 5);
+                p.Add(l => l.Template, (EntityFrameworkAdapterTests.Employee e) => (RenderFragment)(b => b.AddContent(0, e.Name)));
+            });
+
+            cut.WaitForAssertion(() => Assert.Contains("Name1", cut.Markup));
+
+            return cut;
+        }
+
+        sealed class ParkingBothHalves : IAsyncQueryExecutor
+        {
+            readonly IAsyncQueryExecutor inner;
+
+            readonly TaskCompletionSource page = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            readonly TaskCompletionSource count = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public ParkingBothHalves(IAsyncQueryExecutor inner) => this.inner = inner;
+
+            public bool Supported = true;
+
+            public bool Armed;
+
+            public int Pages;
+
+            public int Counts;
+
+            public void ReleasePage() => page.TrySetResult();
+
+            public void ReleaseCount() => count.TrySetResult();
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => Supported && inner.IsSupported(queryable);
+
+            public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                if (Armed && Interlocked.Increment(ref Pages) == 1)
+                {
+                    await page.Task;
+                }
+
+                return await inner.ToListAsync(queryable, CancellationToken.None);
+            }
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                if (Armed && Interlocked.Increment(ref Counts) == 1)
+                {
+                    await count.Task;
+                }
+
+                return await inner.CountAsync(queryable, CancellationToken.None);
+            }
+
+            public bool CanFallBackToSynchronous(Exception exception) =>
+                inner.CanFallBackToSynchronous(exception);
+        }
+
+        [Fact]
+        public async Task ASynchronousReplacementWaitsForTheWholeSupersededLoadAndNotJustItsCurrentQuery()
+        {
+            using var ctx = new TestContext();
+
+            var executor = new ParkingBothHalves(RealExecutor(ctx));
+
+            var cut = PagedList(ctx, executor);
+
+            executor.Armed = true;
+
+            var superseded = cut.InvokeAsync(() => cut.Instance.Reload());
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Counts > 0, TimeSpan.FromSeconds(5)),
+                "the count query should have parked");
+
+            executor.Supported = false;
+
+            var replacement = cut.InvokeAsync(async () =>
+            {
+                await cut.Instance.Reload();
+
+                return cut.Instance.PagedView.Cast<object>().Count();
+            });
+
+            await cut.InvokeAsync(() => { });
+
+            executor.ReleaseCount();
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Pages > 0, TimeSpan.FromSeconds(5)),
+                "the page that follows the count should have started");
+
+            await cut.InvokeAsync(() => { });
+
+            Assert.False(replacement.IsCompleted,
+                "the replacement must still be waiting: the load it superseded has a query still to make");
+
+            executor.ReleasePage();
+
+            await superseded;
+
+            Assert.Equal(5, await replacement);
+        }
+
+        [Fact]
+        public async Task ABusyContextIsNotMistakenForAQueryTheProviderCannotTranslate()
+        {
+            var concurrency = await ProvokeConcurrencyException();
+
+            Assert.IsType<InvalidOperationException>(concurrency);
+
+            using var ctx = new TestContext();
+
+            var throwing = new Throwing(RealExecutor(ctx));
+
+            Assert.True(throwing.CanFallBackToSynchronous(new NotSupportedException("cannot be translated")));
+            Assert.False(throwing.CanFallBackToSynchronous(concurrency));
+
+            var cut = VirtualListBox(ctx, throwing);
+
+            throwing.Failure = new NotSupportedException("The LINQ expression could not be translated.");
+
+            var translated = await cut.InvokeAsync(() => cut.Instance.VirtualItemAt(200))
+                as EntityFrameworkAdapterTests.Employee;
+
+            Assert.Equal("Name201", translated?.Name);
+
+            throwing.Failure = concurrency;
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => cut.InvokeAsync(() => cut.Instance.VirtualItemAt(300)));
+        }
+
+        sealed class Throwing : IAsyncQueryExecutor
+        {
+            readonly IAsyncQueryExecutor inner;
+
+            public Throwing(IAsyncQueryExecutor inner) => this.inner = inner;
+
+            public Exception? Failure;
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                Failure == null ? Task.FromResult(queryable.Count()) : Task.FromException<int>(Failure);
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                Failure == null ? Task.FromResult(queryable.ToList()) : Task.FromException<List<T>>(Failure);
+
+            public bool CanFallBackToSynchronous(Exception exception) =>
+                inner.CanFallBackToSynchronous(exception);
+        }
+
+        static IAsyncQueryExecutor RealExecutor(TestContext ctx)
+        {
+            var services = new ServiceCollection();
+
+            services.AddRadzenQueryableEntityFrameworkAdapter();
+
+            return services.BuildServiceProvider().GetRequiredService<IAsyncQueryExecutor>();
+        }
+
+        async Task<Exception> ProvokeConcurrencyException()
+        {
+            parking.Arm();
+
+            var first = context.People.Skip(400).Take(1).ToListAsync();
+
+            Assert.True(SpinWait.SpinUntil(() => parking.Started > 0, TimeSpan.FromSeconds(5)));
+
+            Exception? caught = null;
+
+            try
+            {
+                await context.People.Skip(1).Take(1).ToListAsync();
+            }
+            catch (Exception exception)
+            {
+                caught = exception;
+            }
+
+            parking.Release();
+
+            await first;
+
+            Assert.NotNull(caught);
+
+            return caught!;
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/AsyncSeamRenderThreadTests.cs
+++ b/Radzen.Blazor.Tests/AsyncSeamRenderThreadTests.cs
@@ -1,0 +1,1065 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class AsyncSeamRenderThreadTests
+    {
+        public class Row
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        sealed class CountingProvider : IQueryProvider
+        {
+            readonly IQueryProvider inner;
+
+            public CountingProvider(IQueryProvider inner) => this.inner = inner;
+
+            public int Executions { get; private set; }
+
+            public Func<bool>? InFlight { get; set; }
+
+            public int Overlapping { get; private set; }
+
+            void Note()
+            {
+                Executions++;
+
+                if (InFlight?.Invoke() == true)
+                {
+                    Overlapping++;
+                }
+            }
+
+            public IQueryable CreateQuery(Expression expression) => inner.CreateQuery(expression);
+
+            public IQueryable<T> CreateQuery<T>(Expression expression) =>
+                new Counting<T>(inner.CreateQuery<T>(expression), this);
+
+            public object Execute(Expression expression)
+            {
+                Note();
+
+                return inner.Execute(expression);
+            }
+
+            public T Execute<T>(Expression expression)
+            {
+                Note();
+
+                return inner.Execute<T>(expression);
+            }
+
+            public void Walked() => Note();
+        }
+
+        sealed class Counting<T> : IQueryable<T>
+        {
+            readonly IQueryable<T> inner;
+            readonly CountingProvider provider;
+
+            public Counting(IQueryable<T> inner, CountingProvider provider)
+            {
+                this.inner = inner;
+                this.provider = provider;
+            }
+
+            public Type ElementType => inner.ElementType;
+
+            public Expression Expression => inner.Expression;
+
+            public IQueryProvider Provider => provider;
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                provider.Walked();
+
+                return inner.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        sealed class YieldingExecutor : IAsyncQueryExecutor
+        {
+            public int Started { get; private set; }
+
+            public int Finished { get; private set; }
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                Started++;
+
+                await Task.Yield();
+
+                Finished++;
+
+                return queryable.Count();
+            }
+
+            public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                Started++;
+
+                await Task.Yield();
+
+                Finished++;
+
+                return queryable.ToList();
+            }
+        }
+
+        static (CountingProvider Provider, IQueryable<Row> Source) Source(int count)
+        {
+            var backing = Enumerable.Range(1, count)
+                .Select(i => new Row { Id = i, Name = "R" + i }).ToList().AsQueryable();
+
+            var provider = new CountingProvider(backing.Provider);
+
+            return (provider, new Counting<Row>(backing, provider));
+        }
+
+        static IRenderedComponent<RadzenDataGrid<Row>> Grid(TestContext ctx, IQueryable<Row> source,
+            Action<ComponentParameterCollectionBuilder<RadzenDataGrid<Row>>> extra)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            return ctx.RenderComponent<RadzenDataGrid<Row>>(p =>
+            {
+                p.Add(g => g.Data, source);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Row>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                });
+                extra(p);
+            });
+        }
+
+        [Fact]
+        public void VirtualizationWithPagingGoesThroughTheExecutor()
+        {
+            using var ctx = new TestContext();
+
+            var (provider, source) = Source(40);
+            var executor = new YieldingExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            cut.WaitForAssertion(() => Assert.True(executor.Started > 0,
+                "the page should be counted and fetched through the executor"));
+
+            cut.WaitForAssertion(() => Assert.Equal(40, cut.Instance.Count));
+        }
+
+        sealed class UntranslatableExecutor : IAsyncQueryExecutor
+        {
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                throw new InvalidOperationException("The LINQ expression could not be translated.");
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                throw new InvalidOperationException("The LINQ expression could not be translated.");
+        }
+
+        [Fact]
+        public void AQueryTheProviderCannotTranslateFallsBackRatherThanThrowing()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(40);
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(new UntranslatableExecutor());
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            Assert.Equal(5, cut.FindAll("tbody tr.rz-data-row").Count);
+            Assert.Equal(40, cut.Instance.Count);
+        }
+
+        [Fact]
+        public void ADropDownFallsBackWhenTheProviderCannotTranslate()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(40);
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(new UntranslatableExecutor());
+
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var cut = ctx.RenderComponent<RadzenDropDown<Row>>(p =>
+            {
+                p.Add(d => d.Data, source);
+                p.Add(d => d.TextProperty, "Name");
+                p.Add(d => d.AllowVirtualization, true);
+            });
+
+            Assert.NotNull(cut.Instance);
+        }
+
+        sealed class ParkingExecutor : IAsyncQueryExecutor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            int calls;
+
+            int executing;
+
+            public bool Parked { get; private set; }
+
+            public bool Executing => Volatile.Read(ref executing) > 0;
+
+            public void Release() => release.TrySetResult();
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                await Park();
+
+                return Run(queryable.Count);
+            }
+
+            public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                await Park();
+
+                return Run(queryable.ToList);
+            }
+
+            TResult Run<TResult>(Func<TResult> query)
+            {
+                Interlocked.Increment(ref executing);
+
+                try
+                {
+                    return query();
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref executing);
+                }
+            }
+
+            async Task Park()
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                {
+                    Parked = true;
+
+                    await release.Task;
+
+                    Parked = false;
+                }
+            }
+        }
+
+        [Fact]
+        public void AVirtualizedGridDoesNotProbeTheSourceWhileItsWindowIsInFlight()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (provider, source) = Source(40);
+            var executor = new ParkingExecutor();
+
+            provider.InFlight = () => executor.Parked && !executor.Executing;
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            cut.WaitForState(() => executor.Parked);
+
+            cut.Render();
+            cut.Render();
+
+            Assert.Equal(0, provider.Overlapping);
+
+            executor.Release();
+        }
+
+        [Fact]
+        public void AVirtualizedListBoxDoesNotEnumerateTheSourceWhileItsWindowIsInFlight()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (provider, source) = Source(40);
+            var executor = new ParkingExecutor();
+
+            provider.InFlight = () => executor.Parked && !executor.Executing;
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = ctx.RenderComponent<RadzenListBox<Row>>(p =>
+            {
+                p.Add(d => d.Data, source);
+                p.Add(d => d.TextProperty, "Name");
+                p.Add(d => d.AllowVirtualization, true);
+                p.Add(d => d.PageSize, 5);
+            });
+
+            cut.WaitForState(() => executor.Parked);
+
+            cut.Render();
+            cut.Render();
+
+            var root = cut.Find("div.rz-listbox");
+
+            root.KeyDown(new KeyboardEventArgs { Code = "ArrowDown", Key = "ArrowDown" });
+            root.KeyDown(new KeyboardEventArgs { Code = "ArrowDown", Key = "ArrowDown" });
+            root.KeyDown(new KeyboardEventArgs { Code = "End", Key = "End" });
+
+            Assert.Equal(0, provider.Overlapping);
+
+            executor.Release();
+        }
+
+        sealed class ImmediateExecutor : IAsyncQueryExecutor
+        {
+            public int Queries { get; private set; }
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                Queries++;
+
+                return Task.FromResult(queryable.Count());
+            }
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                Queries++;
+
+                return Task.FromResult(queryable.ToList());
+            }
+        }
+
+        [Fact]
+        public void AVirtualizedGridDoesNotProbeTheSourceOnItsFirstRender()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (provider, source) = Source(40);
+            var executor = new ImmediateExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            cut.WaitForAssertion(() => Assert.Contains("R1", cut.Markup));
+
+            Assert.True(executor.Queries > 0, "the window should be fetched through the executor");
+            Assert.Equal(executor.Queries, provider.Executions);
+        }
+
+        [Fact]
+        public void AGroupedVirtualizedGridDoesNotProbeTheSourceWhileItsWindowIsInFlight()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (provider, source) = Source(40);
+            var executor = new ParkingExecutor();
+
+            provider.InFlight = () => executor.Parked && !executor.Executing;
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = ctx.RenderComponent<RadzenDataGrid<Row>>(p =>
+            {
+                p.Add(g => g.Data, source);
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.AllowGrouping, true);
+                p.Add(g => g.PageSize, 5);
+                p.Add(g => g.Groups, new System.Collections.ObjectModel.ObservableCollection<GroupDescriptor>
+                {
+                    new GroupDescriptor { Property = nameof(Row.Name) }
+                });
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Row>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                });
+            });
+
+            cut.WaitForState(() => executor.Parked);
+
+            cut.Render();
+            cut.Render();
+
+            Assert.Equal(0, provider.Overlapping);
+
+            executor.Release();
+        }
+
+        [Fact]
+        public void AVirtualizedGridRecoversFromAFilterThatMatchedNothing()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var (_, source) = Source(40);
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(new ImmediateExecutor());
+
+            void Build(ComponentParameterCollectionBuilder<RadzenDataGrid<Row>> p, string? filter)
+            {
+                p.Add(g => g.Data, source);
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.AllowFiltering, true);
+                p.Add(g => g.PageSize, 5);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Row>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.AddAttribute(2, "Filterable", true);
+                    builder.AddAttribute(3, "FilterValue", filter);
+                    builder.AddAttribute(4, "FilterOperator", FilterOperator.Contains);
+                    builder.CloseComponent();
+                });
+            }
+
+            var cut = ctx.RenderComponent<RadzenDataGrid<Row>>(p => Build(p, null));
+
+            Assert.Contains("R1", cut.Markup);
+
+            cut.SetParametersAndRender(p => Build(p, "matches-nothing"));
+
+            Assert.DoesNotContain("R1", cut.Markup);
+
+            cut.SetParametersAndRender(p => Build(p, null));
+
+            Assert.Contains("R1", cut.Markup);
+        }
+
+        [Fact]
+        public void AVirtualizedListBoxFetchesAnOutOfWindowJumpThroughTheExecutor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (provider, source) = Source(40);
+            var executor = new ImmediateExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = ctx.RenderComponent<RadzenListBox<Row>>(p =>
+            {
+                p.Add(d => d.Data, source);
+                p.Add(d => d.TextProperty, "Name");
+                p.Add(d => d.AllowVirtualization, true);
+                p.Add(d => d.PageSize, 5);
+            });
+
+            cut.WaitForAssertion(() => Assert.True(executor.Queries > 0));
+
+            var root = cut.Find("div.rz-listbox");
+
+            root.KeyDown(new KeyboardEventArgs { Code = "End", Key = "End" });
+
+            Assert.Equal(executor.Queries, provider.Executions);
+        }
+
+        sealed class ParkingRowExecutor : IAsyncQueryExecutor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public int Parked;
+
+            public CancellationToken RowToken;
+
+            public bool Untranslatable;
+
+            public void Release() => release.TrySetResult();
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                Task.FromResult(queryable.Count());
+
+            public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                if (queryable.Expression.ToString().Contains("Take(1)", StringComparison.Ordinal))
+                {
+                    RowToken = token;
+
+                    Interlocked.Increment(ref Parked);
+
+                    await release.Task;
+
+                    if (Untranslatable)
+                    {
+                        throw new NotSupportedException("The LINQ expression could not be translated.");
+                    }
+                }
+
+                return queryable.ToList();
+            }
+        }
+
+        static IRenderedComponent<RadzenListBox<Row>> VirtualListBox(TestContext ctx, IQueryable<Row> source)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var cut = ctx.RenderComponent<RadzenListBox<Row>>(p =>
+            {
+                p.Add(d => d.Data, source);
+                p.Add(d => d.TextProperty, "Name");
+                p.Add(d => d.AllowVirtualization, true);
+                p.Add(d => d.PageSize, 5);
+            });
+
+            cut.WaitForAssertion(() => Assert.Contains("R1", cut.Markup));
+
+            return cut;
+        }
+
+        [Fact]
+        public async Task AnOutOfWindowLookupIsSupersededByALaterOne()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(500);
+            var executor = new ParkingRowExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = VirtualListBox(ctx, source);
+
+            var end = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(499));
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked == 1, TimeSpan.FromSeconds(5)));
+
+            var later = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(200));
+
+            await cut.InvokeAsync(() => { });
+
+            Assert.Equal(1, executor.Parked);
+
+            executor.Release();
+
+            Assert.Null(await end);
+            Assert.Equal("R201", ((await later) as Row)?.Name);
+        }
+
+        [Fact]
+        public async Task AnOutOfWindowLookupIsSupersededByAWindowHit()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(500);
+            var executor = new ParkingRowExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = VirtualListBox(ctx, source);
+
+            var end = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(499));
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked == 1, TimeSpan.FromSeconds(5)));
+
+            Assert.Equal("R1", (await cut.InvokeAsync(() => cut.Instance.VirtualItemAt(0)) as Row)?.Name);
+
+            executor.Release();
+
+            Assert.Null(await end);
+        }
+
+        [Fact]
+        public async Task AnOutOfWindowLookupThatFallsBackIsStillGuarded()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(500);
+            var executor = new ParkingRowExecutor { Untranslatable = true };
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = VirtualListBox(ctx, source);
+
+            var lookup = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(499));
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked == 1, TimeSpan.FromSeconds(5)));
+
+            var (_, replacement) = Source(3);
+
+            cut.SetParametersAndRender(p => p.Add(d => d.Data, replacement));
+
+            executor.Release();
+
+            Assert.Null(await lookup);
+        }
+
+        [Fact]
+        public async Task ReplacingTheQueryCancelsTheLookupStillAtTheProvider()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(500);
+            var executor = new ParkingRowExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = VirtualListBox(ctx, source);
+
+            var lookup = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(499));
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked == 1, TimeSpan.FromSeconds(5)));
+
+            Assert.False(executor.RowToken.IsCancellationRequested);
+
+            var (_, replacement) = Source(3);
+
+            cut.SetParametersAndRender(p => p.Add(d => d.Data, replacement));
+
+            Assert.True(executor.RowToken.IsCancellationRequested,
+                "invalidating the query must stand down the lookup still holding the provider");
+
+            executor.Release();
+
+            Assert.Null(await lookup);
+        }
+
+        [Fact]
+        public async Task DisposingCancelsTheLookupStillAtTheProvider()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(500);
+            var executor = new ParkingRowExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = VirtualListBox(ctx, source);
+
+            var lookup = cut.InvokeAsync(() => cut.Instance.VirtualItemAt(499));
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked == 1, TimeSpan.FromSeconds(5)));
+
+            Assert.False(executor.RowToken.IsCancellationRequested);
+
+            await cut.InvokeAsync(() => cut.Instance.Dispose());
+
+            Assert.True(executor.RowToken.IsCancellationRequested);
+
+            executor.Release();
+
+            await lookup;
+        }
+
+        sealed class ParkingWindowExecutor : IAsyncQueryExecutor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public int Parked;
+
+            public CancellationToken WindowToken;
+
+            public void Release() => release.TrySetResult();
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                await Park(token);
+
+                return queryable.Count();
+            }
+
+            public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                await Park(token);
+
+                return queryable.ToList();
+            }
+
+            async Task Park(CancellationToken token)
+            {
+                WindowToken = token;
+
+                Interlocked.Increment(ref Parked);
+
+                await release.Task;
+            }
+        }
+
+        [Fact]
+        public async Task ReloadingCancelsTheVirtualizationRequestBeforeWaitingForIt()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (_, source) = Source(500);
+            var executor = new ParkingWindowExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.AllowPaging, false);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked > 0, TimeSpan.FromSeconds(5)));
+
+            Assert.False(executor.WindowToken.IsCancellationRequested);
+
+            var reload = cut.InvokeAsync(() => cut.Instance.Reload());
+
+            await cut.InvokeAsync(() => { });
+
+            Assert.True(executor.WindowToken.IsCancellationRequested,
+                "the outstanding window fetch must be cancelled before the reload waits for it");
+
+            executor.Release();
+
+            await reload;
+        }
+
+        sealed class TimingOutExecutor : IAsyncQueryExecutor
+        {
+            public bool Failing;
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                Failing
+                    ? throw new OperationCanceledException("the provider gave up")
+                    : Task.FromResult(queryable.Count());
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default) =>
+                Failing
+                    ? throw new OperationCanceledException("the provider gave up")
+                    : Task.FromResult(queryable.ToList());
+        }
+
+        [Fact]
+        public async Task AnUnaskedForCancellationIsNotReportedAsAnEmptyWindow()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (_, source) = Source(40);
+
+            var executor = new TimingOutExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowVirtualization, true);
+                p.Add(g => g.AllowPaging, false);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            executor.Failing = true;
+
+            var request = new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest(
+                0, 5, CancellationToken.None);
+
+            var thrown = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => cut.InvokeAsync(async () => await cut.Instance.LoadItems(request)));
+
+            Assert.Contains("the provider gave up", Flatten(thrown));
+        }
+
+        [Fact]
+        public async Task AnUnaskedForCancellationDoesNotLookLikeASupersededLoad()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (_, source) = Source(40);
+
+            var executor = new TimingOutExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            executor.Failing = true;
+
+            var thrown = await Assert.ThrowsAnyAsync<Exception>(
+                () => cut.InvokeAsync(() => cut.Instance.Reload()));
+
+            Assert.Contains("the provider gave up", Flatten(thrown));
+        }
+
+        [Fact]
+        public async Task AnUnaskedForCancellationIsNotReportedAsAMissingRow()
+        {
+            using var ctx = new TestContext();
+
+            var (_, source) = Source(500);
+            var executor = new TimingOutExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = VirtualListBox(ctx, source);
+
+            executor.Failing = true;
+
+            var thrown = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => cut.InvokeAsync(() => cut.Instance.VirtualItemAt(499)));
+
+            Assert.Contains("the provider gave up", Flatten(thrown));
+        }
+
+        [Fact]
+        public async Task DisposingTheComponentDoesNotDisposeTheTokenALoadStillHolds()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (_, source) = Source(40);
+            var executor = new WaitHandleExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = Grid(ctx, source, p =>
+            {
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 5);
+            });
+
+            executor.Arm();
+
+            var load = cut.InvokeAsync(() => cut.Instance.Reload());
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked, TimeSpan.FromSeconds(5)));
+
+            await cut.InvokeAsync(() => cut.Instance.Dispose());
+
+            executor.Release();
+
+            await load;
+
+            Assert.Null(executor.Failure);
+            Assert.True(executor.Cancelled, "the parked load should have been cancelled");
+        }
+
+        [Fact]
+        public async Task DisposingADataListCancelsItsVirtualRequestWithoutDisposingTheToken()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (_, source) = Source(40);
+            var executor = new WaitHandleExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = ctx.RenderComponent<RadzenDataList<Row>>(p =>
+            {
+                p.Add(d => d.Data, source);
+                p.Add(d => d.AllowVirtualization, true);
+                p.Add<RenderFragment<Row>>(d => d.Template,
+                    item => builder => builder.AddContent(0, item.Name));
+            });
+
+            executor.Arm();
+
+            var load = cut.InvokeAsync(() => cut.Instance.Virtualize!.RefreshDataAsync());
+
+            Assert.True(SpinWait.SpinUntil(() => executor.Parked, TimeSpan.FromSeconds(5)));
+
+            await cut.InvokeAsync(() => cut.Instance.Dispose());
+
+            executor.Release();
+
+            await load;
+
+            Assert.Null(executor.Failure);
+            Assert.True(executor.Cancelled, "the parked virtual request should have been cancelled");
+        }
+
+        sealed class WaitHandleExecutor : IAsyncQueryExecutor
+        {
+            readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            bool armed;
+
+            public bool Parked { get; private set; }
+
+            public bool Cancelled { get; private set; }
+
+            public Exception? Failure { get; private set; }
+
+            public void Arm() => armed = true;
+
+            public void Release() => release.TrySetResult();
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => true;
+
+            public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                await Park(token);
+
+                return queryable.Count();
+            }
+
+            public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                await Park(token);
+
+                return queryable.ToList();
+            }
+
+            async Task Park(CancellationToken token)
+            {
+                if (!armed || Parked)
+                {
+                    return;
+                }
+
+                Parked = true;
+
+                await release.Task;
+
+                try
+                {
+                    Cancelled = token.WaitHandle.WaitOne(0) || token.IsCancellationRequested;
+                }
+                catch (Exception exception)
+                {
+                    Failure = exception;
+                }
+            }
+        }
+
+        static string Flatten(Exception exception)
+        {
+            var text = new System.Text.StringBuilder();
+
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                text.Append(current.Message).Append(' ');
+            }
+
+            return text.ToString();
+        }
+
+        [Fact]
+        public void EveryPivotProviderExecutionIsOneTheExecutorAskedFor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (provider, source) = Source(40);
+            var executor = new YieldingExecutor();
+
+            provider.InFlight = () => executor.Started > executor.Finished;
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = ctx.RenderComponent<RadzenPivotDataGrid<Row>>(p =>
+            {
+                p.Add(g => g.Data, source);
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 5);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenPivotColumn<Row>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                });
+                p.Add<RenderFragment>(g => g.Rows, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenPivotRow<Row>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                });
+                p.Add<RenderFragment>(g => g.Aggregates, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenPivotAggregate<Row>));
+                    builder.AddAttribute(1, "Property", "Id");
+                    builder.AddAttribute(2, "Aggregate", AggregateFunction.Sum);
+                    builder.CloseComponent();
+                });
+            });
+
+            cut.WaitForAssertion(() => Assert.Equal(40, cut.Instance.Count));
+
+            Assert.Equal(0, provider.Overlapping);
+            Assert.True(executor.Started > 0, "the page should be counted and fetched through the executor");
+        }
+
+        [Fact]
+        public void EveryProviderExecutionIsOneTheExecutorAskedFor()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var (provider, source) = Source(40);
+            var executor = new YieldingExecutor();
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            var cut = ctx.RenderComponent<RadzenDataGrid<Row>>(p =>
+            {
+                p.Add(g => g.Data, source);
+                p.Add(g => g.AllowPaging, true);
+                p.Add(g => g.PageSize, 5);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    builder.OpenComponent(0, typeof(RadzenDataGridColumn<Row>));
+                    builder.AddAttribute(1, "Property", "Name");
+                    builder.CloseComponent();
+                });
+            });
+
+            cut.WaitForAssertion(() => Assert.Equal(40, cut.Instance.Count));
+
+            cut.InvokeAsync(() => cut.Instance.GoToPage(2)).GetAwaiter().GetResult();
+
+            Assert.Equal(executor.Started, provider.Executions);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/EntityFrameworkAdapterTests.cs
+++ b/Radzen.Blazor.Tests/EntityFrameworkAdapterTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class EntityFrameworkAdapterTests : IDisposable
+    {
+        readonly SqliteConnection connection = new("DataSource=:memory:");
+        readonly Ctx context;
+
+        public EntityFrameworkAdapterTests()
+        {
+            connection.Open();
+
+            context = new Ctx(new DbContextOptionsBuilder<Ctx>().UseSqlite(connection).Options);
+            context.Database.EnsureCreated();
+
+            context.People.AddRange(Enumerable.Range(1, 40).Select(i => new Employee
+            {
+                Id = i,
+                Name = "Name" + i,
+                Department = i % 4 == 0 ? "Ops" : i % 3 == 0 ? "Sales" : "Engineering",
+                Salary = 1000 + i,
+            }));
+
+            context.SaveChanges();
+        }
+
+        public void Dispose()
+        {
+            context.Dispose();
+            connection.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        Counting executor = null!;
+
+        IRenderedComponent<RadzenDataGrid<Employee>> Render(TestContext ctx,
+            Action<ComponentParameterCollectionBuilder<RadzenDataGrid<Employee>>>? extra = null,
+            bool paging = true)
+        {
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+            ctx.Services.AddRadzenQueryableEntityFrameworkAdapter();
+
+            executor = new Counting(ctx.Services.BuildServiceProvider()
+                .GetRequiredService<IAsyncQueryExecutor>());
+
+            ctx.Services.AddSingleton<IAsyncQueryExecutor>(executor);
+
+            return ctx.RenderComponent<RadzenDataGrid<Employee>>(p =>
+            {
+                p.Add(g => g.Data, context.People);
+                p.Add(g => g.AllowPaging, paging);
+                p.Add(g => g.PageSize, 5);
+                p.Add<RenderFragment>(g => g.Columns, builder =>
+                {
+                    var s = 0;
+
+                    foreach (var (property, title) in new[]
+                             {
+                                 ("Name", "Name"), ("Department", "Department"), ("Salary", "Salary"),
+                             })
+                    {
+                        builder.OpenComponent<RadzenDataGridColumn<Employee>>(s++);
+                        builder.AddAttribute(s++, "Property", property);
+                        builder.AddAttribute(s++, "Title", title);
+                        builder.CloseComponent();
+                    }
+                });
+                extra?.Invoke(p);
+            });
+        }
+
+        static string[] Names(IRenderedComponent<RadzenDataGrid<Employee>> cut) =>
+            cut.FindAll("tbody tr.rz-data-row")
+                .Select(row => row.QuerySelectorAll("td")[0].TextContent.Trim()).ToArray();
+
+        [Fact]
+        public void TheAdapterRegistrationIsAllThatIsNeeded()
+        {
+            using var ctx = new TestContext();
+
+            var cut = Render(ctx);
+
+            cut.WaitForAssertion(() => Assert.Equal(5, cut.FindAll("tbody tr.rz-data-row").Count));
+            Assert.Equal(new[] { "Name1", "Name2", "Name3", "Name4", "Name5" }, Names(cut));
+
+            Assert.True(executor.ToListCalls > 0, "the page should have been fetched through the adapter");
+            Assert.True(executor.CountCalls > 0, "the total should have been counted through the adapter");
+        }
+
+        [Fact]
+        public void ThePagerCountsWhatTheDatabaseSays()
+        {
+            using var ctx = new TestContext();
+
+            var cut = Render(ctx, p => p.Add(g => g.ShowPagingSummary, true));
+
+            cut.WaitForAssertion(() =>
+                Assert.Contains("40", cut.Find(".rz-pager-summary").TextContent, StringComparison.Ordinal));
+
+            Assert.True(executor.CountCalls > 0, "the total should be a COUNT the database ran");
+        }
+
+        [Fact]
+        public void SortingIsTranslatedRatherThanAppliedToThePage()
+        {
+            using var ctx = new TestContext();
+
+            var cut = Render(ctx, p => p.Add(g => g.AllowSorting, true));
+
+            cut.WaitForAssertion(() => Assert.Equal(5, cut.FindAll("tbody tr.rz-data-row").Count));
+
+            cut.InvokeAsync(() => cut.Instance.OrderByDescending("Salary")).GetAwaiter().GetResult();
+
+            cut.WaitForAssertion(() => Assert.Equal(
+                new[] { "Name40", "Name39", "Name38", "Name37", "Name36" }, Names(cut)));
+
+            Assert.True(executor.ToListCalls > 0, "the ordered page should have come through the adapter");
+        }
+
+        [Fact]
+        public void TheCountCarriesTheFilter()
+        {
+            using var ctx = new TestContext();
+
+            var cut = Render(ctx, p =>
+            {
+                p.Add(g => g.AllowFiltering, true);
+                p.Add(g => g.ShowPagingSummary, true);
+            });
+
+            cut.WaitForAssertion(() => Assert.Equal(5, cut.FindAll("tbody tr.rz-data-row").Count));
+
+            cut.InvokeAsync(() => cut.Instance.ColumnsCollection[1]
+                .SetFilterValue("Ops")).GetAwaiter().GetResult();
+            cut.InvokeAsync(() => cut.Instance.Reload()).GetAwaiter().GetResult();
+
+            cut.WaitForAssertion(() =>
+                Assert.Contains("10", cut.Find(".rz-pager-summary").TextContent, StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void AVirtualizedGridFetchesItsWindowsThroughTheAdapter()
+        {
+            using var ctx = new TestContext();
+
+            var cut = Render(ctx, p => p.Add(g => g.AllowVirtualization, true), paging: false);
+
+            cut.WaitForAssertion(() => Assert.Equal(40, cut.FindAll("tbody tr.rz-data-row").Count));
+            Assert.Equal("Name1", Names(cut)[0]);
+
+            Assert.True(executor.ToListCalls > 0, "the window should have come through the adapter");
+        }
+
+        sealed class Counting : IAsyncQueryExecutor
+        {
+            readonly IAsyncQueryExecutor inner;
+
+            public Counting(IAsyncQueryExecutor inner) => this.inner = inner;
+
+            public int CountCalls { get; private set; }
+
+            public int ToListCalls { get; private set; }
+
+            public bool IsSupported<T>(IQueryable<T> queryable) => inner.IsSupported(queryable);
+
+            public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                CountCalls++;
+
+                return inner.CountAsync(queryable, token);
+            }
+
+            public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken token = default)
+            {
+                ToListCalls++;
+
+                return inner.ToListAsync(queryable, token);
+            }
+        }
+
+        public class Employee
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; } = "";
+
+            public string Department { get; set; } = "";
+
+            public decimal Salary { get; set; }
+        }
+
+        public class Ctx : DbContext
+        {
+            public Ctx(DbContextOptions<Ctx> options) : base(options)
+            {
+            }
+
+            public DbSet<Employee> People => Set<Employee>();
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/Radzen.Blazor.Tests.csproj
+++ b/Radzen.Blazor.Tests/Radzen.Blazor.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Radzen.Blazor\Radzen.Blazor.csproj" />
+    <ProjectReference Include="..\Radzen.Blazor.EntityFrameworkAdapter\Radzen.Blazor.EntityFrameworkAdapter.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Radzen.Blazor.Tests/VirtualWindowTests.cs
+++ b/Radzen.Blazor.Tests/VirtualWindowTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using Radzen;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class VirtualWindowTests
+    {
+        static List<string> Rows(params string[] rows) => new(rows);
+
+        [Fact]
+        public void ANewerFetchPublishesOverAnOlderOne()
+        {
+            var window = new VirtualWindow<string>();
+
+            var first = window.BeginFetch();
+            var second = window.BeginFetch();
+
+            Assert.True(window.TryPublish(second, 0, 1, Rows("new")));
+            Assert.True(window.TryPublish(first, 0, 1, Rows("old")) == false);
+
+            Assert.True(window.TryGetAt(0, out var item));
+            Assert.Equal("new", item);
+        }
+
+        [Fact]
+        public void ASupersededFetchCannotPublishAfterTheNewerOneHas()
+        {
+            var window = new VirtualWindow<string>();
+
+            var stale = window.BeginFetch();
+            var current = window.BeginFetch();
+
+            window.TryPublish(current, 0, 3, Rows("a", "b", "c"));
+
+            Assert.False(window.TryPublish(stale, 0, 0, Rows()));
+
+            Assert.True(window.HasAny);
+            Assert.Equal(3, window.TotalCount);
+            Assert.True(window.TryGetAt(0, out var first));
+            Assert.True(window.TryGetAt(2, out var last));
+            Assert.Equal("a", first);
+            Assert.Equal("c", last);
+        }
+
+        [Fact]
+        public void AFetchCannotPublishOnceANewerOneHasBegun()
+        {
+            var window = new VirtualWindow<string>();
+
+            var older = window.BeginFetch();
+            var newer = window.BeginFetch();
+
+            Assert.False(window.TryPublish(older, 0, 1, Rows("older")));
+            Assert.False(window.TryGetAt(0, out _));
+
+            Assert.True(window.TryPublish(newer, 0, 1, Rows("newer")));
+            Assert.True(window.TryGetAt(0, out var item));
+            Assert.Equal("newer", item);
+        }
+
+        [Fact]
+        public void InvalidatingMovesTheQueryGeneration()
+        {
+            var window = new VirtualWindow<string>();
+
+            var generation = window.QueryGeneration;
+
+            window.BeginFetch();
+
+            Assert.Equal(generation, window.QueryGeneration);
+
+            window.Invalidate();
+
+            Assert.NotEqual(generation, window.QueryGeneration);
+        }
+
+        [Fact]
+        public void InvalidatingBarsTheFetchesAlreadyInFlight()
+        {
+            var window = new VirtualWindow<string>();
+
+            var inFlight = window.BeginFetch();
+
+            window.TryPublish(inFlight, 0, 2, Rows("a", "b"));
+
+            var alsoInFlight = window.BeginFetch();
+            window.Invalidate();
+
+            Assert.False(window.TryGetAt(0, out _));
+            Assert.False(window.TryPublish(alsoInFlight, 0, 2, Rows("stale", "stale")));
+            Assert.False(window.TryGetAt(0, out _));
+
+            var replacement = window.BeginFetch();
+
+            Assert.True(window.TryPublish(replacement, 0, 1, Rows("fresh")));
+            Assert.True(window.TryGetAt(0, out var item));
+            Assert.Equal("fresh", item);
+        }
+
+        [Fact]
+        public void HasAnyAssumesRowsUntilAFetchSaysOtherwise()
+        {
+            var window = new VirtualWindow<string>();
+
+            Assert.True(window.HasAny);
+
+            var fetch = window.BeginFetch();
+            window.TryPublish(fetch, 0, 0, Rows());
+
+            Assert.False(window.HasAny);
+
+            window.Invalidate();
+
+            Assert.True(window.HasAny);
+        }
+
+        [Fact]
+        public void TryGetAtResolvesAnIndexWithinTheFetchedWindow()
+        {
+            var window = new VirtualWindow<string>();
+
+            var fetch = window.BeginFetch();
+            window.TryPublish(fetch, 10, 40, Rows("ten", "eleven", "twelve"));
+
+            Assert.True(window.TryGetAt(11, out var hit));
+            Assert.Equal("eleven", hit);
+
+            Assert.False(window.TryGetAt(9, out _));
+            Assert.False(window.TryGetAt(13, out _));
+        }
+    }
+}

--- a/Radzen.Blazor/AsyncQueryCoordinator.cs
+++ b/Radzen.Blazor/AsyncQueryCoordinator.cs
@@ -1,0 +1,450 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Radzen
+{
+    /// <summary>
+    /// Coordinates asynchronous query work for one <see cref="RadzenComponent" />.
+    /// </summary>
+    /// <remarks>
+    /// A coordinator is created only after its owner selects a supported query. Loads publish through
+    /// generation leases because cancellation is advisory; superseding waits for the whole load and its
+    /// FIFO, fault-isolated provider tail. Virtual request sources are cancelled eagerly but disposed only
+    /// by the request lease after provider work exits.
+    /// </remarks>
+    internal sealed class AsyncQueryCoordinator : IDisposable
+    {
+        private const long NoLoad = 0;
+
+        private readonly RadzenComponent owner;
+        private readonly IAsyncQueryExecutor executor;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed",
+            Justification = "The load lease disposes its source only after the load body exits; coordinator disposal only cancels it.")]
+        private CancellationTokenSource? loadCancellation;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed",
+            Justification = "The virtual request lease disposes its source only after the request exits; coordinator disposal only cancels it.")]
+        private CancellationTokenSource? virtualRequest;
+        private long loadOwner = NoLoad;
+        private long loadSequence;
+        private int awaitingProviderTurn;
+        private Task loadCompletion = Task.CompletedTask;
+        private Task providerTail = Task.CompletedTask;
+
+        internal AsyncQueryCoordinator(RadzenComponent owner, IAsyncQueryExecutor executor)
+        {
+            this.owner = owner;
+            this.executor = executor;
+        }
+
+        /// <summary>
+        /// A load's generation claim and the cancellation source it owns until the load body exits.
+        /// </summary>
+        internal readonly struct LoadLease
+        {
+            private readonly AsyncQueryCoordinator coordinator;
+            private readonly CancellationTokenSource source;
+
+            internal LoadLease(AsyncQueryCoordinator coordinator, long generation, CancellationTokenSource source)
+            {
+                this.coordinator = coordinator;
+                Generation = generation;
+                this.source = source;
+                Token = source.Token;
+            }
+
+            internal long Generation { get; }
+
+            internal CancellationToken Token { get; }
+
+            internal bool IsCurrent => coordinator.Owns(this);
+
+            internal CancellationTokenSource Source => source;
+
+            internal Task<int> CountAsync<T>(IQueryable<T> query) =>
+                coordinator.CountAsync(query, Token);
+
+            internal Task<List<T>> ToListAsync<T>(IQueryable<T> query) =>
+                coordinator.ToListAsync(query, Token);
+
+            internal Task<(int Count, List<T> Items)> CountAndPageAsync<T>(IQueryable<T> source,
+                IQueryable<T> page, bool pageIsSubset) =>
+                coordinator.CountAndPageAsync(source, page, pageIsSubset, Token);
+
+            internal void ThrowIfSuperseded()
+            {
+                if (!IsCurrent)
+                {
+                    throw new OperationCanceledException(Token);
+                }
+            }
+        }
+
+        internal readonly record struct VirtualQueryResult<T>(T Value, bool HasValue,
+            bool RequiresSynchronousFallback)
+        {
+            internal static VirtualQueryResult<T> Applied(T value) => new(value, true, false);
+            internal static VirtualQueryResult<T> SynchronousFallback() => new(default!, false, true);
+        }
+
+        /// <summary>
+        /// A linked virtualization request. Disposing it after the request exits clears the coordinator's
+        /// current handle when appropriate and then disposes this request's source.
+        /// </summary>
+        internal readonly struct VirtualRequestLease : IDisposable
+        {
+            private readonly AsyncQueryCoordinator? coordinator;
+            private readonly CancellationTokenSource? source;
+            private readonly CancellationToken requestToken;
+
+            internal VirtualRequestLease(AsyncQueryCoordinator coordinator, CancellationTokenSource source,
+                CancellationToken requestToken)
+            {
+                this.coordinator = coordinator;
+                this.source = source;
+                this.requestToken = requestToken;
+                Token = source.Token;
+            }
+
+            internal CancellationToken Token { get; }
+
+            internal Task<VirtualQueryResult<(int Count, List<T> Items)>> CountAndPageAsync<T>(
+                IQueryable<T> source, IQueryable<T> page, bool pageIsSubset) =>
+                ExecuteAsync((Source: source, Page: page, PageIsSubset: pageIsSubset),
+                    static (coordinator, state, token) => coordinator.CountAndPageWithFallbackAsync(
+                        state.Source, state.Page, state.PageIsSubset, token));
+
+            internal Task<VirtualQueryResult<List<T>>> ToListAsync<T>(IQueryable<T> query) =>
+                ExecuteAsync(query,
+                    static (coordinator, state, token) => coordinator.ToListAsync(state, token));
+
+            private async Task<VirtualQueryResult<TResult>> ExecuteAsync<TState, TResult>(TState state,
+                Func<AsyncQueryCoordinator, TState, CancellationToken, Task<TResult>> query)
+            {
+                try
+                {
+                    TResult result = await query(coordinator!, state, Token);
+                    return VirtualQueryResult<TResult>.Applied(result);
+                }
+                catch (OperationCanceledException) when (Token.IsCancellationRequested)
+                {
+                    requestToken.ThrowIfCancellationRequested();
+                    return default;
+                }
+                catch (Exception exception) when (coordinator!.executor.CanFallBackToSynchronous(exception))
+                {
+                    return VirtualQueryResult<TResult>.SynchronousFallback();
+                }
+            }
+
+            public void Dispose()
+            {
+                if (source != null)
+                {
+                    coordinator!.EndVirtualRequest(source);
+                }
+            }
+        }
+
+        /// <summary>Whether view getters must avoid the source while async work owns the provider.</summary>
+        internal bool LoadPending => loadOwner != NoLoad || awaitingProviderTurn > 0;
+
+        private bool Owns(LoadLease lease) => loadOwner == lease.Generation;
+
+        /// <summary>
+        /// Tracks a virtualization request with a token linked to the one supplied by Virtualize.
+        /// </summary>
+        internal VirtualRequestLease TrackVirtualRequest(CancellationToken request)
+        {
+            CancellationTokenSource? previous = virtualRequest;
+            CancellationTokenSource linked = CancellationTokenSource.CreateLinkedTokenSource(request);
+
+            virtualRequest = linked;
+            previous?.Cancel();
+
+            return new VirtualRequestLease(this, linked, request);
+        }
+
+        private void EndVirtualRequest(CancellationTokenSource request)
+        {
+            if (ReferenceEquals(virtualRequest, request))
+            {
+                virtualRequest = null;
+            }
+
+            request.Dispose();
+        }
+
+        private void CancelVirtualRequest()
+        {
+            virtualRequest?.Cancel();
+        }
+
+        /// <summary>
+        /// Cancels the current load and virtual request, then waits until the superseded load has no more
+        /// provider work to append and the resulting queue tail has settled.
+        /// </summary>
+        internal async Task SupersedeAsyncLoad()
+        {
+            Task outstanding = providerTail;
+            Task superseded = loadCompletion;
+
+            CancelLoad();
+            CancelVirtualRequest();
+
+            if (outstanding.IsCompleted && superseded.IsCompleted)
+            {
+                return;
+            }
+
+            awaitingProviderTurn++;
+
+            try
+            {
+                await superseded;
+                await providerTail;
+            }
+            finally
+            {
+                awaitingProviderTurn--;
+            }
+        }
+
+        private void CancelLoad()
+        {
+            CancellationTokenSource? previous = loadCancellation;
+
+            loadCancellation = null;
+            loadOwner = NoLoad;
+
+            previous?.Cancel();
+        }
+
+        private LoadLease BeginLoad()
+        {
+            CancellationTokenSource? previous = loadCancellation;
+            CancellationTokenSource current = new();
+            long generation = ++loadSequence;
+
+            // Cancellation callbacks may start another load, so publish the new owner first.
+            loadCancellation = current;
+            loadOwner = generation;
+
+            previous?.Cancel();
+
+            return new LoadLease(this, generation, current);
+        }
+
+        private void EndLoad(LoadLease lease)
+        {
+            if (!Owns(lease))
+            {
+                return;
+            }
+
+            loadOwner = NoLoad;
+
+            owner.NotifyAsyncQueryCompleted();
+        }
+
+        /// <summary>
+        /// Runs a load under a generation lease. Superseded cancellation is swallowed, provider-approved
+        /// synchronous fallback is applied only by the owning lease, and the load-owned source is disposed
+        /// only after the body has exited.
+        /// </summary>
+        internal async Task<bool> RunLoadAsync(Func<LoadLease, Task> load,
+            Action? synchronousFallback = null)
+        {
+            LoadLease lease = BeginLoad();
+            bool applied = false;
+            TaskCompletionSource completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            loadCompletion = completion.Task;
+
+            try
+            {
+                await load(lease);
+                applied = Owns(lease);
+            }
+            catch (OperationCanceledException) when (lease.Token.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception) when (executor.CanFallBackToSynchronous(exception))
+            {
+                if (Owns(lease))
+                {
+                    synchronousFallback?.Invoke();
+                    applied = true;
+                }
+            }
+            finally
+            {
+                EndLoad(lease);
+
+                if (ReferenceEquals(loadCancellation, lease.Source))
+                {
+                    loadCancellation = null;
+                }
+
+                lease.Source.Dispose();
+
+                if (ReferenceEquals(loadCompletion, completion.Task))
+                {
+                    loadCompletion = Task.CompletedTask;
+                }
+
+                completion.SetResult();
+            }
+
+            return applied;
+        }
+
+        /// <summary>
+        /// Queues an uncommon provider callback after prior work. The keyboard lookup uses this because it
+        /// must re-check request ownership only once its turn arrives.
+        /// </summary>
+        internal Task<T> QueueAsync<T>(Func<IAsyncQueryExecutor, Task<T>> query)
+        {
+            Task turn = providerTail;
+            Task<T> current = turn.IsCompleted ? Invoke(query) : RunAfter(turn, executor, query);
+
+            TrackTail(current);
+
+            return current;
+        }
+
+        /// <summary>Counts a query in provider order without a capturing delegate.</summary>
+        internal Task<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken) =>
+            QueueAsync((Query: query, Token: cancellationToken),
+                static (executor, state) => executor.CountAsync(state.Query, state.Token));
+
+        /// <summary>Materializes a query in provider order without a capturing delegate.</summary>
+        internal Task<List<T>> ToListAsync<T>(IQueryable<T> query, CancellationToken cancellationToken) =>
+            QueueAsync((Query: query, Token: cancellationToken),
+                static (executor, state) => executor.ToListAsync(state.Query, state.Token));
+
+        /// <summary>
+        /// Materializes a page and, when it is a subset, counts its source in the same provider turn.
+        /// </summary>
+        internal Task<(int Count, List<T> Items)> CountAndPageAsync<T>(IQueryable<T> source,
+            IQueryable<T> page, bool pageIsSubset, CancellationToken cancellationToken)
+            => CountAndPageAsync(source, page, pageIsSubset, cancellationToken, false);
+
+        private Task<(int Count, List<T> Items)> CountAndPageWithFallbackAsync<T>(IQueryable<T> source,
+            IQueryable<T> page, bool pageIsSubset, CancellationToken cancellationToken)
+            => CountAndPageAsync(source, page, pageIsSubset, cancellationToken, true);
+
+        private Task<(int Count, List<T> Items)> CountAndPageAsync<T>(IQueryable<T> source,
+            IQueryable<T> page, bool pageIsSubset, CancellationToken cancellationToken,
+            bool synchronousFallback)
+            => QueueAsync((Source: source, Page: page, PageIsSubset: pageIsSubset,
+                Token: cancellationToken, SynchronousFallback: synchronousFallback),
+                static (executor, state) => RunCountAndPage(executor, state.Source, state.Page,
+                    state.PageIsSubset, state.Token, state.SynchronousFallback));
+
+        private Task<TResult> QueueAsync<TState, TResult>(TState state,
+            Func<IAsyncQueryExecutor, TState, Task<TResult>> query)
+        {
+            Task turn = providerTail;
+            Task<TResult> current = turn.IsCompleted
+                ? Invoke(executor, state, query)
+                : RunAfter(turn, executor, state, query);
+
+            TrackTail(current);
+
+            return current;
+        }
+
+        private void TrackTail(Task current)
+        {
+            providerTail = current.IsCompleted ? Task.CompletedTask : Settle(current);
+        }
+
+        private Task<T> Invoke<T>(Func<IAsyncQueryExecutor, Task<T>> query) => Invoke(executor, query);
+
+        private static Task<T> Invoke<T>(IAsyncQueryExecutor executor,
+            Func<IAsyncQueryExecutor, Task<T>> query)
+        {
+            try
+            {
+                return query(executor);
+            }
+            catch (Exception exception)
+            {
+                return Task.FromException<T>(exception);
+            }
+        }
+
+        private static Task<TResult> Invoke<TState, TResult>(IAsyncQueryExecutor executor, TState state,
+            Func<IAsyncQueryExecutor, TState, Task<TResult>> query)
+        {
+            try
+            {
+                return query(executor, state);
+            }
+            catch (Exception exception)
+            {
+                return Task.FromException<TResult>(exception);
+            }
+        }
+
+        private static async Task<T> RunAfter<T>(Task turn, IAsyncQueryExecutor executor,
+            Func<IAsyncQueryExecutor, Task<T>> query)
+        {
+            await turn;
+
+            return await Invoke(executor, query);
+        }
+
+        private static async Task<TResult> RunAfter<TState, TResult>(Task turn,
+            IAsyncQueryExecutor executor, TState state,
+            Func<IAsyncQueryExecutor, TState, Task<TResult>> query)
+        {
+            await turn;
+
+            return await Invoke(executor, state, query);
+        }
+
+        private static async Task<(int Count, List<T> Items)> RunCountAndPage<T>(
+            IAsyncQueryExecutor executor, IQueryable<T> source, IQueryable<T> page, bool pageIsSubset,
+            CancellationToken cancellationToken, bool synchronousFallback)
+        {
+            try
+            {
+                int count = pageIsSubset
+                    ? await executor.CountAsync(source, cancellationToken)
+                    : 0;
+                List<T> items = await executor.ToListAsync(page, cancellationToken);
+
+                return (pageIsSubset ? count : items.Count, items);
+            }
+            catch (Exception exception) when (synchronousFallback
+                && executor.CanFallBackToSynchronous(exception))
+            {
+                int count = pageIsSubset ? source.Count() : 0;
+                List<T> items = page.ToList();
+                return (pageIsSubset ? count : items.Count, items);
+            }
+        }
+
+        private static async Task Settle(Task query)
+        {
+            try
+            {
+                await query;
+            }
+            catch
+            {
+                // The caller observes the outcome; the queue records only settlement.
+            }
+        }
+
+        public void Dispose()
+        {
+            loadCancellation?.Cancel();
+            virtualRequest?.Cancel();
+        }
+    }
+}

--- a/Radzen.Blazor/AsyncQueryCoordinator.cs
+++ b/Radzen.Blazor/AsyncQueryCoordinator.cs
@@ -27,11 +27,16 @@ namespace Radzen
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed",
             Justification = "The virtual request lease disposes its source only after the request exits; coordinator disposal only cancels it.")]
         private CancellationTokenSource? virtualRequest;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed",
+            Justification = "The queued lookup disposes its source only after provider work exits; coordinator disposal only cancels it.")]
+        private CancellationTokenSource? lookupCancellation;
         private long loadOwner = NoLoad;
         private long loadSequence;
+        private long lookupSequence;
         private int awaitingProviderTurn;
         private Task loadCompletion = Task.CompletedTask;
         private Task providerTail = Task.CompletedTask;
+        private bool disposed;
 
         internal AsyncQueryCoordinator(RadzenComponent owner, IAsyncQueryExecutor executor)
         {
@@ -182,6 +187,12 @@ namespace Radzen
             virtualRequest?.Cancel();
         }
 
+        internal void CancelLookup()
+        {
+            lookupSequence++;
+            lookupCancellation?.Cancel();
+        }
+
         /// <summary>
         /// Cancels the current load and virtual request, then waits until the superseded load has no more
         /// provider work to append and the resulting queue tail has settled.
@@ -315,6 +326,59 @@ namespace Radzen
             return current;
         }
 
+        internal Task<T?> LookupAsync<T>(VirtualWindow<T> window, long queryGeneration,
+            IQueryable<T> view, int index)
+        {
+            long request = ++lookupSequence;
+
+            return QueueAsync(async executor =>
+            {
+                if (!OwnsLookup())
+                {
+                    return default;
+                }
+
+                using var cancellation = new CancellationTokenSource();
+                lookupCancellation = cancellation;
+
+                try
+                {
+                    T? item;
+
+                    try
+                    {
+                        item = (await executor.ToListAsync(view.Skip(index).Take(1), cancellation.Token))
+                            .FirstOrDefault();
+                    }
+                    catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+                    {
+                        return default;
+                    }
+                    catch (Exception exception) when (executor.CanFallBackToSynchronous(exception))
+                    {
+                        if (!OwnsLookup())
+                        {
+                            return default;
+                        }
+
+                        item = view.Skip(index).FirstOrDefault();
+                    }
+
+                    return OwnsLookup() ? item : default;
+                }
+                finally
+                {
+                    if (ReferenceEquals(lookupCancellation, cancellation))
+                    {
+                        lookupCancellation = null;
+                    }
+                }
+
+                bool OwnsLookup() => !disposed && request == lookupSequence
+                    && queryGeneration == window.QueryGeneration;
+            });
+        }
+
         /// <summary>Counts a query in provider order without a capturing delegate.</summary>
         internal Task<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken) =>
             QueueAsync((Query: query, Token: cancellationToken),
@@ -443,8 +507,10 @@ namespace Radzen
 
         public void Dispose()
         {
+            disposed = true;
             loadCancellation?.Cancel();
             virtualRequest?.Cancel();
+            lookupCancellation?.Cancel();
         }
     }
 }

--- a/Radzen.Blazor/DropDownBase.cs
+++ b/Radzen.Blazor/DropDownBase.cs
@@ -36,33 +36,113 @@ namespace Radzen
             }
         }
 
-        List<object>? virtualItems;
-        int virtualStartIndex;
+        // Render and keyboard paths read the fetched window instead of re-entering its provider.
+        readonly VirtualWindow<object> virtualWindow = new();
 
-        internal int VirtualStartIndex => virtualStartIndex;
+        internal int VirtualStartIndex => virtualWindow.StartIndex;
 
         [UnconditionalSuppressMessage(TrimMessages.Trimming, TrimMessages.IL2026, Justification = TrimMessages.DataTypePreserved)]
         private async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<object>> LoadItems(Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
         {
-            var data = Data != null ? Data.Cast<object>() : Enumerable.Empty<object>();
-            var view = (LoadData.HasDelegate ? data : View)?.Cast<object>().AsQueryable() ?? Enumerable.Empty<object>().AsQueryable();
-            var totalItemsCount = LoadData.HasDelegate ? Count : view.Count();
-            var top = request.Count;
+            var fetch = virtualWindow.BeginFetch();
 
-            if (top <= 0)
-            {
-                top = PageSize;
-            }
+            var data = Data != null ? Data.Cast<object>() : Enumerable.Empty<object>();
+
+            var view = (LoadData.HasDelegate ? data : View)?.Cast<object>().AsQueryable() ?? Enumerable.Empty<object>().AsQueryable();
+            var top = GetVirtualPageSize(request.Count, PageSize);
+
+            int totalItemsCount;
+            List<object> window;
 
             if (LoadData.HasDelegate)
             {
                 await LoadData.InvokeAsync(new Radzen.LoadDataArgs() { Skip = request.StartIndex, Top = top, Filter = searchText });
+                totalItemsCount = Count;
+                window = (Data ?? Enumerable.Empty<object>()).Cast<object>().ToList();
+            }
+            else
+            {
+                (totalItemsCount, window) = await WindowAsync(view, request, top);
             }
 
-            virtualStartIndex = request.StartIndex;
-            virtualItems = (LoadData.HasDelegate ? (Data ?? Enumerable.Empty<object>()) : view.Skip(request.StartIndex).Take(top)).Cast<object>().ToList();
+            var hadItems = virtualWindow.HasAny;
 
-            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<object>(virtualItems, LoadData.HasDelegate ? Count : totalItemsCount);
+            if (virtualWindow.TryPublish(fetch, request.StartIndex, totalItemsCount, window)
+                && virtualWindow.HasAny != hadItems)
+            {
+                StateHasChanged();
+            }
+
+            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<object>(window, totalItemsCount);
+        }
+
+        /// <summary>How many items the last virtualized window reported.</summary>
+        int VirtualItemCount() => virtualWindow.TotalCount;
+
+        /// <summary>
+        /// The item at <paramref name="index" /> in the virtualized list, taken from the fetched window
+        /// when it holds that index.
+        /// </summary>
+        internal async Task<object?> VirtualItemAt(int index)
+        {
+            var queryGeneration = virtualWindow.QueryGeneration;
+
+            CancelAsyncQueryLookup();
+
+            if (virtualWindow.TryGetAt(index, out var item))
+            {
+                return item;
+            }
+
+            var view = View?.Cast<object>().AsQueryable();
+
+            if (view == null)
+            {
+                return null;
+            }
+
+            if (!TryGetAsyncQueryCoordinator(view, out var coordinator))
+            {
+                return view.Skip(index).FirstOrDefault();
+            }
+
+            return await coordinator.LookupAsync(virtualWindow, queryGeneration, view, index);
+        }
+
+        /// <summary>Invalidates the virtual window and cancels its outstanding lookup.</summary>
+        void InvalidateVirtualWindow()
+        {
+            virtualWindow.Invalidate();
+
+            CancelAsyncQueryLookup();
+        }
+
+        /// <summary>Whether the list has anything to show.</summary>
+        internal bool HasAnyItems()
+        {
+            if (IsVirtualizationAllowed() && !LoadData.HasDelegate)
+            {
+                return virtualWindow.HasAny;
+            }
+
+            return View != null && View.Cast<object>().Any();
+        }
+
+        async Task<(int Count, List<object> Items)> WindowAsync(IQueryable<object> view,
+            Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request, int top)
+        {
+            if (TryGetAsyncQueryCoordinator(view, out var coordinator))
+            {
+                using var tracked = coordinator.TrackVirtualRequest(request.CancellationToken);
+                var result = await tracked.CountAndPageAsync(view,
+                    view.Skip(request.StartIndex).Take(top), true);
+
+                return result.HasValue
+                    ? result.Value
+                    : (VirtualItemCount(), new List<object>());
+            }
+
+            return (view.Count(), view.Skip(request.StartIndex).Take(top).ToList());
         }
 
         /// <summary>
@@ -410,6 +490,7 @@ namespace Radzen
 
             searchText = null;
             _view = null;
+            InvalidateVirtualWindow();
             await SearchTextChanged.InvokeAsync(searchText);
             if (JSRuntime != null)
             {
@@ -455,6 +536,7 @@ namespace Radzen
                 {
                     _data = value;
                     _view = null;
+                    InvalidateVirtualWindow();
 
                     if (!LoadData.HasDelegate)
                     {
@@ -706,8 +788,7 @@ namespace Radzen
             {
                 if (IsVirtualizationAllowed() && !LoadData.HasDelegate)
                 {
-                    var totalCount = View != null ? View.Cast<object>().Count() : 0;
-                    await JSRuntime.InvokeVoidAsync("Radzen.focusVirtualListItem", list, selectedIndex, totalCount);
+                    await JSRuntime.InvokeVoidAsync("Radzen.focusVirtualListItem", list, selectedIndex, VirtualItemCount());
                 }
                 else
                 {
@@ -754,7 +835,7 @@ namespace Radzen
             {
                 if (useVirtualization)
                 {
-                    virtualTotalCount = View != null ? View.Cast<object>().AsQueryable().Count() : 0;
+                    virtualTotalCount = VirtualItemCount();
                 }
                 else
                 {
@@ -801,7 +882,7 @@ namespace Radzen
                         if (!Multiple && !popupOpened && shouldSelectOnChange != false)
                         {
                             object? selectedItemToChange = useVirtualization
-                                ? View?.Cast<object>().AsQueryable().Skip(selectedIndex).FirstOrDefault()
+                                ? await VirtualItemAt(selectedIndex)
                                 : items.ElementAtOrDefault(selectedIndex);
                             if (selectedItemToChange != null)
                             {
@@ -839,7 +920,7 @@ namespace Radzen
                         if (!Multiple && !popupOpened && shouldSelectOnChange != false)
                         {
                             object? selectedItemToChange = useVirtualization
-                                ? View?.Cast<object>().AsQueryable().Skip(selectedIndex).FirstOrDefault()
+                                ? await VirtualItemAt(selectedIndex)
                                 : items.ElementAtOrDefault(selectedIndex);
                             if (selectedItemToChange != null)
                             {
@@ -868,7 +949,7 @@ namespace Radzen
                     if (selectedIndex >= 0 && selectedIndex <= effectiveCount - 1)
                     {
                         object? itemToSelect = useVirtualization
-                            ? View?.Cast<object>().AsQueryable().Skip(selectedIndex).FirstOrDefault()
+                            ? await VirtualItemAt(selectedIndex)
                             : items.ElementAtOrDefault(selectedIndex);
 
                         await JSRuntime.InvokeAsync<string>("Radzen.setInputValue", search, $"{searchText}".Trim());
@@ -1069,6 +1150,7 @@ namespace Radzen
             if (!LoadData.HasDelegate)
             {
                 _view = null;
+                InvalidateVirtualWindow();
                 if (IsVirtualizationAllowed())
                 {
                     if (virtualize != null)

--- a/Radzen.Blazor/IAsyncQueryExecutor.cs
+++ b/Radzen.Blazor/IAsyncQueryExecutor.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Radzen
+{
+    /// <summary>
+    /// Executes the count and page-materialization steps of a data-bound Radzen component asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// When a component is bound to an <see cref="IQueryable{T}" /> backed by a provider that supports
+    /// asynchronous execution (for example Entity Framework Core), the component would otherwise call the
+    /// synchronous <c>Count()</c> / <c>ToList()</c> operators, which block the calling thread on database I/O.
+    /// Registering an <see cref="IAsyncQueryExecutor" /> in the service collection lets the component
+    /// <c>await</c> real asynchronous queries instead. Radzen.Blazor does not reference any specific data
+    /// provider; an adapter package supplies the implementation (see <c>AddRadzenQueryableEntityFrameworkAdapter</c>).
+    /// When no executor is registered, or the bound queryable is not supported, components fall back to the
+    /// synchronous path unchanged.
+    /// </remarks>
+    public interface IAsyncQueryExecutor
+    {
+        /// <summary>
+        /// Determines whether the specified <paramref name="queryable" /> can be executed asynchronously by
+        /// this executor (for example, whether its provider is an Entity Framework async query provider).
+        /// </summary>
+        bool IsSupported<T>(IQueryable<T> queryable);
+
+        /// <summary>
+        /// Asynchronously counts the elements of <paramref name="queryable" />.
+        /// </summary>
+        Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously materializes <paramref name="queryable" /> into a list.
+        /// </summary>
+        Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Whether a component may answer <paramref name="exception" /> by running the same query
+        /// synchronously instead.
+        /// </summary>
+        /// <remarks>
+        /// The default recognizes conventional query-translation failures. Provider adapters should
+        /// override it when the same exception type can also represent a non-retriable failure.
+        /// </remarks>
+        /// <param name="exception">The exception an awaited query threw.</param>
+        bool CanFallBackToSynchronous(Exception exception) =>
+            exception is InvalidOperationException or NotSupportedException;
+    }
+}

--- a/Radzen.Blazor/PagedDataBoundComponent.cs
+++ b/Radzen.Blazor/PagedDataBoundComponent.cs
@@ -332,11 +332,20 @@ namespace Radzen
             {
                 if (_view == null)
                 {
+                    // Do not re-enter a provider owned by an async load from a render-time getter.
+                    if (AsyncLoadPending)
+                    {
+                        return Enumerable.Empty<T>().AsQueryable();
+                    }
+
                     _view = (AllowPaging && !LoadData.HasDelegate ? View.Skip(skip).Take(PageSize) : View).ToList().AsQueryable();
                 }
                 return _view;
             }
         }
+
+        /// <summary>Whether the component fetches virtual windows instead of rendering PagedView.</summary>
+        private protected virtual bool IsVirtualized => false;
 
         /// <summary>
         /// Gets the view.
@@ -362,11 +371,11 @@ namespace Radzen
         /// </summary>
         public async virtual Task Reload()
         {
-            _view = null;
+            await SupersedeAsyncLoad();
 
-            if (Data != null && !LoadData.HasDelegate)
+            if (!await LoadPagedViewAsync())
             {
-                Count = View.Count();
+                return;
             }
 
             await LoadData.InvokeAsync(new Radzen.LoadDataArgs() { Skip = skip, Top = PageSize });
@@ -377,6 +386,41 @@ namespace Radzen
             {
                 StateHasChanged();
             }
+        }
+
+        private protected ValueTask<bool> LoadPagedViewAsync()
+        {
+            _view = null;
+
+            if (Data == null || LoadData.HasDelegate)
+            {
+                return new(true);
+            }
+
+            var view = View;
+
+            if (!TryGetAsyncQueryCoordinator(view, out var coordinator))
+            {
+                Count = view.Count();
+                return new(true);
+            }
+
+            return new(coordinator.RunLoadAsync(async load =>
+            {
+                if (IsVirtualized && !AllowPaging)
+                {
+                    var virtualCount = await load.CountAsync(view);
+                    load.ThrowIfSuperseded();
+                    Count = virtualCount;
+                    return;
+                }
+
+                var page = AllowPaging ? view.Skip(skip).Take(PageSize) : view;
+                var (count, items) = await load.CountAndPageAsync(view, page, AllowPaging);
+                load.ThrowIfSuperseded();
+                Count = count;
+                _view = items.AsQueryable();
+            }, () => Count = view.Count()));
         }
 
         /// <summary>

--- a/Radzen.Blazor/RadzenComponent.cs
+++ b/Radzen.Blazor/RadzenComponent.cs
@@ -237,15 +237,20 @@ namespace Radzen
             }
         }
 
-        private AsyncQueryCoordinator? asyncQueryCoordinator;
-
         private protected bool HasAsyncQueryExecutor => AsyncQueryExecutor != null;
+
+        private AsyncQueryCoordinator? asyncQueryCoordinator;
 
         // These adapters do not instantiate coordinator state.
         private protected bool AsyncLoadPending => asyncQueryCoordinator?.LoadPending == true;
 
         private protected Task SupersedeAsyncLoad() =>
             asyncQueryCoordinator?.SupersedeAsyncLoad() ?? Task.CompletedTask;
+
+        private protected void CancelAsyncQueryLookup() => asyncQueryCoordinator?.CancelLookup();
+
+        private protected static int GetVirtualPageSize(int requested, int fallback) =>
+            requested > 0 ? requested : fallback;
 
         private protected bool TryGetAsyncQueryCoordinator<T>(IQueryable<T> query,
             [NotNullWhen(true)] out AsyncQueryCoordinator? coordinator)

--- a/Radzen.Blazor/RadzenComponent.cs
+++ b/Radzen.Blazor/RadzenComponent.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
@@ -218,6 +220,53 @@ namespace Radzen
         internal Localizer Localizer => localizer ??=
             Services.GetService<Localizer>() ?? Localizer.Default;
 
+        private bool asyncQueryExecutorResolved;
+        private IAsyncQueryExecutor? asyncQueryExecutor;
+
+        private IAsyncQueryExecutor? AsyncQueryExecutor
+        {
+            get
+            {
+                if (!asyncQueryExecutorResolved)
+                {
+                    asyncQueryExecutorResolved = true;
+                    asyncQueryExecutor = Services?.GetService<IAsyncQueryExecutor>();
+                }
+
+                return asyncQueryExecutor;
+            }
+        }
+
+        private AsyncQueryCoordinator? asyncQueryCoordinator;
+
+        private protected bool HasAsyncQueryExecutor => AsyncQueryExecutor != null;
+
+        // These adapters do not instantiate coordinator state.
+        private protected bool AsyncLoadPending => asyncQueryCoordinator?.LoadPending == true;
+
+        private protected Task SupersedeAsyncLoad() =>
+            asyncQueryCoordinator?.SupersedeAsyncLoad() ?? Task.CompletedTask;
+
+        private protected bool TryGetAsyncQueryCoordinator<T>(IQueryable<T> query,
+            [NotNullWhen(true)] out AsyncQueryCoordinator? coordinator)
+        {
+            var executor = AsyncQueryExecutor;
+
+            if (executor != null && executor.IsSupported(query))
+            {
+                coordinator = asyncQueryCoordinator ??= new AsyncQueryCoordinator(this, executor);
+                return true;
+            }
+
+            coordinator = null;
+            return false;
+        }
+
+        internal virtual void NotifyAsyncQueryCompleted()
+        {
+            StateHasChanged();
+        }
+
         /// <summary>
         /// Returns a localized string for the specified key using the current <see cref="UICulture"/>.
         /// </summary>
@@ -399,6 +448,8 @@ namespace Radzen
         public virtual void Dispose()
         {
             disposed = true;
+
+            asyncQueryCoordinator?.Dispose();
 
             debouncer?.Dispose();
             debouncer = null;

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -98,8 +98,6 @@ namespace Radzen.Blazor
     [UnconditionalSuppressMessage(TrimMessages.Trimming, TrimMessages.IL2091, Justification = TrimMessages.DataTypePreserved)]
     public partial class RadzenDataGrid<TItem> : PagedDataBoundComponent<TItem> where TItem : notnull
     {
-        private static readonly string[] DefaultGroupProperty = new string[] { "it" };
-
         /// <summary>
         /// Gets whether all inline edit validators in the DataGrid are currently valid.
         /// Use this property to check validation state before saving edited rows.
@@ -175,9 +173,10 @@ namespace Radzen.Blazor
             }
         }
 
-        List<TItem> virtualDataItems = new List<TItem>();
+        // Render-time state comes from the fetched windows, never from an in-flight provider query.
+        readonly VirtualWindow<TItem> virtualWindow = new();
+        readonly VirtualWindow<GroupResult> virtualGroupWindow = new();
 
-        int virtualItemsStartIndex;
 
         /// <summary>
         /// Clears the internal data cache and refreshes the DataGrid, reloading data from the source.
@@ -211,15 +210,12 @@ namespace Radzen.Blazor
 
         string? lastLoadDataArgs;
         Task lastLoadDataTask = Task.CompletedTask;
-        private async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>> LoadItems(Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
+        internal async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>> LoadItems(Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
         {
-            var view = AllowPaging ? PagedView : View;
-            var top = request.Count;
+            var fetch = virtualWindow.BeginFetch();
 
-            if(top <= 0)
-            {
-                top = PageSize;
-            }
+            var view = AllowPaging ? PagedView : View;
+            var top = GetVirtualPageSize(request.Count, PageSize);
 
             var filter = isOData == true ?
                     allColumns.ToList().ToODataFilterString<TItem>() : allColumns.ToList().ToFilterString<TItem>();
@@ -232,41 +228,108 @@ namespace Radzen.Blazor
                 lastLoadDataArgs = loadDataArgs;
             }
 
-            var totalItemsCount = (LoadData.HasDelegate ? Count : view.Count()) + itemsToInsert.Count;
+            int totalItemsCount;
+            List<TItem> window;
 
-            virtualDataItems = (LoadData.HasDelegate ? (itemsToInsert.Count > 0 ? itemsToInsert.ToList().Concat(Data ?? Enumerable.Empty<TItem>()) : Data) : itemsToInsert.Count > 0 ? itemsToInsert.ToList().Concat(view.Skip(request.StartIndex).Take(top)) : view.Skip(request.StartIndex).Take(top))?.ToList() ?? new List<TItem>();
+            if (!AllowPaging && typeof(TItem) != typeof(object) && CanUseAsyncQuery
+                && TryGetAsyncQueryCoordinator(view, out var coordinator))
+            {
+                using var tracked = coordinator.TrackVirtualRequest(request.CancellationToken);
+                var result = await tracked.CountAndPageAsync(view,
+                    view.Skip(request.StartIndex).Take(top), true);
 
-            virtualItemsStartIndex = request.StartIndex;
+                if (!result.HasValue)
+                {
+                    return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(
+                        System.Array.Empty<TItem>(), virtualWindow.TotalCount);
+                }
 
-            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(virtualDataItems, totalItemsCount);
+                (totalItemsCount, window) = result.Value;
+            }
+            else if (LoadData.HasDelegate)
+            {
+                totalItemsCount = Count;
+                window = (Data ?? Enumerable.Empty<TItem>()).ToList();
+            }
+            else
+            {
+                totalItemsCount = view.Count();
+                window = view.Skip(request.StartIndex).Take(top).ToList();
+            }
+
+            totalItemsCount += itemsToInsert.Count;
+
+            if (itemsToInsert.Count > 0)
+            {
+                window = itemsToInsert.Concat(window).ToList();
+            }
+
+            var hadRows = virtualWindow.HasAny;
+
+            if (virtualWindow.TryPublish(fetch, request.StartIndex, totalItemsCount, window)
+                && virtualWindow.HasAny != hadRows)
+            {
+                StateHasChanged();
+            }
+
+            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(window, totalItemsCount);
         }
 
         private async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<GroupResult>> LoadGroups(Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
         {
-            var top = request.Count;
+            var fetch = virtualGroupWindow.BeginFetch();
 
-            if(top <= 0)
-            {
-                top = PageSize;
-            }
+            var top = GetVirtualPageSize(request.Count, PageSize);
 
             var view = AllowPaging ? PagedView : View;
 
             var query = Enumerable.Empty<TItem>().AsQueryable();
             var totalItemsCount = 0;
-            _groupedPagedView = Enumerable.Empty<GroupResult>();
+            var grouped = (IEnumerable<GroupResult>)System.Array.Empty<GroupResult>();
 
             if (Groups.Any())
             {
                 query = view.AsQueryable().OrderBy(Groups.Any() ? string.Join(',', Groups.Select(g => g.Property)) : null);
-                _groupedPagedView = await Task.FromResult(query.GroupByMany(Groups.Any() ? Groups.Select(g => g.Property).ToArray() : DefaultGroupProperty).ToList());
 
-                totalItemsCount = await Task.FromResult(_groupedPagedView.Count());
+                if (!AllowPaging && typeof(TItem) != typeof(object) && CanUseAsyncQuery
+                    && TryGetAsyncQueryCoordinator(query, out var coordinator))
+                {
+                    using var tracked = coordinator.TrackVirtualRequest(request.CancellationToken);
+                    var result = await tracked.ToListAsync(query);
+
+                    if (result.HasValue)
+                    {
+                        query = result.Value.AsQueryable();
+                    }
+                    else if (!result.RequiresSynchronousFallback)
+                    {
+                        return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<GroupResult>(
+                            System.Array.Empty<GroupResult>(), virtualGroupWindow.TotalCount);
+                    }
+                }
+
+                var groups = GroupRows(query);
+
+                grouped = groups;
+                totalItemsCount = groups.Count;
             }
 
-            _view = view;
+            var page = grouped.Skip(request.StartIndex).Take(top).ToList();
 
-            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<GroupResult>(_groupedPagedView.Any() ? _groupedPagedView.Skip(request.StartIndex).Take(top) : _groupedPagedView, totalItemsCount);
+            var hadGroups = virtualGroupWindow.HasAny;
+
+            if (virtualGroupWindow.TryPublish(fetch, request.StartIndex, totalItemsCount, page))
+            {
+                _groupedPagedView = grouped;
+                _view = view;
+
+                if (virtualGroupWindow.HasAny != hadGroups)
+                {
+                    StateHasChanged();
+                }
+            }
+
+            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<GroupResult>(page, totalItemsCount);
         }
 
         RenderFragment DrawRows(IList<RadzenDataGridColumn<TItem>> visibleColumns)
@@ -311,7 +374,7 @@ namespace Radzen.Blazor
                                 b.AddAttribute(6, "TItem", typeof(TItem));
                                 b.AddAttribute(7, "Item", context);
                                 b.AddAttribute(8, "InEditMode", IsRowInEditMode(context));
-                                b.AddAttribute(9, "Index", virtualDataItems.IndexOf(context));
+                                b.AddAttribute(9, "Index", virtualWindow.IndexOf(context));
 
                                 // O(1) lookup instead of scanning editContexts.Keys per rendered row.
                                 if (editContexts.TryGetValue(context, out var editContext))
@@ -472,14 +535,21 @@ namespace Radzen.Blazor
             {
                 if (_groupedPagedView == null)
                 {
-                    var orderBy = GetOrderBy();
-                    var query = Groups.Count(g => g.SortOrder == null) == Groups.Count || !string.IsNullOrEmpty(orderBy) ? View : View.OrderBy(string.Join(',', Groups.Select(g => $"{g.Property} {(g.SortOrder == null ? "" : g.SortOrder == SortOrder.Ascending ? " asc" : " desc")}")));
-                    var v = (AllowPaging && !LoadData.HasDelegate ? query.Skip(skip).Take(PageSize) : query).ToList().AsQueryable();
-                    _groupedPagedView = v.GroupByMany(Groups.Select(g => g.Property).ToArray()).ToList();
+                    var query = ComposeGroupedQuery(View, GetOrderBy());
+                    var rows = (AllowPaging && !LoadData.HasDelegate ? query.Skip(skip).Take(PageSize) : query).ToList();
+                    _groupedPagedView = GroupRows(rows);
                 }
                 return _groupedPagedView;
             }
         }
+
+        IQueryable<TItem> ComposeGroupedQuery(IQueryable<TItem> composed, string orderBy) =>
+            Groups.Count(g => g.SortOrder == null) == Groups.Count || !string.IsNullOrEmpty(orderBy)
+                ? composed
+                : composed.OrderBy(string.Join(',', Groups.Select(g => $"{g.Property} {(g.SortOrder == null ? "" : g.SortOrder == SortOrder.Ascending ? " asc" : " desc")}")));
+
+        List<GroupResult> GroupRows(IEnumerable<TItem> rows) =>
+            rows.AsQueryable().GroupByMany(Groups.Select(g => g.Property).ToArray()).ToList();
 
         internal async Task RemoveGroupAsync(GroupDescriptor gd)
         {
@@ -2176,11 +2246,7 @@ namespace Radzen.Blazor
             {
                 if (typeof(TItem) == typeof(object))
                 {
-                    var firstItem = view.FirstOrDefault();
-                    if (firstItem != null)
-                    {
-                        view = QueryableExtension.Cast(view, firstItem.GetType()).AsQueryable().OrderBy(orderBy).Cast<TItem>();
-                    }
+                    view = ApplyObjectTypeOrdering(view, view.FirstOrDefault(), orderBy);
                 }
                 else
                 {
@@ -2261,65 +2327,157 @@ namespace Radzen.Blazor
                     }
                 }
 
-                IQueryable<TItem> view;
-
-                if (childData.Count > 0)
+                // Avoid render-time provider access while an async load owns the source.
+                if (AsyncLoadPending)
                 {
-                    view = GetSelfRefView(base.View, orderBy);
-                }
-                else
-                {
-                    view = base.View.Where<TItem>(allColumns);
-
-                    if (!string.IsNullOrEmpty(orderBy))
-                    {
-                        if (HasSortComparer())
-                        {
-                            view = OrderByComparers(view);
-                        }
-                        else if (typeof(TItem) == typeof(object))
-                        {
-                            var firstItem = view.FirstOrDefault();
-                            if (firstItem != null)
-                            {
-                                view = QueryableExtension.Cast(view, firstItem.GetType());
-                                view = view.OrderBy(orderBy).Cast<TItem>();
-                            }
-                        }
-                        else
-                        {
-                            view = view.OrderBy(orderBy);
-                        }
-                    }
+                    return Enumerable.Empty<TItem>().AsQueryable();
                 }
 
-                if (!IsVirtualizationAllowed() || AllowPaging)
+                var view = ComposeLocalView(orderBy);
+
+                if ((!IsVirtualizationAllowed() || AllowPaging) && !asyncCountApplied)
                 {
-                    var count = view.Count();
-                    if (count != Count)
-                    {
-                        Count = count;
-
-                        if (skip >= Count && Count > PageSize)
-                        {
-                            skip = Count - PageSize;
-                        }
-
-                        if (Count <= PageSize)
-                        {
-                            skip = 0;
-                            CurrentPage = 0;
-                        }
-
-                        CalculatePager();
-
-                        StateHasChanged();
-                    }
+                    ApplyCount(view.Count());
                 }
 
                 return QueryOnlyVisibleColumns ? view
                     .Select(allColumns.Where(c => c.GetVisible() && !string.IsNullOrEmpty(c.Property)).Select(c => c.Property)) : view;
             }
+        }
+
+        IQueryable<TItem> ComposeLocalView(string orderBy)
+        {
+            if (childData.Count > 0)
+            {
+                return GetSelfRefView(base.View, orderBy);
+            }
+
+            var view = base.View.Where<TItem>(allColumns);
+
+            if (!string.IsNullOrEmpty(orderBy))
+            {
+                if (HasSortComparer())
+                {
+                    view = OrderByComparers(view);
+                }
+                else if (typeof(TItem) == typeof(object))
+                {
+                    view = ApplyObjectTypeOrdering(view, view.FirstOrDefault(), orderBy);
+                }
+                else
+                {
+                    view = view.OrderBy(orderBy);
+                }
+            }
+
+            return view;
+        }
+
+        IQueryable<TItem> ApplyObjectTypeOrdering(IQueryable<TItem> view, object? firstItem, string orderBy)
+        {
+            if (firstItem == null)
+            {
+                return view;
+            }
+
+            return QueryableExtension.Cast(view, firstItem.GetType()).OrderBy(orderBy).Cast<TItem>();
+        }
+
+        void ApplyCount(int count)
+        {
+            if (count == Count)
+            {
+                return;
+            }
+
+            Count = count;
+
+            if (skip >= Count && Count > PageSize)
+            {
+                skip = Count - PageSize;
+            }
+
+            if (Count <= PageSize)
+            {
+                skip = 0;
+                CurrentPage = 0;
+            }
+
+            CalculatePager();
+
+            StateHasChanged();
+        }
+
+        async Task MaterializeAsyncCore(IQueryable<TItem> composed, string orderBy,
+            AsyncQueryCoordinator.LoadLease load)
+        {
+            var grouped = Groups.Any();
+            var query = grouped ? ComposeGroupedQuery(composed, orderBy) : composed;
+
+            List<TItem> rows;
+
+            if (AllowPaging)
+            {
+                var count = await load.CountAsync(composed);
+
+                load.ThrowIfSuperseded();
+
+                ApplyCount(count);
+
+                rows = await load.ToListAsync(query.Skip(skip).Take(PageSize));
+
+                load.ThrowIfSuperseded();
+            }
+            else
+            {
+                rows = await load.ToListAsync(query);
+
+                load.ThrowIfSuperseded();
+
+                ApplyCount(rows.Count);
+            }
+
+            asyncCountApplied = true;
+
+            if (grouped)
+            {
+                _groupedPagedView = GroupRows(rows);
+            }
+            else
+            {
+                _view = rows.AsQueryable();
+            }
+        }
+
+        bool CanUseAsyncQuery => !LoadData.HasDelegate && !QueryOnlyVisibleColumns && childData.Count == 0;
+
+        bool asyncCountApplied;
+
+        internal async Task RefreshVirtualizationAsync()
+        {
+            virtualWindow.Invalidate();
+            virtualGroupWindow.Invalidate();
+
+            if (virtualize != null)
+            {
+                await virtualize.RefreshDataAsync();
+            }
+
+            if (groupVirtualize != null)
+            {
+                await groupVirtualize.RefreshDataAsync();
+            }
+
+            StateHasChanged();
+        }
+
+        void ResetView()
+        {
+            _view = null;
+            asyncCountApplied = false;
+
+            virtualWindow.Invalidate();
+            virtualGroupWindow.Invalidate();
         }
 
         RadzenDataGridColumn<TItem>? SortColumn(SortDescriptor descriptor) =>
@@ -2374,6 +2532,11 @@ namespace Radzen.Blazor
             if (Data == null)
             {
                 return false;
+            }
+
+            if (IsVirtualizationAllowed() && !LoadData.HasDelegate)
+            {
+                return Groups.Count > 0 ? virtualGroupWindow.HasAny : virtualWindow.HasAny;
             }
 
             if (Data is IQueryable<TItem> queryable)
@@ -2577,7 +2740,7 @@ namespace Radzen.Blazor
         public void Reset(bool resetColumnState = true, bool resetRowState = false)
         {
             _groupedPagedView = null;
-            _view = null;
+            ResetView();
             _value = new List<TItem>();
 
             if (resetRowState)
@@ -2620,12 +2783,41 @@ namespace Radzen.Blazor
 
         internal async Task ReloadInternal()
         {
+            await SupersedeAsyncLoad();
+
             _groupedPagedView = null;
-            _view = null;
+            ResetView();
 
             if (Data != null && !LoadData.HasDelegate)
             {
                 Count = 1;
+
+                var isObjectType = typeof(TItem) == typeof(object);
+
+                if (CanUseAsyncQuery && HasAsyncQueryExecutor && (!AllowVirtualization || AllowPaging)
+                    && !(isObjectType && HasSortComparer()))
+                {
+                    var orderBy = GetOrderBy();
+
+                    var source = isObjectType ? base.View.Where<TItem>(allColumns) : ComposeLocalView(orderBy);
+
+                    if (TryGetAsyncQueryCoordinator(source, out var coordinator))
+                    {
+                        var applied = await coordinator.RunLoadAsync(async load =>
+                        {
+                            var composed = isObjectType && !string.IsNullOrEmpty(orderBy)
+                                ? ApplyObjectTypeOrdering(source, (await load.ToListAsync(source.Take(1))).FirstOrDefault(), orderBy)
+                                : source;
+
+                            await MaterializeAsyncCore(composed, orderBy, load);
+                        });
+
+                        if (!applied)
+                        {
+                            return;
+                        }
+                    }
+                }
             }
 
             if (AllowVirtualization)
@@ -2943,7 +3135,7 @@ namespace Radzen.Blazor
 
         internal string? RowAriaRowIndex(int index)
         {
-            return IsVirtualizationAllowed() && Groups.Count == 0 ? (virtualItemsStartIndex + index + HeaderRowCount() + 1).ToString(CultureInfo.InvariantCulture) : null;
+            return IsVirtualizationAllowed() && Groups.Count == 0 ? (virtualWindow.StartIndex + index + HeaderRowCount() + 1).ToString(CultureInfo.InvariantCulture) : null;
         }
 
         internal string? RowAriaLevel(TItem item)
@@ -3270,7 +3462,7 @@ namespace Radzen.Blazor
                     if (args.Data != null && !childData.ContainsKey(item))
                     {
                         childData.Add(item, new DataGridChildData<TItem>() { Data = args.Data, ParentChildData = childData.Where(c => c.Value.Data?.Contains(item) == true).Select(c => c.Value).FirstOrDefault() });
-                        _view = null;
+                        ResetView();
                     }
                 }
             }
@@ -3316,7 +3508,7 @@ namespace Radzen.Blazor
 
             if (childData.Remove(item))
             {
-                _view = null;
+                ResetView();
             }
         }
 
@@ -3349,7 +3541,7 @@ namespace Radzen.Blazor
                 if (args.Data != null && !childData.ContainsKey(item))
                 {
                     childData.Add(item, new DataGridChildData<TItem>() { Data = args.Data, ParentChildData = childData.Where(c => c.Value!.Data!.Contains(item)).Select(c => c.Value).FirstOrDefault() });
-                    _view = null;
+                    ResetView();
                 }
             }
             else
@@ -4271,7 +4463,7 @@ namespace Radzen.Blazor
 
             _value = null;
             Data = null;
-            _view = null;
+            ResetView();
             _groupedPagedView = null;
 
             if (Query != null)

--- a/Radzen.Blazor/RadzenDataGridColumn.razor.cs
+++ b/Radzen.Blazor/RadzenDataGridColumn.razor.cs
@@ -1315,10 +1315,7 @@ namespace Radzen.Blazor
                     grid.SaveSettings();
                     if (grid.IsVirtualizationAllowed())
                     {
-                        if (grid.virtualize != null)
-                        {
-                            await grid.virtualize.RefreshDataAsync();
-                        }
+                        await grid.RefreshVirtualizationAsync();
                     }
                     else
                     {
@@ -1344,10 +1341,7 @@ namespace Radzen.Blazor
                         grid.SaveSettings();
                         if (grid.IsVirtualizationAllowed())
                         {
-                            if (grid.virtualize != null)
-                            {
-                                await grid.virtualize.RefreshDataAsync();
-                            }
+                            await grid.RefreshVirtualizationAsync();
                         }
                         else
                         {
@@ -1371,10 +1365,7 @@ namespace Radzen.Blazor
                         grid.SaveSettings();
                         if (grid.IsVirtualizationAllowed())
                         {
-                            if (grid.virtualize != null)
-                            {
-                                await grid.virtualize.RefreshDataAsync();
-                            }
+                            await grid.RefreshVirtualizationAsync();
                         }
                         else
                         {
@@ -1396,10 +1387,7 @@ namespace Radzen.Blazor
                     grid?.SaveSettings();
                     if (grid?.IsVirtualizationAllowed() == true)
                     {
-                        if (grid?.virtualize != null)
-                        {
-                            await grid.virtualize.RefreshDataAsync();
-                        }
+                        await grid.RefreshVirtualizationAsync();
                     }
                     else
                     {

--- a/Radzen.Blazor/RadzenDataList.razor.cs
+++ b/Radzen.Blazor/RadzenDataList.razor.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Components;
 using System.Linq;
 using System.Threading.Tasks;
@@ -38,6 +39,9 @@ namespace Radzen.Blazor
     [CascadingTypeParameter(nameof(TItem))]
     public partial class RadzenDataList<TItem> : PagedDataBoundComponent<TItem>
     {
+        /// <inheritdoc />
+        private protected override bool IsVirtualized => AllowVirtualization;
+
         /// <inheritdoc />
         protected override string GetComponentCssClass()
         {
@@ -112,24 +116,39 @@ namespace Radzen.Blazor
         private async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>> LoadItems(Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
         {
             var view = AllowPaging ? PagedView : View;
-            var top = request.Count;
-
-            if(top <= 0)
-            {
-                top = PageSize;
-            }
+            var top = GetVirtualPageSize(request.Count, PageSize);
 
             await LoadData.InvokeAsync(new Radzen.LoadDataArgs()
             {
                 Skip = request.StartIndex,
                 Top = top
             });
-            
-            var totalItemsCount = LoadData.HasDelegate ? Count : view.Count();
 
-            var virtualDataItems = (LoadData.HasDelegate ? Data : view.Skip(request.StartIndex).Take(top))?.ToList();
+            if (LoadData.HasDelegate)
+            {
+                return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(
+                    Data ?? Enumerable.Empty<TItem>(), Count);
+            }
 
-            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(virtualDataItems ?? Enumerable.Empty<TItem>(), totalItemsCount);
+            var window = view.Skip(request.StartIndex).Take(top);
+
+            if (TryGetAsyncQueryCoordinator(view, out var coordinator))
+            {
+                using var tracked = coordinator.TrackVirtualRequest(request.CancellationToken);
+                var result = await tracked.CountAndPageAsync(view, window, true);
+
+                if (result.HasValue)
+                {
+                    return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(
+                        result.Value.Items, result.Value.Count);
+                }
+
+                return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(
+                    Array.Empty<TItem>(), Count);
+            }
+
+            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>(
+                window.ToList(), view.Count());
         }
         RenderFragment DrawDataListRows()
         {

--- a/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDropDownDataGrid.razor.cs
@@ -745,6 +745,8 @@ namespace Radzen.Blazor
         int? skip;
         async Task OnLoadData(LoadDataArgs args)
         {
+            await SupersedeAsyncLoad();
+
             skip = args.Skip;
 
             if (prevSearch != searchText)
@@ -812,9 +814,34 @@ namespace Radzen.Blazor
                     query = query.OrderBy(args.OrderBy);
                 }
 
-                count = await Task.FromResult(query.Cast<object>().Count());
+                var view = query.Cast<object>();
+                var pageQuery = view.Skip(skip ?? 0).Take(args.Top ?? PageSize);
 
-                pagedData = await Task.FromResult(query.Cast<object>().Skip(skip.HasValue ? skip.Value : 0).Take(args.Top.HasValue ? args.Top.Value : PageSize).ToList());
+                if (TryGetAsyncQueryCoordinator(view, out var coordinator))
+                {
+                    var applied = await coordinator.RunLoadAsync(async load =>
+                    {
+                        var (fetchedCount, fetchedData) = await load.CountAndPageAsync(view, pageQuery, true);
+
+                        load.ThrowIfSuperseded();
+
+                        (count, pagedData) = (fetchedCount, fetchedData);
+                    }, () =>
+                    {
+                        count = view.Count();
+                        pagedData = pageQuery.ToList();
+                    });
+
+                    if (!applied)
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    count = view.Count();
+                    pagedData = pageQuery.ToList();
+                }
 
                 internalView = query;
 

--- a/Radzen.Blazor/RadzenListBox.razor
+++ b/Radzen.Blazor/RadzenListBox.razor
@@ -66,7 +66,7 @@
                     aria-disabled="@(Disabled ? "true" : "false")" aria-activedescendant="@ActiveDescendantId">
                     @RenderItems()
                 </ul>
-                @if (!View.Cast<object>().Any() && !IsLoading)
+                @if (!HasAnyItems() && !IsLoading)
                 {
                     <div class="rz-listbox-empty-message">
                         @if (EmptyTemplate != null)

--- a/Radzen.Blazor/RadzenPivotDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenPivotDataGrid.razor.cs
@@ -852,12 +852,13 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         public async override Task Reload()
         {
-            InvalidatePivotCache();
-            _view = null;
+            await SupersedeAsyncLoad();
 
-            if (Data != null && !LoadData.HasDelegate)
+            InvalidatePivotCache();
+
+            if (!await LoadPagedViewAsync())
             {
-                Count = View.Count();
+                return;
             }
 
             await InvokeLoadData(skip, PageSize);
@@ -2582,6 +2583,12 @@ namespace Radzen.Blazor
         {
             get
             {
+                // Avoid render-time provider access while an async load owns the source.
+                if (AsyncLoadPending)
+                {
+                    return Enumerable.Empty<TItem>().AsQueryable();
+                }
+
                 var baseView = base.View;
 
                 var filters = GetFilters();

--- a/Radzen.Blazor/VirtualWindow.cs
+++ b/Radzen.Blazor/VirtualWindow.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Radzen
+{
+    /// <summary>Owns the last accepted window of rows for a virtualized query.</summary>
+    /// <remarks>
+    /// Fetch identities prevent superseded work from publishing even when cancellation is ignored.
+    /// Invalidating a query also supersedes every fetch composed from it.
+    /// </remarks>
+    /// <typeparam name="T">The row type the window holds.</typeparam>
+    internal sealed class VirtualWindow<T>
+    {
+        List<T>? items;
+
+        long published;
+
+        long sequence;
+
+        /// <summary>Identifies the query from which the current window was composed.</summary>
+        internal long QueryGeneration { get; private set; }
+
+        /// <summary>The index within the whole sequence that the current window starts at.</summary>
+        internal int StartIndex { get; private set; }
+
+        internal int IndexOf(T value) => items?.IndexOf(value) ?? -1;
+
+        /// <summary>How many rows the whole sequence holds, as of the last fetch.</summary>
+        internal int TotalCount { get; private set; }
+
+        // Unknown is treated as non-empty so Virtualize remains rendered long enough to fetch.
+        internal bool HasAny => items == null || TotalCount > 0 || items.Count > 0;
+
+        /// <summary>Claims the identity passed to <see cref="TryPublish" />.</summary>
+        internal long BeginFetch() => ++sequence;
+
+        /// <summary>Publishes a window only when its fetch is still current.</summary>
+        /// <returns>Whether the window was published.</returns>
+        internal bool TryPublish(long fetch, int startIndex, int totalCount, List<T> rows)
+        {
+            if (fetch != sequence || fetch <= published)
+            {
+                return false;
+            }
+
+            published = fetch;
+            StartIndex = startIndex;
+            TotalCount = totalCount;
+            items = rows;
+
+            return true;
+        }
+
+        /// <summary>Discards the window and supersedes every fetch composed from its query.</summary>
+        internal void Invalidate()
+        {
+            items = null;
+            StartIndex = 0;
+            TotalCount = 0;
+            published = sequence;
+
+            QueryGeneration++;
+        }
+
+        internal bool TryGetAt(int index, out T value)
+        {
+            var offset = index - StartIndex;
+
+            if (items != null && offset >= 0 && offset < items.Count)
+            {
+                value = items[offset];
+
+                return true;
+            }
+
+            value = default!;
+
+            return false;
+        }
+    }
+}

--- a/Radzen.sln
+++ b/Radzen.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radzen.Blazor.Api", "Radzen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radzen.Blazor.Api.Generator", "Radzen.Blazor.Api.Generator\Radzen.Blazor.Api.Generator.csproj", "{0CE710A6-8514-4358-ABFF-12943ACD4D72}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radzen.Blazor.EntityFrameworkAdapter", "Radzen.Blazor.EntityFrameworkAdapter\Radzen.Blazor.EntityFrameworkAdapter.csproj", "{8E225C04-F5F9-47F7-9D78-01C5048B00D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,18 @@ Global
 		{0CE710A6-8514-4358-ABFF-12943ACD4D72}.Release|x64.Build.0 = Release|Any CPU
 		{0CE710A6-8514-4358-ABFF-12943ACD4D72}.Release|x86.ActiveCfg = Release|Any CPU
 		{0CE710A6-8514-4358-ABFF-12943ACD4D72}.Release|x86.Build.0 = Release|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Debug|x64.Build.0 = Debug|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Release|x64.ActiveCfg = Release|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Release|x64.Build.0 = Release|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E225C04-F5F9-47F7-9D78-01C5048B00D3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RadzenBlazorDemos.Host/Program.cs
+++ b/RadzenBlazorDemos.Host/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddScoped<CompilerService>();
 builder.Services.AddScoped<ExampleService>();
 
 builder.Services.AddDbContextFactory<NorthwindContext>();
+builder.Services.AddRadzenQueryableEntityFrameworkAdapter();
 
 builder.Services.AddScoped<NorthwindService>();
 builder.Services.AddScoped<NorthwindODataService>();

--- a/RadzenBlazorDemos.Server/Program.cs
+++ b/RadzenBlazorDemos.Server/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddScoped<CompilerService>();
 builder.Services.AddScoped<ExampleService>();
 
 builder.Services.AddDbContextFactory<NorthwindContext>();
+builder.Services.AddRadzenQueryableEntityFrameworkAdapter();
 
 builder.Services.AddScoped<NorthwindService>();
 builder.Services.AddScoped<NorthwindODataService>();

--- a/RadzenBlazorDemos/Pages/DataGridIQueryable.razor
+++ b/RadzenBlazorDemos/Pages/DataGridIQueryable.razor
@@ -40,6 +40,6 @@
  
         employees = dbContext.Employees;
 
-        selectedEmployees = new List<Employee>(){ employees.FirstOrDefault() };
+        selectedEmployees = new List<Employee>() { await employees.FirstOrDefaultAsync() };
     }
 }

--- a/RadzenBlazorDemos/Pages/DataGridIQueryablePage.razor
+++ b/RadzenBlazorDemos/Pages/DataGridIQueryablePage.razor
@@ -4,9 +4,38 @@
     DataGrid <strong>IQueryable</strong>
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
-    Display tabular data with ease. Perform paging, sorting and filtering through Entity Framework without extra code.
+    Bind directly to an Entity Framework <code>IQueryable</code> and let the DataGrid compose and await its paging, sorting and filtering queries.
 </RadzenText>
 
+<RadzenText Anchor="datagrid-iqueryable#paging" TextStyle="TextStyle.H5" TagName="TagName.H2">
+    Paging
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-4">
+    The grid awaits the total count and current page from the bound Entity Framework query.
+</RadzenText>
 <RadzenExample ComponentName="DataGrid" Example="DataGridIQueryable">
     <DataGridIQueryable />
 </RadzenExample>
+
+<RadzenText Anchor="datagrid-iqueryable#virtualization" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    Virtualization
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-4">
+    With virtualization enabled, each visible window is fetched asynchronously from the same bound query.
+</RadzenText>
+<RadzenExample ComponentName="DataGrid" Example="DataGridVirtualization">
+    <DataGridVirtualization />
+</RadzenExample>
+
+<RadzenText Anchor="datagrid-iqueryable#async-setup" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    Enable asynchronous queries
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1">
+    Install <code>Radzen.Blazor.EntityFrameworkAdapter</code> and register it once in <code>Program.cs</code>. No <code>LoadData</code> handler is required.
+</RadzenText>
+<pre class="rz-p-4">
+<code>builder.Services.AddRadzenQueryableEntityFrameworkAdapter();</code>
+</pre>
+<RadzenAlert AlertStyle="AlertStyle.Info" Variant="Variant.Flat" Shade="Shade.Lighter" AllowClose="false">
+    Page, sort, filter, or scroll the examples above. Their EF Core count and materialization queries run asynchronously while the grid retains control of query composition.
+</RadzenAlert>

--- a/RadzenBlazorDemos/Pages/DataGridVirtualization.razor
+++ b/RadzenBlazorDemos/Pages/DataGridVirtualization.razor
@@ -25,7 +25,7 @@
 </RadzenDataGrid>
 
 @code {
-    IEnumerable<OrderDetail> orderDetails;
+    IQueryable<OrderDetail> orderDetails;
 
     protected override async Task OnInitializedAsync()
     {

--- a/RadzenBlazorDemos/Program.cs
+++ b/RadzenBlazorDemos/Program.cs
@@ -14,6 +14,7 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 builder.Services.AddDbContextFactory<NorthwindContext>();
+builder.Services.AddRadzenQueryableEntityFrameworkAdapter();
 
 builder.Services.AddScoped<ILocalizer, DemoLocalizer>();
 builder.Services.AddRadzenComponents();

--- a/RadzenBlazorDemos/RadzenBlazorDemos.csproj
+++ b/RadzenBlazorDemos/RadzenBlazorDemos.csproj
@@ -5,7 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Radzen.Blazor" Version="*" GeneratePathProperty="true" Condition="'$(Configuration)' == 'Release'" />
+    <PackageReference Include="Radzen.Blazor.EntityFrameworkAdapter" Version="*" Condition="'$(Configuration)' == 'Release'" />
     <ProjectReference Include="..\Radzen.Blazor\Radzen.Blazor.csproj" Condition="'$(Configuration)' != 'Release'" />
+    <ProjectReference Include="..\Radzen.Blazor.EntityFrameworkAdapter\Radzen.Blazor.EntityFrameworkAdapter.csproj" Condition="'$(Configuration)' != 'Release'" />
     <ProjectReference Include="..\Radzen.Blazor.Api\Radzen.Blazor.Api.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.*-*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.*-*" PrivateAssets="all" />

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -74,8 +74,13 @@ namespace RadzenBlazorDemos
                         new Example
                         {
                             Name = "IQueryable",
+                            Toc = [
+                                new () { Text = "Paging", Anchor = "#paging" },
+                                new () { Text = "Virtualization", Anchor = "#virtualization" },
+                                new () { Text = "Enable asynchronous queries", Anchor = "#async-setup" }
+                            ],
                             Title = "Bind a Blazor DataGrid to IQueryable and Entity Framework | Free UI Components by Radzen",
-                            Description = "Use RadzenDataGrid to display tabular data with ease. Perform paging, sorting and filtering through Entity Framework without extra code.",
+                            Description = "Bind RadzenDataGrid directly to Entity Framework IQueryable and execute paging, sorting, filtering, and virtualized windows asynchronously without a LoadData handler.",
                             Path = "datagrid-iqueryable",
                             Tags = new [] { "datatable", "datagridview", "dataview", "grid", "table" }
                         },


### PR DESCRIPTION
Binding an Entity Framework Core `IQueryable` directly to a Radzen data component lets the component compose filtering, sorting, and paging that EF can translate to SQL, but the existing path materializes those queries with synchronous `Count()` and `ToList()` calls. That blocks the calling thread on database I/O unless the application replaces normal data binding with a custom `LoadData` handler.

Closes #2688.

This PR adds an opt-in, provider-agnostic async query seam, modeled on Blazor QuickGrid, and wires it through Radzen's data-bound components:

```csharp
// Program.cs
builder.Services.AddRadzenQueryableEntityFrameworkAdapter();
```

With the adapter registered, supported queryables are counted and materialized with awaited provider operations. With no executor registered, an unsupported queryable, or an excluded component path, existing synchronous behavior is unchanged.

## Design

### Provider seam and adapter

- `IAsyncQueryExecutor` provides support detection, async count/materialization, and provider-specific fallback classification without introducing an Entity Framework dependency in `Radzen.Blazor`.
- `Radzen.Blazor.EntityFrameworkAdapter` supplies the EF Core implementation and `AddRadzenQueryableEntityFrameworkAdapter()` registration for net8.0, net9.0, and net10.0.
- EF-specific busy-`DbContext` handling stays within the adapter.

### Per-component lifecycle coordination

Each component lazily creates one internal, sealed `AsyncQueryCoordinator` after an executor accepts a query. The coordinator owns load generations, cancellation sources, virtual requests, FIFO provider serialization, typed count/materialization operations, and owner-only render notification. Synchronous and unsupported paths do not create it.

Readonly `LoadLease` and disposable `VirtualRequestLease` values scope ownership, cancellation, and deferred source disposal. The provider queue has an uncontended fast path, preserves FIFO ordering under contention, and converts synchronous executor throws into faulted tasks.

`RadzenComponent` caches executor resolution and forwards lifecycle operations to its nullable coordinator. `PagedDataBoundComponent` supplies the shared count/page/materialization policy.

### Component coverage

| Component | Async path |
| --- | --- |
| `RadzenDataGrid` | paged, unpaged, virtualized, virtualized with paging, grouped, and supported `object`/dynamic views |
| `RadzenDataList` | reload and virtualized windows |
| `RadzenPivotDataGrid` | its overridden reload path |
| `RadzenDropDown`, `RadzenListBox` | `DropDownBase` virtualization and out-of-window keyboard lookup |
| `RadzenDropDownDataGrid` | search/count/page loading |

For an `object`-typed grid, a one-row async query supplies the runtime element type needed for provider-side ordering.

The DataGrid IQueryable demo registers the EF adapter and presents paged and virtualized async-query examples followed by the opt-in setup.

The adapter's packaged README is release-facing documentation for installation, registration, supported components, fallback behavior, and the per-component `DbContext` concurrency boundary.

Async execution is not selected for `LoadData` callbacks, `QueryOnlyVisibleColumns`, self-referencing hierarchies, `object`-typed grids with an in-memory `SortComparer`, unpaged virtualized `object`-typed grids, or `RadzenGantt`'s hierarchy-wide internal loader. Gantt data that requires asynchronous I/O should be materialized before binding.

## Behavior and safety

- Superseding a load cancels its predecessor and waits for the whole load to exit before a replacement reads the same provider. Cancellation is advisory; serialization prevents a replacement from becoming the second concurrent operation on one `DbContext` when the old provider call ignores or delays cancellation.
- Pending-load suppression keeps render-time getters from synchronously reading a source already owned by an awaited query. Simultaneous superseders retain suppression until every wait exits.
- Reloads cancel an active virtual request before waiting for the provider. A replaced or disposed virtual request retains a valid token until its executor call has returned, then clears and disposes its linked source.
- Only cancellations requested by the component or Virtualize are swallowed. Provider-originated cancellation and other faults still propagate.
- If a provider supports asynchronous execution but rejects a composed query shape, its executor decides whether the existing synchronous fallback is safe.
- Unpaged materialization derives the total from returned rows; paged loads retain the count needed to clamp the page.

No existing parameters, rendered output, query composition semantics, fallback rules, or synchronous behavior are intentionally changed.

## Performance

Paired BenchmarkDotNet runs against the fixed baseline found lower construction and async-path allocations with no steady-state timing regressions. Direct tests also confirm that synchronous and unsupported paths do not create coordinator state.

<details>
  <summary>AI Toolchain</summary>

  VSCode, Claude Code CLI - [Opus 5 - high], reviews from Codex - [5.6 Sol - High]
</details>