### PR TITLE
Spreadsheet: two reader round-trip fixes, 47% less allocation when filling, and a bulk CellStore entrance

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/BooleanRoundTripTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/BooleanRoundTripTests.cs
@@ -1,0 +1,129 @@
+using System.IO;
+using System.Linq;
+using System.IO.Compression;
+using System.Xml.Linq;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class BooleanRoundTripTests
+{
+    private static Worksheet RoundTrip(Workbook workbook)
+    {
+        using var stream = new MemoryStream();
+
+        workbook.SaveToStream(stream);
+        stream.Position = 0;
+
+        return Workbook.LoadFromStream(stream).Sheets[0];
+    }
+
+    [Fact]
+    public void BooleanSurvivesTheRoundTrip()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 3, 1);
+
+        sheet.Cells[0, 0].Value = true;
+        sheet.Cells[1, 0].Value = false;
+
+        Assert.Equal(CellDataType.Boolean, sheet.Cells[0, 0].ValueType);
+
+        var loaded = RoundTrip(workbook);
+
+        Assert.Equal(CellDataType.Boolean, loaded.Cells[0, 0].ValueType);
+        Assert.Equal(true, loaded.Cells[0, 0].Value);
+
+        Assert.Equal(CellDataType.Boolean, loaded.Cells[1, 0].ValueType);
+        Assert.Equal(false, loaded.Cells[1, 0].Value);
+    }
+
+    // ECMA-376 types <v> as ST_Xstring, so a producer may write the word. This writer writes 1 and 0,
+    // which is why the file has to be edited to produce the case at all.
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("True", true)]
+    [InlineData("false", false)]
+    [InlineData("FALSE", false)]
+    [InlineData("0", false)]
+    public void ABooleanWrittenAsAWordIsRead(string written, bool expected)
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 1);
+
+        sheet.Cells[0, 0].Value = true;
+
+        using var saved = new MemoryStream();
+
+        workbook.SaveToStream(saved);
+        saved.Position = 0;
+
+        using var edited = WithCellValue(saved, written);
+
+        var loaded = Workbook.LoadFromStream(edited).Sheets[0];
+
+        Assert.Equal(CellDataType.Boolean, loaded.Cells[0, 0].ValueType);
+        Assert.Equal(expected, loaded.Cells[0, 0].Value);
+    }
+
+    // Numbers keep the branch they always took: the boolean is chosen by t="b" and not by what the
+    // text happens to say, so a cell holding 1 is still the number 1.
+    [Fact]
+    public void NumbersAreUnaffected()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 3, 1);
+
+        sheet.Cells[0, 0].Value = 42;
+        sheet.Cells[1, 0].Value = 1;
+        sheet.Cells[2, 0].Value = 0;
+
+        var loaded = RoundTrip(workbook);
+
+        Assert.Equal(CellDataType.Number, loaded.Cells[0, 0].ValueType);
+        Assert.Equal(42d, loaded.Cells[0, 0].Value);
+
+        Assert.Equal(CellDataType.Number, loaded.Cells[1, 0].ValueType);
+        Assert.Equal(1d, loaded.Cells[1, 0].Value);
+
+        Assert.Equal(CellDataType.Number, loaded.Cells[2, 0].ValueType);
+        Assert.Equal(0d, loaded.Cells[2, 0].Value);
+    }
+
+    /// <summary>Rewrites the single cell's &lt;v&gt;, so the file reads as another producer's.</summary>
+    private static MemoryStream WithCellValue(Stream source, string value)
+    {
+        var result = new MemoryStream();
+        source.CopyTo(result);
+        result.Position = 0;
+
+        using (var archive = new ZipArchive(result, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = archive.GetEntry("xl/worksheets/sheet1.xml")!;
+            XDocument doc;
+            using (var stream = entry.Open())
+            {
+                doc = XDocument.Load(stream);
+            }
+
+            var ns = doc.Root!.Name.Namespace;
+            var cell = doc.Descendants(ns + "c").First();
+
+            Assert.Equal("b", cell.Attribute("t")!.Value);
+
+            cell.Element(ns + "v")!.Value = value;
+
+            entry.Delete();
+            var newEntry = archive.CreateEntry("xl/worksheets/sheet1.xml");
+            using var output = newEntry.Open();
+            doc.Save(output);
+        }
+
+        result.Position = 0;
+        return result;
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/BooleanRoundTripTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/BooleanRoundTripTests.cs
@@ -41,8 +41,6 @@ public class BooleanRoundTripTests
         Assert.Equal(false, loaded.Cells[1, 0].Value);
     }
 
-    // ECMA-376 types <v> as ST_Xstring, so a producer may write the word. This writer writes 1 and 0,
-    // which is why the file has to be edited to produce the case at all.
     [Theory]
     [InlineData("true", true)]
     [InlineData("TRUE", true)]
@@ -70,8 +68,6 @@ public class BooleanRoundTripTests
         Assert.Equal(expected, loaded.Cells[0, 0].Value);
     }
 
