### PR TITLE
Fix: RadzenDataGrid, a reset reads the declared OrderIndex again

### DIFF
--- a/Radzen.Blazor.Tests/DataGridSettingsResetTests.cs
+++ b/Radzen.Blazor.Tests/DataGridSettingsResetTests.cs
@@ -1,0 +1,80 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Radzen.Blazor.Tests
+{
+    public class DataGridSettingsResetTests
+    {
+        class Row
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public string City { get; set; } = string.Empty;
+        }
+
+        // Declared out of their markup order on purpose: the rendered order is Name, City, Id, and
+        // the declaration order is Id, Name, City. A reset that reads OrderIndex gives the first;
+        // one that rebuilds the column list without reading it gives the second.
+        static IRenderedComponent<RadzenDataGrid<Row>> Render(TestContext ctx)
+        {
+            return ctx.RenderComponent<RadzenDataGrid<Row>>(builder =>
+            {
+                builder.Add(p => p.Data, new List<Row> { new Row { Id = 1, Name = "One", City = "Paris" } });
+                builder.Add(p => p.AllowColumnReorder, true);
+                builder.Add(p => p.SettingsChanged, EventCallback.Factory.Create<DataGridSettings>(ctx.Renderer, _ => { }));
+                builder.Add<RenderFragment>(p => p.Columns, columns =>
+                {
+                    columns.OpenComponent(0, typeof(RadzenDataGridColumn<Row>));
+                    columns.AddAttribute(1, "Property", "Id");
+                    columns.AddAttribute(2, "Title", "Id");
+                    columns.AddAttribute(3, "OrderIndex", 2);
+                    columns.CloseComponent();
+
+                    columns.OpenComponent(4, typeof(RadzenDataGridColumn<Row>));
+                    columns.AddAttribute(5, "Property", "Name");
+                    columns.AddAttribute(6, "Title", "Name");
+                    columns.AddAttribute(7, "OrderIndex", 0);
+                    columns.CloseComponent();
+
+                    columns.OpenComponent(8, typeof(RadzenDataGridColumn<Row>));
+                    columns.AddAttribute(9, "Property", "City");
+                    columns.AddAttribute(10, "Title", "City");
+                    columns.AddAttribute(11, "OrderIndex", 1);
+                    columns.CloseComponent();
+                });
+            });
+        }
+
+        static string[] HeaderTitles(IRenderedComponent<RadzenDataGrid<Row>> component) =>
+            component.FindAll("th .rz-column-title-content")
+                .Select(cell => cell.TextContent.Trim())
+                .ToArray();
+
+        [Fact]
+        public async Task DataGrid_SettingsSetToNull_RestoresDeclaredOrderIndex()
+        {
+            using var ctx = new TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.JSInterop.SetupModule("_content/Radzen.Blazor/Radzen.Blazor.js");
+
+            var component = Render(ctx);
+            var grid = component.Instance;
+
+            Assert.Equal(new[] { "Name", "City", "Id" }, HeaderTitles(component));
+
+            // The state a reset is undoing: something was stored, so the setter's null branch runs.
+            await component.InvokeAsync(() => grid.Settings = new DataGridSettings());
+            await component.InvokeAsync(() => grid.Settings = null);
+
+            component.Render();
+
+            // Not Id, Name, City - that is the order the columns were declared in, which is what a
+            // reset that rebuilds the list from allColumns without ordering it produces.
+            Assert.Equal(new[] { "Name", "City", "Id" }, HeaderTitles(component));
+        }
+    }
+}

--- a/Radzen.Blazor/RadzenDataGrid.razor.cs
+++ b/Radzen.Blazor/RadzenDataGrid.razor.cs
@@ -4701,7 +4701,7 @@ namespace Radzen.Blazor
                         CurrentPage = 0;
                         skip = 0;
                         Reset(true);
-                        columns = allColumns.Where(c => c.Parent == null).ToList();
+                        UpdateColumnsOrder();
                         InvokeAsync(Reload);
 
                         canSaveSettings = true;


### PR DESCRIPTION
## Current behavior

Resetting a grid with `Settings = null` puts its columns back in **declaration** order, ignoring the `OrderIndex` each column declares. The columns stay that way until something else happens to reorder them.

## Steps to reproduce

```razor
<RadzenDataGrid @ref="grid" Data="@orders" TItem="Order" AllowColumnReorder="true"
                SettingsChanged="@(s => settings = s)" Settings="@settings">
    <Columns>
        <RadzenDataGridColumn TItem="Order" Property="Id"   Title="Id"   OrderIndex="2" />
        <RadzenDataGridColumn TItem="Order" Property="Name" Title="Name" OrderIndex="0" />
        <RadzenDataGridColumn TItem="Order" Property="City" Title="City" OrderIndex="1" />
    </Columns>
</RadzenDataGrid>

@code {
    RadzenDataGrid<Order> grid;
    DataGridSettings settings;

    // Whatever a "reset layout" button does.
    void Reset() => grid.Settings = null;
}
```

1. Load the page. The headers read **Name, City, Id**, which is what `OrderIndex` asks for.
2. Call `Reset()`.

**Observed:** the headers read **Id, Name, City** — the order the columns were declared in.

**Expected:** they read **Name, City, Id** again. A reset should put the grid back to what its markup declares, and the markup declares an order.

## Cause

`Reset(true)` clears each column's runtime order override with `SetOrderIndex(null)` and rebuilds `columns` from `allColumns` in declaration order. `GetOrderIndex()` is `orderIndex ?? OrderIndex`, so after that clear it correctly answers the column's *declared* `OrderIndex` — but nothing on the reset path reads it.

`UpdateColumnsOrder()` is the only method that orders `columns` by `GetOrderIndex()`, and its callers are `AddColumn`, `RemoveColumn`, the reorder drag, `LoadSettingsInternal`, and the column's own `OrderIndex`-changed path. A reset is none of them.

## The change

One line in the `Settings` setter. The setter repeated the `columns = allColumns.Where(c => c.Parent == null).ToList()` that `Reset(true)` had just done; `UpdateColumnsOrder()` takes its place rather than being added beside it.

## Tests

* **New test** — `Radzen.Blazor.Tests/DataGridSettingsResetTests.cs`, written to fail on master first. It renders the three columns above, asserts the headers are `Name, City, Id`, sets `Settings = null`, and asserts they still are. On master it fails with `Actual: ["Id", "Name", "City"]`.
* **Existing tests** — the full `Radzen.Blazor.Tests` suite passes on the branch: **5115 passed, 0 failed**.