### PR TITLE
Fix: QueryableExtension, filter an array-valued property on its element type

### DIFF
--- a/Radzen.Blazor.Tests/QueryableExtensionTests.cs
+++ b/Radzen.Blazor.Tests/QueryableExtensionTests.cs
@@ -1626,6 +1626,61 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void Where_FiltersArrayValuedProperty_WithEquals()
+        {
+            var testData = new[]
+            {
+                new { Id = 1, Codes = new[] { 10, 20 } },
+                new { Id = 2, Codes = new[] { 30 } },
+                new { Id = 3, Codes = new[] { 20, 40 } }
+            }.AsQueryable();
+
+            var filters = new List<FilterDescriptor>
+            {
+                new FilterDescriptor
+                {
+                    Property = "Codes",
+                    FilterValue = 20,
+                    FilterOperator = FilterOperator.Equals
+                }
+            };
+
+            var result = testData.Where(filters, LogicalFilterOperator.And, FilterCaseSensitivity.Default).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, r => r.Id == 1);
+            Assert.Contains(result, r => r.Id == 3);
+        }
+
+        [Fact]
+        public void Where_FiltersCollectionItemProperty_WhenCollectionIsArray()
+        {
+            var testData = new[]
+            {
+                new { Id = 1, Tags = new[] { new { Name = "tag1", Value = 10 } } },
+                new { Id = 2, Tags = new[] { new { Name = "tag3", Value = 30 } } },
+                new { Id = 3, Tags = new[] { new { Name = "tag1", Value = 50 } } }
+            }.AsQueryable();
+
+            var filters = new List<FilterDescriptor>
+            {
+                new FilterDescriptor
+                {
+                    Property = "Tags",
+                    FilterProperty = "Name",
+                    FilterValue = "tag1",
+                    FilterOperator = FilterOperator.Equals
+                }
+            };
+
+            var result = testData.Where(filters, LogicalFilterOperator.And, FilterCaseSensitivity.Default).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, r => r.Id == 1);
+            Assert.Contains(result, r => r.Id == 3);
+        }
+
+        [Fact]
         public void Where_FiltersNestedCollectionItemProperty()
         {
             var testData = new[]

--- a/Radzen.Blazor/QueryableExtension.cs
+++ b/Radzen.Blazor/QueryableExtension.cs
@@ -830,7 +830,13 @@ namespace Radzen
             var propertyName = !isEnumerable && !IsEnumerable(p.Type) ? (!string.IsNullOrWhiteSpace(filter.FilterProperty) ? filter.FilterProperty : filter.Property) : filter.Property;
             Expression property = !string.IsNullOrEmpty(propertyName) ? GetNestedPropertyExpression(parameter, propertyName, type) : Expression.Constant(null);
 
-            Type? collectionItemType = IsEnumerable(property.Type) && property.Type.IsGenericType ? property.Type.GetGenericArguments()[0] : null;
+            // An array is enumerable but not generic, so asking only for generic arguments left an array
+            // property with no item type - and the filter was then built against the array itself,
+            // which throws ("the binary operator Equal is not defined for Int32[] and Int32").
+            Type? collectionItemType = !IsEnumerable(property.Type) ? null
+                : property.Type.IsGenericType ? property.Type.GetGenericArguments()[0]
+                : property.Type.IsArray ? property.Type.GetElementType()
+                : null;
 
             ParameterExpression? collectionItemTypeParameter = collectionItemType != null ? Expression.Parameter(collectionItemType, "x") : null;
 


### PR DESCRIPTION
I hit this filtering a grid column bound to an `int[]` property. `IsEnumerable` says an array is a collection — there is even a test asserting `IsEnumerable(typeof(int[]))` - but `GetExpression` only asks for an item type when the property is *generic*, so an array falls through with none. The filter is then built against the array itself and throws: *"The binary operator Equal is not defined for the types 'System.Int32[]' and 'System.Int32'."*

This adds the array case beside the generic one:

- an array property resolves its item type via `GetElementType()`
- non-generic, non-array enumerables still resolve to no item type, exactly as before
- `string` is unaffected — `IsEnumerable` already excludes it

Two tests cover the paths that were throwing: an array of values filtered directly, and an array of complex items filtered through `FilterProperty`. Both fail on master with the error above.