### PR TITLE
Demos: only write image files from the upload endpoint

### DIFF
--- a/RadzenBlazorDemos.Host/Controllers/UploadController.cs
+++ b/RadzenBlazorDemos.Host/Controllers/UploadController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Hosting;
 using System;
@@ -16,6 +17,12 @@ namespace RadzenBlazorDemos
         {
             this.environment = environment;
         }
+
+        // SVG is excluded because it can carry script.
+        static readonly string[] AllowedImageExtensions =
+        {
+            ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
+        };
 
         [HttpPut("api/upload/stream")]
         public async Task<IActionResult> Stream()
@@ -60,7 +67,14 @@ namespace RadzenBlazorDemos
                 // Used for demo purposes only
                 DeleteOldFiles();
 
-                var fileName = $"upload-{DateTime.Today.ToString("yyyy-MM-dd")}-{Guid.NewGuid()}{Path.GetExtension(file.FileName)}";
+                var extension = Path.GetExtension(file.FileName);
+
+                if (!AllowedImageExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+                {
+                    return BadRequest("Only image files can be uploaded.");
+                }
+
+                var fileName = $"upload-{DateTime.Today.ToString("yyyy-MM-dd")}-{Guid.NewGuid()}{extension}";
 
                 using (var stream = new FileStream(Path.Combine(environment.WebRootPath, fileName), FileMode.Create))
                 {

--- a/RadzenBlazorDemos.Server/Controllers/UploadController.cs
+++ b/RadzenBlazorDemos.Server/Controllers/UploadController.cs
@@ -1,8 +1,10 @@
+using System;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 
 namespace RadzenBlazorDemos.Server.Controllers
 {
-    [DisableRequestSizeLimit]
+    [RequestSizeLimit(50 * 1024 * 1024)]
     public class UploadController : Controller
     {
         private readonly IWebHostEnvironment environment;
@@ -11,6 +13,12 @@ namespace RadzenBlazorDemos.Server.Controllers
         {
             this.environment = environment;
         }
+
+        // SVG is excluded because it can carry script.
+        static readonly string[] AllowedImageExtensions =
+        {
+            ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
+        };
 
         [HttpPut("api/upload/stream")]
         public async Task<IActionResult> Stream()
@@ -48,7 +56,14 @@ namespace RadzenBlazorDemos.Server.Controllers
             {
                 DeleteOldFiles();
 
-                var fileName = $"upload-{DateTime.Today:yyyy-MM-dd}-{Guid.NewGuid()}{Path.GetExtension(file.FileName)}";
+                var extension = Path.GetExtension(file.FileName);
+
+                if (!AllowedImageExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+                {
+                    return BadRequest("Only image files can be uploaded.");
+                }
+
+                var fileName = $"upload-{DateTime.Today:yyyy-MM-dd}-{Guid.NewGuid()}{extension}";
 
                 using (var stream = new FileStream(Path.Combine(environment.WebRootPath, fileName), FileMode.Create))
                 {


### PR DESCRIPTION
The upload demos take the stored file's extension straight from the client's
`Content-Disposition` header. Nothing sanitises it, and `wwwroot` is served by
`UseStaticFiles` with no authentication, so an `.html` or `.svg` upload came
back as a working same-origin URL serving whatever markup it carried.

Both demo upload controllers now write only raster image extensions
(`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`) and reject anything else with
a 400. SVG is deliberately excluded because it can carry script.

`RadzenBlazorDemos.Server` also swaps `DisableRequestSizeLimit` for a 50 MB
limit: `Stream` buffers the whole request body into a `MemoryStream`, so one
large PUT was an out-of-memory. 50 MB is well beyond anything the upload demos
send.

This touches the demo site only - no component code changes.
