### PR TITLE
RadzenTimeline: Add process-tracker support

### DIFF
--- a/Radzen.Blazor.Tests/TimelineItemTests.cs
+++ b/Radzen.Blazor.Tests/TimelineItemTests.cs
@@ -192,5 +192,80 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains("check", component.Markup);
         }
+
+        [Fact]
+        public void TimelineItem_Appends_PointClass_ToPointElement()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimelineItem>(parameters =>
+            {
+                parameters.Add(p => p.PointClass, "my-point");
+            });
+
+            Assert.Contains("rz-timeline-point-base my-point", component.Markup);
+        }
+
+        [Fact]
+        public void TimelineItem_Renders_Current_AsAriaCurrentStep()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimelineItem>(parameters =>
+            {
+                parameters.Add(p => p.Current, true);
+            });
+
+            Assert.Contains(@"aria-current=""step""", component.Markup);
+        }
+
+        [Fact]
+        public void TimelineItem_Omits_AriaCurrent_WhenNotCurrent()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimelineItem>();
+
+            Assert.DoesNotContain("aria-current", component.Markup);
+        }
+
+        [Fact]
+        public void TimelineItem_Renders_ListItemRole()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimelineItem>();
+
+            Assert.Contains(@"role=""listitem""", component.Markup);
+        }
+
+        [Fact]
+        public void TimelineItem_Renders_LineStyle()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimelineItem>(parameters =>
+            {
+                parameters.Add(p => p.LineStyle, PointStyle.Success);
+            });
+
+            Assert.Contains("rz-timeline-line-success", component.Markup);
+        }
+
+        [Fact]
+        public void TimelineItem_Omits_LineStyleClass_WhenLineStyleNotSet()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimelineItem>();
+
+            Assert.DoesNotContain("rz-timeline-line-", component.Markup);
+        }
+
+        [Fact]
+        public void TimelineItem_Renders_Current_AsStyleHook()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimelineItem>(parameters =>
+            {
+                parameters.Add(p => p.Current, true);
+            });
+
+            Assert.Contains("rz-timeline-item-current", component.Markup);
+        }
     }
 }

--- a/Radzen.Blazor.Tests/TimelineTests.cs
+++ b/Radzen.Blazor.Tests/TimelineTests.cs
@@ -126,6 +126,39 @@ namespace Radzen.Blazor.Tests
 
             Assert.Contains("rz-timeline-column", component.Markup);
         }
+
+        [Fact]
+        public void Timeline_Renders_ListRole()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimeline>();
+
+            Assert.Contains(@"role=""list""", component.Markup);
+        }
+
+        [Fact]
+        public void Timeline_Marks_OnlyTheConnectorOwner_WithItsLineStyle()
+        {
+            using var ctx = new TestContext();
+            var component = ctx.RenderComponent<RadzenTimeline>(parameters =>
+            {
+                parameters.Add(p => p.Items, builder =>
+                {
+                    builder.OpenComponent<RadzenTimelineItem>(0);
+                    builder.AddAttribute(1, nameof(RadzenTimelineItem.LineStyle), (PointStyle?)PointStyle.Success);
+                    builder.CloseComponent();
+                    builder.OpenComponent<RadzenTimelineItem>(3);
+                    builder.CloseComponent();
+                });
+            });
+
+            var items = component.FindAll(".rz-timeline-item");
+
+            // The connector spans both items, but only the item that declares it is marked - the
+            // stylesheet reaches the next item's half through the sibling combinator.
+            Assert.Contains("rz-timeline-line-success", items[0].ClassName);
+            Assert.DoesNotContain("rz-timeline-line", items[1].ClassName);
+        }
+
     }
 }
-

--- a/Radzen.Blazor/RadzenTimeline.razor
+++ b/Radzen.Blazor/RadzenTimeline.razor
@@ -2,7 +2,7 @@
 
 @if (Visible)
 {
-<div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
+<div @ref="@Element" style="@Style" role="list" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
 @Items
 </div>
 }