-    // Numbers keep the branch they always took: the boolean is chosen by t="b" and not by what the
-    // text happens to say, so a cell holding 1 is still the number 1.
     [Fact]
     public void NumbersAreUnaffected()
     {

--- a/Radzen.Blazor.Tests/Spreadsheet/CellDataEmptyTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CellDataEmptyTests.cs
@@ -7,7 +7,6 @@ namespace Radzen.Blazor.Spreadsheet.Tests;
 
 public class CellDataEmptyTests
 {
-    // CellData carries a value and a type and neither can be set, so every empty cell points at one.
     [Fact]
     public void EmptyCellsShareOneCellData()
     {
@@ -21,7 +20,6 @@ public class CellDataEmptyTests
         Assert.NotSame(CellData.Empty, sheet.Cells[0, 0].Data);
         Assert.Same(CellData.Empty, sheet.Cells[1, 1].Data);
 
-        // And the shared instance still says what an empty cell says.
         Assert.True(sheet.Cells[1, 1].IsEmpty);
         Assert.Equal(CellDataType.Empty, sheet.Cells[1, 1].ValueType);
         Assert.Null(sheet.Cells[1, 1].Value);

--- a/Radzen.Blazor.Tests/Spreadsheet/CellDataEmptyTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CellDataEmptyTests.cs
@@ -1,0 +1,29 @@
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class CellDataEmptyTests
+{
+    // CellData carries a value and a type and neither can be set, so every empty cell points at one.
+    [Fact]
+    public void EmptyCellsShareOneCellData()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 4, 4);
+
+        Assert.Same(CellData.Empty, sheet.Cells[0, 0].Data);
+        Assert.Same(sheet.Cells[0, 0].Data, sheet.Cells[1, 1].Data);
+
+        sheet.Cells[0, 0].Value = "written";
+
+        Assert.NotSame(CellData.Empty, sheet.Cells[0, 0].Data);
+        Assert.Same(CellData.Empty, sheet.Cells[1, 1].Data);
+
+        // And the shared instance still says what an empty cell says.
+        Assert.True(sheet.Cells[1, 1].IsEmpty);
+        Assert.Equal(CellDataType.Empty, sheet.Cells[1, 1].ValueType);
+        Assert.Null(sheet.Cells[1, 1].Value);
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/CellStoreSetValuesTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CellStoreSetValuesTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class CellStoreSetValuesTests
+{
+    private static IReadOnlyList<IReadOnlyList<object?>?> Block(params object?[][] rows) => rows;
+
+    [Fact]
+    public void FillsTheBlockFromTheGivenOrigin()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 10, 10);
+
+        sheet.Cells.SetValues(2, 1, Block(
+            ["a", 1],
+            ["b", 2]));
+
+        Assert.Equal("a", sheet.Cells[2, 1].Value);
+        Assert.Equal(1d, sheet.Cells[2, 2].Value);
+        Assert.Equal("b", sheet.Cells[3, 1].Value);
+        Assert.Equal(2d, sheet.Cells[3, 2].Value);
+
+        // Nothing outside the block was touched.
+        Assert.True(sheet.Cells[2, 0].IsEmpty);
+        Assert.True(sheet.Cells[4, 1].IsEmpty);
+    }
+
+    [Fact]
+    public void AgreesWithTheIndexerCellForCell()
+    {
+        object?[][] rows =
+        [
+            ["text", 1, 2.5, true, new DateTime(2020, 3, 4)],
+            [null, -1, 0.0, false, "trailing"],
+        ];
+
+        var bulk = new Workbook().AddSheet("Sheet1", 4, 5);
+        bulk.Cells.SetValues(0, 0, rows);
+
+        var loop = new Workbook().AddSheet("Sheet1", 4, 5);
+        for (var r = 0; r < rows.Length; r++)
+        {
+            for (var c = 0; c < rows[r].Length; c++)
+            {
+                loop.Cells[r, c].Value = rows[r][c];
+            }
+        }
+
+        for (var r = 0; r < rows.Length; r++)
+        {
+            for (var c = 0; c < rows[r].Length; c++)
+            {
+                Assert.Equal(loop.Cells[r, c].Value, bulk.Cells[r, c].Value);
+                Assert.Equal(loop.Cells[r, c].ValueType, bulk.Cells[r, c].ValueType);
+            }
+        }
+    }
+
+    [Fact]
+    public void OverwritesCellsThatAlreadyHaveValues()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 4, 4);
+
+        sheet.Cells[0, 0].Value = "old";
+        sheet.Cells[0, 0].Format.Bold = true;
+
+        sheet.Cells.SetValues(0, 0, Block(["new"]));
+
+        Assert.Equal("new", sheet.Cells[0, 0].Value);
+
+        // The cell object is reused, so anything else on it survives - which is what assigning through
+        // the indexer does too.
+        Assert.True(sheet.Cells[0, 0].Format.Bold);
+    }
+
+    [Fact]
+    public void RaggedAndNullRowsLeaveTheRestAlone()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 5, 5);
+
+        sheet.Cells.SetValues(0, 0, Block(
+            ["a", "b", "c"],
+            null,
+            ["d"]));
+
+        Assert.Equal("c", sheet.Cells[0, 2].Value);
+        Assert.True(sheet.Cells[1, 0].IsEmpty);
+        Assert.Equal("d", sheet.Cells[2, 0].Value);
+        Assert.True(sheet.Cells[2, 1].IsEmpty);
+    }
+
+    [Fact]
+    public void EmptyInputDoesNothing()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 4, 4);
+
+        sheet.Cells.SetValues(0, 0, Array.Empty<IReadOnlyList<object?>?>());
+        sheet.Cells.SetValues(0, 0, Block(null, null));
+
+        Assert.True(sheet.Cells[0, 0].IsEmpty);
+    }
+
+    [Fact]
+    public void NullInputThrows() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new Workbook().AddSheet("Sheet1", 4, 4).Cells.SetValues(0, 0, null!));
+
+    // The bounds check is done once for the block rather than per cell, so it has to be done against
+    // the far corner - a block that starts inside the sheet and runs off it must still throw.
+    [Theory]
+    [InlineData(0, 0, 5, 2)]
+    [InlineData(0, 0, 2, 5)]
+    [InlineData(3, 3, 2, 2)]
+    [InlineData(-1, 0, 1, 1)]
+    public void ABlockThatDoesNotFitThrows(int row, int column, int height, int width)
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 4, 4);
+
+        var rows = new IReadOnlyList<object?>?[height];
+        for (var r = 0; r < height; r++)
+        {
+            rows[r] = new object?[width];
+        }
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => sheet.Cells.SetValues(row, column, rows));
+    }
+
+    // A formula over the block is correct when the call returns.
+    [Fact]
+    public void FormulasOverTheBlockAreEvaluatedAfterIt()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 5, 3);
+
+        sheet.Cells[4, 0].Formula = "=SUM(A1:A3)";
+
+        sheet.Cells.SetValues(0, 0, Block([1], [2], [3]));
+
+        Assert.Equal(6d, sheet.Cells[4, 0].Value);
+    }
+
+    // A value written over a formula replaces it. Cell.Value leaves Formula alone, so without clearing
+    // it the value is written and then evaluated back over by the formula that is still there.
+    [Fact]
+    public void AFormulaInsideTheBlockIsReplacedByTheValueWrittenOverIt()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 5, 3);
+
+        sheet.Cells[2, 0].Value = 10;
+        sheet.Cells[0, 0].Formula = "=A3+1";
+
+        Assert.Equal(11d, sheet.Cells[0, 0].Value);
+
+        sheet.Cells.SetValues(0, 0, Block(["x"]));
+
+        Assert.Equal("x", sheet.Cells[0, 0].Value);
+        Assert.Null(sheet.Cells[0, 0].Formula);
+    }
+
+    // And a formula outside the block still sees the write, which is what the batch is for.
+    [Fact]
+    public void AFormulaOverAReplacedFormulaIsEvaluatedAgainstTheValue()
+    {
+        var sheet = new Workbook().AddSheet("Sheet1", 5, 3);
+
+        sheet.Cells[2, 0].Value = 10;
+        sheet.Cells[0, 0].Formula = "=A3+1";
+        sheet.Cells[4, 0].Formula = "=A1*2";
+
+        Assert.Equal(22d, sheet.Cells[4, 0].Value);
+
+        sheet.Cells.SetValues(0, 0, Block([5]));
+
+        Assert.Equal(5d, sheet.Cells[0, 0].Value);
+        Assert.Equal(10d, sheet.Cells[4, 0].Value);
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/CellStoreSetValuesTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CellStoreSetValuesTests.cs
@@ -25,7 +25,6 @@ public class CellStoreSetValuesTests
         Assert.Equal("b", sheet.Cells[3, 1].Value);
         Assert.Equal(2d, sheet.Cells[3, 2].Value);
 
-        // Nothing outside the block was touched.
         Assert.True(sheet.Cells[2, 0].IsEmpty);
         Assert.True(sheet.Cells[4, 1].IsEmpty);
     }
