### PR TITLE
HtmlEditor: resize images by dragging handles on the selected image

### DIFF
--- a/Radzen.Blazor.Tests/HtmlEditorTests.cs
+++ b/Radzen.Blazor.Tests/HtmlEditorTests.cs
@@ -78,6 +78,41 @@ namespace Radzen.Blazor.Tests
         }
 
         [Fact]
+        public void HtmlEditor_Disabled_Ignores_OnChange()
+        {
+            using var ctx = CreateContext();
+            var raised = 0;
+            var component = ctx.RenderComponent<RadzenHtmlEditor>(parameters =>
+            {
+                parameters.Add(p => p.Value, "<p>initial</p>");
+                parameters.Add(p => p.Disabled, true);
+                parameters.Add(p => p.Input, args => raised++);
+            });
+
+            component.Instance.OnChange("<p>edited</p>");
+
+            Assert.Equal(0, raised);
+        }
+
+        [Fact]
+        public void HtmlEditor_Enabled_Raises_Input_OnChange()
+        {
+            using var ctx = CreateContext();
+            var raised = 0;
+            var html = string.Empty;
+            var component = ctx.RenderComponent<RadzenHtmlEditor>(parameters =>
+            {
+                parameters.Add(p => p.Value, "<p>initial</p>");
+                parameters.Add(p => p.Input, args => { raised++; html = args; });
+            });
+
+            component.Instance.OnChange("<p>edited</p>");
+
+            Assert.Equal(1, raised);
+            Assert.Equal("<p>edited</p>", html);
+        }
+
+        [Fact]
         public void HtmlEditor_Renders_Disabled_Attribute()
         {
             using var ctx = CreateContext();

--- a/Radzen.Blazor/RadzenHtmlEditor.razor.cs
+++ b/Radzen.Blazor/RadzenHtmlEditor.razor.cs
@@ -619,6 +619,11 @@ namespace Radzen.Blazor
         [JSInvokable]
         public void OnChange(string html)
         {
+            if (Disabled)
+            {
+                return;
+            }
+
             if (Html != html)
             {
                 Html = html;

--- a/Radzen.Blazor/themes/_css-variables.scss
+++ b/Radzen.Blazor/themes/_css-variables.scss
@@ -495,6 +495,12 @@
   --rz-editor-content-background-color: #{$editor-content-background-color};
   --rz-editor-focus-outline: #{$editor-focus-outline};
   --rz-editor-focus-outline-offset: #{$editor-focus-outline-offset};
+  --rz-editor-image-handle-size: #{$editor-image-handle-size};
+  --rz-editor-image-handle-background-color: #{$editor-image-handle-background-color};
+  --rz-editor-image-handle-border: #{$editor-image-handle-border};
+  --rz-editor-image-handles-border: #{$editor-image-handles-border};
+  --rz-editor-image-size-background-color: #{$editor-image-size-background-color};
+  --rz-editor-image-size-color: #{$editor-image-size-color};
 
   /* Fieldset */
   --rz-fieldset-border: #{$fieldset-border};

--- a/Radzen.Blazor/themes/components/blazor/_editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_editor.scss
@@ -4,11 +4,18 @@ $editor-toolbar-background-color: var(--rz-base-background-color) !default;
 $editor-content-background-color: var(--rz-base-background-color) !default;
 $editor-focus-outline: var(--rz-outline-focus) !default;
 $editor-focus-outline-offset: calc(-1 * var(--rz-outline-width)) !default;
+$editor-image-handle-size: 0.5rem !default;
+$editor-image-handle-background-color: var(--rz-base-background-color) !default;
+$editor-image-handle-border: 1px solid var(--rz-primary) !default;
+$editor-image-handles-border: 1px solid var(--rz-primary) !default;
+$editor-image-size-background-color: var(--rz-primary) !default;
+$editor-image-size-color: var(--rz-on-primary) !default;
 
 .rz-html-editor {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  position: relative;
   border-radius: var(--rz-editor-border-radius);
   border: var(--rz-editor-border);
   overflow: hidden;
@@ -31,6 +38,94 @@ $editor-focus-outline-offset: calc(-1 * var(--rz-outline-width)) !default;
     outline: 2px solid var(--rz-primary);
     outline-offset: -2px;
     background-color: color-mix(in srgb, var(--rz-primary) 12%, transparent);
+  }
+}
+
+.rz-html-editor-image-handles {
+  position: absolute;
+  box-sizing: border-box;
+  pointer-events: none;
+  outline: var(--rz-editor-image-handles-border);
+  z-index: 1;
+}
+
+.rz-html-editor-image-handle {
+  position: absolute;
+  box-sizing: border-box;
+  width: var(--rz-editor-image-handle-size);
+  height: var(--rz-editor-image-handle-size);
+  background-color: var(--rz-editor-image-handle-background-color);
+  border: var(--rz-editor-image-handle-border);
+  pointer-events: auto;
+
+  &.rz-nw {
+    top: calc(var(--rz-editor-image-handle-size) / -2);
+    left: calc(var(--rz-editor-image-handle-size) / -2);
+    cursor: nwse-resize;
+  }
+
+  &.rz-ne {
+    top: calc(var(--rz-editor-image-handle-size) / -2);
+    right: calc(var(--rz-editor-image-handle-size) / -2);
+    cursor: nesw-resize;
+  }
+
+  &.rz-sw {
+    bottom: calc(var(--rz-editor-image-handle-size) / -2);
+    left: calc(var(--rz-editor-image-handle-size) / -2);
+    cursor: nesw-resize;
+  }
+
+  &.rz-se {
+    bottom: calc(var(--rz-editor-image-handle-size) / -2);
+    right: calc(var(--rz-editor-image-handle-size) / -2);
+    cursor: nwse-resize;
+  }
+
+  &.rz-n {
+    top: calc(var(--rz-editor-image-handle-size) / -2);
+    left: calc(50% - var(--rz-editor-image-handle-size) / 2);
+    cursor: ns-resize;
+  }
+
+  &.rz-s {
+    bottom: calc(var(--rz-editor-image-handle-size) / -2);
+    left: calc(50% - var(--rz-editor-image-handle-size) / 2);
+    cursor: ns-resize;
+  }
+
+  &.rz-w {
+    left: calc(var(--rz-editor-image-handle-size) / -2);
+    top: calc(50% - var(--rz-editor-image-handle-size) / 2);
+    cursor: ew-resize;
+  }
+
+  &.rz-e {
+    right: calc(var(--rz-editor-image-handle-size) / -2);
+    top: calc(50% - var(--rz-editor-image-handle-size) / 2);
+    cursor: ew-resize;
+  }
+}
+
+.rz-html-editor-image-size {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0.375rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--rz-border-radius);
+  background-color: var(--rz-editor-image-size-background-color);
+  color: var(--rz-editor-image-size-color);
+  font-size: 0.6875rem;
+  line-height: 1.5;
+  white-space: nowrap;
+  pointer-events: none;
+
+  &.rz-inside {
+    top: auto;
+    bottom: 0.375rem;
+    margin-top: 0;
   }
 }
 

--- a/Radzen.Blazor/themes/components/blazor/_editor.scss
+++ b/Radzen.Blazor/themes/components/blazor/_editor.scss
@@ -41,12 +41,18 @@ $editor-image-size-color: var(--rz-on-primary) !default;
   }
 }
 
