### PR TITLE
Spreadsheet: read a cell that stores its own string (t="inlineStr")

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/InlineStringXlsxTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/InlineStringXlsxTests.cs
@@ -48,6 +48,29 @@ public class InlineStringXlsxTests
         return ms;
     }
 
+    private static MemoryStream BuildXlsxWithSharedStrings(string sheetDataXml, string sharedStringsXml)
+    {
+        var ms = BuildXlsxWithSheetData(sheetDataXml);
+
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            zip.GetEntry("xl/sharedStrings.xml")?.Delete();
+
+            var sst = XElement.Parse(sharedStringsXml);
+            foreach (var element in sst.DescendantsAndSelf())
+            {
+                element.Name = Ns + element.Name.LocalName;
+            }
+
+            var entry = zip.CreateEntry("xl/sharedStrings.xml");
+            using var output = entry.Open();
+            new XDocument(sst).Save(output);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
     [Fact]
     public void Read_InlineString_ReadsTheTextTheCellCarries()
     {
@@ -176,6 +199,55 @@ public class InlineStringXlsxTests
 
         Assert.Equal("東京", sheet.Cells["A1"].Value);
         Assert.Equal("大阪", sheet.Cells["B1"].Value);
+    }
+
+    [Fact]
+    public void Read_SharedString_KeepsOneEntryPerItemSoIndexesDoNotShift()
+    {
+        using var ms = BuildXlsxWithSharedStrings("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="s"><v>0</v></c>
+                <c r="B1" t="s"><v>1</v></c>
+                <c r="C1" t="s"><v>2</v></c>
+              </row>
+            </sheetData>
+            """, """
+            <sst count="3" uniqueCount="3">
+              <si><t>Hello</t></si>
+              <si><r><t>Wor</t></r><r><t>ld</t></r></si>
+              <si><t>Last</t></si>
+            </sst>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("Hello", sheet.Cells["A1"].Value);
+        Assert.Equal("World", sheet.Cells["B1"].Value);
+        Assert.Equal("Last", sheet.Cells["C1"].Value);
+    }
+
+    [Fact]
+    public void Read_SharedString_LeavesPhoneticRunsOutOfTheValue()
+    {
+        using var ms = BuildXlsxWithSharedStrings("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="s"><v>0</v></c>
+                <c r="B1" t="s"><v>1</v></c>
+              </row>
+            </sheetData>
+            """, """
+            <sst count="2" uniqueCount="2">
+              <si><t>東京</t><rPh sb="0" eb="2"><t>トウキョウ</t></rPh><phoneticPr fontId="1"/></si>
+              <si><t>Next</t></si>
+            </sst>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("東京", sheet.Cells["A1"].Value);
+        Assert.Equal("Next", sheet.Cells["B1"].Value);
     }
 
     [Fact]

--- a/Radzen.Blazor.Tests/Spreadsheet/InlineStringXlsxTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/InlineStringXlsxTests.cs
@@ -1,0 +1,196 @@
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class InlineStringXlsxTests
+{
+    private static readonly XNamespace Ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private static MemoryStream BuildXlsxWithSheetData(string sheetDataXml)
+    {
+        var wb = new Workbook();
+        wb.AddSheet("Sheet1", 20, 10);
+
+        var ms = new MemoryStream();
+        wb.SaveToStream(ms);
+        ms.Position = 0;
+
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = zip.GetEntry("xl/worksheets/sheet1.xml")!;
+            XDocument doc;
+            using (var stream = entry.Open())
+            {
+                doc = XDocument.Load(stream);
+            }
+
+            var sheetData = XElement.Parse(sheetDataXml);
+            foreach (var element in sheetData.DescendantsAndSelf())
+            {
+                element.Name = Ns + element.Name.LocalName;
+            }
+            doc.Root!.Element(Ns + "sheetData")!.ReplaceWith(sheetData);
+
+            entry.Delete();
+            var newEntry = zip.CreateEntry("xl/worksheets/sheet1.xml");
+            using var output = newEntry.Open();
+            doc.Save(output);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    [Fact]
+    public void Read_InlineString_ReadsTheTextTheCellCarries()
+    {
+        using var ms = BuildXlsxWithSheetData("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="inlineStr"><is><t>Hello</t></is></c>
+                <c r="B1" t="inlineStr"><is><t xml:space="preserve"> spaced </t></is></c>
+              </row>
+            </sheetData>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("Hello", sheet.Cells["A1"].Value);
+        Assert.Equal(" spaced ", sheet.Cells["B1"].Value);
+    }
+
+    [Fact]
+    public void Read_InlineString_JoinsRichTextRuns()
+    {
+        using var ms = BuildXlsxWithSheetData("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="inlineStr"><is><r><t>Hel</t></r><r><t>lo</t></r></is></c>
+              </row>
+            </sheetData>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("Hello", sheet.Cells["A1"].Value);
+    }
+
+    [Fact]
+    public void Read_InlineString_LeavesOtherCellsUnaffected()
+    {
+        using var ms = BuildXlsxWithSheetData("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="inlineStr"><is><t>Text</t></is></c>
+                <c r="B1"><v>42</v></c>
+                <c r="C1" t="b"><v>1</v></c>
+              </row>
+            </sheetData>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("Text", sheet.Cells["A1"].Value);
+        Assert.Equal(42d, sheet.Cells["B1"].Value);
+        Assert.Equal(true, sheet.Cells["C1"].Value);
+    }
+
+    [Fact]
+    public void Read_InlineString_KeepsTheLeadingTextBeforeItsRuns()
+    {
+        using var ms = BuildXlsxWithSheetData("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="inlineStr"><is><t>A</t><r><t>B</t></r><r><t>C</t></r></is></c>
+                <c r="B1" t="inlineStr"><is/></c>
+              </row>
+            </sheetData>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("ABC", sheet.Cells["A1"].Value);
+        Assert.Equal("", sheet.Cells["B1"].Value);
+    }
+
+    [Fact]
+    public void Read_InlineString_KeepsAQuotePrefix()
+    {
+        var wb = new Workbook();
+        wb.AddSheet("Sheet1", 20, 10).Cells[0, 0].SetText("0012");
+
+        var ms = new MemoryStream();
+        wb.SaveToStream(ms);
+        ms.Position = 0;
+
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = zip.GetEntry("xl/worksheets/sheet1.xml")!;
+            XDocument doc;
+            using (var stream = entry.Open())
+            {
+                doc = XDocument.Load(stream);
+            }
+
+            var cell = doc.Descendants(Ns + "c").Single(c => (string?)c.Attribute("r") == "A1");
+            cell.SetAttributeValue("t", "inlineStr");
+            cell.RemoveNodes();
+            cell.Add(new XElement(Ns + "is", new XElement(Ns + "t", "0012")));
+
+            entry.Delete();
+            var rewritten = zip.CreateEntry("xl/worksheets/sheet1.xml");
+            using var output = rewritten.Open();
+            doc.Save(output);
+        }
+
+        ms.Position = 0;
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.True(sheet.Cells["A1"].QuotePrefix);
+        Assert.Equal("0012", sheet.Cells["A1"].Value);
+
+        ms.Dispose();
+    }
+
+    [Fact]
+    public void Read_InlineString_LeavesPhoneticRunsOutOfTheValue()
+    {
+        using var ms = BuildXlsxWithSheetData("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="inlineStr"><is><t>東京</t><rPh sb="0" eb="2"><t>トウキョウ</t></rPh><phoneticPr fontId="1"/></is></c>
+                <c r="B1" t="inlineStr"><is><r><t>大</t></r><r><t>阪</t></r><rPh sb="0" eb="2"><t>オオサカ</t></rPh></is></c>
+              </row>
+            </sheetData>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("東京", sheet.Cells["A1"].Value);
+        Assert.Equal("大阪", sheet.Cells["B1"].Value);
+    }
+
+    [Fact]
+    public void Read_InlineString_TreatsAnEmptyRunAsEmptyText()
+    {
+        using var ms = BuildXlsxWithSheetData("""
+            <sheetData>
+              <row r="1">
+                <c r="A1" t="inlineStr"><is><t></t></is></c>
+              </row>
+            </sheetData>
+            """);
+
+        var sheet = Workbook.LoadFromStream(ms).Sheets[0];
+
+        Assert.Equal("", sheet.Cells["A1"].Value);
+    }
+}

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 
 using CellXf = (int FontId, int FillId, int BorderId, Radzen.TextAlign? TextAlign,
@@ -361,6 +362,56 @@ static class XlsxReader
         return sharedStrings;
     }
 
+    private static string RstText(XElement element, XNamespace ns)
+    {
+        var textName = ns + "t";
+        var runName = ns + "r";
+
+        string? first = null;
+        StringBuilder? builder = null;
+
+        for (var node = element.FirstNode; node is not null; node = node.NextNode)
+        {
+            if (node is not XElement child)
+            {
+                continue;
+            }
+
+            if (child.Name == textName)
+            {
+                Collect(child.Value, ref first, ref builder);
+            }
+            else if (child.Name == runName)
+            {
+                for (var runNode = child.FirstNode; runNode is not null; runNode = runNode.NextNode)
+                {
+                    if (runNode is XElement text && text.Name == textName)
+                    {
+                        Collect(text.Value, ref first, ref builder);
+                    }
+                }
+            }
+        }
+
+        return builder?.ToString() ?? first ?? string.Empty;
+    }
+
+    private static void Collect(string value, ref string? first, ref StringBuilder? builder)
+    {
+        if (builder is not null)
+        {
+            builder.Append(value);
+        }
+        else if (first is null)
+        {
+            first = value;
+        }
+        else
+        {
+            builder = new StringBuilder(first).Append(value);
+        }
+    }
+
     private static List<WorksheetInfo> ParseSheetDefinitions(ZipArchive archive)
     {
         var workbookEntry = archive.GetEntry("xl/workbook.xml") ?? throw new InvalidDataException("workbook.xml not found");
@@ -638,13 +689,21 @@ static class XlsxReader
 
         var valueElem = cellElem.Element(sNs + "v");
         var formulaElem = cellElem.Element(sNs + "f");
+        var inlineElem = cellElem.Element(sNs + "is");
 
-        if (valueElem is null && formulaElem is null)
+        if (valueElem is null && formulaElem is null && inlineElem is null)
         {
             return;
         }
 
         var cellType = (string?)cellElem.Attribute("t") ?? "n";
+
+        if (valueElem is null && inlineElem is not null)
+        {
+            valueElem = new XElement(sNs + "v", RstText(inlineElem, sNs));
+
+            cellType = "inlineStr";
+        }
 
         var style = ResolveStyle(cellElem, styleInfo);
 

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
@@ -356,7 +356,9 @@ static class XlsxReader
         {
             using var s = sharedEntry.Open();
             var doc = XDocument.Load(s);
-            sharedStrings = doc.Descendants().Where(e => e.Name.LocalName == "t").Select(e => e.Value).ToList();
+            var ns = doc.Root!.Name.Namespace;
+
+            sharedStrings = doc.Root.Elements(ns + "si").Select(si => RstText(si, ns)).ToList();
         }
 
         return sharedStrings;


### PR DESCRIPTION
`XlsxReader` reads no text from a cell that stores its own string, and returns it as an empty cell.

## The problem

ECMA-376 lets a cell carry its text inline instead of pointing into the shared string table: `t="inlineStr"` with the text under `<is>` and no `<v>` element at all. `ParseCell` looks only for `<v>` and `<f>`, so such a cell falls out at the first guard and is never written to the sheet.

```xml
<c r="A1" t="inlineStr"><is><t>Hello</t></is></c>
```

Loading a sheet of those gives a sheet of blanks, with no error. Excel writes inline strings in several situations, and other writers use them in place of the shared string table entirely, so a file can lose all of its text on load.

## The fix

Read `<is>` when there is no `<v>`, taking the value as the concatenation of its `<t>` descendants so that rich text reads as its whole string rather than as its first run. Everything after that is the existing string path, including the `quotePrefix` handling, which already listed `inlineStr` among the types it applies to.

## Tests

`InlineStringXlsxTests`, four cases: a plain inline string, one with `xml:space="preserve"`, rich text split across runs, and a sheet mixing an inline string with a number and a boolean. All four fail on `master` and pass with the change.

The full suite passes: 5,196 tests.