@@ -73,8 +72,6 @@ public class CellStoreSetValuesTests
 
         Assert.Equal("new", sheet.Cells[0, 0].Value);
 
-        // The cell object is reused, so anything else on it survives - which is what assigning through
-        // the indexer does too.
         Assert.True(sheet.Cells[0, 0].Format.Bold);
     }
 
@@ -110,8 +107,6 @@ public class CellStoreSetValuesTests
         Assert.Throws<ArgumentNullException>(() =>
             new Workbook().AddSheet("Sheet1", 4, 4).Cells.SetValues(0, 0, null!));
 
-    // The bounds check is done once for the block rather than per cell, so it has to be done against
-    // the far corner - a block that starts inside the sheet and runs off it must still throw.
     [Theory]
     [InlineData(0, 0, 5, 2)]
     [InlineData(0, 0, 2, 5)]
@@ -130,7 +125,6 @@ public class CellStoreSetValuesTests
         Assert.Throws<ArgumentOutOfRangeException>(() => sheet.Cells.SetValues(row, column, rows));
     }
 
-    // A formula over the block is correct when the call returns.
     [Fact]
     public void FormulasOverTheBlockAreEvaluatedAfterIt()
     {
@@ -143,8 +137,6 @@ public class CellStoreSetValuesTests
         Assert.Equal(6d, sheet.Cells[4, 0].Value);
     }
 
