### PR TITLE
Reduce XlsxWriter allocation: 442 MB to 12 MB over 550,000 cells, zero-GC

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/ColumnRefTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/ColumnRefTests.cs
@@ -1,0 +1,71 @@
+using System;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class ColumnRefTests
+{
+    [Theory]
+    [InlineData(0, "A")]
+    [InlineData(25, "Z")]
+    [InlineData(26, "AA")]
+    [InlineData(27, "AB")]
+    [InlineData(51, "AZ")]
+    [InlineData(52, "BA")]
+    [InlineData(701, "ZZ")]
+    [InlineData(702, "AAA")]
+    [InlineData(16383, "XFD")]
+    public void ToString_WritesTheColumnInA1Notation(int column, string expected)
+    {
+        Assert.Equal(expected, ColumnRef.ToString(column));
+    }
+
+    [Fact]
+    public void ToString_RejectsANegativeColumn()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ColumnRef.ToString(-1));
+    }
+
+    [Theory]
+    [InlineData(0, 0, "A1")]
+    [InlineData(1, 26, "AA2")]
+    [InlineData(99, 702, "AAA100")]
+    public void CellRef_ToString_WritesTheColumnThenTheRow(int row, int column, string expected)
+    {
+        Assert.Equal(expected, new CellRef(row, column).ToString());
+    }
+
+    [Theory]
+    [InlineData(1048575, 16383, "XFD1048576")]
+    [InlineData(int.MaxValue, 0, "A-2147483648")]
+    public void CellRef_ToString_WritesTheWidestReferences(int row, int column, string expected)
+    {
+        Assert.Equal(expected, new CellRef(row, column).ToString());
+    }
+
+    [Fact]
+    public void CellRef_ToString_WritesTheWidestReferenceOfAll()
+    {
+        var reference = new CellRef(int.MaxValue, 2147483646)
+        {
+            IsRowAbsolute = true,
+            IsColumnAbsolute = true,
+        };
+
+        var text = reference.ToString();
+
+        Assert.Equal("$FXSHRXW$-2147483648", text);
+        Assert.Equal(CellRef.MaxLength, text.Length);
+    }
+
+    [Fact]
+    public void CellRef_ToString_MarksAnAbsoluteReference()
+    {
+        var reference = new CellRef(1, 27) { IsRowAbsolute = true, IsColumnAbsolute = true };
+
+        Assert.Equal("$AB$2", reference.ToString());
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/SharedStringTableTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SharedStringTableTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class SharedStringTableTests
+{
+    [Fact]
+    public void GetOrAdd_NumbersStringsInTheOrderTheyArrive()
+    {
+        using var table = new SharedStringTable();
+
+        Assert.Equal(0, table.GetOrAdd("b"));
+        Assert.Equal(1, table.GetOrAdd("a"));
+        Assert.Equal(2, table.GetOrAdd(string.Empty));
+
+        Assert.Equal(new[] { "b", "a", string.Empty }, table.Strings.ToArray());
+        Assert.Equal(3, table.Count);
+    }
+
+    [Fact]
+    public void GetOrAdd_ReturnsTheIndexAnEqualStringAlreadyHas()
+    {
+        using var table = new SharedStringTable();
+
+        table.GetOrAdd("Yes");
+        table.GetOrAdd("No");
+
+        Assert.Equal(0, table.GetOrAdd(new string("Yes".ToCharArray())));
+        Assert.Equal(1, table.GetOrAdd("No"));
+        Assert.Equal(2, table.Count);
+    }
+
+    [Fact]
+    public void GetOrAdd_KeepsEveryIndexAcrossGrowth()
+    {
+        using var table = new SharedStringTable();
+
+        var texts = new List<string>();
+
+        for (var i = 0; i < 100_000; i++)
+        {
+            var text = "row " + i.ToString(CultureInfo.InvariantCulture);
+            texts.Add(text);
+
+            Assert.Equal(i, table.GetOrAdd(text));
+        }
+
+        for (var i = 0; i < texts.Count; i++)
+        {
+            Assert.Equal(i, table.GetOrAdd(texts[i]));
+        }
+
+        Assert.Equal(texts.Count, table.Count);
+        Assert.Equal(texts, table.Strings.ToArray());
+    }
+
+    [Fact]
+    public void GetOrAdd_LooksAStringUpAtTheCapacityBoundaryWithoutAdding()
+    {
+        using var table = new SharedStringTable();
+
+        // 256 is the table's first capacity; a hit while it is full must not add or grow.
+        for (var i = 0; i < 256; i++)
+        {
+            table.GetOrAdd(i.ToString(CultureInfo.InvariantCulture));
+        }
+
+        Assert.Equal(0, table.GetOrAdd("0"));
+        Assert.Equal(255, table.GetOrAdd("255"));
+        Assert.Equal(256, table.Count);
+
+        Assert.Equal(256, table.GetOrAdd("256"));
+        Assert.Equal(0, table.GetOrAdd("0"));
+        Assert.Equal(257, table.Count);
+    }
+
+    [Fact]
+    public void Dispose_EmptiesTheTable()
+    {
+        var table = new SharedStringTable();
+
+        for (var i = 0; i < 1000; i++)
+        {
+            table.GetOrAdd(i.ToString(CultureInfo.InvariantCulture));
+        }
+
+        table.Dispose();
+
+        Assert.Equal(0, table.Count);
+        Assert.True(table.Strings.IsEmpty);
+        Assert.Equal(0, table.GetOrAdd("again"));
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/SharedStringTableTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SharedStringTableTests.cs
@@ -64,7 +64,6 @@ public class SharedStringTableTests
     {
         using var table = new SharedStringTable();
 
-        // 256 is the table's first capacity; a hit while it is full must not add or grow.
         for (var i = 0; i < 256; i++)
         {
             table.GetOrAdd(i.ToString(CultureInfo.InvariantCulture));

--- a/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterCellFormatTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterCellFormatTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class XlsxWriterCellFormatTests
+{
+    private static readonly XNamespace Main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private static Dictionary<string, XDocument> Save(Workbook workbook)
+    {
+        using var stream = new MemoryStream();
+        workbook.SaveToStream(stream);
+        stream.Position = 0;
+
+        var parts = new Dictionary<string, XDocument>();
+        using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
+
+        foreach (var entry in zip.Entries.Where(e => e.FullName.EndsWith(".xml", StringComparison.Ordinal)))
+        {
+            using var part = entry.Open();
+            parts[entry.FullName] = XDocument.Load(part);
+        }
+
+        return parts;
+    }
+
+    private static XElement CellFormat(Dictionary<string, XDocument> parts, string reference)
+    {
+        var cell = parts["xl/worksheets/sheet1.xml"].Descendants(Main + "c")
+            .Single(c => (string?)c.Attribute("r") == reference);
+
+        var index = int.Parse((string)cell.Attribute("s")!, CultureInfo.InvariantCulture);
+
+        return parts["xl/styles.xml"].Root!.Element(Main + "cellXfs")!
+            .Elements(Main + "xf").ElementAt(index);
+    }
+
+    [Fact]
+    public void Save_DoesNotGiveAnUnformattedCellAFormat()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 4, 1);
+
+        sheet.Cells[0, 0].SetValue("text");
+        sheet.Cells[1, 0].Value = 42;
+        sheet.Cells[2, 0].Value = true;
+
+        sheet.Cells[3, 0].Value = new DateTime(2020, 1, 1);
+
+        using var stream = new MemoryStream();
+        workbook.SaveToStream(stream);
+
+        for (var row = 0; row < 4; row++)
+        {
+            Assert.Null(sheet.Cells[row, 0].FormatOrNull);
+        }
+    }
+
+    [Fact]
+    public void Save_KeepsAFormatTheCellWasGiven()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 1, 1);
+
+        sheet.Cells[0, 0].Value = 42;
+        sheet.Cells[0, 0].Format.Bold = true;
+
+        using var stream = new MemoryStream();
+        workbook.SaveToStream(stream);
+
+        Assert.True(sheet.Cells[0, 0].FormatOrNull?.Bold);
+    }
+
+    [Fact]
+    public void Save_StylesADateWithNoFormatAsADate()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 1, 1);
+
+        sheet.Cells[0, 0].Value = new DateTime(2020, 1, 1);
+
+        var xf = CellFormat(Save(workbook), "A1");
+
+        Assert.Equal("14", (string?)xf.Attribute("numFmtId"));
+        Assert.Equal("1", (string?)xf.Attribute("applyNumberFormat"));
+    }
+
+    [Fact]
+    public void Save_MarksAQuotePrefixedCellWithNoFormat()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 1, 1);
+
+        sheet.Cells[0, 0].SetValue("'4.00E+003");
+
+        var xf = CellFormat(Save(workbook), "A1");
+
+        Assert.Equal("1", (string?)xf.Attribute("quotePrefix"));
+        Assert.Equal("1", (string?)xf.Attribute("applyQuotePrefix"));
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
@@ -135,6 +135,46 @@ public class XlsxWriterSheetOrderTests
     }
 
     [Fact]
+    public void Save_NumbersAMergeAnchorsStyleWhereTheAnchorIsWritten()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 4, 4);
+
+        sheet.Cells[2, 0].Value = 3;
+        sheet.Cells[2, 0].Format.Italic = true;
+        sheet.MergedCells.Add(new RangeRef(new CellRef(2, 0), new CellRef(2, 1)));
+
+        sheet.Cells[0, 0].Value = 1;
+        sheet.Cells[0, 0].Format.Bold = true;
+
+        var cells = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "c")
+            .ToDictionary(c => (string)c.Attribute("r")!, c => int.Parse((string)c.Attribute("s")!, CultureInfo.InvariantCulture));
+
+        Assert.True(cells["A1"] < cells["A3"]);
+        Assert.Equal(cells["A3"], cells["B3"]);
+    }
+
+    [Fact]
+    public void Save_NumbersAMergeAnchorsStyleWhereItsFirstPlaceholderIsWritten()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 4, 4);
+
+        sheet.Cells[2, 0].Format.Italic = true;
+        sheet.MergedCells.Add(new RangeRef(new CellRef(2, 0), new CellRef(2, 2)));
+
+        sheet.Cells[0, 0].Value = 1;
+        sheet.Cells[0, 0].Format.Bold = true;
+
+        var cells = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "c")
+            .ToDictionary(c => (string)c.Attribute("r")!, c => int.Parse((string)c.Attribute("s")!, CultureInfo.InvariantCulture));
+
+        Assert.False(cells.ContainsKey("A3"));
+        Assert.True(cells["A1"] < cells["B3"]);
+        Assert.Equal(cells["B3"], cells["C3"]);
+    }
+
+    [Fact]
     public void Save_WritesAMergeThatReachesPastTheSheetBounds()
     {
         var workbook = new Workbook();
@@ -184,6 +224,35 @@ public class XlsxWriterSheetOrderTests
         Assert.NotNull(cells["A8"]);
         Assert.Equal(cells["A8"], cells["A9"]);
         Assert.Equal(cells["A8"], cells["A10"]);
+    }
+
+    [Fact]
+    public void Save_WritesAnAddressTwoMergesCoverOnceWithTheFirstMergesStyle()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 24);
+
+        // Wide enough that the placeholder list is past the length List.Sort handles with a stable
+        // insertion sort, so the insertion index is what keeps the first merge's copy first.
+        sheet.Cells[0, 0].SetValue("first");
+        sheet.Cells[0, 0].Format.Bold = true;
+        sheet.MergedCells.Add(new RangeRef(new CellRef(0, 0), new CellRef(1, 20)));
+
+        sheet.Cells[1, 1].SetValue("second");
+        sheet.Cells[1, 1].Format.Italic = true;
+        sheet.MergedCells.Add(new RangeRef(new CellRef(1, 1), new CellRef(2, 3)));
+
+        var cells = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "c").ToList();
+        var references = cells.Select(c => (string?)c.Attribute("r")).ToList();
+
+        Assert.Equal(references.Distinct().Count(), references.Count);
+
+        var styles = cells.ToDictionary(c => (string)c.Attribute("r")!, c => (string?)c.Attribute("s"));
+
+        Assert.Equal(styles["A1"], styles["C2"]);
+        Assert.Equal(styles["A1"], styles["D2"]);
+        Assert.Equal(styles["B2"], styles["C3"]);
+        Assert.NotEqual(styles["A1"], styles["B2"]);
     }
 
     [Fact]

--- a/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
@@ -135,6 +135,58 @@ public class XlsxWriterSheetOrderTests
     }
 
     [Fact]
+    public void Save_WritesAMergeThatReachesPastTheSheetBounds()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 10, 1);
+
+        sheet.Cells[9, 0].SetValue("last");
+        sheet.MergedCells.Add(new RangeRef(new CellRef(0, 0), new CellRef(9, 0)));
+
+        sheet.Rows.Count = 5;
+
+        var references = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "c")
+            .Select(c => (string?)c.Attribute("r"))
+            .ToList();
+
+        Assert.Equal(new[] { "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10" }, references);
+    }
+
+    [Fact]
+    public void Save_DoesNotAddACellForAnEmptyMergeAnchor()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 4, 4);
+
+        sheet.MergedCells.Add(new RangeRef(new CellRef(1, 1), new CellRef(2, 2)));
+
+        Part(workbook, "xl/worksheets/sheet1.xml");
+
+        Assert.Equal(0, sheet.Cells.PopulatedCount);
+    }
+
+    [Fact]
+    public void Save_StylesAMergeWhoseAnchorIsPastTheSheetBounds()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 10, 1);
+
+        sheet.Cells[7, 0].SetValue("anchor");
+        sheet.Cells[7, 0].Format.Bold = true;
+        sheet.MergedCells.Add(new RangeRef(new CellRef(7, 0), new CellRef(9, 0)));
+
+        sheet.Rows.Count = 5;
+
+        var cells = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "c")
+            .ToDictionary(c => (string)c.Attribute("r")!, c => (string?)c.Attribute("s"));
+
+        Assert.Equal(new[] { "A8", "A9", "A10" }, cells.Keys);
+        Assert.NotNull(cells["A8"]);
+        Assert.Equal(cells["A8"], cells["A9"]);
+        Assert.Equal(cells["A8"], cells["A10"]);
+    }
+
+    [Fact]
     public void Save_IndexesSharedStringsInTheOrderTheCellsAreWritten()
     {
         var strings = Part(FilledBackwards(), "xl/sharedStrings.xml")

--- a/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
@@ -232,8 +232,6 @@ public class XlsxWriterSheetOrderTests
         var workbook = new Workbook();
         var sheet = workbook.AddSheet("Sheet1", 8, 24);
 
-        // Wide enough that the placeholder list is past the length List.Sort handles with a stable
-        // insertion sort, so the insertion index is what keeps the first merge's copy first.
         sheet.Cells[0, 0].SetValue("first");
         sheet.Cells[0, 0].Format.Bold = true;
         sheet.MergedCells.Add(new RangeRef(new CellRef(0, 0), new CellRef(1, 20)));

--- a/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
@@ -256,6 +256,38 @@ public class XlsxWriterSheetOrderTests
     }
 
     [Fact]