--- a/Radzen.Blazor/RadzenTimelineItem.razor
+++ b/Radzen.Blazor/RadzenTimelineItem.razor
@@ -2,10 +2,10 @@
 
 @if (Visible)
 {
-<div @ref="@Element" style="@Style" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
+<div @ref="@Element" style="@Style" role="listitem" aria-current="@AriaCurrent" @attributes="Attributes" class="@GetCssClass()" id="@GetId()">
     <div class="rz-timeline-content-start">@(LabelContent)@(Label)</div>
     <div class="rz-timeline-axis">
-        <div class=@PointClass>@PointContent</div>
+        <div class=@PointCssClass>@PointContent</div>
     </div>
     <div class="rz-timeline-content-end">@(ChildContent)@(Text)</div>
 </div>

--- a/Radzen.Blazor/RadzenTimelineItem.razor.cs
+++ b/Radzen.Blazor/RadzenTimelineItem.razor.cs
@@ -76,10 +76,37 @@ namespace Radzen.Blazor
         [Parameter]
         public int PointShadow { get; set; } = 1;
 
-        private string PointClass => ClassList.Create($"rz-timeline-point")
+        /// <summary>
+        /// Gets or sets additional CSS classes applied to the point element itself, rather than to the item.
+        /// Use it to style the marker beyond what <see cref="PointStyle"/> and <see cref="PointVariant"/> express -
+        /// a focus ring on the active step, a transition, an animation.
+        /// </summary>
+        [Parameter]
+        public string? PointClass { get; set; }
+
+        /// <summary>
+        /// Gets or sets the style of the connector running from this item to the next one rendered.
+        /// The last item has no outgoing connector, so its value is ignored. Leave it <c>null</c> to keep the
+        /// theme line colour.
+        /// </summary>
+        [Parameter]
+        public PointStyle? LineStyle { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this item is the step currently in progress. It is marked
+        /// <c>aria-current="step"</c> and its point is drawn with a ring in the point's own colour.
+        /// At most one item in a timeline should set it.
+        /// </summary>
+        [Parameter]
+        public bool Current { get; set; }
+
+        private string? AriaCurrent => Current ? "step" : null;
+
+        private string PointCssClass => ClassList.Create($"rz-timeline-point")
                                 .Add($"rz-timeline-point-{PointVariant.ToString().ToLowerInvariant()}")
                                 .Add($"rz-shadow-{PointShadow.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}")
                                 .Add($"rz-timeline-point-{PointStyle.ToString().ToLowerInvariant()}")
+                                .Add(PointClass)
                                 .ToString();
 
         /// <inheritdoc />
@@ -100,7 +127,10 @@ namespace Radzen.Blazor
                 pointSizeCSS = "lg";
             }
 
-            return ClassList.Create($"rz-timeline-item rz-timeline-axis-{pointSizeCSS}").ToString();
+            return ClassList.Create($"rz-timeline-item rz-timeline-axis-{pointSizeCSS}")
+                            .Add($"rz-timeline-line-{LineStyle?.ToString().ToLowerInvariant()}", LineStyle != null)
+                            .Add("rz-timeline-item-current", Current)
+                            .ToString();
         }
     }
 }

--- a/Radzen.Blazor/themes/_css-variables.scss
+++ b/Radzen.Blazor/themes/_css-variables.scss
@@ -1357,12 +1357,16 @@
   --rz-timeline-item-padding: #{$rz-timeline-item-padding};
   --rz-timeline-axis-size: #{$rz-timeline-axis-size};
   --rz-timeline-point-size: #{$rz-timeline-point-size};
+  --rz-timeline-point-font-size: #{$rz-timeline-point-font-size};
+  --rz-timeline-point-ring-width: #{$rz-timeline-point-ring-width};
+  --rz-timeline-point-ring-tint: #{$rz-timeline-point-ring-tint};
   --rz-timeline-point-border: #{$rz-timeline-point-border};
   --rz-timeline-point-border-radius: #{$rz-timeline-point-border-radius};
   --rz-timeline-point-background-color: #{$rz-timeline-point-background-color};
   --rz-timeline-point-color: #{$rz-timeline-point-color};
   --rz-timeline-line-color: #{$rz-timeline-line-color};
   --rz-timeline-line-width: #{$rz-timeline-line-width};