-    // A value written over a formula replaces it. Cell.Value leaves Formula alone, so without clearing
-    // it the value is written and then evaluated back over by the formula that is still there.
     [Fact]
     public void AFormulaInsideTheBlockIsReplacedByTheValueWrittenOverIt()
     {
@@ -161,7 +153,6 @@ public class CellStoreSetValuesTests
         Assert.Null(sheet.Cells[0, 0].Formula);
     }
 
-    // And a formula outside the block still sees the write, which is what the batch is for.
     [Fact]
     public void AFormulaOverAReplacedFormulaIsEvaluatedAgainstTheValue()
     {

--- a/Radzen.Blazor.Tests/Spreadsheet/QuotePrefixRoundTripTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/QuotePrefixRoundTripTests.cs
@@ -41,7 +41,6 @@ public class QuotePrefixRoundTripTests
         Assert.True(loaded.Cells[0, 0].QuotePrefix);
     }
 
-    // Text without the marker is still inferred, which is what a cell typed as a number relies on.
     [Fact]
     public void TextWithoutTheMarkerIsStillInferred()
     {
@@ -56,9 +55,6 @@ public class QuotePrefixRoundTripTests
         Assert.False(loaded.Cells[0, 0].QuotePrefix);
     }
 
-    // The flag lives on the cell format and the format is shared by key, so a number or a date can
-    // carry it without ever having been text. Only a text cell is read back as text; the others keep
-    // the type they were written with, or a SUM over the range silently drops them.
     [Fact]
     public void ATypedCellCarryingTheFlagKeepsItsType()
     {
@@ -79,9 +75,6 @@ public class QuotePrefixRoundTripTests
         Assert.Equal(CellDataType.Number, loaded.Cells[0, 0].ValueType);
         Assert.Equal(5d, loaded.Cells[0, 0].Value);
 
-        // A number rather than a date: QuotePrefix is part of the style key, so a cell carrying it does
-        // not share the format that makes a serial read as a date. That is the writer's, it predates
-        // this, and it still sums - which a string would not.
         Assert.Equal(CellDataType.Number, loaded.Cells[1, 0].ValueType);
         Assert.Equal(43894d, loaded.Cells[1, 0].Value);
 

--- a/Radzen.Blazor.Tests/Spreadsheet/QuotePrefixRoundTripTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/QuotePrefixRoundTripTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class QuotePrefixRoundTripTests
+{
+    private static Worksheet RoundTrip(Workbook workbook)
+    {
+        using var stream = new MemoryStream();
+
+        workbook.SaveToStream(stream);
+        stream.Position = 0;
+
+        return Workbook.LoadFromStream(stream).Sheets[0];
+    }
+
+    [Theory]
+    [InlineData("007")]
+    [InlineData("1E3")]
+    [InlineData("00123")]
+    [InlineData("2020-03-04")]
+    [InlineData("1/2")]
+    public void TextEnteredWithALeadingApostropheStaysText(string text)
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 1);
+
+        sheet.Cells[0, 0].SetValue("'" + text);
+
+        Assert.Equal(CellDataType.String, sheet.Cells[0, 0].ValueType);
+
+        var loaded = RoundTrip(workbook);
+
+        Assert.Equal(CellDataType.String, loaded.Cells[0, 0].ValueType);
+        Assert.Equal(text, loaded.Cells[0, 0].Value);
+        Assert.True(loaded.Cells[0, 0].QuotePrefix);
+    }
+
+    // Text without the marker is still inferred, which is what a cell typed as a number relies on.
+    [Fact]
+    public void TextWithoutTheMarkerIsStillInferred()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 1);
+
+        sheet.Cells[0, 0].Value = "007";
+
+        var loaded = RoundTrip(workbook);
+
+        Assert.Equal(CellDataType.Number, loaded.Cells[0, 0].ValueType);
+        Assert.False(loaded.Cells[0, 0].QuotePrefix);
+    }
+
+    // The flag lives on the cell format and the format is shared by key, so a number or a date can
+    // carry it without ever having been text. Only a text cell is read back as text; the others keep
+    // the type they were written with, or a SUM over the range silently drops them.
+    [Fact]
+    public void ATypedCellCarryingTheFlagKeepsItsType()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 4, 1);
+
+        sheet.Cells[0, 0].Value = 5;
+        sheet.Cells[0, 0].QuotePrefix = true;
+
+        sheet.Cells[1, 0].Value = new DateTime(2020, 3, 4);
+        sheet.Cells[1, 0].QuotePrefix = true;
+
+        sheet.Cells[2, 0].Value = true;
+        sheet.Cells[2, 0].QuotePrefix = true;
+
+        var loaded = RoundTrip(workbook);
+
+        Assert.Equal(CellDataType.Number, loaded.Cells[0, 0].ValueType);
+        Assert.Equal(5d, loaded.Cells[0, 0].Value);
+
+        // A number rather than a date: QuotePrefix is part of the style key, so a cell carrying it does
+        // not share the format that makes a serial read as a date. That is the writer's, it predates
+        // this, and it still sums - which a string would not.
+        Assert.Equal(CellDataType.Number, loaded.Cells[1, 0].ValueType);
+        Assert.Equal(43894d, loaded.Cells[1, 0].Value);
+
+        Assert.Equal(CellDataType.Boolean, loaded.Cells[2, 0].ValueType);
+        Assert.Equal(true, loaded.Cells[2, 0].Value);
+    }
+}

