### PR TITLE
Fix: ArithmeticException in RadzenRangeNavigator before its width is measured

### DIFF
--- a/Radzen.Blazor.Tests/ChartTestHelper.cs
+++ b/Radzen.Blazor.Tests/ChartTestHelper.cs
@@ -6,7 +6,7 @@ namespace Radzen.Blazor.Tests
 {
     internal static class ChartTestHelper
     {
-        internal static TestContext CreateChartContext()
+        internal static TestContext CreateChartContext(double navigatorWidth = 200, double navigatorHeight = 200)
         {
             var ctx = new TestContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -15,7 +15,7 @@ namespace Radzen.Blazor.Tests
             ctx.JSInterop.Setup<Rect>("Radzen.createResizable", _ => true)
                 .SetResult(new Rect { Left = 0, Top = 0, Width = 200, Height = 200 });
             ctx.JSInterop.Setup<double[]>("Radzen.createRangeNavigator", _ => true)
-                .SetResult(new double[] { 200, 200 });
+                .SetResult(new double[] { navigatorWidth, navigatorHeight });
             ctx.Services.AddScoped<TooltipService>();
             return ctx;
         }

--- a/Radzen.Blazor.Tests/LinearScaleTests.cs
+++ b/Radzen.Blazor.Tests/LinearScaleTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class LinearScaleTests
+    {
+        [Theory]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        public void NiceNumber_WithNonFiniteRange_ReturnsOne(double range)
+        {
+            var scale = new LinearScale();
+
+            Assert.Equal(1, scale.NiceNumber(range, false));
+            Assert.Equal(1, scale.NiceNumber(range, true));
+        }
+
+        [Theory]
+        // Neither measured nor fed data, so both ranges keep the infinite ScaleRange defaults.
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity)]
+        // Fed data, but the output has no size yet.
+        [InlineData(10, 100, 0, 0)]
+        public void Ticks_WithUnmeasuredScale_ReturnsFiniteRange(double inputStart, double inputEnd, double outputStart, double outputEnd)
+        {
+            var scale = new LinearScale
+            {
+                Input = new ScaleRange { Start = inputStart, End = inputEnd },
+                Output = new ScaleRange { Start = outputStart, End = outputEnd }
+            };
+
+            var (start, end, step) = scale.Ticks(0);
+
+            Assert.True(double.IsFinite(start));
+            Assert.True(double.IsFinite(end));
+            Assert.True(double.IsFinite(step));
+            Assert.True(step > 0);
+        }
+
+        [Fact]
+        public void Ticks_WithMeasuredScale_IsUnaffected()
+        {
+            var scale = new LinearScale
+            {
+                Input = new ScaleRange { Start = 0, End = 90 },
+                Output = new ScaleRange { Start = 0, End = 500 }
+            };
+
+            var (start, end, step) = scale.Ticks(100);
+
+            Assert.Equal(0, start);
+            Assert.Equal(100, end);
+            Assert.Equal(20, step);
+        }
+    }
+}

--- a/Radzen.Blazor.Tests/RangeNavigatorTests.cs
+++ b/Radzen.Blazor.Tests/RangeNavigatorTests.cs
@@ -159,5 +159,40 @@ namespace Radzen.Blazor.Tests
 
             Assert.Equal("50.00", component.Instance.GetHandleLabel(0.5));
         }
+
+        [Fact]
+        public void RangeNavigator_WithLineSeries_SkipsSeries_BeforeWidthIsMeasured()
+        {
+            // Rendering the series against the unmeasured scales used to throw (#2693).
+            using var ctx = CreateChartContext(navigatorWidth: 0, navigatorHeight: 0);
+
+            var component = RenderNavigatorWithLineSeries(ctx);
+
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.Start, 0.1));
+
+            Assert.DoesNotContain("rz-range-nav-series", component.Markup);
+        }
+
+        [Fact]
+        public void RangeNavigator_WithLineSeries_RendersSeries_AfterWidthIsMeasured()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx);
+
+            Assert.Contains("rz-range-nav-series", component.Markup);
+            Assert.DoesNotContain("NaN", component.Markup);
+        }
+
+        private static IRenderedComponent<RadzenRangeNavigator> RenderNavigatorWithLineSeries(TestContext ctx)
+        {
+            return ctx.RenderComponent<RadzenRangeNavigator>(parameters =>
+                parameters.AddChildContent<RadzenRangeNavigatorLineSeries<DataItem>>(series =>
+                {
+                    series.Add(p => p.Data, SampleData);
+                    series.Add(p => p.CategoryProperty, nameof(DataItem.Category));
+                    series.Add(p => p.ValueProperty, nameof(DataItem.Value));
+                }));
+        }
     }
 }