+    public void Save_SpansARowFromAPlaceholderBeforeItsFirstCell()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 8);
+
+        sheet.MergedCells.Add(new RangeRef(new CellRef(4, 0), new CellRef(4, 1)));
+        sheet.Cells[4, 3].SetValue("cell");
+
+        var row = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "row").Single();
+
+        Assert.Equal("5", (string?)row.Attribute("r"));
+        Assert.Equal("2:4", (string?)row.Attribute("spans"));
+        Assert.Equal(new[] { "B5", "D5" }, row.Elements(Main + "c").Select(c => (string?)c.Attribute("r")));
+    }
+
+    [Fact]
+    public void Save_SpansARowThatHoldsOnlyPlaceholders()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 8);
+
+        sheet.MergedCells.Add(new RangeRef(new CellRef(0, 0), new CellRef(1, 2)));
+
+        var rows = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "row").ToList();
+
+        Assert.Equal(new[] { "1", "2" }, rows.Select(r => (string?)r.Attribute("r")));
+        Assert.Equal("2:3", (string?)rows[0].Attribute("spans"));
+        Assert.Equal("1:3", (string?)rows[1].Attribute("spans"));
+        Assert.Equal(new[] { "A2", "B2", "C2" }, rows[1].Elements(Main + "c").Select(c => (string?)c.Attribute("r")));
+    }
+
+    [Fact]
     public void Save_IndexesSharedStringsInTheOrderTheCellsAreWritten()
     {
         var strings = Part(FilledBackwards(), "xl/sharedStrings.xml")

--- a/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class XlsxWriterSheetOrderTests
+{
+    private static readonly XNamespace Main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private static XDocument Part(Workbook workbook, string name)
+    {
+        using var stream = new MemoryStream();
+        workbook.SaveToStream(stream);
+        stream.Position = 0;
+
+        using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
+        using var part = zip.GetEntry(name)!.Open();
+
+        return XDocument.Load(part);
+    }
+
+    private static Workbook FilledBackwards()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 4, 4);
+
+        for (var row = 2; row >= 0; row--)
+        {
+            for (var column = 2; column >= 0; column--)
+            {
+                sheet.Cells[row, column].SetValue($"r{row}c{column}");
+            }
+        }
+
+        return workbook;
+    }
+
+    [Fact]
+    public void Save_WritesRowsAndCellsInAscendingOrder()
+    {
+        var sheetData = Part(FilledBackwards(), "xl/worksheets/sheet1.xml")
+            .Descendants(Main + "sheetData").Single();
+
+        var rows = sheetData.Elements(Main + "row").ToList();
+
+        Assert.Equal(new[] { "1", "2", "3" }, rows.Select(r => (string?)r.Attribute("r")));
+
+        foreach (var row in rows)
+        {
+            var references = row.Elements(Main + "c").Select(c => (string?)c.Attribute("r")).ToList();
+
+            Assert.Equal(references.OrderBy(r => r, System.StringComparer.Ordinal), references);
+        }
+    }
+
+    [Fact]
+    public void Save_MergesPlaceholdersAndStyledRowsIntoTheCellOrder()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 8);
+
+        sheet.Cells[2, 5].SetValue("right");
+        sheet.Cells[2, 0].SetValue("left");
+        sheet.Cells[6, 1].SetValue("last");
+
+        sheet.MergedCells.Add(new RangeRef(new CellRef(2, 3), new CellRef(2, 6)));
+
+        sheet.Rows[4] = 40.0;
+        sheet.Rows.Hide(4);
+        sheet.Rows.Hide(7);
+
+        var sheetData = Part(workbook, "xl/worksheets/sheet1.xml")
+            .Descendants(Main + "sheetData").Single();
+
+        var rows = sheetData.Elements(Main + "row").ToList();
+
+        Assert.Equal(new[] { "3", "5", "7", "8" }, rows.Select(r => (string?)r.Attribute("r")));
+
+        var merged = rows[0];
+
+        Assert.Equal(
+            new[] { "A3", "E3", "F3", "G3" },
+            merged.Elements(Main + "c").Select(c => (string?)c.Attribute("r")));
+
+        Assert.Equal("1:7", (string?)merged.Attribute("spans"));
+
+        Assert.NotNull(merged.Elements(Main + "c")
+            .Single(c => (string?)c.Attribute("r") == "F3").Element(Main + "v"));
+
+        Assert.All(
+            merged.Elements(Main + "c").Where(c => (string?)c.Attribute("r") is "E3" or "G3"),
+            c => Assert.Empty(c.Elements()));
+
+        var styled = rows[1];
+
+        Assert.Equal("1", (string?)styled.Attribute("customHeight"));
+        Assert.Equal("1", (string?)styled.Attribute("hidden"));
+        Assert.Null(styled.Attribute("spans"));
+        Assert.Empty(styled.Elements());
+    }
+
+    [Fact]
+    public void Save_NumbersCellStylesInTheOrderTheCellsAreWritten()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 4, 4);
+
+        sheet.Cells[2, 0].Value = 3;
+        sheet.Cells[2, 0].Format.Italic = true;
+
+        sheet.Cells[0, 0].Value = 1;
+        sheet.Cells[0, 0].Format.Bold = true;
+
+        var cells = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "c")
+            .ToDictionary(c => (string)c.Attribute("r")!, c => int.Parse((string)c.Attribute("s")!, CultureInfo.InvariantCulture));
+
+        Assert.True(cells["A1"] < cells["A3"]);
+
+        var fonts = Part(workbook, "xl/styles.xml").Root!.Element(Main + "fonts")!.Elements(Main + "font").ToList();
+        var xfs = Part(workbook, "xl/styles.xml").Root!.Element(Main + "cellXfs")!.Elements(Main + "xf").ToList();
+
+        int FontOf(string reference) =>
+            int.Parse((string)xfs[cells[reference]].Attribute("fontId")!, CultureInfo.InvariantCulture);
+
+        Assert.NotNull(fonts[FontOf("A1")].Element(Main + "b"));
+        Assert.NotNull(fonts[FontOf("A3")].Element(Main + "i"));
+    }
+
+    [Fact]
+    public void Save_IndexesSharedStringsInTheOrderTheCellsAreWritten()
+    {
+        var strings = Part(FilledBackwards(), "xl/sharedStrings.xml")
+            .Root!.Elements(Main + "si")
+            .Select(si => si.Element(Main + "t")!.Value);
+
+        Assert.Equal(new[] { "r0c0", "r0c1", "r0c2", "r1c0", "r1c1", "r1c2", "r2c0", "r2c1", "r2c2" }, strings);
+    }
+}

--- a/Radzen.Blazor/Documents/Spreadsheet/CellRef.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellRef.cs
@@ -160,7 +160,6 @@ public readonly struct CellRef(int row, int column) : IEquatable<CellRef>
         var isColumnAbsolute = false;
         var isRowAbsolute = false;
 
-
         // Optional $ before column
         if (i < index.Length && index[i] == '$')
         {

--- a/Radzen.Blazor/Documents/Spreadsheet/CellRef.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellRef.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Text;
+using System.Globalization;
 
 namespace Radzen.Documents.Spreadsheet;
 
@@ -71,23 +71,35 @@ public readonly struct CellRef(int row, int column) : IEquatable<CellRef>
     /// <returns></returns>
     public override string ToString()
     {
-        var sb = StringBuilderCache.Acquire();
+        Span<char> reference = stackalloc char[MaxLength];
+
+        return new string(reference[..Format(reference)]);
+    }
+
+    internal const int MaxLength = 2 + ColumnRef.MaxLetters + 11;
+
+    internal int Format(Span<char> destination)
+    {
+        var length = 0;
 
         if (IsColumnAbsolute)
         {
-            sb.Append('$');
+            destination[length++] = '$';
         }
 
-        sb.Append(ColumnRef.ToString(Column));
+        length += ColumnRef.Format(destination[length..], Column);
 
         if (IsRowAbsolute)
         {
-            sb.Append('$');
+            destination[length++] = '$';
         }
 
-        sb.Append(Row + 1);
+        if (!(Row + 1).TryFormat(destination[length..], out var digits, provider: CultureInfo.InvariantCulture))
+        {
+            throw new ArgumentException($"A reference needs up to {MaxLength} characters.", nameof(destination));
+        }
 
-        return StringBuilderCache.GetStringAndRelease(sb);
+        return length + digits;
     }
 
     /// <summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
@@ -98,14 +98,9 @@ public class CellStore(Worksheet sheet)
     /// <returns>True if the cell exists in the store; otherwise, false.</returns>
     public bool TryGet(int row, int column, out Cell cell)
     {
-        if (InBounds(row, column) && data.TryGetValue((row, column), out cell!))
-        {
-            return true;
-        }
+        cell = (InBounds(row, column) ? Find(row, column) : null)!;
 
-        cell = null!;
-
-        return false;
+        return cell is not null;
     }
 
     internal IEnumerable<Cell> GetPopulatedCells() => data.Values;
@@ -132,7 +127,9 @@ public class CellStore(Worksheet sheet)
 
     internal int PopulatedCount => data.Count;
 
-    internal bool HasCell(int row, int column) => data.ContainsKey((row, column));
+    internal bool HasCell(int row, int column) => Find(row, column) is not null;
+
+    internal Cell? Find(int row, int column) => data.TryGetValue((row, column), out var cell) ? cell : null;
 
     private static void UpdateCellAddress((int row, int column) oldKey, (int row, int column) newKey, Cell cell)
     {

--- a/Radzen.Blazor/Documents/Spreadsheet/ColumnRef.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/ColumnRef.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 
 namespace Radzen.Documents.Spreadsheet;
 
@@ -42,26 +41,35 @@ public readonly struct ColumnRef(int column) : IEquatable<ColumnRef>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the column index is negative.</exception>
     public static string ToString(int column)
     {
+        Span<char> letters = stackalloc char[MaxLetters];
+
+        return new string(letters[..Format(letters, column)]);
+    }
+
+    internal const int MaxLetters = 7;
+
+    internal static int Format(Span<char> destination, int column)
+    {
         if (column < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(column), "Column index must be non-negative.");
         }
 
-        var sb = StringBuilderCache.Acquire();
-        var start = sb.Length;
+        var length = 0;
         column++;
         while (column > 0)
         {
             column--;
-            sb.Append((char)('A' + column % 26));
+            destination[length++] = (char)('A' + column % 26);
             column /= 26;
         }
-        // Digits were appended least-significant first; reverse in place.
-        for (int i = start, j = sb.Length - 1; i < j; i++, j--)
+        // Digits were written least-significant first; reverse in place.
+        for (int i = 0, j = length - 1; i < j; i++, j--)
         {
-            (sb[i], sb[j]) = (sb[j], sb[i]);
+            (destination[i], destination[j]) = (destination[j], destination[i]);
         }
-        return StringBuilderCache.GetStringAndRelease(sb);
+
+        return length;
     }
 
     /// <inheritdoc/>

--- a/Radzen.Blazor/Documents/Spreadsheet/ColumnRef.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/ColumnRef.cs
@@ -63,7 +63,6 @@ public readonly struct ColumnRef(int column) : IEquatable<ColumnRef>
             destination[length++] = (char)('A' + column % 26);
             column /= 26;
         }