--- a/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
@@ -198,8 +198,6 @@ public class Cell
     internal void SetText(string value)
     {
         Formula = null;
-        // Bypass the Value setter: the quote prefix means literal text, so the
-        // string must not go through type inference ('0123 stays "0123").
         Data = CellData.FromString(value);
         QuotePrefix = true;
 

--- a/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
@@ -192,6 +192,21 @@ public class Cell
     }
 
     /// <summary>
+    /// Stores the value as literal text and sets <see cref="QuotePrefix"/> - the apostrophe protocol
+    /// of <see cref="SetValue"/> without the apostrophe.
+    /// </summary>
+    internal void SetText(string value)
+    {
+        Formula = null;
+        // Bypass the Value setter: the quote prefix means literal text, so the
+        // string must not go through type inference ('0123 stays "0123").
+        Data = CellData.FromString(value);
+        QuotePrefix = true;
+
+        Worksheet.OnCellValueChanged(this);
+    }
+
+    /// <summary>
     /// Gets the value of the cell as a string, or the formula if it exists.
     /// </summary>
     public string? GetValue()
@@ -233,12 +248,7 @@ public class Cell
     {
         if (value is not null && value.StartsWith('\''))
         {
-            Formula = null;
-            // Bypass the Value setter: the quote prefix means literal text, so the
-            // string must not go through type inference ('0123 stays "0123").
-            Data = CellData.FromString(value[1..]);
-            QuotePrefix = true;
-            Worksheet.OnCellValueChanged(this);
+            SetText(value[1..]);
         }
         else if (value?.StartsWith('=') == true && value != "=")
         {

--- a/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
@@ -155,7 +155,7 @@ public class Cell
     /// <summary>
     /// Gets the current value and its type as a CellData object.
     /// </summary>
-    public CellData Data { get; internal set; } = new CellData(null);
+    public CellData Data { get; internal set; } = CellData.Empty;
 
 
     /// <summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
@@ -100,6 +100,16 @@ public class CellData : IComparable, IComparable<CellData>
     public CellDataType Type { get; }
 
     /// <summary>
+    /// The empty value, shared. <see cref="CellData"/> carries a value and a type and neither can be
+    /// set, so every empty cell can point at one instance instead of allocating its own.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="Cell"/> holds this until it is given a value, so no cell allocates an instance to
+    /// represent nothing.
+    /// </remarks>
+    public static CellData Empty { get; } = new(null);
+
+    /// <summary>
     /// Creates a new instance of CellData with the specified data. String values are type-inferred
     /// using the invariant culture.
     /// </summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/CellDependencyGraph.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellDependencyGraph.cs
@@ -18,7 +18,6 @@ internal class CellDependencyGraph
         return [];
     }
 
-    // Whether anything depends on this cell, without building the walk to find out.
     public bool HasDependents(Cell cell) => dependents.TryGetValue(cell, out var cells) && cells.Count > 0;
 
     public IEnumerable<Cell> GetTopologicallySortedDependencies(Cell cell) => GetTopologicallySortedDependencies(GetDependentCells(cell));

--- a/Radzen.Blazor/Documents/Spreadsheet/CellDependencyGraph.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellDependencyGraph.cs
@@ -18,6 +18,9 @@ internal class CellDependencyGraph
         return [];
     }
 