+  --rz-timeline-line-gap: #{$rz-timeline-line-gap};
   --rz-timeline-line-border-radius: #{$rz-timeline-line-border-radius};
 
   /* TimestampPicker */

--- a/Radzen.Blazor/themes/components/blazor/_timeline.scss
+++ b/Radzen.Blazor/themes/components/blazor/_timeline.scss
@@ -9,9 +9,29 @@ $rz-timeline-point-color: var(--rz-text-color) !default;
 $rz-timeline-line-color: var(--rz-base-300) !default;
 $rz-timeline-line-width: 0.125rem !default;
 $rz-timeline-line-border-radius: calc(var(--rz-border-radius) * 20) !default;
+$rz-timeline-point-font-size: 1rem !default;
+$rz-timeline-line-gap: 0px !default;
+$rz-timeline-point-ring-width: 0.25rem !default;
+$rz-timeline-point-ring-tint: 35% !default;
+
+// The current-step ring is drawn from the point's own colour, which works for every severity but not
+// for the muted base/light/dark points - a 35% tint of those is invisible against the page. They ring
+// in a mid-scale grey instead, which reads on a light and a dark ground alike.
+$timeline-point-ring-colors: () !default;
+$timeline-point-ring-colors: map.merge(
+  (
+    base: var(--rz-base-500),
+    light: var(--rz-base-500),
+    dark: var(--rz-base-500)
+  ),
+  $timeline-point-ring-colors
+);
 $rz-timeline-line-position-offset: calc(var(--rz-timeline-item-padding) + (var(--rz-timeline-axis-size) / 2) - (var(--rz-timeline-line-width) / 2));