-        // Digits were written least-significant first; reverse in place.
         for (int i = 0, j = length - 1; i < j; i++, j--)
         {
             (destination[i], destination[j]) = (destination[j], destination[i]);

--- a/Radzen.Blazor/Documents/Spreadsheet/Format.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Format.cs
@@ -347,7 +347,21 @@ public class Format
     /// <summary>
     /// Gets a value indicating whether all format properties are at their default values.
     /// </summary>
-    public bool IsDefault => Properties.All(p => !p.IsSet(this));
+    public bool IsDefault
+    {
+        get
+        {
+            foreach (var property in Properties)
+            {
+                if (property.IsSet(this))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
 
     internal Format Merge(Format format)
     {

--- a/Radzen.Blazor/Documents/Spreadsheet/SharedStringTable.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/SharedStringTable.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Buffers;
+
+namespace Radzen.Documents.Spreadsheet;
+
+#nullable enable
+
+/// <summary>
+/// The shared string table a workbook is saved with: each distinct string once, at the index its cells are
+/// written with, over arrays rented from <see cref="ArrayPool{T}"/> and returned when the save is done.
+/// </summary>
+/// <remarks>
+/// A <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/> allocates its arrays anew on every
+/// save and doubles them as it grows. Renting them instead means a save after the first in a process pays
+/// nothing for the table however it grows, so it needs no hint about how many strings a sheet holds.
+/// </remarks>
+sealed class SharedStringTable : IDisposable
+{
+    private const int InitialCapacity = 256;
+
+    private string[] strings = [];
+    private int[] buckets = [];
+    private int capacity;
+    private int mask;
+    private int count;
+
+    /// <summary>
+    /// The number of distinct strings in the table.
+    /// </summary>
+    public int Count => count;
+
+    /// <summary>
+    /// The strings in the order of their indices.
+    /// </summary>
+    public ReadOnlySpan<string> Strings => strings.AsSpan(0, count);
+
+    /// <summary>
+    /// Returns the index of <paramref name="text"/>, adding it at the next index if it is not in the table.
+    /// </summary>
+    public int GetOrAdd(string text)
+    {
+        var slot = 0;
+
+        if (capacity > 0)
+        {
+            var index = IndexOf(text, out slot);
+
+            if (index >= 0)
+            {
+                return index;
+            }
+        }
+
+        if (count == capacity)
+        {
+            Grow();
+            slot = EmptySlot(text);
+        }
+
+        strings[count] = text;
+        buckets[slot] = count + 1;
+
+        return count++;
+    }
+
+    // The index of text, or -1 with slot left at the empty bucket where it would go.
+    private int IndexOf(string text, out int slot)
+    {
+        slot = text.GetHashCode(StringComparison.Ordinal) & mask;
+
+        while (true)
+        {
+            var index = buckets[slot] - 1;
+
+            if (index < 0)
+            {
+                return -1;
+            }
+
+            if (string.Equals(strings[index], text, StringComparison.Ordinal))
+            {
+                return index;
+            }
+
+            slot = (slot + 1) & mask;
+        }
+    }
+
+    private int EmptySlot(string text)
+    {
+        var slot = text.GetHashCode(StringComparison.Ordinal) & mask;
+
+        while (buckets[slot] != 0)
+        {
+            slot = (slot + 1) & mask;
+        }
+
+        return slot;
+    }
+
+    // The buckets hold an index plus one, so a rented bucket array cleared to zero is empty, and they stay
+    // at most half full so a probe is short.
+    private void Grow()
+    {
+        var oldStrings = strings;
+        var oldBuckets = buckets;
+
+        capacity = capacity == 0 ? InitialCapacity : capacity * 2;
+        mask = capacity * 2 - 1;
+
+        strings = ArrayPool<string>.Shared.Rent(capacity);
+        buckets = ArrayPool<int>.Shared.Rent(capacity * 2);
+        Array.Clear(buckets, 0, capacity * 2);
+
+        for (var index = 0; index < count; index++)
+        {
+            strings[index] = oldStrings[index];
+            buckets[EmptySlot(oldStrings[index])] = index + 1;
+        }
+
+        if (count > 0)
+        {
+            ArrayPool<string>.Shared.Return(oldStrings, clearArray: true);
+            ArrayPool<int>.Shared.Return(oldBuckets);
+        }
+    }
+
+    /// <summary>
+    /// Returns the arrays to the pool. The table is empty afterwards.
+    /// </summary>
+    public void Dispose()
+    {
+        if (capacity > 0)
+        {
+            ArrayPool<string>.Shared.Return(strings, clearArray: true);
+            ArrayPool<int>.Shared.Return(buckets);
+        }
+
+        strings = [];
+        buckets = [];
+        capacity = 0;
+        mask = 0;
+        count = 0;
+    }
+}

--- a/Radzen.Blazor/Documents/Spreadsheet/SharedStringTable.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/SharedStringTable.cs
@@ -5,15 +5,6 @@ namespace Radzen.Documents.Spreadsheet;
 
 #nullable enable
 
-/// <summary>
-/// The shared string table a workbook is saved with: each distinct string once, at the index its cells are
-/// written with, over arrays rented from <see cref="ArrayPool{T}"/> and returned when the save is done.
-/// </summary>
-/// <remarks>
-/// A <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/> allocates its arrays anew on every
-/// save and doubles them as it grows. Renting them instead means a save after the first in a process pays
-/// nothing for the table however it grows, so it needs no hint about how many strings a sheet holds.
-/// </remarks>
 sealed class SharedStringTable : IDisposable
 {
     private const int InitialCapacity = 256;
@@ -24,19 +15,10 @@ sealed class SharedStringTable : IDisposable
     private int mask;
     private int count;
 
-    /// <summary>
-    /// The number of distinct strings in the table.
-    /// </summary>
     public int Count => count;
 
-    /// <summary>
-    /// The strings in the order of their indices.
-    /// </summary>
     public ReadOnlySpan<string> Strings => strings.AsSpan(0, count);
 
-    /// <summary>
-    /// Returns the index of <paramref name="text"/>, adding it at the next index if it is not in the table.
-    /// </summary>
     public int GetOrAdd(string text)
     {
         var slot = 0;
@@ -63,7 +45,6 @@ sealed class SharedStringTable : IDisposable
         return count++;
     }
 
-    // The index of text, or -1 with slot left at the empty bucket where it would go.
     private int IndexOf(string text, out int slot)
     {
         slot = text.GetHashCode(StringComparison.Ordinal) & mask;
@@ -98,8 +79,6 @@ sealed class SharedStringTable : IDisposable
         return slot;
     }
 
-    // The buckets hold an index plus one, so a rented bucket array cleared to zero is empty, and they stay
-    // at most half full so a probe is short.
     private void Grow()
     {
         var oldStrings = strings;
@@ -125,9 +104,6 @@ sealed class SharedStringTable : IDisposable
         }
     }
 
-    /// <summary>
-    /// Returns the arrays to the pool. The table is empty afterwards.
-    /// </summary>
     public void Dispose()
     {
         if (capacity > 0)

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1356,22 +1356,14 @@ class XlsxWriter(Workbook sourceWorkbook)
     private void WriteRows(XmlWriter writer, Worksheet sheet, Cell[] cells, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var count = 0;
-        var interned = 0;
 
         foreach (var cell in sheet.Cells.GetPopulatedCells())
         {
             if (IsWritten(cell))
             {
                 cells[count++] = cell;
-
-                if (cell.ValueType == CellDataType.String && string.IsNullOrEmpty(cell.Formula))
-                {
-                    interned++;
-                }
             }
         }
-
-        sharedStrings.EnsureCapacity(sharedStrings.Count + interned);
 
         Array.Sort(cells, 0, count, CellOrder.Instance);
 

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1375,7 +1375,7 @@ class XlsxWriter(Workbook sourceWorkbook)
 
         Array.Sort(cells, 0, count, CellOrder.Instance);
 
-        var placeholders = CreateMergePlaceholders(sheet, styleTracker);
+        var placeholders = CreateMergePlaceholders(sheet);
         var styledRows = CollectStyledRowIndices(sheet);
 
         var cellIndex = 0;
@@ -1454,12 +1454,12 @@ class XlsxWriter(Workbook sourceWorkbook)
                 }
                 else
                 {
-                    var (address, styleId) = placeholders[placeholderIndex++];
+                    var placeholder = placeholders[placeholderIndex++];
 
                     if (placeholderColumn > writtenColumn)
                     {
                         writtenColumn = placeholderColumn;
-                        WritePlaceholder(writer, address, styleId);
+                        WritePlaceholder(writer, placeholder.Address, GetPlaceholderStyle(placeholder.Anchor, styleTracker));
                     }
                 }
             }
@@ -1687,17 +1687,14 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteFullEndElement();
     }
 
-    private List<(CellRef Address, int? StyleId)> CreateMergePlaceholders(Worksheet sheet, StyleTracker styleTracker)
+    private static List<Placeholder> CreateMergePlaceholders(Worksheet sheet)
     {
-        var placeholders = new List<(CellRef Address, int? StyleId)>();
+        var placeholders = new List<Placeholder>();
 
         foreach (var range in sheet.MergedCells.Ranges)
         {
             var anchor = sheet.Cells.Find(range.Start.Row, range.Start.Column);
-
-            int? anchorStyleId = anchor is not null && HasCellFormatting(anchor)
-                ? GetOrCreateCellStyle(anchor, styleTracker)
-                : null;
+            var style = anchor is not null && HasCellFormatting(anchor) ? new MergeAnchor(anchor) : null;
 
             for (var r = range.Start.Row; r <= range.End.Row; r++)
             {
@@ -1715,15 +1712,48 @@ class XlsxWriter(Workbook sourceWorkbook)
                         continue;
                     }
 
-                    placeholders.Add((new CellRef(r, c), anchorStyleId));
+                    placeholders.Add(new Placeholder(new CellRef(r, c), placeholders.Count, style));
                 }
             }
         }
 
-        return placeholders
-            .OrderBy(placeholder => placeholder.Address.Row)
-            .ThenBy(placeholder => placeholder.Address.Column)
-            .ToList();
+        placeholders.Sort();
+
+        return placeholders;
+    }
+
+    private int? GetPlaceholderStyle(MergeAnchor? anchor, StyleTracker styleTracker)
+    {
+        if (anchor is null)
+        {
+            return null;
+        }
+
+        return anchor.StyleId ??= GetOrCreateCellStyle(anchor.Cell, styleTracker);
+    }
+
+    private sealed class MergeAnchor(Cell cell)
+    {
+        public Cell Cell => cell;
+
+        public int? StyleId;
+    }
+
+    private readonly record struct Placeholder(CellRef Address, int Order, MergeAnchor? Anchor) : IComparable<Placeholder>
+    {
+        public int CompareTo(Placeholder other)
+        {
+            var byRow = Address.Row.CompareTo(other.Address.Row);
+
+            if (byRow != 0)
+            {
+                return byRow;
+            }
+
+            var byColumn = Address.Column.CompareTo(other.Address.Column);
+
+            return byColumn != 0 ? byColumn : Order.CompareTo(other.Order);
+        }
     }
 
     private sealed class CellOrder : IComparer<Cell>

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 namespace Radzen.Documents.Spreadsheet;
 
@@ -929,9 +930,6 @@ class XlsxWriter(Workbook sourceWorkbook)
     private void SaveSheet(ZipArchive archive, Worksheet sheet, string sheetName, int sheetId, string relId, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc, Dictionary<string, string> mediaMap, ref int globalMediaIndex, ref int globalTableIndex)
     {
         var sheetDoc = CreateSheetDocument(sheet, sheetId, relId);
-        var sheetData = sheetDoc.Root!.Element(XName.Get("sheetData", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"))!;
-
-        ProcessSheetData(sheet, sheetData, styleTracker, sharedStrings, sharedStringsDoc);
 
         AddMergedCells(sheet, sheetDoc);
 
@@ -1000,7 +998,7 @@ class XlsxWriter(Workbook sourceWorkbook)
 
         using (var entry = archive.CreateEntry($"xl/worksheets/{sheetName}").Open())
         {
-            sheetDoc.Save(entry);
+            WriteSheetXml(entry, sheetDoc, sheet, styleTracker, sharedStrings, sharedStringsDoc);
         }
 
         if (sheetRelEntries.Count > 0)
@@ -1307,7 +1305,45 @@ class XlsxWriter(Workbook sourceWorkbook)
         return groups;
     }
 
-    private void ProcessSheetData(Worksheet sheet, XElement sheetData, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc)
+    // Indent alone, so the byte order mark, the indent string and the newline stay whatever
+    // XDocument.Save would have written - the newline among them is the platform's.
+    private static readonly XmlWriterSettings SheetXmlSettings = new() { Indent = true };
+
+    private static readonly XName SheetDataElement = XName.Get("sheetData", Main);
+
+    private void WriteSheetXml(Stream stream, XDocument sheetDoc, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc)
+    {
+        var root = sheetDoc.Root!;
+
+        using var writer = XmlWriter.Create(stream, SheetXmlSettings);
+
+        writer.WriteStartDocument();
+        writer.WriteStartElement(root.Name.LocalName, root.Name.NamespaceName);
+
+        foreach (var attribute in root.Attributes())
+        {
+            writer.WriteAttributeString(attribute.Name.LocalName, attribute.Name.NamespaceName, attribute.Value);
+        }
+
+        foreach (var element in root.Elements())
+        {
+            if (element.Name == SheetDataElement)
+            {
+                writer.WriteStartElement(SheetDataElement.LocalName, Main);
+                WriteSheetData(writer, sheet, styleTracker, sharedStrings, sharedStringsDoc);
+                writer.WriteEndElement();
+            }
+            else
+            {
+                element.WriteTo(writer);
+            }
+        }
+
+        writer.WriteEndElement();
+        writer.WriteEndDocument();
+    }
+
+    private void WriteSheetData(XmlWriter writer, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc)
     {
         var sharedFormulas = BuildSharedFormulaGroups(sheet);
 
@@ -1355,9 +1391,36 @@ class XlsxWriter(Workbook sourceWorkbook)
                 row = Math.Min(row, styledRows[styledRowIndex]);
             }
 
-            var rowElement = CreateRowElement(sheet, row);
             var firstColumn = -1;
             var lastColumn = -1;
+
+            for (var i = cellIndex; i < cells.Count && cells[i].Address.Row == row; i++)
+            {
+                var column = cells[i].Address.Column;
+
+                if (firstColumn < 0 || column < firstColumn)
+                {
+                    firstColumn = column;
+                }
+
+                lastColumn = Math.Max(lastColumn, column);
+            }
+
+            for (var i = placeholderIndex; i < placeholders.Count && placeholders[i].Address.Row == row; i++)
+            {
+                var column = placeholders[i].Address.Column;
+
+                if (firstColumn < 0 || column < firstColumn)
+                {
+                    firstColumn = column;
+                }
+
+                lastColumn = Math.Max(lastColumn, column);
+            }
+
+            WriteRowStart(writer, sheet, row, firstColumn, lastColumn);
+
+            var writtenColumn = -1;
 
             while (true)
             {
@@ -1374,39 +1437,21 @@ class XlsxWriter(Workbook sourceWorkbook)
                     break;
                 }
 
-                int column;
-                XElement element;
-
                 if (cellColumn <= placeholderColumn)
                 {
-                    var cell = cells[cellIndex++];
-                    column = cellColumn;
-                    element = CreateCellElement(sheet, row, column, cell, styleTracker, sharedStrings, sharedStringsDoc, sharedFormulas);
+                    writtenColumn = cellColumn;
+                    WriteCell(writer, cells[cellIndex++], styleTracker, sharedStrings, sharedStringsDoc, sharedFormulas);
                 }
                 else
                 {
-                    (var address, element) = placeholders[placeholderIndex++];
-                    column = address.Column;
+                    var (address, styleId) = placeholders[placeholderIndex++];
+
+                    if (placeholderColumn > writtenColumn)
+                    {
+                        writtenColumn = placeholderColumn;
+                        WritePlaceholder(writer, address, styleId);
+                    }
                 }
-
-                // Two ranges covering one position contribute one placeholder between them.
-                if (column <= lastColumn)
-                {
-                    continue;
-                }
-
-                if (firstColumn < 0)
-                {
-                    firstColumn = column;
-                }
-
-                lastColumn = column;
-                rowElement.Add(element);
-            }
-
-            if (firstColumn >= 0)
-            {
-                rowElement.Add(new XAttribute("spans", $"{firstColumn + 1}:{lastColumn + 1}"));
             }
 
             while (styledRowIndex < styledRows.Count && styledRows[styledRowIndex] <= row)
@@ -1414,14 +1459,167 @@ class XlsxWriter(Workbook sourceWorkbook)
                 styledRowIndex++;
             }
 
-            sheetData.Add(rowElement);
+            writer.WriteEndElement();
         }
     }
 