+    // Whether anything depends on this cell, without building the walk to find out.
+    public bool HasDependents(Cell cell) => dependents.TryGetValue(cell, out var cells) && cells.Count > 0;
+
     public IEnumerable<Cell> GetTopologicallySortedDependencies(Cell cell) => GetTopologicallySortedDependencies(GetDependentCells(cell));
 
     public IEnumerable<Cell> GetTopologicallySortedDependencies() => GetTopologicallySortedDependencies(dependencies.Keys);

--- a/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
@@ -285,8 +285,6 @@ public class CellStore(Worksheet sheet)
             {
                 var cell = GetOrAdd(row + r, column + c);
 
-                // The value setter leaves Formula alone, so without this the formula stays and is
-                // evaluated back over what was just written.
                 cell.Formula = null;
                 cell.Value = line[c];
             }

--- a/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
@@ -41,12 +41,7 @@ public class CellStore(Worksheet sheet)
         {
             EnsureWithinBounds(row, column);
 
-            if (!data.TryGetValue((row, column), out var cell))
-            {
-                this[row, column] = cell = new(Worksheet, new CellRef(row, column));
-            }
-
-            return cell;
+            return GetOrAdd(row, column);
         }
 
         set
@@ -218,6 +213,94 @@ public class CellStore(Worksheet sheet)
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Fills a rectangular block of cells from a jagged array, in one pass.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Filling a sheet a cell at a time through <see cref="this[int, int]"/> pays, per cell, two
+    /// bounds checks and two dictionary operations - the getter looks the cell up, misses, and the
+    /// setter it delegates to looks it up again to insert - plus whatever rehashing the dictionary
+    /// does on the way up to its final size. This does the bounds check once for the block, sizes the
+    /// dictionary once and looks each cell up once.
+    /// </para>
+    /// <para>
+    /// Not wrapped in an update batch. Each write notifies its own dependents, exactly as an
+    /// assignment through the indexer does; suspending evaluation would make the sheet re-run every
+    /// formula it has, including the ones that do not read the block.
+    /// </para>
+    /// <para>
+    /// Rows may be ragged; a short row leaves the cells past its end untouched, and a null row is
+    /// skipped. A value replaces whatever the cell held, a formula included. Values are assigned
+    /// through <see cref="Cell.Value"/>, so the same type inference applies as when they are written
+    /// one at a time.
+    /// </para>
+    /// </remarks>
+    /// <param name="row">The zero-based row the block starts at.</param>
+    /// <param name="column">The zero-based column the block starts at.</param>
+    /// <param name="values">The values, one array per row.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="values"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The block does not fit in the sheet.</exception>
+    public void SetValues(int row, int column, IReadOnlyList<IReadOnlyList<object?>?> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        if (values.Count == 0)
+        {
+            return;
+        }
+
+        var widest = 0;
+        var total = 0;
+
+        for (var r = 0; r < values.Count; r++)
+        {
+            if (values[r] is { } line)
+            {
+                widest = Math.Max(widest, line.Count);
+                total += line.Count;
+            }
+        }
+
+        if (total == 0)
+        {
+            return;
+        }
+
+        EnsureWithinBounds(row, column);
+        EnsureWithinBounds(row + values.Count - 1, column + widest - 1);
+
+        data.EnsureCapacity(data.Count + total);
+
+        for (var r = 0; r < values.Count; r++)
+        {
+            if (values[r] is not { } line)
+            {
+                continue;
+            }
+
+            for (var c = 0; c < line.Count; c++)
+            {
+                var cell = GetOrAdd(row + r, column + c);
+
+                // The value setter leaves Formula alone, so without this the formula stays and is
+                // evaluated back over what was just written.
+                cell.Formula = null;
+                cell.Value = line[c];
+            }
+        }
+    }
+
+    private Cell GetOrAdd(int row, int column)
+    {
+        if (!data.TryGetValue((row, column), out var cell))
+        {
+            this[row, column] = cell = new Cell(Worksheet, new CellRef(row, column));
+        }
+
+        return cell;
     }
 
     /// <summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Worksheet.cs
@@ -398,7 +398,7 @@ public partial class Worksheet
 
         // During a batch, EndUpdate recalculates dependent formulas once. The changed cell
         // itself is not a formula node, so it would never be notified - fire its event here.
-        if (!IsUpdating)
+        if (!IsUpdating && graph.HasDependents(cell))
         {
             var dependents = graph.GetTopologicallySortedDependencies(cell);
 

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
@@ -5,6 +5,13 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Xml.Linq;
+
+// The cell format record ParseCellStyles builds, named so that it can be resolved once per cell and
+// handed on rather than looked up again by everything that reads it.
+using CellXf = (int FontId, int FillId, int BorderId, Radzen.TextAlign? TextAlign,
+    Radzen.VerticalAlign? VerticalAlign, bool WrapText, int NumFmtId, bool? Locked, bool? FormulaHidden,
+    bool QuotePrefix);
+
 namespace Radzen.Documents.Spreadsheet;
 
 #nullable enable
@@ -641,6 +648,8 @@ static class XlsxReader
 
         var cellType = (string?)cellElem.Attribute("t") ?? "n";
 
+        var style = ResolveStyle(cellElem, styleInfo);
+
         var formulaValue = formulaElem?.Value;
 
         // ECMA-376 part 1, 18.3.1.40 (shared formulas)
@@ -682,18 +691,32 @@ static class XlsxReader
                     _ => valueElem!.Value
                 };
 