--- a/Radzen.Blazor/LinearScale.cs
+++ b/Radzen.Blazor/LinearScale.cs
@@ -65,6 +65,16 @@ namespace Radzen.Blazor
 
         public override (double Start, double End, double Step) Ticks(int distance)
         {
+            // An unmeasured scale keeps the infinite ScaleRange defaults, which NiceNumber()
+            // below cannot round. Substitute a finite domain first, as the other scales do.
+            if (!double.IsFinite(Input.Start) || !double.IsFinite(Input.End))
+            {
+                Input.Start = 0;
+                Input.End = 2;
+                Step = 1;
+                Round = false;
+            }
+
             var ticks = CalculateTickCount(distance);
             var start = Input.Start;
             var end = Input.End;
@@ -113,14 +123,7 @@ namespace Radzen.Blazor
                 end = Math.Ceiling(end / step) * step;
             }
 
-            if (!double.IsFinite(Input.Start) || !double.IsFinite(Input.End))
-            {
-                Input.Start = start = 0;
-                Input.End = end = 2;
-                Step = step = 1;
-                Round = false;
-            }
-
+            // The rounding above can still overflow a finite domain.
             if (!double.IsFinite(start) || !double.IsFinite(end))
             {
                 Input.Start = start = 0;

--- a/Radzen.Blazor/RadzenRangeNavigator.razor
+++ b/Radzen.Blazor/RadzenRangeNavigator.razor
@@ -7,7 +7,7 @@
 @if (Visible)
 {
 <div @ref="Element" @attributes="@Attributes" class="@GetCssClass()" style="@Style" id="@GetId()">
-    @if (NavigatorSeries.Count > 0)
+    @if (NavigatorSeries.Count > 0 && Width > 0)
     {
         <svg style="width: 100%; height: 100%;">
             @foreach (var series in NavigatorSeries)

--- a/Radzen.Blazor/ScaleBase.cs
+++ b/Radzen.Blazor/ScaleBase.cs
@@ -134,7 +134,9 @@ namespace Radzen.Blazor
         /// <param name="round">Wether to round.</param>
         public double NiceNumber(double range, bool round)
         {
-            if (range == 0)
+            // Callers normalize a degenerate domain first, but Math.Sign() throws on NaN and this
+            // is public API, so treat a non-finite range like a zero one rather than throwing.
+            if (range == 0 || !double.IsFinite(range))
             {
                 return 1;
             }


### PR DESCRIPTION
`RadzenRangeNavigator` only initializes its scales once JS interop reports the element width, but the template rendered the child series regardless. On any render before that measurement - the parent re-rendering after an async data load, for example - the series called `Ticks()` on a value scale which still had the infinite `ScaleRange` defaults for both its input and its output, and the tick math turned those into a NaN which `Math.Sign()` rejects, so `NiceNumber()` threw "Function does not accept floating point Not-a-Number values".

`LinearScale.Ticks()` already substituted a finite domain for a non-finite input, but only at the very end, after the five `NiceNumber()` calls that need it. Move that reset to the top of the method, where `LogarithmicScale` and `DateScale` already do theirs, and drop the duplicate it leaves behind. `NiceNumber()` now also treats a non-finite range like a zero one, since it is public API and this is the second report of it throwing from a degenerate scale (see #1885).

Finally, skip rendering the navigator series until the width is known, matching the guards the same template already has on its axis and handle labels.