-$rz-timeline-line-start-offset: calc(var(--rz-timeline-item-padding) + (var(--rz-timeline-point-size) / 2) - (var(--rz-timeline-line-width) / 2));
-$rz-timeline-line-end-offset: calc(100% - var(--rz-timeline-item-padding) - (var(--rz-timeline-point-size) / 2) - (var(--rz-timeline-line-width) / 2));
+
+// Distance from the item's leading edge to the centre of its point, along the timeline's main axis.
+// The line is split there into a leading and a trailing half so each connector can be styled on its own.
+$rz-timeline-point-offset-start: calc(var(--rz-timeline-item-padding) + (var(--rz-timeline-point-size) / 2));
+$rz-timeline-point-offset-end: calc(100% - var(--rz-timeline-item-padding) - (var(--rz-timeline-point-size) / 2));
 
 $timeline-point-sizes: () !default;
 $timeline-point-sizes: map.merge(
@@ -44,6 +64,20 @@ $timeline-point-sizes: map.merge(
   &.rz-timeline-column {
     flex-direction: column;
 
+    // The line offset is the same whether or not the timeline is reversed; only the content alignment
+    // below differs, so these sit above the reverse split rather than being repeated inside it.
+    &.rz-timeline-start,
+    &.rz-timeline-left {
+      .rz-timeline-item:before,
+      .rz-timeline-item:after {left: $rz-timeline-line-position-offset; right: auto;}
+    }
+
+    &.rz-timeline-end,
+    &.rz-timeline-right {
+      .rz-timeline-item:before,
+      .rz-timeline-item:after {right: $rz-timeline-line-position-offset; left: auto;}
+    }
+
     // LinePosition.Center
     .rz-timeline-item {flex-direction: row;}
     .rz-timeline-content-start {text-align: right;}
@@ -61,10 +95,6 @@ $timeline-point-sizes: map.merge(
 
     // LinePosition.Start
     &.rz-timeline-start:not(.rz-timeline-reverse) {
-      .rz-timeline-item:before {
-        left: $rz-timeline-line-position-offset;
-        right: auto;
-      }
       .rz-timeline-content-start {display: none;}
       .rz-timeline-content-end {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: start;}
     }
@@ -72,20 +102,12 @@ $timeline-point-sizes: map.merge(
     // LinePosition.End
     &.rz-timeline-end:not(.rz-timeline-reverse) {
       .rz-timeline-item {flex-direction: row-reverse;}
-      .rz-timeline-item:before {
-        right: $rz-timeline-line-position-offset;
-        left: auto;
-      }
       .rz-timeline-content-start {display: none;}
       .rz-timeline-content-end {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: end;}
     }
 
     // LinePosition.Left
     &.rz-timeline-left:not(.rz-timeline-reverse) {
-      .rz-timeline-item:before {
-        left: $rz-timeline-line-position-offset;
-        right: auto;
-      }
       .rz-timeline-content-start {display: none;}
       .rz-timeline-content-end {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: left;}
     }
@@ -93,10 +115,6 @@ $timeline-point-sizes: map.merge(
     // LinePosition.Right
     &.rz-timeline-right:not(.rz-timeline-reverse) {
       .rz-timeline-item {flex-direction: row-reverse;}
-      .rz-timeline-item:before {
-        right: $rz-timeline-line-position-offset;
-        left: auto;
-      }
       .rz-timeline-content-start {display: none;}
       .rz-timeline-content-end {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: right;}
     }
@@ -121,10 +139,6 @@ $timeline-point-sizes: map.merge(
 
       // LinePosition.Start
       &.rz-timeline-start {
-        .rz-timeline-item:before {
-          left: $rz-timeline-line-position-offset;
-          right: auto;
-        }
         .rz-timeline-content-start {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: start;}
         .rz-timeline-content-end {display: none;}
       }
@@ -132,20 +146,12 @@ $timeline-point-sizes: map.merge(
       // LinePosition.End
       &.rz-timeline-end {
         .rz-timeline-item {flex-direction: row;}
-        .rz-timeline-item:before {
-          right: $rz-timeline-line-position-offset;
-          left: auto;
-        }
         .rz-timeline-content-start {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: end;}
         .rz-timeline-content-end {display: none;}
       }
 
       // LinePosition.Left
       &.rz-timeline-left {
-        .rz-timeline-item:before {
-          left: $rz-timeline-line-position-offset;
-          right: auto;
-        }
         .rz-timeline-content-start {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: left;}
         .rz-timeline-content-end {display: none;}
       }
@@ -153,10 +159,6 @@ $timeline-point-sizes: map.merge(
       // LinePosition.Right
       &.rz-timeline-right {
         .rz-timeline-item {flex-direction: row;}
-        .rz-timeline-item:before {
-          right: $rz-timeline-line-position-offset;
-          left: auto;
-        }
         .rz-timeline-content-start {max-width: calc(100% - var(--rz-timeline-axis-size)); text-align: right;}
         .rz-timeline-content-end {display: none;}
       }
@@ -166,6 +168,18 @@ $timeline-point-sizes: map.merge(
   // Orientation.Horizontal
   &.rz-timeline-row {
     flex-direction: row;
+
+    &.rz-timeline-start,
+    &.rz-timeline-top {
+      .rz-timeline-item:before,
+      .rz-timeline-item:after {top: $rz-timeline-line-position-offset; bottom: auto;}
+    }
+
+    &.rz-timeline-end,
+    &.rz-timeline-bottom {
+      .rz-timeline-item:before,
+      .rz-timeline-item:after {bottom: $rz-timeline-line-position-offset; top: auto;}
+    }
 
     // LinePosition.Center
     .rz-timeline-item {flex-direction: column; justify-content: end; width: 100%;}
@@ -178,10 +192,6 @@ $timeline-point-sizes: map.merge(
     // LinePosition.Start/Top
     &.rz-timeline-start:not(.rz-timeline-reverse),
     &.rz-timeline-top:not(.rz-timeline-reverse) {
-      .rz-timeline-item:before {
-        top: $rz-timeline-line-position-offset;
-        bottom: auto;
-      }
       .rz-timeline-content-start {display: none;}
       .rz-timeline-content-end {max-height: calc(100% - var(--rz-timeline-axis-size));}
     }
@@ -190,10 +200,6 @@ $timeline-point-sizes: map.merge(
     &.rz-timeline-end:not(.rz-timeline-reverse),
     &.rz-timeline-bottom:not(.rz-timeline-reverse) {
       .rz-timeline-item {flex-direction: column-reverse;}
-      .rz-timeline-item:before {
-        bottom: $rz-timeline-line-position-offset;
-        top: auto;
-      }
       .rz-timeline-content-start {display: none;}
       .rz-timeline-content-end {max-height: calc(100% - var(--rz-timeline-axis-size));}
     }
@@ -212,10 +218,6 @@ $timeline-point-sizes: map.merge(
       // LinePosition.Start/Top
       &.rz-timeline-start,
       &.rz-timeline-top {
-        .rz-timeline-item:before {
-          top: $rz-timeline-line-position-offset;
-          bottom: auto;
-        }
         .rz-timeline-content-start {max-height: calc(100% - var(--rz-timeline-axis-size));}
         .rz-timeline-content-end {display: none;}
       }
@@ -224,10 +226,6 @@ $timeline-point-sizes: map.merge(
       &.rz-timeline-end,
       &.rz-timeline-bottom {
         .rz-timeline-item {flex-direction: column;}
-        .rz-timeline-item:before {
-          bottom: $rz-timeline-line-position-offset;
-          top: auto;
-        }
         .rz-timeline-content-start {max-height: calc(100% - var(--rz-timeline-axis-size));}
         .rz-timeline-content-end {display: none;}
       }
@@ -239,6 +237,10 @@ $timeline-point-sizes: map.merge(
   display: flex;
   padding: var(--rz-timeline-item-padding);
   position: relative;
+  // Where along the main axis the point's centre sits, and so where the line splits into its two
+  // halves. Only align-items start and end move it off centre; normal and stretch both stretch the
+  // axis to the item, which centres the point by construction.
+  --rz-timeline-point-offset: 50%;
 
   .rz-timeline-align-items-center & {
     align-items: center;
@@ -250,10 +252,12 @@ $timeline-point-sizes: map.merge(
 
   .rz-timeline-align-items-start & {
     align-items: start;
+    --rz-timeline-point-offset: #{$rz-timeline-point-offset-start};
   }
 
   .rz-timeline-align-items-end & {
     align-items: end;
+    --rz-timeline-point-offset: #{$rz-timeline-point-offset-end};
   }
 
   .rz-timeline-align-items-stretch & {
@@ -261,82 +265,85 @@ $timeline-point-sizes: map.merge(
   }
 
   // Timeline Line
-  &:before {
+  //
+  // Drawn as two halves that stop at the edge of the point: :before runs from the item's leading edge to
+  // the point, :after from the point to the trailing edge. A connector between two points is therefore
+  // the trailing half of one item plus the leading half of the next, and the two can be coloured together
+  // to style that connector on its own. The first item has no leading half and the last no trailing half,
+  // which is what stops the line short of the outer points.
+  //
+  // By default the halves meet under the centre of the point, so the line reads as continuous and a
+  // thick one can serve as a track behind the points. Set --rz-timeline-line-gap to hold them off the
+  // point instead - to the point's radius, say - which is what a tinted or translucent point needs,
+  // since it cannot hide the line the way the severity styles do.
+  &:before,
+  &:after {
     content: '';
     position: absolute;
     background-color: var(--rz-timeline-line-color);
   }
 
-  .rz-timeline-column &:before {
+  &:first-child:before,
+  &:last-child:after {
+    content: none;
+  }
+
+  .rz-timeline-column &:before,
+  .rz-timeline-column &:after {
     width: var(--rz-timeline-line-width);
-    top: 0;
-    bottom: 0;
     left: calc(50% - (var(--rz-timeline-line-width) / 2));
     right: auto;
   }
 
-  .rz-timeline-column &:first-child:before {
-    top: calc(50% - (var(--rz-timeline-line-width) / 2));
+  .rz-timeline-column &:before {
+    top: 0;
+    bottom: calc(100% - var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap));
+  }
+
+  .rz-timeline-column &:after {
+    top: calc(var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap));
+    bottom: 0;
+  }
+
+  .rz-timeline-column &:first-child:after {
+    top: calc(var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap) - (var(--rz-timeline-line-width) / 2));
     border-top-left-radius: var(--rz-timeline-line-border-radius);
     border-top-right-radius: var(--rz-timeline-line-border-radius);
-  }
-
-  .rz-timeline-column.rz-timeline-align-items-start &:first-child:before {
-    top: $rz-timeline-line-start-offset;
-  }
-
-  .rz-timeline-column.rz-timeline-align-items-end &:first-child:before {
-    top: $rz-timeline-line-end-offset;
   }
 
   .rz-timeline-column &:last-child:before {
-    bottom: calc(50% - (var(--rz-timeline-line-width) / 2));
+    bottom: calc(100% - var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap) - (var(--rz-timeline-line-width) / 2));
     border-bottom-left-radius: var(--rz-timeline-line-border-radius);
     border-bottom-right-radius: var(--rz-timeline-line-border-radius);
   }
 
-  .rz-timeline-column.rz-timeline-align-items-start &:last-child:before {
-    bottom: $rz-timeline-line-end-offset;
-  }
-
-  .rz-timeline-column.rz-timeline-align-items-end &:last-child:before {
-    bottom: $rz-timeline-line-start-offset;
+  .rz-timeline-row &:before,
+  .rz-timeline-row &:after {
+    height: var(--rz-timeline-line-width);
+    top: calc(50% - (var(--rz-timeline-line-width) / 2));
+    bottom: auto;
   }
 
   .rz-timeline-row &:before {
-    top: calc(50% - (var(--rz-timeline-line-width) / 2));
-    bottom: auto;
     left: 0;
-    right: 0;
-    height: var(--rz-timeline-line-width);
+    right: calc(100% - var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap));
   }
 
-  .rz-timeline-row &:first-child:before {
-    left: calc(50% - (var(--rz-timeline-line-width) / 2));
+  .rz-timeline-row &:after {
+    left: calc(var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap));
+    right: 0;
+  }
+
+  .rz-timeline-row &:first-child:after {
+    left: calc(var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap) - (var(--rz-timeline-line-width) / 2));
     border-top-left-radius: var(--rz-timeline-line-border-radius);
     border-bottom-left-radius: var(--rz-timeline-line-border-radius);
   }
 
-  .rz-timeline-row.rz-timeline-align-items-start &:first-child:before {
-    left: $rz-timeline-line-start-offset;
-  }
-
-  .rz-timeline-row.rz-timeline-align-items-end &:first-child:before {
-    left: $rz-timeline-line-end-offset;
-  }
-
   .rz-timeline-row &:last-child:before {
-    right: calc(50% - (var(--rz-timeline-line-width) / 2));
+    right: calc(100% - var(--rz-timeline-point-offset) + var(--rz-timeline-line-gap) - (var(--rz-timeline-line-width) / 2));
     border-top-right-radius: var(--rz-timeline-line-border-radius);
     border-bottom-right-radius: var(--rz-timeline-line-border-radius);
-  }
-
-  .rz-timeline-row.rz-timeline-align-items-start &:last-child:before {
-    right: $rz-timeline-line-end-offset;
-  }
-
-  .rz-timeline-row.rz-timeline-align-items-end &:last-child:before {
-    right: $rz-timeline-line-start-offset;
   }
 }
 
@@ -365,6 +372,9 @@ $timeline-point-sizes: map.merge(
 // Timeline Point Wrapper
 .rz-timeline-axis {
   position: relative;
+  // Both line halves are positioned and the trailing one follows the point in document order, so without
+  // this the line would paint over the ring a current point draws outside itself.
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -416,6 +426,28 @@ $timeline-point-sizes: map.merge(
     color: map.get($rule, color);
   }
 
+  // A connector spans two items - the trailing half of the item that owns it and the leading half of
+  // the next one - so RadzenTimelineItem.LineStyle marks only the owner and the sibling combinator
+  // reaches the other half. A hidden item renders no element, so the connector spans across it.
+  .rz-timeline-line-#{$style}:after,
+  .rz-timeline-line-#{$style} + .rz-timeline-item:before {
+    background-color: map.get($rule, background-color);
+  }
+
+  $ring-color: map.get($rule, background-color);
+  @if map.has-key($timeline-point-ring-colors, $style) {
+    $ring-color: map.get($timeline-point-ring-colors, $style);
+  }
+
+  // The line runs under the point and is masked by it, so the ring has to be opaque to mask it too -
+  // a translucent one lets the connector show through. It is mixed into the same background the point
+  // border is drawn in, for the same reason. An outline rather than a box-shadow: every point carries
+  // an rz-shadow-* utility class, and those declare box-shadow with !important.
+  .rz-timeline-item-current .rz-timeline-point-#{$style} {
+    outline: var(--rz-timeline-point-ring-width) solid
+             color-mix(in srgb, #{$ring-color} var(--rz-timeline-point-ring-tint), var(--rz-base-background-color));
+  }
+
   .rz-timeline-point-outlined.rz-timeline-point-#{$style} {
     background-color: var(--rz-base-background-color);
     color: map.get($rule, background-color);
@@ -430,9 +462,10 @@ $timeline-point-sizes: map.merge(
 @each $size, $timeline-point in $timeline-point-sizes {
   .rz-timeline-axis-#{$size} {
     --rz-timeline-point-size: #{map.get($timeline-point, size)};
-
-    .rz-timeline-point .rzi {
-      font-size: map.get($timeline-point, font-size);
-    }
+    --rz-timeline-point-font-size: #{map.get($timeline-point, font-size)};
   }
+}
+
+.rz-timeline-point .rzi {
+  font-size: var(--rz-timeline-point-font-size);
 }

--- a/RadzenBlazorDemos/Pages/TimelinePage.razor
+++ b/RadzenBlazorDemos/Pages/TimelinePage.razor
@@ -87,6 +87,16 @@
     <TimelinePointShadow />
 </RadzenExample>
 
+<RadzenText Anchor="timeline#process-tracker" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
+    Process Tracker
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Set <code>LineStyle</code> on an item to style the connector running from it to the next item, so a timeline can show how far a process has got. Mark the step in progress with <code>Current</code>, which draws a ring in the point's own colour and renders it as <code>aria-current="step"</code>. For styling the marker beyond what <code>PointStyle</code> and <code>PointVariant</code> express, <code>PointClass</code> adds your own classes to it. The line runs under the points by default, so a thick one reads as a track behind them; set <code>--rz-timeline-line-gap</code> (to <code>calc(var(--rz-timeline-point-size) / 2)</code> here) to hold it off the points instead, which is what a translucent or tinted point needs.
+</RadzenText>
+<RadzenExample ComponentName="Timeline" Example="TimelineProcessTracker">
+    <TimelineProcessTracker />
+</RadzenExample>
+
 <RadzenText Anchor="timeline#point-content" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-8">
     Point Content
 </RadzenText>

--- a/RadzenBlazorDemos/Pages/TimelineProcessTracker.razor
+++ b/RadzenBlazorDemos/Pages/TimelineProcessTracker.razor
@@ -1,0 +1,52 @@
+﻿<RadzenTimeline Orientation="Orientation.Horizontal" LinePosition="LinePosition.Top"
+                style="--rz-timeline-line-gap: calc(var(--rz-timeline-point-size) / 2);">
+    <Items>
+        @foreach (var step in steps)
+        {
+            <RadzenTimelineItem PointSize="PointSize.Large"
+                                PointStyle="@PointStyleFor(step)"
+                                PointVariant="@PointVariantFor(step)"
+                                LineStyle="@(step.Status == StepStatus.Complete ? PointStyle.Success : null)"
+                                Current="@(step.Status == StepStatus.Current)">
+                <ChildContent>
+                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.P" class="rz-m-0">@step.Label</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Caption" TagName="TagName.P" class="rz-m-0 rz-color-base-500">@step.Detail</RadzenText>
+                </ChildContent>
+                <PointContent>
+                    <RadzenIcon Icon="@IconFor(step)" />
+                </PointContent>
+            </RadzenTimelineItem>
+        }
+    </Items>
+</RadzenTimeline>
+
+@code {
+    enum StepStatus { Complete, Current, Pending }
+
+    record Step(string Label, string Detail, StepStatus Status);
+
+    readonly Step[] steps =
+    [
+        new("Ordered", "12 Mar", StepStatus.Complete),
+        new("Packed", "13 Mar", StepStatus.Complete),
+        new("Shipped", "In transit", StepStatus.Current),
+        new("Delivered", "Est. 18 Mar", StepStatus.Pending),
+    ];
+
+    static PointStyle PointStyleFor(Step step) => step.Status switch
+    {
+        StepStatus.Complete => PointStyle.Success,
+        StepStatus.Current => PointStyle.Primary,
+        _ => PointStyle.Base,
+    };
+
+    static Variant PointVariantFor(Step step) =>
+        step.Status == StepStatus.Pending ? Variant.Outlined : Variant.Filled;
+
+    static string IconFor(Step step) => step.Status switch
+    {
+        StepStatus.Complete => "check",
+        StepStatus.Current => "local_shipping",
+        _ => "more_horiz",
+    };
+}

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -2142,7 +2142,7 @@ namespace RadzenBlazorDemos
                 },
                 new Example
                 {
-                    Toc = [ new () { Text = "Basic Usage", Anchor = "#basic-usage" }, new () { Text = "Orientation and Position", Anchor = "#orientation-and-position" }, new () { Text = "Align Items", Anchor = "#align-items" }, new () { Text = "Styling", Anchor = "#line-width" }, new () { Text = "Point Size", Anchor = "#point-size" }, new () { Text = "Point Style", Anchor = "#point-style" }, new () { Text = "Point Variant", Anchor = "#point-variant" }, new () { Text = "Point Shadow", Anchor = "#point-shadow" }, new () { Text = "Point Content", Anchor = "#point-content" } ],
+                    Toc = [ new () { Text = "Basic Usage", Anchor = "#basic-usage" }, new () { Text = "Orientation and Position", Anchor = "#orientation-and-position" }, new () { Text = "Align Items", Anchor = "#align-items" }, new () { Text = "Styling", Anchor = "#line-width" }, new () { Text = "Point Size", Anchor = "#point-size" }, new () { Text = "Point Style", Anchor = "#point-style" }, new () { Text = "Point Variant", Anchor = "#point-variant" }, new () { Text = "Point Shadow", Anchor = "#point-shadow" }, new () { Text = "Process Tracker", Anchor = "#process-tracker" }, new () { Text = "Point Content", Anchor = "#point-content" } ],
                     Name = "Timeline",
                     Path = "timeline",
                     Description = "Blazor Timeline component for displaying a chronological sequence of events with flexible orientation and styling.",


### PR DESCRIPTION
The timeline could not express a progress tracker: its line was a single pseudo-element spanning each item's whole box, so coloring one item painted half of the connector on either side of its point rather than a connector between two points.

Split the line into a leading and a trailing half, and add `RadzenTimelineItem.LineStyle` to style the connector running from an item to the next. A connector spans two items, so `LineStyle` marks only the item that owns it and the sibling combinator reaches the other half — which keeps DOM order the single source of truth for both halves and for the first/last caps, and makes a connector span a hidden item for free.

The halves stop at the edge of the point rather than meeting under its centre, so a point does not have to be opaque to hide the line. The severity styles are opaque, but a tinted fill a caller supplies need not be, and the line showed through one.

The split also replaces the first/last-child offset rules that used to stop the line short of the outer points: those fall out of the first item having no leading half and the last no trailing half, leaving one `--rz-timeline-point-offset` where there were eight align-items-specific rules. The line-position overrides collapse likewise, since the offsets never depended on Reverse.

Alongside it:

- Current marks the step in progress: `aria-current="step"`, and a ring drawn from the point's own color. Muted base points ring in a mid-scale grey, since a tint of those is invisible against the page. It is an outline rather than a box-shadow because every point carries an `rz-shadow-*` class, and those declare `box-shadow` with `!important`.
- `PointClas`s reaches the point element, for the genuinely bespoke.
- The point glyph size moves to `--rz-timeline-point-font-size` so a custom `--rz-timeline-point-size` can carry a matching glyph.

Rendering the nine existing orientation, `line-position`, `reverse` and `align-items` permutations before and after the line change is pixel-identical.

<img width="700" height="1480" alt="image" src="https://github.com/user-attachments/assets/53c4f7e2-3407-4e06-80f2-7a57a9c3d648" />