-                sheet.Cells[address.Row, address.Column].SetValueInvariant(value);
+                // ECMA-376 part 1, 18.8.45: quotePrefix on the cell's format marks a value entered as
+                // literal text, and only a text cell can have been. SetValueInvariant infers a type
+                // from the text, which turns "007" into 7 and "1E3" into 1000.
+                if (style is { QuotePrefix: true } && cellType is "s" or "str" or "inlineStr")
+                {
+                    sheet.Cells[address.Row, address.Column].SetText(value);
+                }
+                else
+                {
+                    sheet.Cells[address.Row, address.Column].SetValueInvariant(value);
+                }
             }
         }
 
-        ApplyCellStyle(cellElem, sheet, address, styleInfo);
+        ApplyCellStyle(sheet, address, styleInfo, style);
     }
 
-    private static void ApplyCellStyle(XElement cellElem, Worksheet sheet, CellRef address, StyleInfo styleInfo)
+    private static CellXf? ResolveStyle(XElement cellElem, StyleInfo styleInfo) =>
+        cellElem.Attribute("s")?.Value is string styleId &&
+        styleInfo.CellStyles.TryGetValue(int.Parse(styleId, CultureInfo.InvariantCulture), out var found)
+            ? found
+            : null;
+
+    private static void ApplyCellStyle(Worksheet sheet, CellRef address, StyleInfo styleInfo, CellXf? resolved)
     {
-        var styleId = cellElem.Attribute("s")?.Value;
-        if (styleId is not null &&
-            styleInfo.CellStyles.TryGetValue(int.Parse(styleId, CultureInfo.InvariantCulture), out var style))
+        if (resolved is { } style)
         {
             var fmt = sheet.Cells[address.Row, address.Column].Format;
 

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
@@ -6,8 +6,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Xml.Linq;
 
-// The cell format record ParseCellStyles builds, named so that it can be resolved once per cell and
-// handed on rather than looked up again by everything that reads it.
 using CellXf = (int FontId, int FillId, int BorderId, Radzen.TextAlign? TextAlign,
     Radzen.VerticalAlign? VerticalAlign, bool WrapText, int NumFmtId, bool? Locked, bool? FormulaHidden,
     bool QuotePrefix);
@@ -676,8 +674,7 @@ static class XlsxReader
         }
         else if (valueElem is not null)
         {
-            // ECMA-376 part 1, 18.18.11: t="b" is a boolean. Its <v> is ST_Xstring, so a producer may
-            // write the word rather than 1 or 0.
+            // ECMA-376 part 1, 18.18.11 (t="b"), 22.9.2.19 (ST_Xstring)
             if (cellType == "b")
             {
                 sheet.Cells[address.Row, address.Column].Value =
@@ -691,9 +688,7 @@ static class XlsxReader
                     _ => valueElem!.Value
                 };
 
-                // ECMA-376 part 1, 18.8.45: quotePrefix on the cell's format marks a value entered as
-                // literal text, and only a text cell can have been. SetValueInvariant infers a type
-                // from the text, which turns "007" into 7 and "1E3" into 1000.
+                // ECMA-376 part 1, 18.8.45 (quotePrefix)
                 if (style is { QuotePrefix: true } && cellType is "s" or "str" or "inlineStr")
                 {
                     sheet.Cells[address.Row, address.Column].SetText(value);

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
@@ -667,13 +667,23 @@ static class XlsxReader
         }
         else if (valueElem is not null)
         {
-            var value = cellType switch
+            // ECMA-376 part 1, 18.18.11: t="b" is a boolean. Its <v> is ST_Xstring, so a producer may
+            // write the word rather than 1 or 0.
+            if (cellType == "b")
             {
-                "s" => sharedStrings[Convert.ToInt32(valueElem!.Value, CultureInfo.InvariantCulture)],
-                _ => valueElem!.Value
-            };
+                sheet.Cells[address.Row, address.Column].Value =
+                    valueElem.Value is "1" || bool.TryParse(valueElem.Value, out var flag) && flag;
+            }
+            else
+            {
+                var value = cellType switch
+                {
+                    "s" => sharedStrings[Convert.ToInt32(valueElem!.Value, CultureInfo.InvariantCulture)],
+                    _ => valueElem!.Value
+                };
 
-            sheet.Cells[address.Row, address.Column].SetValueInvariant(value);
+                sheet.Cells[address.Row, address.Column].SetValueInvariant(value);
+            }
         }
 
         ApplyCellStyle(cellElem, sheet, address, styleInfo);


### PR DESCRIPTION
Five independent changes to `Radzen.Documents.Spreadsheet`, found while writing a data-grid export over
it. Each commit stands alone and can be taken or dropped separately.

### 1. Read a boolean cell back as a boolean

`XlsxWriter` writes `t="b"` correctly. `XlsxReader` ignored the attribute — every type but a shared
string fell through to `SetValueInvariant`, which re-infers from the text — so `<v>1</v>` came back as
the number 1. A boolean written by the library did not survive being read by it.

ECMA-376 types `<v>` as `ST_Xstring`, so a producer may write the word rather than the digit. The branch
accepts `1` and anything `bool.TryParse` takes, which is what the old path accepted before it.

### 2. Keep a quote-prefixed cell as text when reading

`quotePrefix` on a cell's format marks a value entered as literal text (ECMA-376 §18.8.45). `XlsxReader`
parsed the attribute into its style table, then set the value through the type-inferring path anyway —
so `007` came back as 7 and `1E3` as 1000. Same shape as (1): the file was correct and the reader
re-typed it.

Only a text cell is read back as text. The flag lives on the cell format and formats are shared by key,
so a number or a date can carry it without ever having been text; without that guard those load as
strings and a `SUM` over the range silently drops them.

The style is resolved once at the top of `ParseCell` and handed to `ApplyCellStyle`, which used to look
it up again for the same cell.

### 3. Do not walk the dependency graph for a cell nothing depends on

`OnCellValueChanged` runs on every write to `Cell.Value` and asks which cells depend on it.
`GetTopologicallySortedDependencies` allocates a `HashSet`, a `List` and a `Stack` before it can answer,
so a sheet with no formulas pays three allocations per cell for an empty result. `HasDependents` answers
off the dictionary already kept.

No API change.

### 4. Share one `CellData` for every empty cell

`Cell` initialised `Data` with `new CellData(null)`, so every cell allocated an object representing
nothing — and discarded it on first write. `CellData` has no setters, so one instance serves them all.

Adds `CellData.Empty`.

### 5. `CellStore.SetValues`, a bulk entrance

Filling a cell at a time grows the cell dictionary from empty, rehashing its way up to the final size.
`SetValues` knows how big the block is before it starts and sizes the dictionary once. It also does the
bounds check once for the block rather than once per cell.

**No update batch.** Each write notifies its own dependents, exactly as an assignment through the
indexer does — see below. A value replaces whatever the cell held, a formula included.

Adds `SetValues`. This is the only commit that adds meaningful public API.

## Measurements

50,000 rows × 11 columns of mixed strings, numbers, dates and booleans — 550,000 cells — three
interleaved passes, allocation via `GC.GetTotalAllocatedBytes(precise: true)`. **The values are
constructed before the measured region**, so the figures are the sheet's cost rather than the test
data's.

| | a cell at a time | via `SetValues` |
| --- | --- | --- |
| upstream | 197.6 MB | — |
| + no dependency walk (3) | 130.5 MB | — |
| + shared empty `CellData` (4) | 113.7 MB | — |
| + `SetValues` (5) | 113.7 MB | **94.0 MB** |

**52% less allocation**, and the drop to 113.7 MB arrives without any caller changing a line.

`SetValues`' share of that is **entirely the dictionary pre-sizing**: commenting out its
`EnsureCapacity` puts the arm back to 113.7 MB exactly, byte for byte with the indexer loop. The bounds
check it also saves per cell costs no allocation, and does not show above the noise in time.

Wall-clock is not quoted as a result anywhere here. On this machine the same benchmark arm has come back
at 1.36×, 1.40× and 1.79× of its baseline across three runs of one unchanged binary; `SetValues` itself
has measured both faster and slower than the indexer loop depending on the shape of the harness, while
its allocation was identical to the tenth of a megabyte every time.

*(An earlier version of this description gave 217 → 150 → 133 → 114 MB. Those came from a throwaway
harness that no longer existed; the rebuilt one reports about 20% lower at every rung because it builds
the test values outside the measured region rather than inside it. The code is the same either way — the
old numbers were simply not reproducible, so they have been replaced by ones that are.)*

### Why `SetValues` does not batch

`Worksheet.Batch` suspends formula evaluation, and `EndUpdate` then walks **every formula cell on the
sheet** with no dirty tracking. A 10×10 block written to a sheet carrying 5,000 unrelated formulas:

| | allocated |
| --- | --- |
| `SetValues`, no batch | **0.02 MB** |
| the same inside a batch | **1.94 MB** |

A hundredfold for a hundred cells, all of it re-evaluating formulas that never read the block. On a
sheet with no formulas the two are identical to the byte — 94.0 MB either way over 550,000 cells — which
is why no test can see the difference.

`Worksheet.Batch` itself is untouched and still used by `Sort`, `DeleteRow` and `InsertRow`; what
changed is that `SetValues` does not call it.
