### PR TITLE
Fix a resize drag pinning a nested RadzenDataGrid's frozen columns to the outer grid's offsets

### DIFF
--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -5545,13 +5545,34 @@ window.Radzen = {
         resize.mouseUpHandler();
     }
   },
+  // A grid rendered inside another grid's row-detail template is a descendant of it, so every lookup
+  // here is scoped to this grid's own table and to a row's own cells. Descendant queries reach the
+  // inner grid and pin its cells to the outer grid's offsets.
+  frozenCellsOf: function(row, side) {
+      var found = [];
+      if (!row) return found;
+      var prefix = 'rz-frozen-cell-' + side;
+      for (var i = 0; i < row.children.length; i++) {
+          var cell = row.children[i];
+          if (cell.classList.contains(prefix)
+              || cell.classList.contains(prefix + '-end')
+              || cell.classList.contains(prefix + '-inner')) {
+              found.push(cell);
+          }
+      }
+      return found;
+  },
   updateFrozenColumnPositions: function(gridElement) {
       if (!gridElement) return;
+      // This grid's own table. querySelector returns the first in document order, which is this
+      // grid's rather than one nested inside it.
+      var table = gridElement.querySelector('.rz-grid-table');
+      if (!table) return;
       // Get frozen cell positions from the header row first, then apply to all rows
-      var headerRow = gridElement.querySelector('thead tr');
+      var headerRow = table.querySelector(':scope > thead > tr');
       if (!headerRow) return;
-      var leftHeaderCells = headerRow.querySelectorAll('.rz-frozen-cell-left, .rz-frozen-cell-left-end, .rz-frozen-cell-left-inner');
-      var rightHeaderCells = headerRow.querySelectorAll('.rz-frozen-cell-right, .rz-frozen-cell-right-end, .rz-frozen-cell-right-inner');
+      var leftHeaderCells = Radzen.frozenCellsOf(headerRow, 'left');
+      var rightHeaderCells = Radzen.frozenCellsOf(headerRow, 'right');
       // Calculate offsets from header widths
       var leftOffsets = [];
       var offset = 0;
@@ -5565,15 +5586,15 @@ window.Radzen = {
           rightOffsets[i] = offset;
           offset += rightHeaderCells[i].getBoundingClientRect().width;
       }
-      // Apply offsets to all rows
-      var rows = gridElement.querySelectorAll('tr');
+      // Apply offsets to this grid's own rows
+      var rows = table.querySelectorAll(':scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr');
       for (var r = 0; r < rows.length; r++) {
           var row = rows[r];
-          var leftCells = row.querySelectorAll('.rz-frozen-cell-left, .rz-frozen-cell-left-end, .rz-frozen-cell-left-inner');
+          var leftCells = Radzen.frozenCellsOf(row, 'left');
           for (var i = 0; i < leftCells.length && i < leftOffsets.length; i++) {
               leftCells[i].style.setProperty('inset-inline-start', leftOffsets[i] + 'px');
           }
-          var rightCells = row.querySelectorAll('.rz-frozen-cell-right, .rz-frozen-cell-right-end, .rz-frozen-cell-right-inner');
+          var rightCells = Radzen.frozenCellsOf(row, 'right');
           for (var i = 0; i < rightCells.length && i < rightOffsets.length; i++) {
               rightCells[i].style.setProperty('inset-inline-end', rightOffsets[i] + 'px');
           }


### PR DESCRIPTION
## The problem

`Radzen.updateFrozenColumnPositions` applies its sticky offsets with **descendant** queries rather than scoped ones. A `RadzenDataGrid` rendered inside another grid's row-detail template is a descendant of that grid, so the inner grid's frozen columns are pinned to the **outer** grid's offsets.

Two places do it:

* `var rows = gridElement.querySelectorAll('tr');` matches the nested grid's rows as well as the grid's own.
* For the detail row that contains the nested grid, `row.querySelectorAll('.rz-frozen-cell-left, ...')` matches the nested grid's cells.

The routine runs from the column-resize move handler, so this happens on every frame of a drag anywhere in the outer grid. It is reached whenever `gridElement.querySelector('.rz-frozen-cell') != null`, which a nested grid's cell alone satisfies.

## Steps to reproduce

1. A `RadzenDataGrid` with `AllowColumnResize="true"` and two frozen columns.
2. Its row-detail template renders a second `RadzenDataGrid` that also has frozen columns, of different widths.
3. Expand a row and drag any column resizer in the outer grid.

## Observed vs expected

Outer grid with two frozen columns, the first 129px wide; nested grid with two frozen columns, the first 49px wide.

| cell | before | after | correct |
| --- | ---: | ---: | ---: |
| outer, 1st frozen | `0px` | `0px` | `0px` |
| outer, 2nd frozen | `129px` | `129px` | `129px` |
| **nested, 1st frozen** | `0px` | not written | `0px` |
| **nested, 2nd frozen** | **`129px`** | not written | `49px` |

The nested grid's second frozen column is pinned 80px out of place, using an offset measured from a table it does not belong to. Expected: the outer grid writes offsets only onto its own cells, and the nested grid keeps whatever its own layout gives it.

Checked in a browser against the markup shape described above; that is where the before/after numbers come from.

## The fix

Every lookup is scoped to the grid's own table and to a row's own cells:

* the table is resolved once with `gridElement.querySelector('.rz-grid-table')`, which returns this grid's rather than a nested one's, since it is first in document order;
* rows come from `':scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr'`;
* a row's frozen cells are found by walking its own `children` instead of a descendant selector. `frozenCellsOf` keeps that class test in one place and is also used for the header row.

The outer grid's own output is unchanged — the table above shows its two cells identical before and after — so this is a pure narrowing of what the routine touches.