-    private List<(CellRef Address, XElement Element)> CreateMergePlaceholders(Worksheet sheet, StyleTracker styleTracker)
+    private static void WriteRowStart(XmlWriter writer, Worksheet sheet, int row, int firstColumn, int lastColumn)
     {
-        var placeholders = new List<(CellRef Address, XElement Element)>();
-        var ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        writer.WriteStartElement("row", Main);
+        writer.WriteAttributeString("r", XmlConvert.ToString(row + 1));
+
+        // Only persist height if it differs from the default
+        if (Math.Abs(sheet.Rows[row] - sheet.Rows.Size) > 1e-6)
+        {
+            writer.WriteAttributeString("ht", XmlConvert.ToString(sheet.Rows[row]));
+            writer.WriteAttributeString("customHeight", "1");
+        }
+
+        if (sheet.Rows.IsHidden(row))
+        {
+            writer.WriteAttributeString("hidden", "1");
+        }
+
+        if (firstColumn >= 0)
+        {
+            writer.WriteAttributeString("spans", string.Create(CultureInfo.InvariantCulture, $"{firstColumn + 1}:{lastColumn + 1}"));
+        }
+    }
+
+    private static void WritePlaceholder(XmlWriter writer, CellRef address, int? styleId)
+    {
+        writer.WriteStartElement("c", Main);
+        writer.WriteAttributeString("r", address.ToString());
+
+        if (styleId is not null)
+        {
+            writer.WriteAttributeString("s", XmlConvert.ToString(styleId.Value));
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private void WriteCell(XmlWriter writer, Cell cell, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    {
+        var isFormula = !string.IsNullOrEmpty(cell.Formula);
+
+        writer.WriteStartElement("c", Main);
+        writer.WriteAttributeString("r", cell.Address.ToString());
+
+        if (HasCellFormatting(cell))
+        {
+            writer.WriteAttributeString("s", XmlConvert.ToString(GetOrCreateCellStyle(cell, styleTracker)));
+        }
+
+        var type = CellTypeAttribute(cell, isFormula);
+
+        if (type is not null)
+        {
+            writer.WriteAttributeString("t", type);
+        }
+
+        if (isFormula)
+        {
+            WriteFormula(writer, cell, sharedFormulas);
+            WriteTypedValue(writer, cell);
+        }
+        else if (cell.ValueType == CellDataType.String)
+        {
+            var text = cell.Value as string ?? string.Empty;
+
+            if (!sharedStrings.TryGetValue(text, out var index))
+            {
+                index = sharedStrings.Count;
+                sharedStrings[text] = index;
+                sharedStringsDoc.Root!.Add(new XElement(SiElement, new XElement(TElement, text)));
+            }
+
+            WriteValue(writer, XmlConvert.ToString(index));
+        }
+        else
+        {
+            WriteTypedValue(writer, cell);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static string? CellTypeAttribute(Cell cell, bool isFormula) => cell.ValueType switch
+    {
+        CellDataType.String => isFormula ? "str" : "s",
+        CellDataType.Boolean => "b",
+        CellDataType.Error => "e",
+        _ => null,
+    };
+
+    private static void WriteFormula(XmlWriter writer, Cell cell, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    {
+        var formula = cell.Formula!.StartsWith('=') ? cell.Formula![1..] : cell.Formula!;
+
+        writer.WriteStartElement("f", Main);
+
+        if (sharedFormulas.TryGetValue(cell.Address, out var shared))
+        {
+            writer.WriteAttributeString("t", "shared");
+
+            if (shared.Ref is not null)
+            {
+                writer.WriteAttributeString("ref", shared.Ref);
+            }
+
+            writer.WriteAttributeString("si", XmlConvert.ToString(shared.Si));
+
+            if (shared.Ref is null)
+            {
+                writer.WriteEndElement();
+
+                return;
+            }
+        }
+
+        writer.WriteString(formula);
+        writer.WriteFullEndElement();
+    }
+
+    private static void WriteTypedValue(XmlWriter writer, Cell cell)
+    {
+        switch (cell.ValueType)
+        {
+            case CellDataType.Number:
+            case CellDataType.String:
+                WriteValue(writer, FormatValueInvariant(cell.Value));
+                break;
+
+            case CellDataType.Boolean:
+                WriteValue(writer, cell.Value is true ? "1" : "0");
+                break;
+
+            case CellDataType.Date:
+                if (cell.Value is DateTime dateValue)
+                {
+                    WriteValue(writer, dateValue.ToNumber().ToString(CultureInfo.InvariantCulture));
+                }
+                break;
+
+            case CellDataType.Error:
+                WriteValue(writer, cell.Value is CellError error ? CellErrorToString(error) : "#NAME?");
+                break;
+
+            case CellDataType.Empty:
+                break;
+        }
+    }
+
+    private static void WriteValue(XmlWriter writer, string text)
+    {
+        writer.WriteStartElement("v", Main);
+        writer.WriteString(text);
+        writer.WriteFullEndElement();
+    }
+
+    private List<(CellRef Address, int? StyleId)> CreateMergePlaceholders(Worksheet sheet, StyleTracker styleTracker)
+    {
+        var placeholders = new List<(CellRef Address, int? StyleId)>();
 
         foreach (var range in sheet.MergedCells.Ranges)
         {
@@ -1445,17 +1643,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                         continue;
                     }
 
-                    var address = new CellRef(r, c);
-
-                    var placeholder = new XElement(XName.Get("c", ns),
-                        new XAttribute("r", address.ToString()));
-
-                    if (anchorStyleId is not null)
-                    {
-                        placeholder.Add(new XAttribute("s", anchorStyleId.Value));
-                    }
-
-                    placeholders.Add((address, placeholder));
+                    placeholders.Add((new CellRef(r, c), anchorStyleId));
                 }
             }
         }
@@ -1485,42 +1673,6 @@ class XlsxWriter(Workbook sourceWorkbook)
         rows.Sort();
 
         return rows;
-    }
-
-    private static XElement CreateRowElement(Worksheet sheet, int row)
-    {
-        var rowElement = new XElement(XName.Get("row", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
-            new XAttribute("r", row + 1));
-
-        // Only persist height if it differs from the default
-        if (Math.Abs(sheet.Rows[row] - sheet.Rows.Size) > 1e-6)
-        {
-            rowElement.Add(new XAttribute("ht", sheet.Rows[row]));
-            rowElement.Add(new XAttribute("customHeight", "1"));
-        }
-
-        if (sheet.Rows.IsHidden(row))
-        {
-            rowElement.Add(new XAttribute("hidden", "1"));
-        }
-
-        return rowElement;
-    }
-
-    private XElement CreateCellElement(Worksheet sheet, int row, int col, Cell cell, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
-    {
-        var cellElement = new XElement(XName.Get("c", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
-            new XAttribute("r", new CellRef(row, col).ToString()));
-
-        if (HasCellFormatting(cell))
-        {
-            var styleId = GetOrCreateCellStyle(cell, styleTracker);
-            cellElement.Add(new XAttribute("s", styleId));
-        }
-
-        AddCellValue(cellElement, cell, sharedStrings, sharedStringsDoc, sharedFormulas);
-
-        return cellElement;
     }
 
     private static bool HasCellFormatting(Cell cell)
@@ -1837,10 +1989,10 @@ class XlsxWriter(Workbook sourceWorkbook)
         };
     }
 
-    private static readonly XName VElement = XName.Get("v", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
-    private static readonly XName FElement = XName.Get("f", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
-    private static readonly XName SiElement = XName.Get("si", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
-    private static readonly XName TElement = XName.Get("t", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+    private const string Main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private static readonly XName SiElement = XName.Get("si", Main);
+    private static readonly XName TElement = XName.Get("t", Main);
 
     private static string CellErrorToString(CellError error) => error switch
     {
@@ -1852,98 +2004,6 @@ class XlsxWriter(Workbook sourceWorkbook)
         CellError.NA    => "#N/A",
         _               => "#NAME?",
     };
-
-    private static void AddCellValue(XElement cellElement, Cell cell, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
-    {
-        if (!string.IsNullOrEmpty(cell.Formula))
-        {
-            var formulaValue = cell.Formula.StartsWith('=') ? cell.Formula[1..] : cell.Formula;
-            var formulaElement = new XElement(FElement);
-
-            if (sharedFormulas.TryGetValue(cell.Address, out var shared))
-            {
-                formulaElement.Add(new XAttribute("t", "shared"));
-
-                if (shared.Ref is not null)
-                {
-                    formulaElement.Add(new XAttribute("ref", shared.Ref));
-                }
-
-                formulaElement.Add(new XAttribute("si", shared.Si));
-
-                if (shared.Ref is not null)
-                {
-                    formulaElement.Value = formulaValue;
-                }
-            }
-            else
-            {
-                formulaElement.Value = formulaValue;
-            }
-
-            cellElement.Add(formulaElement);
-            EmitTypedValue(cellElement, cell, isFormula: true);
-        }
-        else if (cell.ValueType == CellDataType.String)
-        {
-            var strValue = cell.Value as string ?? string.Empty;
-            if (!sharedStrings.TryGetValue(strValue, out var index))
-            {
-                index = sharedStrings.Count;
-                sharedStrings[strValue] = index;
-                sharedStringsDoc.Root!.Add(new XElement(SiElement,
-                    new XElement(TElement, strValue)));
-            }
-
-            cellElement.Add(new XAttribute("t", "s"));
-            cellElement.Add(new XElement(VElement, index));
-        }
-        else
-        {
-            EmitTypedValue(cellElement, cell, isFormula: false);
-        }
-    }
-
-    private static void EmitTypedValue(XElement cellElement, Cell cell, bool isFormula)
-    {
-        switch (cell.ValueType)
-        {
-            case CellDataType.Number:
-                // Default cell type is "n"; do not emit redundant t attribute.
-                cellElement.Add(new XElement(VElement, FormatValueInvariant(cell.Value)));
-                break;
-
-            case CellDataType.String:
-                // Only reachable on formula cells (string-result formulas).
-                cellElement.Add(new XAttribute("t", "str"));
-                cellElement.Add(new XElement(VElement, FormatValueInvariant(cell.Value)));
-                break;
-
-            case CellDataType.Boolean:
-                cellElement.Add(new XAttribute("t", "b"));
-                cellElement.Add(new XElement(VElement, cell.Value is true ? "1" : "0"));
-                break;
-
-            case CellDataType.Date:
-                if (cell.Value is DateTime dateValue)
-                {
-                    cellElement.Add(new XElement(VElement,
-                        dateValue.ToNumber().ToString(CultureInfo.InvariantCulture)));
-                }
-                break;
-
-            case CellDataType.Error:
-                cellElement.Add(new XAttribute("t", "e"));
-                var errorString = cell.Value is CellError err
-                    ? CellErrorToString(err)
-                    : "#NAME?";
-                cellElement.Add(new XElement(VElement, errorString));
-                break;
-
-            case CellDataType.Empty:
-                break;
-        }
-    }
 
     private static void AddMergedCells(Worksheet sheet, XDocument sheetDoc)
     {

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1311,29 +1311,122 @@ class XlsxWriter(Workbook sourceWorkbook)
     {
         var sharedFormulas = BuildSharedFormulaGroups(sheet);
 
-        // row -> (col -> <c> element). SortedDictionary keeps cells in column
-        // order within each row, as required by ECMA-376.
-        var rowMap = new SortedDictionary<int, SortedDictionary<int, XElement>>();
+        // GetPopulatedCells enumerates a dictionary, so that order is recovered by sorting.
+        var cells = new List<Cell>(sheet.Cells.PopulatedCount);
 
-        SortedDictionary<int, XElement> EnsureRow(int row) =>
-            rowMap.TryGetValue(row, out var existing)
-                ? existing
-                : (rowMap[row] = new SortedDictionary<int, XElement>());
-
-        // 1. Real data cells.
-        foreach (var cell in sheet.Cells.GetPopulatedCells().Where(c => c.Value is not null || c.Formula is not null))
+        foreach (var cell in sheet.Cells.GetPopulatedCells())
         {
-            var rowDict = EnsureRow(cell.Address.Row);
-            rowDict[cell.Address.Column] = CreateCellElement(sheet, cell.Address.Row, cell.Address.Column, cell, styleTracker, sharedStrings, sharedStringsDoc, sharedFormulas);
+            if (IsWritten(cell))
+            {
+                cells.Add(cell);
+            }
         }
 
-        // 2. Empty <c> placeholders for cells inside merge ranges. Excel
-        // always writes these (carrying the anchor's style) so border/fill
-        // styling visually applies across the merged range.
+        cells.Sort(static (left, right) =>
+        {
+            var byRow = left.Address.Row.CompareTo(right.Address.Row);
+
+            return byRow != 0 ? byRow : left.Address.Column.CompareTo(right.Address.Column);
+        });
+
+        var placeholders = CreateMergePlaceholders(sheet, styleTracker);
+        var styledRows = CollectStyledRowIndices(sheet);
+
+        var cellIndex = 0;
+        var placeholderIndex = 0;
+        var styledRowIndex = 0;
+
+        while (cellIndex < cells.Count || placeholderIndex < placeholders.Count || styledRowIndex < styledRows.Count)
+        {
+            var row = int.MaxValue;
+
+            if (cellIndex < cells.Count)
+            {
+                row = Math.Min(row, cells[cellIndex].Address.Row);
+            }
+
+            if (placeholderIndex < placeholders.Count)
+            {
+                row = Math.Min(row, placeholders[placeholderIndex].Address.Row);
+            }
+
+            if (styledRowIndex < styledRows.Count)
+            {
+                row = Math.Min(row, styledRows[styledRowIndex]);
+            }
+
+            var rowElement = CreateRowElement(sheet, row);
+            var firstColumn = -1;
+            var lastColumn = -1;
+
+            while (true)
+            {
+                var cellColumn = cellIndex < cells.Count && cells[cellIndex].Address.Row == row
+                    ? cells[cellIndex].Address.Column
+                    : int.MaxValue;
+
+                var placeholderColumn = placeholderIndex < placeholders.Count && placeholders[placeholderIndex].Address.Row == row
+                    ? placeholders[placeholderIndex].Address.Column
+                    : int.MaxValue;
+
+                if (cellColumn == int.MaxValue && placeholderColumn == int.MaxValue)
+                {
+                    break;
+                }
+
+                int column;
+                XElement element;
+
+                if (cellColumn <= placeholderColumn)
+                {
+                    var cell = cells[cellIndex++];
+                    column = cellColumn;
+                    element = CreateCellElement(sheet, row, column, cell, styleTracker, sharedStrings, sharedStringsDoc, sharedFormulas);
+                }
+                else
+                {
+                    (var address, element) = placeholders[placeholderIndex++];
+                    column = address.Column;
+                }
+
+                // Two ranges covering one position contribute one placeholder between them.
+                if (column <= lastColumn)
+                {
+                    continue;
+                }
+
+                if (firstColumn < 0)
+                {
+                    firstColumn = column;
+                }
+
+                lastColumn = column;
+                rowElement.Add(element);
+            }
+
+            if (firstColumn >= 0)
+            {
+                rowElement.Add(new XAttribute("spans", $"{firstColumn + 1}:{lastColumn + 1}"));
+            }
+
+            while (styledRowIndex < styledRows.Count && styledRows[styledRowIndex] <= row)
+            {
+                styledRowIndex++;
+            }
+
+            sheetData.Add(rowElement);
+        }
+    }
+
+    private List<(CellRef Address, XElement Element)> CreateMergePlaceholders(Worksheet sheet, StyleTracker styleTracker)
+    {
+        var placeholders = new List<(CellRef Address, XElement Element)>();
         var ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
         foreach (var range in sheet.MergedCells.Ranges)
         {
             var anchor = sheet.Cells[range.Start];
+
             int? anchorStyleId = HasCellFormatting(anchor)
                 ? GetOrCreateCellStyle(anchor, styleTracker)
                 : null;
@@ -1347,53 +1440,51 @@ class XlsxWriter(Workbook sourceWorkbook)
                         continue;
                     }
 
-                    var rowDict = EnsureRow(r);
-                    if (rowDict.ContainsKey(c))
+                    if (sheet.Cells.HasCell(r, c) && IsWritten(sheet.Cells[r, c]))
                     {
                         continue;
                     }
 
+                    var address = new CellRef(r, c);
+
                     var placeholder = new XElement(XName.Get("c", ns),
-                        new XAttribute("r", new CellRef(r, c).ToString()));
+                        new XAttribute("r", address.ToString()));
+
                     if (anchorStyleId is not null)
                     {
                         placeholder.Add(new XAttribute("s", anchorStyleId.Value));
                     }
-                    rowDict[c] = placeholder;
+
+                    placeholders.Add((address, placeholder));
                 }
             }
         }
 
-        // 3. Rows with custom height or hidden state but no cells.
-        foreach (var rowIndex in sheet.Rows.GetCustomSizedIndices())
+        return placeholders
+            .OrderBy(placeholder => placeholder.Address.Row)
+            .ThenBy(placeholder => placeholder.Address.Column)
+            .ToList();
+    }
+
+    private static bool IsWritten(Cell cell) => cell.Value is not null || cell.Formula is not null;
+
+    private static List<int> CollectStyledRowIndices(Worksheet sheet)
+    {
+        var rows = new List<int>();
+
+        foreach (var row in sheet.Rows.GetCustomSizedIndices())
         {
-            EnsureRow(rowIndex);
+            rows.Add(row);
         }
 
-        foreach (var rowIndex in sheet.Rows.GetHiddenIndices())
+        foreach (var row in sheet.Rows.GetHiddenIndices())
         {
-            EnsureRow(rowIndex);
+            rows.Add(row);
         }
 
-        // 4. Emit.
-        foreach (var (row, rowDict) in rowMap)
-        {
-            var rowElement = CreateRowElement(sheet, row);
+        rows.Sort();
 
-            if (rowDict.Count > 0)
-            {
-                var firstCol = rowDict.Keys.First();
-                var lastCol  = rowDict.Keys.Last();
-                rowElement.Add(new XAttribute("spans", $"{firstCol + 1}:{lastCol + 1}"));
-
-                foreach (var (_, cellEl) in rowDict)
-                {
-                    rowElement.Add(cellEl);
-                }
-            }
-
-            sheetData.Add(rowElement);
-        }
+        return rows;
     }
 
     private static XElement CreateRowElement(Worksheet sheet, int row)

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1786,16 +1786,18 @@ class XlsxWriter(Workbook sourceWorkbook)
         return cell.FormatOrNull?.IsDefault == false || cell.ValueType == CellDataType.Date || cell.QuotePrefix;
     }
 
+    private static readonly Format DefaultFormat = new();
+
     private int GetOrCreateCellStyle(Cell cell, StyleTracker styleTracker)
     {
-        var format = cell.FormatOrNull;
+        var format = cell.FormatOrNull ?? DefaultFormat;
 
         var fontId = GetOrCreateFontStyle(format, styleTracker);
         var fillId = GetOrCreateFillStyle(format, styleTracker);
         var numFmtId = GetOrCreateNumberFormat(cell, format, styleTracker);
         var borderId = GetOrCreateBorderStyle(format, styleTracker);
 
-        var styleKey = new CellStyleKey(fontId, fillId, borderId, format?.TextAlign, format?.VerticalAlign, format?.WrapText == true, numFmtId, format?.Locked, format?.FormulaHidden, cell.QuotePrefix);
+        var styleKey = new CellStyleKey(fontId, fillId, borderId, format.TextAlign, format.VerticalAlign, format.WrapText, numFmtId, format.Locked, format.FormulaHidden, cell.QuotePrefix);
 
         if (!styleTracker.CellStyles.TryGetValue(styleKey, out int styleId))
         {
@@ -1807,9 +1809,9 @@ class XlsxWriter(Workbook sourceWorkbook)
         return styleId;
     }
 
-    private int GetOrCreateFontStyle(Format? format, StyleTracker styleTracker)
+    private int GetOrCreateFontStyle(Format format, StyleTracker styleTracker)
     {
-        var fontKey = new FontKey(format?.Color, format?.Bold == true, format?.Italic == true, format?.Underline == true, format?.Strikethrough == true, format?.FontFamily, format?.FontSize);
+        var fontKey = new FontKey(format.Color, format.Bold, format.Italic, format.Underline, format.Strikethrough, format.FontFamily, format.FontSize);
 
         if (!styleTracker.FontStyles.TryGetValue(fontKey, out int fontId))
         {
@@ -1821,9 +1823,9 @@ class XlsxWriter(Workbook sourceWorkbook)
         return fontId;
     }
 
-    private int GetOrCreateFillStyle(Format? format, StyleTracker styleTracker)
+    private int GetOrCreateFillStyle(Format format, StyleTracker styleTracker)
     {
-        var backgroundColor = format?.BackgroundColor;
+        var backgroundColor = format.BackgroundColor;
 
         if (backgroundColor is null)
         {
@@ -1840,12 +1842,12 @@ class XlsxWriter(Workbook sourceWorkbook)
         return fillId;
     }
 
-    private int GetOrCreateBorderStyle(Format? format, StyleTracker styleTracker)
+    private int GetOrCreateBorderStyle(Format format, StyleTracker styleTracker)
     {
-        var bt = format?.BorderTop;
-        var br = format?.BorderRight;
-        var bb = format?.BorderBottom;
-        var bl = format?.BorderLeft;
+        var bt = format.BorderTop;
+        var br = format.BorderRight;
+        var bb = format.BorderBottom;
+        var bl = format.BorderLeft;
 
         if (bt is null && br is null && bb is null && bl is null)
         {
@@ -1899,9 +1901,9 @@ class XlsxWriter(Workbook sourceWorkbook)
         borderElement.Add(sideElement);
     }
 
-    private static int GetOrCreateNumberFormat(Cell cell, Format? format, StyleTracker styleTracker)
+    private static int GetOrCreateNumberFormat(Cell cell, Format format, StyleTracker styleTracker)
     {
-        var formatCode = format?.NumberFormat;
+        var formatCode = format.NumberFormat;
 
         // Auto-apply default date format for date values without explicit format
         if (string.IsNullOrEmpty(formatCode) && cell.ValueType == CellDataType.Date)
@@ -1947,10 +1949,10 @@ class XlsxWriter(Workbook sourceWorkbook)
         return newId;
     }
 
-    private void CreateFontElement(Format? format, int fontId, StyleTracker styleTracker)
+    private void CreateFontElement(Format format, int fontId, StyleTracker styleTracker)
     {
-        var fontSize = format?.FontSize ?? 11;
-        var fontName = format?.FontFamily ?? "Aptos Narrow";
+        var fontSize = format.FontSize ?? 11;
+        var fontName = format.FontFamily ?? "Aptos Narrow";
 
         var fontElement = new XElement(XName.Get("font", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
             new XElement(XName.Get("sz", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
@@ -1958,24 +1960,24 @@ class XlsxWriter(Workbook sourceWorkbook)
             new XElement(XName.Get("name", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
                 new XAttribute("val", fontName)));
 
-        if (format?.Color is not null)
+        if (format.Color is not null)
         {
             fontElement.Add(new XElement(XName.Get("color", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
                 new XAttribute("rgb", format.Color.ToXLSXColor())));
         }
-        if (format?.Bold == true)
+        if (format.Bold)
         {
             fontElement.Add(new XElement(XName.Get("b", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
-        if (format?.Italic == true)
+        if (format.Italic)
         {
             fontElement.Add(new XElement(XName.Get("i", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
-        if (format?.Underline == true)
+        if (format.Underline)
         {
             fontElement.Add(new XElement(XName.Get("u", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
-        if (format?.Strikethrough == true)
+        if (format.Strikethrough)
         {
             fontElement.Add(new XElement(XName.Get("strike", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
@@ -1998,7 +2000,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         styleTracker.FillsElement.Attribute("count")!.Value = (styleTracker.FillStyles.Count + 2).ToString(CultureInfo.InvariantCulture);
     }
 
-    private void CreateCellStyleElement(Cell cell, Format? format, int fontId, int fillId, int borderId, int numFmtId, StyleTracker styleTracker)
+    private void CreateCellStyleElement(Cell cell, Format format, int fontId, int fillId, int borderId, int numFmtId, StyleTracker styleTracker)
     {
         var xfElement = new XElement(XName.Get("xf", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
             new XAttribute("numFmtId", numFmtId.ToString(CultureInfo.InvariantCulture)),
@@ -2011,14 +2013,14 @@ class XlsxWriter(Workbook sourceWorkbook)
             new XAttribute("applyNumberFormat", numFmtId > 0 ? "1" : "0"),
             new XAttribute("applyBorder", borderId > 0 ? "1" : "0"));
 
-        if (format is not null && (format.TextAlign is not null || format.VerticalAlign is not null || format.WrapText))
+        if (format.TextAlign is not null || format.VerticalAlign is not null || format.WrapText)
         {
             var alignmentElement = CreateAlignmentElement(format);
             xfElement.Add(alignmentElement);
             xfElement.Add(new XAttribute("applyAlignment", "1"));
         }
 
-        if (format?.Locked is not null || format?.FormulaHidden is not null)
+        if (format.Locked is not null || format.FormulaHidden is not null)
         {
             var protectionElement = new XElement(XName.Get("protection", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"));
             if (format.Locked is not null)

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1693,9 +1693,9 @@ class XlsxWriter(Workbook sourceWorkbook)
 
         foreach (var range in sheet.MergedCells.Ranges)
         {
-            var anchor = sheet.Cells[range.Start];
+            var anchor = sheet.Cells.Find(range.Start.Row, range.Start.Column);
 
-            int? anchorStyleId = HasCellFormatting(anchor)
+            int? anchorStyleId = anchor is not null && HasCellFormatting(anchor)
                 ? GetOrCreateCellStyle(anchor, styleTracker)
                 : null;
 
@@ -1708,7 +1708,9 @@ class XlsxWriter(Workbook sourceWorkbook)
                         continue;
                     }
 
-                    if (sheet.Cells.HasCell(r, c) && IsWritten(sheet.Cells[r, c]))
+                    var cell = sheet.Cells.Find(r, c);
+
+                    if (cell is not null && IsWritten(cell))
                     {
                         continue;
                     }

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1434,65 +1434,69 @@ class XlsxWriter(Workbook sourceWorkbook)
 
     private static bool HasCellFormatting(Cell cell)
     {
-        return !cell.Format.IsDefault || cell.ValueType == CellDataType.Date || cell.QuotePrefix;
+        return cell.FormatOrNull?.IsDefault == false || cell.ValueType == CellDataType.Date || cell.QuotePrefix;
     }
 
     private int GetOrCreateCellStyle(Cell cell, StyleTracker styleTracker)
     {
-        var fontId = GetOrCreateFontStyle(cell, styleTracker);
-        var fillId = GetOrCreateFillStyle(cell, styleTracker);
-        var numFmtId = GetOrCreateNumberFormat(cell, styleTracker);
-        var borderId = GetOrCreateBorderStyle(cell, styleTracker);
+        var format = cell.FormatOrNull;
 
-        var styleKey = new CellStyleKey(fontId, fillId, borderId, cell.Format.TextAlign, cell.Format.VerticalAlign, cell.Format.WrapText, numFmtId, cell.Format.Locked, cell.Format.FormulaHidden, cell.QuotePrefix);
+        var fontId = GetOrCreateFontStyle(format, styleTracker);
+        var fillId = GetOrCreateFillStyle(format, styleTracker);
+        var numFmtId = GetOrCreateNumberFormat(cell, format, styleTracker);
+        var borderId = GetOrCreateBorderStyle(format, styleTracker);
+
+        var styleKey = new CellStyleKey(fontId, fillId, borderId, format?.TextAlign, format?.VerticalAlign, format?.WrapText == true, numFmtId, format?.Locked, format?.FormulaHidden, cell.QuotePrefix);
 
         if (!styleTracker.CellStyles.TryGetValue(styleKey, out int styleId))
         {
             styleId = styleTracker.CellStyles.Count + 1;
             styleTracker.CellStyles[styleKey] = styleId;
-            CreateCellStyleElement(cell, fontId, fillId, borderId, numFmtId, styleTracker);
+            CreateCellStyleElement(cell, format, fontId, fillId, borderId, numFmtId, styleTracker);
         }
 
         return styleId;
     }
 
-    private int GetOrCreateFontStyle(Cell cell, StyleTracker styleTracker)
+    private int GetOrCreateFontStyle(Format? format, StyleTracker styleTracker)
     {
-        var fontKey = new FontKey(cell.Format.Color, cell.Format.Bold, cell.Format.Italic, cell.Format.Underline, cell.Format.Strikethrough, cell.Format.FontFamily, cell.Format.FontSize);
+        var fontKey = new FontKey(format?.Color, format?.Bold == true, format?.Italic == true, format?.Underline == true, format?.Strikethrough == true, format?.FontFamily, format?.FontSize);
 
         if (!styleTracker.FontStyles.TryGetValue(fontKey, out int fontId))
         {
             fontId = styleTracker.FontStyles.Count + 1;
             styleTracker.FontStyles[fontKey] = fontId;
-            CreateFontElement(cell, fontId, styleTracker);
+            CreateFontElement(format, fontId, styleTracker);
         }
 
         return fontId;
     }
 
-    private int GetOrCreateFillStyle(Cell cell, StyleTracker styleTracker)
+    private int GetOrCreateFillStyle(Format? format, StyleTracker styleTracker)
     {
-        if (cell.Format.BackgroundColor is null)
+        var backgroundColor = format?.BackgroundColor;
+
+        if (backgroundColor is null)
         {
             return 0;
         }
 
-        if (!styleTracker.FillStyles.TryGetValue(cell.Format.BackgroundColor, out int fillId))
+        if (!styleTracker.FillStyles.TryGetValue(backgroundColor, out int fillId))
         {
             fillId = styleTracker.FillStyles.Count + 2; // Start from 2 as 0 and 1 are reserved
-            styleTracker.FillStyles[cell.Format.BackgroundColor] = fillId;
-            CreateFillElement(cell, fillId, styleTracker);
+            styleTracker.FillStyles[backgroundColor] = fillId;
+            CreateFillElement(backgroundColor, fillId, styleTracker);
         }
 
         return fillId;
     }
 
-    private int GetOrCreateBorderStyle(Cell cell, StyleTracker styleTracker)
+    private int GetOrCreateBorderStyle(Format? format, StyleTracker styleTracker)
     {
-        var bt = cell.Format.BorderTop;
-        var br = cell.Format.BorderRight;
-        var bb = cell.Format.BorderBottom;
-        var bl = cell.Format.BorderLeft;
+        var bt = format?.BorderTop;
+        var br = format?.BorderRight;
+        var bb = format?.BorderBottom;
+        var bl = format?.BorderLeft;
 
         if (bt is null && br is null && bb is null && bl is null)
         {
@@ -1510,22 +1514,22 @@ class XlsxWriter(Workbook sourceWorkbook)
         {
             borderId = styleTracker.BorderStyles.Count + 1;
             styleTracker.BorderStyles[borderKey] = borderId;
-            CreateBorderElement(cell, styleTracker);
+            CreateBorderElement(bl, br, bt, bb, styleTracker);
         }
 
         return borderId;
     }
 
-    private static void CreateBorderElement(Cell cell, StyleTracker styleTracker)
+    private static void CreateBorderElement(BorderStyle? left, BorderStyle? right, BorderStyle? top, BorderStyle? bottom, StyleTracker styleTracker)
     {
         var ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
 
         var borderElement = new XElement(XName.Get("border", ns));
 
-        AddBorderSide(borderElement, "left", cell.Format.BorderLeft, ns);
-        AddBorderSide(borderElement, "right", cell.Format.BorderRight, ns);
-        AddBorderSide(borderElement, "top", cell.Format.BorderTop, ns);
-        AddBorderSide(borderElement, "bottom", cell.Format.BorderBottom, ns);
+        AddBorderSide(borderElement, "left", left, ns);
+        AddBorderSide(borderElement, "right", right, ns);
+        AddBorderSide(borderElement, "top", top, ns);
+        AddBorderSide(borderElement, "bottom", bottom, ns);
         borderElement.Add(new XElement(XName.Get("diagonal", ns)));
 
         styleTracker.BordersElement.Add(borderElement);
@@ -1546,9 +1550,9 @@ class XlsxWriter(Workbook sourceWorkbook)
         borderElement.Add(sideElement);
     }
 
-    private static int GetOrCreateNumberFormat(Cell cell, StyleTracker styleTracker)
+    private static int GetOrCreateNumberFormat(Cell cell, Format? format, StyleTracker styleTracker)
     {
-        var formatCode = cell.Format.NumberFormat;
+        var formatCode = format?.NumberFormat;
 
         // Auto-apply default date format for date values without explicit format
         if (string.IsNullOrEmpty(formatCode) && cell.ValueType == CellDataType.Date)
@@ -1594,10 +1598,10 @@ class XlsxWriter(Workbook sourceWorkbook)
         return newId;
     }
 
-    private void CreateFontElement(Cell cell, int fontId, StyleTracker styleTracker)
+    private void CreateFontElement(Format? format, int fontId, StyleTracker styleTracker)
     {
-        var fontSize = cell.Format.FontSize ?? 11;
-        var fontName = cell.Format.FontFamily ?? "Aptos Narrow";
+        var fontSize = format?.FontSize ?? 11;
+        var fontName = format?.FontFamily ?? "Aptos Narrow";
 
         var fontElement = new XElement(XName.Get("font", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
             new XElement(XName.Get("sz", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
@@ -1605,24 +1609,24 @@ class XlsxWriter(Workbook sourceWorkbook)
             new XElement(XName.Get("name", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
                 new XAttribute("val", fontName)));
 
-        if (cell.Format.Color is not null)
+        if (format?.Color is not null)
         {
             fontElement.Add(new XElement(XName.Get("color", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
-                new XAttribute("rgb", cell.Format.Color.ToXLSXColor())));
+                new XAttribute("rgb", format.Color.ToXLSXColor())));
         }
-        if (cell.Format.Bold)
+        if (format?.Bold == true)
         {
             fontElement.Add(new XElement(XName.Get("b", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
-        if (cell.Format.Italic)
+        if (format?.Italic == true)
         {
             fontElement.Add(new XElement(XName.Get("i", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
-        if (cell.Format.Underline)
+        if (format?.Underline == true)
         {
             fontElement.Add(new XElement(XName.Get("u", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
-        if (cell.Format.Strikethrough)
+        if (format?.Strikethrough == true)
         {
             fontElement.Add(new XElement(XName.Get("strike", "http://schemas.openxmlformats.org/spreadsheetml/2006/main")));
         }
@@ -1631,13 +1635,13 @@ class XlsxWriter(Workbook sourceWorkbook)
         styleTracker.FontsElement.Attribute("count")!.Value = (styleTracker.FontStyles.Count + 1).ToString(CultureInfo.InvariantCulture);
     }
 
-    private void CreateFillElement(Cell cell, int fillId, StyleTracker styleTracker)
+    private void CreateFillElement(string backgroundColor, int fillId, StyleTracker styleTracker)
     {
         var fillElement = new XElement(XName.Get("fill", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
             new XElement(XName.Get("patternFill", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
                 new XAttribute("patternType", "solid"),
                 new XElement(XName.Get("fgColor", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
-                    new XAttribute("rgb", cell.Format.BackgroundColor!.ToXLSXColor())),
+                    new XAttribute("rgb", backgroundColor.ToXLSXColor())),
                 new XElement(XName.Get("bgColor", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
                     new XAttribute("indexed", "64"))));
 
@@ -1645,7 +1649,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         styleTracker.FillsElement.Attribute("count")!.Value = (styleTracker.FillStyles.Count + 2).ToString(CultureInfo.InvariantCulture);
     }
 
-    private void CreateCellStyleElement(Cell cell, int fontId, int fillId, int borderId, int numFmtId, StyleTracker styleTracker)
+    private void CreateCellStyleElement(Cell cell, Format? format, int fontId, int fillId, int borderId, int numFmtId, StyleTracker styleTracker)
     {
         var xfElement = new XElement(XName.Get("xf", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
             new XAttribute("numFmtId", numFmtId.ToString(CultureInfo.InvariantCulture)),
@@ -1658,23 +1662,23 @@ class XlsxWriter(Workbook sourceWorkbook)
             new XAttribute("applyNumberFormat", numFmtId > 0 ? "1" : "0"),
             new XAttribute("applyBorder", borderId > 0 ? "1" : "0"));
 
-        if (cell.Format.TextAlign is not null || cell.Format.VerticalAlign is not null || cell.Format.WrapText)
+        if (format is not null && (format.TextAlign is not null || format.VerticalAlign is not null || format.WrapText))
         {
-            var alignmentElement = CreateAlignmentElement(cell);
+            var alignmentElement = CreateAlignmentElement(format);
             xfElement.Add(alignmentElement);
             xfElement.Add(new XAttribute("applyAlignment", "1"));
         }
 
-        if (cell.Format.Locked is not null || cell.Format.FormulaHidden is not null)
+        if (format?.Locked is not null || format?.FormulaHidden is not null)
         {
             var protectionElement = new XElement(XName.Get("protection", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"));
-            if (cell.Format.Locked is not null)
+            if (format.Locked is not null)
             {
-                protectionElement.Add(new XAttribute("locked", cell.Format.Locked.Value ? "1" : "0"));
+                protectionElement.Add(new XAttribute("locked", format.Locked.Value ? "1" : "0"));
             }
-            if (cell.Format.FormulaHidden is not null)
+            if (format.FormulaHidden is not null)
             {
-                protectionElement.Add(new XAttribute("hidden", cell.Format.FormulaHidden.Value ? "1" : "0"));
+                protectionElement.Add(new XAttribute("hidden", format.FormulaHidden.Value ? "1" : "0"));
             }
             xfElement.Add(protectionElement);
             xfElement.Add(new XAttribute("applyProtection", "1"));
@@ -1690,13 +1694,13 @@ class XlsxWriter(Workbook sourceWorkbook)
         styleTracker.CellXfsElement.Attribute("count")!.Value = (styleTracker.CellStyles.Count + 1).ToString(CultureInfo.InvariantCulture);
     }
 
-    private static XElement CreateAlignmentElement(Cell cell)
+    private static XElement CreateAlignmentElement(Format format)
     {
         var alignmentElement = new XElement(XName.Get("alignment", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"));
 
-        if (cell.Format.TextAlign is not null)
+        if (format.TextAlign is not null)
         {
-            var horizontalAlign = cell.Format.TextAlign switch
+            var horizontalAlign = format.TextAlign switch
             {
                 TextAlign.Center => "center",
                 TextAlign.Right => "right",
@@ -1706,9 +1710,9 @@ class XlsxWriter(Workbook sourceWorkbook)
             alignmentElement.Add(new XAttribute("horizontal", horizontalAlign));
         }
 
-        if (cell.Format.VerticalAlign is not null)
+        if (format.VerticalAlign is not null)
         {
-            var verticalAlign = cell.Format.VerticalAlign switch
+            var verticalAlign = format.VerticalAlign switch
             {
                 VerticalAlign.Middle => "center",
                 VerticalAlign.Bottom => "bottom",
@@ -1717,7 +1721,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             alignmentElement.Add(new XAttribute("vertical", verticalAlign));
         }
 
-        if (cell.Format.WrapText)
+        if (format.WrapText)
         {
             alignmentElement.Add(new XAttribute("wrapText", "1"));
         }
@@ -1846,8 +1850,6 @@ class XlsxWriter(Workbook sourceWorkbook)
                 break;
 
             case CellDataType.Empty:
-                // No cached value to emit. For formulas, leave it absent so
-                // Excel recalculates on open.
                 break;
         }
     }
@@ -2197,7 +2199,6 @@ class XlsxWriter(Workbook sourceWorkbook)
             sheetDoc.Root!.Add(dataValidationsElement);
         }
     }
-
 
     private static XElement? CreateFilterColumn(SheetFilter filter, RangeRef autoFilterRange)
     {

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1393,51 +1393,49 @@ class XlsxWriter(Workbook sourceWorkbook)
                 row = Math.Min(row, styledRows[styledRowIndex]);
             }
 
+            var cellEnd = cellIndex;
+
+            while (cellEnd < count && cells[cellEnd].Address.Row == row)
+            {
+                cellEnd++;
+            }
+
+            var placeholderEnd = placeholderIndex;
+
+            while (placeholderEnd < placeholders.Count && placeholders[placeholderEnd].Address.Row == row)
+            {
+                placeholderEnd++;
+            }
+
             var firstColumn = -1;
             var lastColumn = -1;
 
-            for (var i = cellIndex; i < count && cells[i].Address.Row == row; i++)
+            if (cellEnd > cellIndex)
             {
-                var column = cells[i].Address.Column;
-
-                if (firstColumn < 0 || column < firstColumn)
-                {
-                    firstColumn = column;
-                }
-
-                lastColumn = Math.Max(lastColumn, column);
+                firstColumn = cells[cellIndex].Address.Column;
+                lastColumn = cells[cellEnd - 1].Address.Column;
             }
 
-            for (var i = placeholderIndex; i < placeholders.Count && placeholders[i].Address.Row == row; i++)
+            if (placeholderEnd > placeholderIndex)
             {
-                var column = placeholders[i].Address.Column;
+                var column = placeholders[placeholderIndex].Address.Column;
 
                 if (firstColumn < 0 || column < firstColumn)
                 {
                     firstColumn = column;
                 }
 
-                lastColumn = Math.Max(lastColumn, column);
+                lastColumn = Math.Max(lastColumn, placeholders[placeholderEnd - 1].Address.Column);
             }
 
             WriteRowStart(writer, sheet, row, firstColumn, lastColumn);
 
             var writtenColumn = -1;
 
-            while (true)
+            while (cellIndex < cellEnd || placeholderIndex < placeholderEnd)
             {
-                var cellColumn = cellIndex < count && cells[cellIndex].Address.Row == row
-                    ? cells[cellIndex].Address.Column
-                    : int.MaxValue;
-
-                var placeholderColumn = placeholderIndex < placeholders.Count && placeholders[placeholderIndex].Address.Row == row
-                    ? placeholders[placeholderIndex].Address.Column
-                    : int.MaxValue;
-
-                if (cellColumn == int.MaxValue && placeholderColumn == int.MaxValue)
-                {
-                    break;
-                }
+                var cellColumn = cellIndex < cellEnd ? cells[cellIndex].Address.Column : int.MaxValue;
+                var placeholderColumn = placeholderIndex < placeholderEnd ? placeholders[placeholderIndex].Address.Column : int.MaxValue;
 
                 if (cellColumn <= placeholderColumn)
                 {

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -19,6 +19,10 @@ class XlsxWriter(Workbook sourceWorkbook)
 
     private readonly IReadOnlyList<Worksheet> sheets = sourceWorkbook.Sheets;
 
+    private const int ScratchLength = 64;
+
+    private readonly char[] scratch = new char[ScratchLength];
+
     public void Write(Stream stream)
     {
         using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
@@ -1452,10 +1456,10 @@ class XlsxWriter(Workbook sourceWorkbook)
         }
     }
 
-    private static void WriteRowStart(XmlWriter writer, Worksheet sheet, int row, int firstColumn, int lastColumn)
+    private void WriteRowStart(XmlWriter writer, Worksheet sheet, int row, int firstColumn, int lastColumn)
     {
         writer.WriteStartElement("row", Main);
-        writer.WriteAttributeString("r", XmlConvert.ToString(row + 1));
+        WriteNumberAttribute(writer, "r", row + 1);
 
         // Only persist height if it differs from the default
         if (Math.Abs(sheet.Rows[row] - sheet.Rows.Size) > 1e-6)
@@ -1471,20 +1475,58 @@ class XlsxWriter(Workbook sourceWorkbook)
 
         if (firstColumn >= 0)
         {
-            writer.WriteAttributeString("spans", string.Create(CultureInfo.InvariantCulture, $"{firstColumn + 1}:{lastColumn + 1}"));
+            (firstColumn + 1).TryFormat(scratch, out var first, provider: CultureInfo.InvariantCulture);
+            scratch[first] = ':';
+            (lastColumn + 1).TryFormat(scratch.AsSpan(first + 1), out var last, provider: CultureInfo.InvariantCulture);
+
+            writer.WriteStartAttribute("spans");
+            writer.WriteRaw(scratch, 0, first + 1 + last);
+            writer.WriteEndAttribute();
         }
     }
 
-    private static void WritePlaceholder(XmlWriter writer, CellRef address, int? styleId)
+    private void WritePlaceholder(XmlWriter writer, CellRef address, int? styleId)
     {
         writer.WriteStartElement("c", Main);
-        writer.WriteAttributeString("r", address.ToString());
+        WriteReferenceAttribute(writer, address);
 
         if (styleId is not null)
         {
-            writer.WriteAttributeString("s", XmlConvert.ToString(styleId.Value));
+            WriteNumberAttribute(writer, "s", styleId.Value);
         }
 
+        writer.WriteEndElement();
+    }
+
+    private void WriteReferenceAttribute(XmlWriter writer, CellRef address)
+    {
+        var length = address.Format(scratch);
+
+        writer.WriteStartAttribute("r");
+        writer.WriteRaw(scratch, 0, length);
+        writer.WriteEndAttribute();
+    }
+
+    private void WriteNumberAttribute(XmlWriter writer, string name, int value)
+    {
+        value.TryFormat(scratch, out var length, provider: CultureInfo.InvariantCulture);
+
+        writer.WriteStartAttribute(name);
+        writer.WriteRaw(scratch, 0, length);
+        writer.WriteEndAttribute();
+    }
+
+    private void WriteNumberValue(XmlWriter writer, int value)
+    {
+        value.TryFormat(scratch, out var length, provider: CultureInfo.InvariantCulture);
+
+        WriteRawValue(writer, length);
+    }
+
+    private void WriteRawValue(XmlWriter writer, int length)
+    {
+        writer.WriteStartElement("v", Main);
+        writer.WriteRaw(scratch, 0, length);
         writer.WriteEndElement();
     }
 
@@ -1493,11 +1535,11 @@ class XlsxWriter(Workbook sourceWorkbook)
         var isFormula = !string.IsNullOrEmpty(cell.Formula);
 
         writer.WriteStartElement("c", Main);
-        writer.WriteAttributeString("r", cell.Address.ToString());
+        WriteReferenceAttribute(writer, cell.Address);
 
         if (HasCellFormatting(cell))
         {
-            writer.WriteAttributeString("s", XmlConvert.ToString(GetOrCreateCellStyle(cell, styleTracker)));
+            WriteNumberAttribute(writer, "s", GetOrCreateCellStyle(cell, styleTracker));
         }
 
         var type = CellTypeAttribute(cell, isFormula);
@@ -1522,7 +1564,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                 sharedStrings[text] = index;
             }
 
-            WriteValue(writer, XmlConvert.ToString(index));
+            WriteNumberValue(writer, index);
         }
         else
         {
@@ -1540,7 +1582,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         _ => null,
     };
 
-    private static void WriteFormula(XmlWriter writer, Cell cell, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    private void WriteFormula(XmlWriter writer, Cell cell, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var formula = cell.Formula!.StartsWith('=') ? cell.Formula![1..] : cell.Formula!;
 
@@ -1555,7 +1597,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                 writer.WriteAttributeString("ref", shared.Ref);
             }
 
-            writer.WriteAttributeString("si", XmlConvert.ToString(shared.Si));
+            WriteNumberAttribute(writer, "si", shared.Si);
 
             if (shared.Ref is null)
             {
@@ -1569,13 +1611,20 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteFullEndElement();
     }
 
-    private static void WriteTypedValue(XmlWriter writer, Cell cell)
+    private void WriteTypedValue(XmlWriter writer, Cell cell)
     {
         switch (cell.ValueType)
         {
             case CellDataType.Number:
             case CellDataType.String:
-                WriteValue(writer, FormatValueInvariant(cell.Value));
+                if (TryFormatNumber(cell.Value, out var length))
+                {
+                    WriteRawValue(writer, length);
+                }
+                else
+                {
+                    WriteValue(writer, FormatValueInvariant(cell.Value));
+                }
                 break;
 
             case CellDataType.Boolean:
@@ -1585,7 +1634,9 @@ class XlsxWriter(Workbook sourceWorkbook)
             case CellDataType.Date:
                 if (cell.Value is DateTime dateValue)
                 {
-                    WriteValue(writer, dateValue.ToNumber().ToString(CultureInfo.InvariantCulture));
+                    dateValue.ToNumber().TryFormat(scratch, out var digits, provider: CultureInfo.InvariantCulture);
+
+                    WriteRawValue(writer, digits);
                 }
                 break;
 
@@ -1595,6 +1646,21 @@ class XlsxWriter(Workbook sourceWorkbook)
 
             case CellDataType.Empty:
                 break;
+        }
+    }
+
+    private bool TryFormatNumber(object? value, out int length)
+    {
+        switch (value)
+        {
+            case double d: return d.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
+            case int i: return i.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
+            case long l: return l.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
+            case decimal m: return m.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
+            case float f: return f.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
+            default:
+                length = 0;
+                return false;
         }
     }
 

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -26,12 +26,11 @@ class XlsxWriter(Workbook sourceWorkbook)
         var styleTracker = CreateStylesDocument();
 
         var sharedStrings = new Dictionary<string, int>();
-        var sharedStringsDoc = CreateSharedStringsDocument(sharedStrings);
 
         var totalTables = 0;
-        SaveSheets(archive, styleTracker, sharedStrings, sharedStringsDoc, ref totalTables);
+        SaveSheets(archive, styleTracker, sharedStrings, ref totalTables);
         SaveStyles(archive, styleTracker);
-        UpdateAndSaveSharedStrings(archive, sharedStrings, sharedStringsDoc);
+        SaveSharedStrings(archive, sharedStrings);
         SaveWorkbook(archive);
         SaveTheme(archive);
         SaveDocPropsCore(archive);
@@ -759,14 +758,6 @@ class XlsxWriter(Workbook sourceWorkbook)
         rels.Save(entry);
     }
 
-    private static XDocument CreateSharedStringsDocument(Dictionary<string, int> sharedStrings)
-    {
-        return new XDocument(
-            new XElement(XName.Get("sst", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
-                new XAttribute("count", "0"),
-                new XAttribute("uniqueCount", "0")));
-    }
-
     private static void SaveStyles(ZipArchive archive, StyleTracker styleTracker)
     {
         using var entry = archive.CreateEntry("xl/styles.xml").Open();
@@ -872,7 +863,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                 new XAttribute("builtinId", "0")));
     }
 
-    private void SaveSheets(ZipArchive archive, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc, ref int globalTableIndex)
+    private void SaveSheets(ZipArchive archive, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, ref int globalTableIndex)
     {
         var workbookRels = CreateWorkbookRelationships();
         var workbookRelsElement = workbookRels.Root!;
@@ -900,7 +891,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                 new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"),
                 new XAttribute("Target", $"worksheets/{sheetName}")));
 
-            SaveSheet(archive, sheet, sheetName, sheetId, relId, styleTracker, sharedStrings, sharedStringsDoc, mediaMap, ref globalMediaIndex, ref globalTableIndex);
+            SaveSheet(archive, sheet, sheetName, sheetId, relId, styleTracker, sharedStrings, mediaMap, ref globalMediaIndex, ref globalTableIndex);
         }
 
         workbookRelsElement.Add(new XElement(XName.Get("Relationship", pkgNs),
@@ -927,7 +918,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             new XElement(XName.Get("Relationships", "http://schemas.openxmlformats.org/package/2006/relationships")));
     }
 
-    private void SaveSheet(ZipArchive archive, Worksheet sheet, string sheetName, int sheetId, string relId, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc, Dictionary<string, string> mediaMap, ref int globalMediaIndex, ref int globalTableIndex)
+    private void SaveSheet(ZipArchive archive, Worksheet sheet, string sheetName, int sheetId, string relId, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, Dictionary<string, string> mediaMap, ref int globalMediaIndex, ref int globalTableIndex)
     {
         var sheetDoc = CreateSheetDocument(sheet, sheetId, relId);
 
@@ -998,7 +989,7 @@ class XlsxWriter(Workbook sourceWorkbook)
 
         using (var entry = archive.CreateEntry($"xl/worksheets/{sheetName}").Open())
         {
-            WriteSheetXml(entry, sheetDoc, sheet, styleTracker, sharedStrings, sharedStringsDoc);
+            WriteSheetXml(entry, sheetDoc, sheet, styleTracker, sharedStrings);
         }
 
         if (sheetRelEntries.Count > 0)
@@ -1305,17 +1296,15 @@ class XlsxWriter(Workbook sourceWorkbook)
         return groups;
     }
 
-    // Indent alone, so the byte order mark, the indent string and the newline stay whatever
-    // XDocument.Save would have written - the newline among them is the platform's.
-    private static readonly XmlWriterSettings SheetXmlSettings = new() { Indent = true };
+    private static readonly XmlWriterSettings PartXmlSettings = new() { Indent = true };
 
     private static readonly XName SheetDataElement = XName.Get("sheetData", Main);
 
-    private void WriteSheetXml(Stream stream, XDocument sheetDoc, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc)
+    private void WriteSheetXml(Stream stream, XDocument sheetDoc, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings)
     {
         var root = sheetDoc.Root!;
 
-        using var writer = XmlWriter.Create(stream, SheetXmlSettings);
+        using var writer = XmlWriter.Create(stream, PartXmlSettings);
 
         writer.WriteStartDocument();
         writer.WriteStartElement(root.Name.LocalName, root.Name.NamespaceName);
@@ -1330,7 +1319,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             if (element.Name == SheetDataElement)
             {
                 writer.WriteStartElement(SheetDataElement.LocalName, Main);
-                WriteSheetData(writer, sheet, styleTracker, sharedStrings, sharedStringsDoc);
+                WriteSheetData(writer, sheet, styleTracker, sharedStrings);
                 writer.WriteEndElement();
             }
             else
@@ -1343,7 +1332,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteEndDocument();
     }
 
-    private void WriteSheetData(XmlWriter writer, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc)
+    private void WriteSheetData(XmlWriter writer, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings)
     {
         var sharedFormulas = BuildSharedFormulaGroups(sheet);
 
@@ -1440,7 +1429,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                 if (cellColumn <= placeholderColumn)
                 {
                     writtenColumn = cellColumn;
-                    WriteCell(writer, cells[cellIndex++], styleTracker, sharedStrings, sharedStringsDoc, sharedFormulas);
+                    WriteCell(writer, cells[cellIndex++], styleTracker, sharedStrings, sharedFormulas);
                 }
                 else
                 {
@@ -1499,7 +1488,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteEndElement();
     }
 
-    private void WriteCell(XmlWriter writer, Cell cell, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    private void WriteCell(XmlWriter writer, Cell cell, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var isFormula = !string.IsNullOrEmpty(cell.Formula);
 
@@ -1531,7 +1520,6 @@ class XlsxWriter(Workbook sourceWorkbook)
             {
                 index = sharedStrings.Count;
                 sharedStrings[text] = index;
-                sharedStringsDoc.Root!.Add(new XElement(SiElement, new XElement(TElement, text)));
             }
 
             WriteValue(writer, XmlConvert.ToString(index));
@@ -1990,9 +1978,6 @@ class XlsxWriter(Workbook sourceWorkbook)
     }
 
     private const string Main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
-
-    private static readonly XName SiElement = XName.Get("si", Main);
-    private static readonly XName TElement = XName.Get("t", Main);
 
     private static string CellErrorToString(CellError error) => error switch
     {
@@ -2572,7 +2557,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         _ => DynamicFilterType.Today,
     };
 
-    private static void UpdateAndSaveSharedStrings(ZipArchive archive, Dictionary<string, int> sharedStrings, XDocument sharedStringsDoc)
+    private static void SaveSharedStrings(ZipArchive archive, Dictionary<string, int> sharedStrings)
     {
         if (sharedStrings.Count == 0)
         {
@@ -2581,12 +2566,34 @@ class XlsxWriter(Workbook sourceWorkbook)
             return;
         }
 
-        var sstElement = sharedStringsDoc.Root!;
-        sstElement.Attribute("count")!.Value = sharedStrings.Count.ToString(CultureInfo.InvariantCulture);
-        sstElement.Attribute("uniqueCount")!.Value = sharedStrings.Count.ToString(CultureInfo.InvariantCulture);
+        var strings = new string[sharedStrings.Count];
+
+        foreach (var (text, index) in sharedStrings)
+        {
+            strings[index] = text;
+        }
+
+        var count = sharedStrings.Count.ToString(CultureInfo.InvariantCulture);
 
         using var entry = archive.CreateEntry("xl/sharedStrings.xml").Open();
-        sharedStringsDoc.Save(entry);
+        using var writer = XmlWriter.Create(entry, PartXmlSettings);
+
+        writer.WriteStartDocument();
+        writer.WriteStartElement("sst", Main);
+        writer.WriteAttributeString("count", count);
+        writer.WriteAttributeString("uniqueCount", count);
+
+        foreach (var text in strings)
+        {
+            writer.WriteStartElement("si", Main);
+            writer.WriteStartElement("t", Main);
+            writer.WriteString(text);
+            writer.WriteFullEndElement();
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
+        writer.WriteEndDocument();
     }
 
     private void SaveWorkbook(ZipArchive archive)

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -30,7 +30,7 @@ class XlsxWriter(Workbook sourceWorkbook)
 
         var styleTracker = CreateStylesDocument();
 
-        var sharedStrings = new Dictionary<string, int>();
+        using var sharedStrings = new SharedStringTable();
 
         var totalTables = 0;
         SaveSheets(archive, styleTracker, sharedStrings, ref totalTables);
@@ -868,7 +868,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                 new XAttribute("builtinId", "0")));
     }
 
-    private void SaveSheets(ZipArchive archive, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, ref int globalTableIndex)
+    private void SaveSheets(ZipArchive archive, StyleTracker styleTracker, SharedStringTable sharedStrings, ref int globalTableIndex)
     {
         var workbookRels = CreateWorkbookRelationships();
         var workbookRelsElement = workbookRels.Root!;
@@ -923,7 +923,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             new XElement(XName.Get("Relationships", "http://schemas.openxmlformats.org/package/2006/relationships")));
     }
 
-    private void SaveSheet(ZipArchive archive, Worksheet sheet, string sheetName, int sheetId, string relId, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, Dictionary<string, string> mediaMap, ref int globalMediaIndex, ref int globalTableIndex)
+    private void SaveSheet(ZipArchive archive, Worksheet sheet, string sheetName, int sheetId, string relId, StyleTracker styleTracker, SharedStringTable sharedStrings, Dictionary<string, string> mediaMap, ref int globalMediaIndex, ref int globalTableIndex)
     {
         var sheetDoc = CreateSheetDocument(sheet, sheetId, relId);
 
@@ -1305,7 +1305,7 @@ class XlsxWriter(Workbook sourceWorkbook)
 
     private static readonly XName SheetDataElement = XName.Get("sheetData", Main);
 
-    private void WriteSheetXml(Stream stream, XDocument sheetDoc, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings)
+    private void WriteSheetXml(Stream stream, XDocument sheetDoc, Worksheet sheet, StyleTracker styleTracker, SharedStringTable sharedStrings)
     {
         var root = sheetDoc.Root!;
 
@@ -1337,7 +1337,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteEndDocument();
     }
 
-    private void WriteSheetData(XmlWriter writer, Worksheet sheet, StyleTracker styleTracker, Dictionary<string, int> sharedStrings)
+    private void WriteSheetData(XmlWriter writer, Worksheet sheet, StyleTracker styleTracker, SharedStringTable sharedStrings)
     {
         var sharedFormulas = BuildSharedFormulaGroups(sheet);
 
@@ -1353,7 +1353,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         }
     }
 
-    private void WriteRows(XmlWriter writer, Worksheet sheet, Cell[] cells, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    private void WriteRows(XmlWriter writer, Worksheet sheet, Cell[] cells, StyleTracker styleTracker, SharedStringTable sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var count = 0;
 
@@ -1536,7 +1536,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteEndElement();
     }
 
-    private void WriteCell(XmlWriter writer, Cell cell, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    private void WriteCell(XmlWriter writer, Cell cell, StyleTracker styleTracker, SharedStringTable sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var isFormula = !string.IsNullOrEmpty(cell.Formula);
 
@@ -1562,15 +1562,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         }
         else if (cell.ValueType == CellDataType.String)
         {
-            var text = cell.Value as string ?? string.Empty;
-
-            if (!sharedStrings.TryGetValue(text, out var index))
-            {
-                index = sharedStrings.Count;
-                sharedStrings[text] = index;
-            }
-
-            WriteNumberValue(writer, index);
+            WriteNumberValue(writer, sharedStrings.GetOrAdd(cell.Value as string ?? string.Empty));
         }
         else
         {
@@ -2672,20 +2664,13 @@ class XlsxWriter(Workbook sourceWorkbook)
         _ => DynamicFilterType.Today,
     };
 
-    private static void SaveSharedStrings(ZipArchive archive, Dictionary<string, int> sharedStrings)
+    private static void SaveSharedStrings(ZipArchive archive, SharedStringTable sharedStrings)
     {
         if (sharedStrings.Count == 0)
         {
             // No string cells in the workbook; skip the part entirely. Its
             // relationship and Content_Types Override are also omitted.
             return;
-        }
-
-        var strings = new string[sharedStrings.Count];
-
-        foreach (var (text, index) in sharedStrings)
-        {
-            strings[index] = text;
         }
 
         var count = sharedStrings.Count.ToString(CultureInfo.InvariantCulture);
@@ -2698,7 +2683,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteAttributeString("count", count);
         writer.WriteAttributeString("uniqueCount", count);
 
-        foreach (var text in strings)
+        foreach (var text in sharedStrings.Strings)
         {
             writer.WriteStartElement("si", Main);
             writer.WriteStartElement("t", Main);

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1478,7 +1478,6 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteStartElement("row", Main);
         WriteNumberAttribute(writer, "r", row + 1);
 
-        // Only persist height if it differs from the default
         if (Math.Abs(sheet.Rows[row] - sheet.Rows.Size) > 1e-6)
         {
             writer.WriteAttributeString("ht", XmlConvert.ToString(sheet.Rows[row]));

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -1340,23 +1341,39 @@ class XlsxWriter(Workbook sourceWorkbook)
     {
         var sharedFormulas = BuildSharedFormulaGroups(sheet);
 
-        // GetPopulatedCells enumerates a dictionary, so that order is recovered by sorting.
-        var cells = new List<Cell>(sheet.Cells.PopulatedCount);
+        var cells = ArrayPool<Cell>.Shared.Rent(sheet.Cells.PopulatedCount);
+
+        try
+        {
+            WriteRows(writer, sheet, cells, styleTracker, sharedStrings, sharedFormulas);
+        }
+        finally
+        {
+            ArrayPool<Cell>.Shared.Return(cells, clearArray: true);
+        }
+    }
+
+    private void WriteRows(XmlWriter writer, Worksheet sheet, Cell[] cells, StyleTracker styleTracker, Dictionary<string, int> sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    {
+        var count = 0;
+        var interned = 0;
 
         foreach (var cell in sheet.Cells.GetPopulatedCells())
         {
             if (IsWritten(cell))
             {
-                cells.Add(cell);
+                cells[count++] = cell;
+
+                if (cell.ValueType == CellDataType.String && string.IsNullOrEmpty(cell.Formula))
+                {
+                    interned++;
+                }
             }
         }
 
-        cells.Sort(static (left, right) =>
-        {
-            var byRow = left.Address.Row.CompareTo(right.Address.Row);
+        sharedStrings.EnsureCapacity(sharedStrings.Count + interned);
 
-            return byRow != 0 ? byRow : left.Address.Column.CompareTo(right.Address.Column);
-        });
+        Array.Sort(cells, 0, count, CellOrder.Instance);
 
         var placeholders = CreateMergePlaceholders(sheet, styleTracker);
         var styledRows = CollectStyledRowIndices(sheet);
@@ -1365,11 +1382,11 @@ class XlsxWriter(Workbook sourceWorkbook)
         var placeholderIndex = 0;
         var styledRowIndex = 0;
 
-        while (cellIndex < cells.Count || placeholderIndex < placeholders.Count || styledRowIndex < styledRows.Count)
+        while (cellIndex < count || placeholderIndex < placeholders.Count || styledRowIndex < styledRows.Count)
         {
             var row = int.MaxValue;
 
-            if (cellIndex < cells.Count)
+            if (cellIndex < count)
             {
                 row = Math.Min(row, cells[cellIndex].Address.Row);
             }
@@ -1387,7 +1404,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             var firstColumn = -1;
             var lastColumn = -1;
 
-            for (var i = cellIndex; i < cells.Count && cells[i].Address.Row == row; i++)
+            for (var i = cellIndex; i < count && cells[i].Address.Row == row; i++)
             {
                 var column = cells[i].Address.Column;
 
@@ -1417,7 +1434,7 @@ class XlsxWriter(Workbook sourceWorkbook)
 
             while (true)
             {
-                var cellColumn = cellIndex < cells.Count && cells[cellIndex].Address.Row == row
+                var cellColumn = cellIndex < count && cells[cellIndex].Address.Row == row
                     ? cells[cellIndex].Address.Column
                     : int.MaxValue;
 
@@ -1706,6 +1723,18 @@ class XlsxWriter(Workbook sourceWorkbook)
             .OrderBy(placeholder => placeholder.Address.Row)
             .ThenBy(placeholder => placeholder.Address.Column)
             .ToList();
+    }
+
+    private sealed class CellOrder : IComparer<Cell>
+    {
+        public static readonly CellOrder Instance = new();
+
+        public int Compare(Cell? left, Cell? right)
+        {
+            var byRow = left!.Address.Row.CompareTo(right!.Address.Row);
+
+            return byRow != 0 ? byRow : left.Address.Column.CompareTo(right.Address.Column);
+        }
     }
 
     private static bool IsWritten(Cell cell) => cell.Value is not null || cell.Formula is not null;

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1659,17 +1659,14 @@ class XlsxWriter(Workbook sourceWorkbook)
 
     private bool TryFormatNumber(object? value, out int length)
     {
-        switch (value)
+        if (value is ISpanFormattable number)
         {
-            case double d: return d.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
-            case int i: return i.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
-            case long l: return l.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
-            case decimal m: return m.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
-            case float f: return f.TryFormat(scratch, out length, provider: CultureInfo.InvariantCulture);
-            default:
-                length = 0;
-                return false;
+            return number.TryFormat(scratch, out length, default, CultureInfo.InvariantCulture);
         }
+
+        length = 0;
+
+        return false;
     }
 
     private static void WriteValue(XmlWriter writer, string text)


### PR DESCRIPTION
Reduces what `Workbook.SaveToStream` allocates, such no GC is necessary. Standalone commits measured over a
50,000 x 11 sheet (550,000 cells):

| | allocated |
| --- | --- |
| `master` | 442 MB |
| read a cell's format without creating one | 337 |
| format a cell reference into a span | 270 |
| sort the cells once instead of a tree per row | 215 |
| write the cells to the stream instead of building them as a tree | 81 |
| write the shared string table from the table | 64 |
| write references and numbers to the stream as characters | 25.7 |
| rent the sort array, size the string table | **17.7** |
| *review:* drop the string table hint | 21.6 MB |
| *review:* keep the shared string table in rented arrays | **12.4 MB** |

Measured into a `MemoryStream`; with the sink outside the window it is 9.6 MB. Each commit message
carries its own mechanism and figure.

## Against ClosedXML 0.104.2

BenchmarkDotNet, `[MemoryDiagnoser]`, same sheet. Both save arms build a workbook per invocation.

| save only | Mean | Allocated | Gen0 | Gen1 | Gen2 |
| --- | --- | --- | --- | --- | --- |
| `master` | 1,094.2 ms | 442.01 MB | 53000 | 28000 | 1000 |
| this branch | **261.0 ms** | **12.35 MB** | **-** | **-** | **-** |
| ClosedXML, in the `master` run *(control)* | 522.4 ms | 278.70 MB | 21000 | 1000 | 1000 |

The two builds are separate runs, so the control is there to say whether they compare: its allocation is
identical and its time moved 4.7%, which puts the save at **4.0x faster** normalised against it and **36x**
less allocated. It causes no collection of any generation.

Collections in a whole export are the fill's, not the writer's:

| | Allocated | Gen0 | Gen1 | Gen2 |
| --- | --- | --- | --- | --- |
| fill only (`CellStore.SetValues`) | 93.97 MB | 10667 | 5667 | 1000 |
| fill and save | 111.64 MB | 10000 | 5000 | 1000 |

Whole export, `master` against this branch. One process cannot hold two builds, so these are two runs
with ClosedXML as a control:

| run | | Mean | Allocated | Gen0 | Gen1 | Gen2 |
| --- | --- | --- | --- | --- | --- | --- |
| on `master` | this package | 1,396.0 ms | 535.99 MB | 65000 | 33000 | 3000 |
| on `master` | ClosedXML *(control)* | 630.8 ms | 353.81 MB | 29000 | 6000 | 3000 |
| on this branch | this package | 556.2 ms | 106.32 MB | 10000 | 5000 | 1000 |

Against the control measured beside it, the
export goes from **2.21x** ClosedXML's time on `master` to **0.71x** on this branch.

## Produced file

`Sort the cells once` numbers the shared string table and `cellXfs` in document order rather than in the order `CellStore` enumerates. `Give a merge anchor its style where the merge is written` (review) extends that to a formatted merge anchor, whose style is now numbered where the merge appears instead of ahead of every cell. Every index still selects what it selected - tests pin both tables and the merge case, and ClosedXML reads the file back with the same values and styles. Two workbooks with the same contents now serialise the same way whatever order they were filled in.

The other commits change no byte of a saved workbook. Checked against a workbook carrying a drawing, a table, hyperlinks, merges, conditional formatting, data validations, an autofilter, sheet protection, frozen panes, shared formulas with a master and a follower, error cells, a text-result formula, a quote prefix, hidden and custom-sized rows and columns, escaped text with a surrogate pair, and a sheet with no cells: sixteen parts, byte for byte.

## Points to check

- `WriteRaw` does not escape. Only a cell reference and an invariant-culture number reach it; text goes
  through `WriteString`.
- The shared string table is sized by a sheet's string cells, not the distinct strings among them.
- `CellRef.ToString` and `ColumnRef.ToString(int)` are public and now format through a span. Output is
  unchanged, including the row at `int.MaxValue`.

5,169 tests green, and green at each commit on its own.

Figures are allocation rather than wall-clock, from interleaved A/B runs of two builds, with each
mechanism confirmed by removing the line. The benchmark project and harnesses are left out of this PR;
happy to open them separately.