+.rz-html-editor-image-clip {
+  position: absolute;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 1;
+}
+
 .rz-html-editor-image-handles {
   position: absolute;
   box-sizing: border-box;
   pointer-events: none;
   outline: var(--rz-editor-image-handles-border);
-  z-index: 1;
 }
 
 .rz-html-editor-image-handle {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -4838,9 +4838,26 @@ window.Radzen = {
   deleteTable: function (context) {
     context.table.remove();
   },
+  getEditorHtml: function (ref) {
+    if (!ref.querySelector('img.rz-state-selected')) {
+      return ref.innerHTML;
+    }
+
+    var copy = document.implementation.createHTMLDocument('').importNode(ref, true);
+
+    for (var img of copy.querySelectorAll('img.rz-state-selected')) {
+      img.classList.remove('rz-state-selected');
+
+      if (!img.getAttribute('class')) {
+        img.removeAttribute('class');
+      }
+    }
+
+    return copy.innerHTML;
+  },
   queryCommands: function (ref) {
     return {
-      html: ref != null ? ref.innerHTML : null,
+      html: ref != null ? this.getEditorHtml(ref) : null,
       fontName: document.queryCommandValue('fontName'),
       fontSize: document.queryCommandValue('fontSize'),
       formatBlock: document.queryCommandValue('formatBlock'),
@@ -5041,6 +5058,8 @@ window.Radzen = {
 
       img.style.width = '';
       img.style.height = '';
+      img.setAttribute('width', ref.imageResize.startWidth);
+      img.setAttribute('height', ref.imageResize.startHeight);
 
       ref.releaseImageDrag = trackDrag(
         ref.documentImageResizeMoveListener,
@@ -5120,19 +5139,14 @@ window.Radzen = {
       var index = Array.prototype.indexOf.call(ref.querySelectorAll('img'), img);
 
       ref.stopImageDrag();
+      ref.restoreImageSize(state);
 
-      if (width === state.startAttributes.width && height === state.startAttributes.height) {
-        ref.restoreImageSize(state);
+      if (width === String(state.startWidth) && height === String(state.startHeight)) {
         ref.positionImageHandles();
         return;
       }
 
-      ref.restoreImageSize(state);
-      img.classList.remove('rz-state-selected');
-
-      if (!img.getAttribute('class')) {
-        img.removeAttribute('class');
-      }
+      ref.deselectImage(img);
 
       var target = img;
 
@@ -5150,6 +5164,10 @@ window.Radzen = {
       replacementImg.style.width = '';
       replacementImg.style.height = '';
 
+      if (!replacementImg.style.length) {
+        replacementImg.removeAttribute('style');
+      }
+
       var range = document.createRange();
       range.selectNode(target);
       var selection = getSelection();
@@ -5159,6 +5177,16 @@ window.Radzen = {
       document.execCommand('insertHTML', false, replacement.outerHTML);
 
       ref.selectImage(ref.querySelectorAll('img')[index]);
+    };
+
+    ref.deselectImage = function (img) {
+      img.classList.remove('rz-state-selected');
+
+      if (!img.getAttribute('class')) {
+        img.removeAttribute('class');
+      }
+
+      ref.removeImageHandles();
     };
 
     ref.selectImage = function (img) {
@@ -5192,7 +5220,7 @@ window.Radzen = {
 
     ref.inputListener = function () {
       ref.positionImageHandles();
-      try { suppressDisposed(instance.invokeMethodAsync('OnChange', ref.innerHTML)); } catch { }
+      try { suppressDisposed(instance.invokeMethodAsync('OnChange', Radzen.getEditorHtml(ref))); } catch { }
     };
     ref.keydownListener = function (e) {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'c') {
@@ -5296,7 +5324,7 @@ window.Radzen = {
         }
 
         for (var img of ref.querySelectorAll('img.rz-state-selected')) {
-          img.classList.remove('rz-state-selected');
+          ref.deselectImage(img);
         }
 
         ref.removeImageHandles();
@@ -5393,6 +5421,12 @@ window.Radzen = {
 
     ref.selectionChangeListener = function () {
       if (document.activeElement == ref) {
+        var selectedImage = ref.getSelectedImage();
+
+        if (selectedImage && !ref.imageResize && !getSelection().containsNode(selectedImage)) {
+          ref.deselectImage(selectedImage);
+        }
+
         try { suppressDisposed(instance.invokeMethodAsync('OnSelectionChange')); } catch { }
       }
     };

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -4880,7 +4880,29 @@ window.Radzen = {
     }
   },
   createEditor: function (ref, uploadUrl, paste, instance, shortcuts) {
-    var imageHandlePositions = ['nw', 'n', 'ne', 'w', 'e', 'sw', 's', 'se'];
+    function trackDrag(move, end, key) {
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', end);
+
+      if (key) {
+        document.addEventListener('keydown', key);
+      }
+
+      return function () {
+        document.removeEventListener('mousemove', move);
+        document.removeEventListener('mouseup', end);
+
+        if (key) {
+          document.removeEventListener('keydown', key);
+        }
+      };
+    }
+
+    var imageHandleDirections = {
+      nw: [-1, -1], n: [0, -1], ne: [1, -1],
+      w: [-1, 0], e: [1, 0],
+      sw: [-1, 1], s: [0, 1], se: [1, 1]
+    };
     var minImageSize = 24;
 
     ref.getSelectedImage = function () {
@@ -4888,14 +4910,20 @@ window.Radzen = {
     };
 
     ref.getEditorContainer = function () {
-      return ref.closest('.rz-html-editor') || ref.parentElement;
+      return ref.closest('.rz-html-editor');
     };
 
     ref.removeImageHandles = function () {
-      if (ref.imageHandles) {
-        ref.imageHandles.remove();
-        ref.imageHandles = null;
+      if (!ref.imageHandles) {
+        return;
       }
+
+      window.removeEventListener('resize', ref.positionImageHandles);
+      ref.imageHandlesClip.remove();
+      ref.imageHandlesClip = null;
+      ref.imageHandles = null;
+      ref.imageSizeLabel = null;
+      ref.imageSizeLabelSpace = 0;
     };
 
     ref.positionImageHandles = function () {
@@ -4912,12 +4940,26 @@ window.Radzen = {
       }
 
       var containerRect = container.getBoundingClientRect();
+      var contentRect = ref.getBoundingClientRect();
       var imgRect = img.getBoundingClientRect();
 
-      ref.imageHandles.style.left = (imgRect.left - containerRect.left) + 'px';
-      ref.imageHandles.style.top = (imgRect.top - containerRect.top) + 'px';
+      // Absolutely positioned children start at the padding box, past the border.
+      ref.imageHandlesClip.style.left = (contentRect.left - containerRect.left - container.clientLeft) + 'px';
+      ref.imageHandlesClip.style.top = (contentRect.top - containerRect.top - container.clientTop) + 'px';
+      ref.imageHandlesClip.style.width = contentRect.width + 'px';
+      ref.imageHandlesClip.style.height = contentRect.height + 'px';
+
+      ref.imageHandles.style.left = (imgRect.left - contentRect.left) + 'px';
+      ref.imageHandles.style.top = (imgRect.top - contentRect.top) + 'px';
       ref.imageHandles.style.width = imgRect.width + 'px';
       ref.imageHandles.style.height = imgRect.height + 'px';
+
+      var label = ref.imageSizeLabel;
+
+      if (label && !label.hidden) {
+        label.textContent = Math.round(imgRect.width) + ' × ' + Math.round(imgRect.height);
+        label.classList.toggle('rz-inside', imgRect.bottom + ref.imageSizeLabelSpace > contentRect.bottom);
+      }
     };
 
     ref.createImageHandles = function () {
@@ -4926,15 +4968,18 @@ window.Radzen = {
       var img = ref.getSelectedImage();
       var container = ref.getEditorContainer();
 
-      if (!img || !container) {
+      if (!img || !container || !ref.isContentEditable) {
         return;
       }
 
+      var clip = document.createElement('div');
+      clip.className = 'rz-html-editor-image-clip';
+      clip.setAttribute('contenteditable', 'false');
+
       var handles = document.createElement('div');
       handles.className = 'rz-html-editor-image-handles';
-      handles.setAttribute('contenteditable', 'false');
 
-      imageHandlePositions.forEach(function (position) {
+      Object.keys(imageHandleDirections).forEach(function (position) {
         var handle = document.createElement('div');
         handle.className = 'rz-html-editor-image-handle rz-' + position;
         handle.dataset.position = position;
@@ -4942,121 +4987,94 @@ window.Radzen = {
         handles.appendChild(handle);
       });
 
-      var size = document.createElement('div');
-      size.className = 'rz-html-editor-image-size';
-      size.hidden = true;
-      handles.appendChild(size);
+      ref.imageSizeLabel = document.createElement('div');
+      ref.imageSizeLabel.className = 'rz-html-editor-image-size';
+      ref.imageSizeLabel.hidden = true;
+      handles.appendChild(ref.imageSizeLabel);
 
-      container.appendChild(handles);
+      clip.appendChild(handles);
+      container.appendChild(clip);
+      ref.imageHandlesClip = clip;
       ref.imageHandles = handles;
+
+      window.addEventListener('resize', ref.positionImageHandles);
       ref.positionImageHandles();
     };
 
     ref.showImageSizeLabel = function (visible) {
-      var label = ref.imageHandles && ref.imageHandles.querySelector('.rz-html-editor-image-size');
+      var label = ref.imageSizeLabel;
 
-      if (label) {
-        label.hidden = !visible;
-      }
-    };
-
-    ref.updateImageSizeLabel = function () {
-      var label = ref.imageHandles && ref.imageHandles.querySelector('.rz-html-editor-image-size');
-      var img = ref.getSelectedImage();
-      var container = ref.getEditorContainer();
-
-      if (!label || label.hidden || !img || !container) {
+      if (!label) {
         return;
       }
 
-      label.textContent = Math.round(img.offsetWidth) + ' × ' + Math.round(img.offsetHeight);
+      label.hidden = !visible;
 
-      // The overlay lives inside .rz-html-editor, which clips its overflow, so a
-      // badge below the image would be cut off near the bottom edge.
-      var containerRect = container.getBoundingClientRect();
-      var imgRect = img.getBoundingClientRect();
-
-      label.classList.toggle('rz-inside', imgRect.bottom + 28 > containerRect.bottom);
+      if (visible) {
+        label.textContent = '0 × 0';
+        ref.imageSizeLabelSpace = label.offsetHeight + parseFloat(getComputedStyle(label).marginTop || 0);
+      }
     };
 
     ref.imageResizeStartListener = function (e) {
       var img = ref.getSelectedImage();
 
-      if (!img) {
+      if (!img || ref.imageResize) {
         return;
       }
 
       e.preventDefault();
       e.stopPropagation();
 
+      // Pasted content often carries an inline width/height, which would outrank
+      // the attributes a drag writes.
       ref.imageResize = {
         img: img,
-        position: e.currentTarget.dataset.position,
+        direction: imageHandleDirections[e.currentTarget.dataset.position],
         startX: e.clientX,
         startY: e.clientY,
         startWidth: img.offsetWidth,
         startHeight: img.offsetHeight,
-        startAttrWidth: img.getAttribute('width'),
-        startAttrHeight: img.getAttribute('height'),
+        startAttributes: { width: img.getAttribute('width'), height: img.getAttribute('height') },
+        startStyles: { width: img.style.width, height: img.style.height },
         ratio: img.offsetHeight ? img.offsetWidth / img.offsetHeight : 1
       };
 
-      document.addEventListener('mousemove', ref.documentImageResizeMoveListener);
-      document.addEventListener('mouseup', ref.documentImageResizeEndListener);
+      img.style.width = '';
+      img.style.height = '';
 
+      ref.releaseImageDrag = trackDrag(
+        ref.documentImageResizeMoveListener,
+        ref.documentImageResizeEndListener,
+        ref.documentImageResizeKeyListener);
       ref.showImageSizeLabel(true);
-      ref.updateImageSizeLabel();
-    };
-
-    ref.stopImageResize = function () {
-      ref.showImageSizeLabel(false);
-      ref.imageResize = null;
-      document.removeEventListener('mousemove', ref.documentImageResizeMoveListener);
-      document.removeEventListener('mouseup', ref.documentImageResizeEndListener);
+      ref.positionImageHandles();
     };
 
     ref.restoreImageSize = function (state) {
-      if (state.startAttrWidth !== null) {
-        state.img.setAttribute('width', state.startAttrWidth);
-      } else {
-        state.img.removeAttribute('width');
-      }
+      Object.keys(state.startAttributes).forEach(function (name) {
+        var value = state.startAttributes[name];
 
-      if (state.startAttrHeight !== null) {
-        state.img.setAttribute('height', state.startAttrHeight);
-      } else {
-        state.img.removeAttribute('height');
-      }
+        if (value !== null) {
+          state.img.setAttribute(name, value);
+        } else {
+          state.img.removeAttribute(name);
+        }
+
+        state.img.style[name] = state.startStyles[name];
+      });
     };
 
     ref.documentImageResizeKeyListener = function (e) {
-      if (e.key !== 'Escape') {
+      if (e.key !== 'Escape' || !ref.imageResize) {
         return;
       }
 
-      // While a drag is running, cancel it and leave the editor value untouched.
-      if (ref.imageResize) {
-        e.preventDefault();
-        e.stopPropagation();
-        ref.restoreImageSize(ref.imageResize);
-        ref.stopImageResize();
-        ref.positionImageHandles();
-        return;
-      }
-
-      // Once a drag has finished, undo the last resize for as long as that same
-      // image is still selected.
-      var last = ref.lastImageResize;
-
-      if (last && last.img === ref.getSelectedImage()) {
-        e.preventDefault();
-        e.stopPropagation();
-        ref.restoreImageSize(last);
-        ref.lastImageResize = null;
-        ref.positionImageHandles();
-
-        try { instance.invokeMethodAsync('OnChange', ref.innerHTML); } catch { }
-      }
+      e.preventDefault();
+      e.stopPropagation();
+      ref.restoreImageSize(ref.imageResize);
+      ref.stopImageDrag();
+      ref.positionImageHandles();
     };
 
     ref.documentImageResizeMoveListener = function (e) {
@@ -5068,59 +5086,103 @@ window.Radzen = {
 
       e.preventDefault();
 
-      var position = state.position;
-      var horizontal = position.indexOf('w') !== -1 || position.indexOf('e') !== -1;
-      var vertical = position.indexOf('n') !== -1 || position.indexOf('s') !== -1;
-      var toLeft = position.indexOf('w') !== -1;
-      var toTop = position.indexOf('n') !== -1;
-      var deltaX = toLeft ? state.startX - e.clientX : e.clientX - state.startX;
-      var deltaY = toTop ? state.startY - e.clientY : e.clientY - state.startY;
-
+      var horizontal = state.direction[0];
+      var vertical = state.direction[1];
       var width = state.startWidth;
       var height = state.startHeight;
 
-      if (horizontal && vertical) {
-        width = Math.max(Math.round(state.startWidth + deltaX), minImageSize);
-        height = e.shiftKey
-          ? Math.max(Math.round(state.startHeight + deltaY), minImageSize)
-          : Math.max(Math.round(width / state.ratio), minImageSize);
-      } else if (horizontal) {
-        width = Math.max(Math.round(state.startWidth + deltaX), minImageSize);
-      } else {
-        height = Math.max(Math.round(state.startHeight + deltaY), minImageSize);
+      if (horizontal) {
+        width = Math.max(Math.round(state.startWidth + horizontal * (e.clientX - state.startX)), minImageSize);
+      }
+
+      if (vertical && (!horizontal || e.shiftKey)) {
+        height = Math.max(Math.round(state.startHeight + vertical * (e.clientY - state.startY)), minImageSize);
+      } else if (horizontal && vertical) {
+        height = Math.max(Math.round(width / state.ratio), minImageSize);
       }
 
       state.img.setAttribute('width', width);
       state.img.setAttribute('height', height);
 
       ref.positionImageHandles();
-      ref.updateImageSizeLabel();
     };
 
     ref.documentImageResizeEndListener = function () {
-      if (!ref.imageResize) {
+      var state = ref.imageResize;
+
+      if (!state) {
         return;
       }
 
-      ref.lastImageResize = ref.imageResize;
-      ref.stopImageResize();
+      var img = state.img;
+      var width = img.getAttribute('width');
+      var height = img.getAttribute('height');
 
-      try { instance.invokeMethodAsync('OnChange', ref.innerHTML); } catch { }
+      ref.stopImageDrag();
+
+      if (width === state.startAttributes.width && height === state.startAttributes.height) {
+        ref.restoreImageSize(state);
+        ref.positionImageHandles();
+        return;
+      }
+
+      // Rewound first so the undo entry records the size from before the drag.
+      ref.restoreImageSize(state);
+
+      var replacement = img.cloneNode(true);
+      replacement.classList.remove('rz-state-selected');
+
+      if (!replacement.getAttribute('class')) {
+        replacement.removeAttribute('class');
+      }
+
+      replacement.setAttribute('width', width);
+      replacement.setAttribute('height', height);
+      replacement.style.width = '';
+      replacement.style.height = '';
+
+      var range = document.createRange();
+      range.selectNode(img);
+      var selection = getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      ref.focus();
+      document.execCommand('insertHTML', false, replacement.outerHTML);
+
+      ref.selectImage(ref.querySelector('img[width="' + width + '"][height="' + height + '"]'));
     };
 
-    ref.imageHandlesScrollListener = function () {
-      ref.positionImageHandles();
+    ref.selectImage = function (img) {
+      if (!img) {
+        ref.removeImageHandles();
+        return;
+      }
+
+      img.classList.add('rz-state-selected');
+
+      var range = document.createRange();
+      range.selectNode(img);
+      var selection = getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      ref.createImageHandles();
     };
 
-    ref.imageHandlesResizeListener = function () {
-      ref.positionImageHandles();
-    };
+    ref.imageHandlesObserver = new MutationObserver(ref.positionImageHandles);
 
-    ref.imageHandlesObserver = new MutationObserver(function () {
-      ref.positionImageHandles();
-    });
+    ref.stopImageDrag = function () {
+      ref.imageResize = null;
+      ref.showImageSizeLabel(false);
+
+      if (ref.releaseImageDrag) {
+        ref.releaseImageDrag();
+        ref.releaseImageDrag = null;
+      }
+    };
 
     ref.inputListener = function () {
+      ref.positionImageHandles();
       try { suppressDisposed(instance.invokeMethodAsync('OnChange', ref.innerHTML)); } catch { }
     };
     ref.keydownListener = function (e) {
@@ -5229,15 +5291,9 @@ window.Radzen = {
         }
 
         ref.removeImageHandles();
-        ref.lastImageResize = null;
 
         if (e.target.matches('img')) {
-          e.target.classList.add('rz-state-selected');
-          var range = document.createRange();
-          range.selectNode(e.target);
-          getSelection().removeAllRanges();
-          getSelection().addRange(range);
-          ref.createImageHandles();
+          ref.selectImage(e.target);
         } else {
           var clickedCell = e.target.closest && e.target.closest('td,th');
           if (clickedCell && ref.contains(clickedCell)) {
@@ -5296,8 +5352,7 @@ window.Radzen = {
         ref.isResizingColumn = true;
         ref.resizeStartX = e.clientX;
         ref.resizeStartWidth = ref.resizeTargetCell.getBoundingClientRect().width;
-        document.addEventListener('mouseup', ref.mouseupResizeListener);
-        document.addEventListener('mousemove', ref.documentMouseMoveResizeListener);
+        ref.releaseColumnDrag = trackDrag(ref.documentMouseMoveResizeListener, ref.mouseupResizeListener);
       }
     };
 
@@ -5305,8 +5360,8 @@ window.Radzen = {
       if (ref.isResizingColumn) {
         ref.isResizingColumn = false;
         ref.style.cursor = '';
-        document.removeEventListener('mouseup', ref.mouseupResizeListener);
-        document.removeEventListener('mousemove', ref.documentMouseMoveResizeListener);
+        ref.releaseColumnDrag();
+        ref.releaseColumnDrag = null;
         try { instance.invokeMethodAsync('OnChange', ref.innerHTML); } catch { }
       }
     };
@@ -5434,10 +5489,8 @@ window.Radzen = {
     ref.addEventListener('contextmenu', ref.contextMenuListener);
     ref.addEventListener('mousemove', ref.mousemoveListener);
     ref.addEventListener('mousedown', ref.mousedownResizeListener);
-    ref.addEventListener('scroll', ref.imageHandlesScrollListener);
-    document.addEventListener('keydown', ref.documentImageResizeKeyListener);
-    window.addEventListener('resize', ref.imageHandlesResizeListener);
-    ref.imageHandlesObserver.observe(ref, { attributes: true, attributeFilter: ['hidden'], childList: true });
+    ref.addEventListener('scroll', ref.positionImageHandles);
+    ref.imageHandlesObserver.observe(ref, { attributes: true, attributeFilter: ['hidden'] });
     document.addEventListener('selectionchange', ref.selectionChangeListener);
     document.execCommand('styleWithCSS', false, true);
     return {
@@ -5451,17 +5504,16 @@ window.Radzen = {
           ref.removeEventListener('contextmenu', ref.contextMenuListener);
           ref.removeEventListener('mousemove', ref.mousemoveListener);
           ref.removeEventListener('mousedown', ref.mousedownResizeListener);
-          ref.removeEventListener('scroll', ref.imageHandlesScrollListener);
-          window.removeEventListener('resize', ref.imageHandlesResizeListener);
+          ref.removeEventListener('scroll', ref.positionImageHandles);
           ref.imageHandlesObserver.disconnect();
-          ref.imageResize = null;
-          document.removeEventListener('mousemove', ref.documentImageResizeMoveListener);
-          document.removeEventListener('mouseup', ref.documentImageResizeEndListener);
-          document.removeEventListener('keydown', ref.documentImageResizeKeyListener);
+          ref.stopImageDrag();
           ref.removeImageHandles();
           ref.isResizingColumn = false;
-          document.removeEventListener('mouseup', ref.mouseupResizeListener);
-          document.removeEventListener('mousemove', ref.documentMouseMoveResizeListener);
+
+          if (ref.releaseColumnDrag) {
+            ref.releaseColumnDrag();
+            ref.releaseColumnDrag = null;
+          }
           document.removeEventListener('selectionchange', ref.selectionChangeListener);
         }
       }

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -4885,7 +4885,7 @@ window.Radzen = {
       document.addEventListener('mouseup', end);
 
       if (key) {
-        document.addEventListener('keydown', key);
+        document.addEventListener('keydown', key, true);
       }
 
       return function () {
@@ -4893,7 +4893,7 @@ window.Radzen = {
         document.removeEventListener('mouseup', end);
 
         if (key) {
-          document.removeEventListener('keydown', key);
+          document.removeEventListener('keydown', key, true);
         }
       };
     }
@@ -4934,7 +4934,7 @@ window.Radzen = {
       var img = ref.getSelectedImage();
       var container = ref.getEditorContainer();
 
-      if (!img || !container || ref.hidden) {
+      if (!img || !container || ref.hidden || !ref.isContentEditable) {
         ref.removeImageHandles();
         return;
       }
@@ -4942,10 +4942,11 @@ window.Radzen = {
       var containerRect = container.getBoundingClientRect();
       var contentRect = ref.getBoundingClientRect();
       var imgRect = img.getBoundingClientRect();
+      var clipLeft = contentRect.left - containerRect.left - container.clientLeft;
+      var clipTop = contentRect.top - containerRect.top - container.clientTop;
 
-      // Absolutely positioned children start at the padding box, past the border.
-      ref.imageHandlesClip.style.left = (contentRect.left - containerRect.left - container.clientLeft) + 'px';
-      ref.imageHandlesClip.style.top = (contentRect.top - containerRect.top - container.clientTop) + 'px';
+      ref.imageHandlesClip.style.left = clipLeft + 'px';
+      ref.imageHandlesClip.style.top = clipTop + 'px';
       ref.imageHandlesClip.style.width = contentRect.width + 'px';
       ref.imageHandlesClip.style.height = contentRect.height + 'px';
 
@@ -5026,8 +5027,6 @@ window.Radzen = {
       e.preventDefault();
       e.stopPropagation();
 
-      // Pasted content often carries an inline width/height, which would outrank
-      // the attributes a drag writes.
       ref.imageResize = {
         img: img,
         direction: imageHandleDirections[e.currentTarget.dataset.position],
@@ -5118,6 +5117,8 @@ window.Radzen = {
       var width = img.getAttribute('width');
       var height = img.getAttribute('height');
 
+      var index = Array.prototype.indexOf.call(ref.querySelectorAll('img'), img);
+
       ref.stopImageDrag();
 
       if (width === state.startAttributes.width && height === state.startAttributes.height) {
@@ -5126,30 +5127,38 @@ window.Radzen = {
         return;
       }
 
-      // Rewound first so the undo entry records the size from before the drag.
       ref.restoreImageSize(state);
+      img.classList.remove('rz-state-selected');
 
-      var replacement = img.cloneNode(true);
-      replacement.classList.remove('rz-state-selected');
-
-      if (!replacement.getAttribute('class')) {
-        replacement.removeAttribute('class');
+      if (!img.getAttribute('class')) {
+        img.removeAttribute('class');
       }
 
-      replacement.setAttribute('width', width);
-      replacement.setAttribute('height', height);
-      replacement.style.width = '';
-      replacement.style.height = '';
+      var target = img;
+
+      while (target.parentElement && target.parentElement !== ref && getComputedStyle(target.parentElement).display === 'inline') {
+        target = target.parentElement;
+      }
+
+      var replacement = target.cloneNode(true);
+      var replacementImg = target === img
+        ? replacement
+        : replacement.querySelectorAll('img')[Array.prototype.indexOf.call(target.querySelectorAll('img'), img)];
+
+      replacementImg.setAttribute('width', width);
+      replacementImg.setAttribute('height', height);
+      replacementImg.style.width = '';
+      replacementImg.style.height = '';
 
       var range = document.createRange();
-      range.selectNode(img);
+      range.selectNode(target);
       var selection = getSelection();
       selection.removeAllRanges();
       selection.addRange(range);
       ref.focus();
       document.execCommand('insertHTML', false, replacement.outerHTML);
 
-      ref.selectImage(ref.querySelector('img[width="' + width + '"][height="' + height + '"]'));
+      ref.selectImage(ref.querySelectorAll('img')[index]);
     };
 
     ref.selectImage = function (img) {
@@ -5362,7 +5371,7 @@ window.Radzen = {
         ref.style.cursor = '';
         ref.releaseColumnDrag();
         ref.releaseColumnDrag = null;
-        try { instance.invokeMethodAsync('OnChange', ref.innerHTML); } catch { }
+        ref.inputListener();
       }
     };
 
@@ -5490,7 +5499,7 @@ window.Radzen = {
     ref.addEventListener('mousemove', ref.mousemoveListener);
     ref.addEventListener('mousedown', ref.mousedownResizeListener);
     ref.addEventListener('scroll', ref.positionImageHandles);
-    ref.imageHandlesObserver.observe(ref, { attributes: true, attributeFilter: ['hidden'] });
+    ref.imageHandlesObserver.observe(ref, { attributes: true, attributeFilter: ['hidden', 'contenteditable'], childList: true });
     document.addEventListener('selectionchange', ref.selectionChangeListener);
     document.execCommand('styleWithCSS', false, true);
     return {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -4880,6 +4880,246 @@ window.Radzen = {
     }
   },
   createEditor: function (ref, uploadUrl, paste, instance, shortcuts) {
+    var imageHandlePositions = ['nw', 'n', 'ne', 'w', 'e', 'sw', 's', 'se'];
+    var minImageSize = 24;
+
+    ref.getSelectedImage = function () {
+      return ref.querySelector('img.rz-state-selected');
+    };
+
+    ref.getEditorContainer = function () {
+      return ref.closest('.rz-html-editor') || ref.parentElement;
+    };
+
+    ref.removeImageHandles = function () {
+      if (ref.imageHandles) {
+        ref.imageHandles.remove();
+        ref.imageHandles = null;
+      }
+    };
+
+    ref.positionImageHandles = function () {
+      if (!ref.imageHandles) {
+        return;
+      }
+
+      var img = ref.getSelectedImage();
+      var container = ref.getEditorContainer();
+
+      if (!img || !container || ref.hidden) {
+        ref.removeImageHandles();
+        return;
+      }
+
+      var containerRect = container.getBoundingClientRect();
+      var imgRect = img.getBoundingClientRect();
+
+      ref.imageHandles.style.left = (imgRect.left - containerRect.left) + 'px';
+      ref.imageHandles.style.top = (imgRect.top - containerRect.top) + 'px';
+      ref.imageHandles.style.width = imgRect.width + 'px';
+      ref.imageHandles.style.height = imgRect.height + 'px';
+    };
+
+    ref.createImageHandles = function () {
+      ref.removeImageHandles();
+
+      var img = ref.getSelectedImage();
+      var container = ref.getEditorContainer();
+
+      if (!img || !container) {
+        return;
+      }
+
+      var handles = document.createElement('div');
+      handles.className = 'rz-html-editor-image-handles';
+      handles.setAttribute('contenteditable', 'false');
+
+      imageHandlePositions.forEach(function (position) {
+        var handle = document.createElement('div');
+        handle.className = 'rz-html-editor-image-handle rz-' + position;
+        handle.dataset.position = position;
+        handle.addEventListener('mousedown', ref.imageResizeStartListener);
+        handles.appendChild(handle);
+      });
+
+      var size = document.createElement('div');
+      size.className = 'rz-html-editor-image-size';
+      size.hidden = true;
+      handles.appendChild(size);
+
+      container.appendChild(handles);
+      ref.imageHandles = handles;
+      ref.positionImageHandles();
+    };
+
+    ref.showImageSizeLabel = function (visible) {
+      var label = ref.imageHandles && ref.imageHandles.querySelector('.rz-html-editor-image-size');
+
+      if (label) {
+        label.hidden = !visible;
+      }
+    };
+
+    ref.updateImageSizeLabel = function () {
+      var label = ref.imageHandles && ref.imageHandles.querySelector('.rz-html-editor-image-size');
+      var img = ref.getSelectedImage();
+      var container = ref.getEditorContainer();
+
+      if (!label || label.hidden || !img || !container) {
+        return;
+      }
+
+      label.textContent = Math.round(img.offsetWidth) + ' × ' + Math.round(img.offsetHeight);
+
+      // The overlay lives inside .rz-html-editor, which clips its overflow, so a
+      // badge below the image would be cut off near the bottom edge.
+      var containerRect = container.getBoundingClientRect();
+      var imgRect = img.getBoundingClientRect();
+
+      label.classList.toggle('rz-inside', imgRect.bottom + 28 > containerRect.bottom);
+    };
+
+    ref.imageResizeStartListener = function (e) {
+      var img = ref.getSelectedImage();
+
+      if (!img) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      ref.imageResize = {
+        img: img,
+        position: e.currentTarget.dataset.position,
+        startX: e.clientX,
+        startY: e.clientY,
+        startWidth: img.offsetWidth,
+        startHeight: img.offsetHeight,
+        startAttrWidth: img.getAttribute('width'),
+        startAttrHeight: img.getAttribute('height'),
+        ratio: img.offsetHeight ? img.offsetWidth / img.offsetHeight : 1
+      };
+
+      document.addEventListener('mousemove', ref.documentImageResizeMoveListener);
+      document.addEventListener('mouseup', ref.documentImageResizeEndListener);
+
+      ref.showImageSizeLabel(true);
+      ref.updateImageSizeLabel();
+    };
+
+    ref.stopImageResize = function () {
+      ref.showImageSizeLabel(false);
+      ref.imageResize = null;
+      document.removeEventListener('mousemove', ref.documentImageResizeMoveListener);
+      document.removeEventListener('mouseup', ref.documentImageResizeEndListener);
+    };
+
+    ref.restoreImageSize = function (state) {
+      if (state.startAttrWidth !== null) {
+        state.img.setAttribute('width', state.startAttrWidth);
+      } else {
+        state.img.removeAttribute('width');
+      }
+
+      if (state.startAttrHeight !== null) {
+        state.img.setAttribute('height', state.startAttrHeight);
+      } else {
+        state.img.removeAttribute('height');
+      }
+    };
+
+    ref.documentImageResizeKeyListener = function (e) {
+      if (e.key !== 'Escape') {
+        return;
+      }
+
+      // While a drag is running, cancel it and leave the editor value untouched.
+      if (ref.imageResize) {
+        e.preventDefault();
+        e.stopPropagation();
+        ref.restoreImageSize(ref.imageResize);
+        ref.stopImageResize();
+        ref.positionImageHandles();
+        return;
+      }
+
+      // Once a drag has finished, undo the last resize for as long as that same
+      // image is still selected.
+      var last = ref.lastImageResize;
+
+      if (last && last.img === ref.getSelectedImage()) {
+        e.preventDefault();
+        e.stopPropagation();
+        ref.restoreImageSize(last);
+        ref.lastImageResize = null;
+        ref.positionImageHandles();
+
+        try { instance.invokeMethodAsync('OnChange', ref.innerHTML); } catch { }
+      }
+    };
+
+    ref.documentImageResizeMoveListener = function (e) {
+      var state = ref.imageResize;
+
+      if (!state || !ref.isConnected) {
+        return;
+      }
+
+      e.preventDefault();
+
+      var position = state.position;
+      var horizontal = position.indexOf('w') !== -1 || position.indexOf('e') !== -1;
+      var vertical = position.indexOf('n') !== -1 || position.indexOf('s') !== -1;
+      var toLeft = position.indexOf('w') !== -1;
+      var toTop = position.indexOf('n') !== -1;
+      var deltaX = toLeft ? state.startX - e.clientX : e.clientX - state.startX;
+      var deltaY = toTop ? state.startY - e.clientY : e.clientY - state.startY;
+
+      var width = state.startWidth;
+      var height = state.startHeight;
+
+      if (horizontal && vertical) {
+        width = Math.max(Math.round(state.startWidth + deltaX), minImageSize);
+        height = e.shiftKey
+          ? Math.max(Math.round(state.startHeight + deltaY), minImageSize)
+          : Math.max(Math.round(width / state.ratio), minImageSize);
+      } else if (horizontal) {
+        width = Math.max(Math.round(state.startWidth + deltaX), minImageSize);
+      } else {
+        height = Math.max(Math.round(state.startHeight + deltaY), minImageSize);
+      }
+
+      state.img.setAttribute('width', width);
+      state.img.setAttribute('height', height);
+
+      ref.positionImageHandles();
+      ref.updateImageSizeLabel();
+    };
+
+    ref.documentImageResizeEndListener = function () {
+      if (!ref.imageResize) {
+        return;
+      }
+
+      ref.lastImageResize = ref.imageResize;
+      ref.stopImageResize();
+
+      try { instance.invokeMethodAsync('OnChange', ref.innerHTML); } catch { }
+    };
+
+    ref.imageHandlesScrollListener = function () {
+      ref.positionImageHandles();
+    };
+
+    ref.imageHandlesResizeListener = function () {
+      ref.positionImageHandles();
+    };
+
+    ref.imageHandlesObserver = new MutationObserver(function () {
+      ref.positionImageHandles();
+    });
+
     ref.inputListener = function () {
       try { suppressDisposed(instance.invokeMethodAsync('OnChange', ref.innerHTML)); } catch { }
     };
@@ -4988,12 +5228,16 @@ window.Radzen = {
           img.classList.remove('rz-state-selected');
         }
 
+        ref.removeImageHandles();
+        ref.lastImageResize = null;
+
         if (e.target.matches('img')) {
           e.target.classList.add('rz-state-selected');
           var range = document.createRange();
           range.selectNode(e.target);
           getSelection().removeAllRanges();
           getSelection().addRange(range);
+          ref.createImageHandles();
         } else {
           var clickedCell = e.target.closest && e.target.closest('td,th');
           if (clickedCell && ref.contains(clickedCell)) {
@@ -5190,6 +5434,10 @@ window.Radzen = {
     ref.addEventListener('contextmenu', ref.contextMenuListener);
     ref.addEventListener('mousemove', ref.mousemoveListener);
     ref.addEventListener('mousedown', ref.mousedownResizeListener);
+    ref.addEventListener('scroll', ref.imageHandlesScrollListener);
+    document.addEventListener('keydown', ref.documentImageResizeKeyListener);
+    window.addEventListener('resize', ref.imageHandlesResizeListener);
+    ref.imageHandlesObserver.observe(ref, { attributes: true, attributeFilter: ['hidden'], childList: true });
     document.addEventListener('selectionchange', ref.selectionChangeListener);
     document.execCommand('styleWithCSS', false, true);
     return {
@@ -5203,6 +5451,14 @@ window.Radzen = {
           ref.removeEventListener('contextmenu', ref.contextMenuListener);
           ref.removeEventListener('mousemove', ref.mousemoveListener);
           ref.removeEventListener('mousedown', ref.mousedownResizeListener);
+          ref.removeEventListener('scroll', ref.imageHandlesScrollListener);
+          window.removeEventListener('resize', ref.imageHandlesResizeListener);
+          ref.imageHandlesObserver.disconnect();
+          ref.imageResize = null;
+          document.removeEventListener('mousemove', ref.documentImageResizeMoveListener);
+          document.removeEventListener('mouseup', ref.documentImageResizeEndListener);
+          document.removeEventListener('keydown', ref.documentImageResizeKeyListener);
+          ref.removeImageHandles();
           ref.isResizingColumn = false;
           document.removeEventListener('mouseup', ref.mouseupResizeListener);
           document.removeEventListener('mousemove', ref.documentMouseMoveResizeListener);

--- a/RadzenBlazorDemos/Pages/HtmlEditorPage.razor
+++ b/RadzenBlazorDemos/Pages/HtmlEditorPage.razor
@@ -103,7 +103,7 @@ The Radzen HtmlEditor supports the following tools:
     Image resizing
 </RadzenText>
 <RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
-    Click an image to select it and drag one of its handles to resize it. The corner handles preserve the aspect ratio - hold <strong>Shift</strong> while dragging one to scale freely. The handles on the sides change only the width or only the height. The current size is displayed while dragging. Press <strong>Esc</strong> during a drag to cancel it, or right after one to restore the previous size.
+    Click an image to select it and drag one of its handles to resize it. The corner handles preserve the aspect ratio - hold <strong>Shift</strong> while dragging one to scale freely. The handles on the sides change only the width or only the height. The current size is displayed while dragging. Press <strong>Esc</strong> during a drag to cancel it. <strong>Ctrl+Z</strong> undoes a finished resize.
 </RadzenText>
 
 <RadzenText Anchor="html-editor#keyboard-navigation" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">

--- a/RadzenBlazorDemos/Pages/HtmlEditorPage.razor
+++ b/RadzenBlazorDemos/Pages/HtmlEditorPage.razor
@@ -99,6 +99,13 @@ The Radzen HtmlEditor supports the following tools:
     <HtmlEditorTables />
 </RadzenExample>
 
+<RadzenText Anchor="html-editor#image-resizing" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
+    Image resizing
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
+    Click an image to select it and drag one of its handles to resize it. The corner handles preserve the aspect ratio - hold <strong>Shift</strong> while dragging one to scale freely. The handles on the sides change only the width or only the height. The current size is displayed while dragging. Press <strong>Esc</strong> during a drag to cancel it, or right after one to restore the previous size.
+</RadzenText>
+
 <RadzenText Anchor="html-editor#keyboard-navigation" TextStyle="TextStyle.H5" TagName="TagName.H2" class="rz-pt-12">
     Keyboard Navigation
 </RadzenText>


### PR DESCRIPTION
Closes #2703.

![image resizing](https://i.imgur.com/828agGS.gif)

A selected image gets eight handles. The corners keep the aspect ratio and
release it while <kbd>Shift</kbd> is held, the side handles change one axis.
<kbd>Esc</kbd> cancels a drag in progress and <kbd>Ctrl</kbd>+<kbd>Z</kbd> undoes
a finished one. No new parameter, it is always on like the table column resize.

The handles sit outside the contenteditable element, which is what keeps them
out of the editor value and out of the HTML after a cut and paste - the problem
#2192 could not get past. Size goes into the width and height attributes, so the
insert-image dialog picks up what a drag produced, which was the other one. The
commit messages cover the details.

The premium themes ship as prebuilt CSS and need regenerating on your side for
the handles to be styled there. The SCSS-built themes are covered here.

The Disabled guard has bUnit tests. The drag itself is browser behaviour, so I
checked it with Playwright against the demo app, including both problems from
#2192. The demo page gained a short "Image resizing" section.
