### PR TITLE
Spreadsheet: reduce fill and save allocation (zero-GC)

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/AutoFitExportTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/AutoFitExportTests.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+public class AutoFitExportTests
+{
+    [Fact]
+    public void Save_AutoFitColumnWithCellBelowShrunkRowCount_DoesNotThrow()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 20, 4);
+
+        sheet.Cells["A10"].Value = "a wide piece of text";
+        sheet.Columns.SetAutoFit(0);
+
+        sheet.Rows.Count = 5;
+
+        workbook.SaveToStream(Stream.Null);
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/CellDataTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CellDataTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Xunit;
 using Radzen.Documents.Spreadsheet;
 namespace Radzen.Blazor.Spreadsheet.Tests;
@@ -34,5 +35,55 @@ public class CellDataTests
         var a = new CellData(1.0);
         var b = new CellData("hello");
         Assert.False(a.IsEqualTo(b));
+    }
+
+    private static Worksheet CreateSheet()
+    {
+        var workbook = new Workbook();
+
+        return workbook.AddSheet("Sheet1", 8, 4);
+    }
+
+    [Fact]
+    public void Data_ReadTwiceFromOneCell_IsEqualAndHashesAlike()
+    {
+        var sheet = CreateSheet();
+        sheet.Cells["A1"].Value = 42.0;
+
+        var first = sheet.Cells["A1"].Data;
+        var second = sheet.Cells["A1"].Data;
+
+        Assert.NotSame(first, second);
+        Assert.True(first.Equals(second));
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void Data_ReadTwiceFromOneCell_IsFoundInAHashSet()
+    {
+        var sheet = CreateSheet();
+        sheet.Cells["A1"].SetValueInvariant("0123");
+
+        var set = new HashSet<CellData> { sheet.Cells["A1"].Data };
+
+        Assert.Contains(sheet.Cells["A1"].Data, set);
+    }
+
+    [Fact]
+    public void Equals_SameValueAndType_IsTrue()
+    {
+        Assert.True(CellData.FromNumber(42).Equals(CellData.FromNumber(42)));
+        Assert.True(CellData.FromString("a").Equals(CellData.FromString("a")));
+        Assert.True(CellData.Empty.Equals(new CellData(null)));
+    }
+
+    [Fact]
+    public void Equals_DifferentValueOrType_IsFalse()
+    {
+        Assert.False(CellData.FromNumber(42).Equals(CellData.FromNumber(43)));
+        Assert.False(CellData.FromNumber(1).Equals(CellData.FromString("one")));
+        Assert.False(CellData.FromNumber(42).Equals(null));
+        Assert.False(CellData.FromNumber(42).Equals("not a cell value"));
     }
 }

--- a/Radzen.Blazor.Tests/Spreadsheet/CellStoreRegressionTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/CellStoreRegressionTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Globalization;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+public class CellStoreRegressionTests
+{
+    private sealed class CountingCellStore(Worksheet sheet) : CellStore(sheet)
+    {
+        public int Assignments { get; private set; }
+
+        public override Cell this[int row, int column]
+        {
+            get => base[row, column];
+            set
+            {
+                Assignments++;
+                base[row, column] = value;
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadingAMissingCell_DispatchesThroughTheOverriddenSetter()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 4);
+        var store = new CountingCellStore(sheet);
+
+        _ = store[2, 1];
+
+        Assert.Equal(1, store.Assignments);
+    }
+
+    [Fact]
+    public void BulkFill_OnADerivedStore_DispatchesThroughTheOverriddenSetter()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 4);
+        var store = new CountingCellStore(sheet);
+
+        store.SetValues(0, 0, [[1, 2], [3, 4]]);
+
+        Assert.Equal(4, store.Assignments);
+    }
+
+    private sealed class SnapshotCellStore(Worksheet sheet) : CellStore(sheet)
+    {
+        public override Cell this[int row, int column]
+        {
+            get => base[row, column].Clone();
+            set => base[row, column] = value;
+        }
+    }
+
+    [Fact]
+    public void BulkFill_OnADerivedStoreThatSnapshotsItsGetter_WritesThroughToTheStore()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 4);
+        var store = new SnapshotCellStore(sheet);
+
+        store.SetValues(0, 0, [[42]]);
+
+        Assert.True(store.TryGet(0, 0, out var stored));
+        Assert.Equal(42d, stored.Value);
+    }
+
+    [Theory]
+    [InlineData("text", CellDataType.String)]
+    [InlineData(1.5, CellDataType.Number)]
+    [InlineData(true, CellDataType.Boolean)]
+    [InlineData(null, CellDataType.Empty)]
+    public void CellDataTypeIsTheValuesType(object? value, CellDataType expected)
+    {
+        Assert.Equal(expected, CellStore.TypeOf(value));
+        Assert.Equal(expected, new CellData(value, CultureInfo.InvariantCulture).Type);
+    }
+
+    [Fact]
+    public void CellDataTypeIsTheValuesType_ForTheRemainingFactories()
+    {
+        Assert.Equal(CellData.FromDate(new DateTime(2024, 1, 1)).Type, CellStore.TypeOf(new DateTime(2024, 1, 1)));
+        Assert.Equal(CellData.FromError(CellError.Name).Type, CellStore.TypeOf(CellError.Name));
+        Assert.Equal(CellData.FromString("0123").Type, CellStore.TypeOf("0123"));
+        Assert.Equal(CellData.FromNumber(1).Type, CellStore.TypeOf(1d));
+    }
+
+    [Fact]
+    public void QuotePrefix_SurvivesTheCellItWasSetOn()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 8, 4);
+
+        sheet.Cells.SetValues(0, 0, [["0123"]]);
+        Assert.False(sheet.Cells[0, 0].QuotePrefix);
+
+        sheet.Cells[0, 0].SetValue("'0123");
+
+        Assert.True(sheet.Cells[0, 0].QuotePrefix);
+        Assert.Equal("0123", sheet.Cells[0, 0].Value);
+        Assert.Equal(CellDataType.String, sheet.Cells[0, 0].ValueType);
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetCultureTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/SpreadsheetCultureTests.cs
@@ -341,7 +341,8 @@ public class SpreadsheetCultureTests
 
         command.Unexecute();
 
-        Assert.Same(before, sheet.Cells["A1"].Data);
+        Assert.Equal(before.Type, sheet.Cells["A1"].Data.Type);
+        Assert.Equal(before.Value, sheet.Cells["A1"].Data.Value);
         Assert.Equal(CellDataType.String, sheet.Cells["A1"].ValueType);
     }
 

--- a/Radzen.Blazor/Documents/Spreadsheet/Axis.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Axis.cs
@@ -150,6 +150,8 @@ public class Axis(double size, int count)
         return autoFit.Contains(index);
     }
 
+    internal bool HasAutoFit => autoFit.Count > 0;
+
     // No change event: the flag has no visual effect, it only feeds the XLSX writer.
     internal void SetAutoFit(int index)
     {

--- a/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
@@ -17,7 +17,32 @@ public class Cell
     /// </summary>
     public Worksheet Worksheet { get; private set; }
 
-    private Format? format;
+    private sealed class Extras
+    {
+        public Format? Format;
+        public Hyperlink? Hyperlink;
+        public string? Formula;
+        public FormulaSyntaxTree? FormulaSyntaxTree;
+        public IReadOnlyList<string>? ValidationErrors;
+        public Action<Cell>? Changed;
+    }
+
+    private Extras? extras;
+
+    private Extras Rare => extras ??= new Extras();
+
+    private Format? format
+    {
+        get => extras?.Format;
+        set
+        {
+            if (value is null && extras is null)
+            {
+                return;
+            }
+            Rare.Format = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the format of the cell. Setting null clears the format.
@@ -27,25 +52,30 @@ public class Cell
     {
         get
         {
-            if (format is null)
+            var current = extras?.Format;
+
+            if (current is null)
             {
-                format = new Format();
-                format.Changed += OnFormatChanged;
+                current = new Format();
+                current.Changed += OnFormatChanged;
+                Rare.Format = current;
             }
-            return format;
+            return current;
         }
 
         set
         {
-            if (ReferenceEquals(format, value))
+            var current = extras?.Format;
+
+            if (ReferenceEquals(current, value))
             {
                 return;
             }
-            format?.Changed -= OnFormatChanged;
+            current?.Changed -= OnFormatChanged;
 
             format = value;
 
-            format?.Changed += OnFormatChanged;
+            value?.Changed += OnFormatChanged;
 
             OnFormatChanged();
         }
@@ -97,7 +127,7 @@ public class Cell
 
         Hyperlink = other.Hyperlink?.Clone();
 
-        Changed?.Invoke(this);
+        extras?.Changed?.Invoke(this);
     }
 
     // Excel's full clear: contents, format, quote prefix and hyperlink. Clear Contents
@@ -111,7 +141,7 @@ public class Cell
         OnChanged();
     }
 
-    internal Format? FormatOrNull => format;
+    internal Format? FormatOrNull => extras?.Format;
 
     /// <summary>
     /// Gets the text displayed in the cell: the number format applied to the value, or the value as a string.
@@ -144,33 +174,60 @@ public class Cell
 
     private void OnFormatChanged()
     {
-        Changed?.Invoke(this);
+        extras?.Changed?.Invoke(this);
     }
 
     /// <summary>
     /// Gets or sets the hyperlink associated with this cell.
     /// </summary>
-    public Hyperlink? Hyperlink { get; set; }
+    public Hyperlink? Hyperlink
+    {
+        get => extras?.Hyperlink;
+        set
+        {
+            if (value is null && extras is null)
+            {
+                return;
+            }
+            Rare.Hyperlink = value;
+        }
+    }
+
+    private object? value;
+
+    private CellDataType type = CellDataType.Empty;
 
     /// <summary>
     /// Gets the current value and its type as a CellData object.
     /// </summary>
-    public CellData Data { get; internal set; } = CellData.Empty;
+    public CellData Data
+    {
+        get => value is null ? CellData.Empty : new CellData(value, type);
 
+        internal set
+        {
+            this.value = value.Value;
+            type = value.Type;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the value of the cell.
     /// </summary>
     public object? Value
     {
-        get => Data.Value;
+        get => value;
         set
         {
-            if (Equals(Data.Value, value) && !QuotePrefix)
+            if (Equals(this.value, value) && !QuotePrefix)
             {
                 return;
             }
-            Data = new CellData(value, Culture);
+
+            CellData.Infer(value, Culture, out var inferred, out var inferredType);
+
+            this.value = inferred;
+            type = inferredType;
             QuotePrefix = false;
 
             Worksheet.OnCellValueChanged(this);
@@ -224,15 +281,17 @@ public class Cell
     /// </summary>
     public string? GetValueAsString() => FormatValue(Culture);
 
-    private string? FormatValue(CultureInfo culture)
+    private string? FormatValue(CultureInfo culture) => FormatValue(Value, culture);
+
+    internal static string? FormatValue(object? value, CultureInfo culture)
     {
-        return Value switch
+        return value switch
         {
             null => null,
             CellError error => error.ToString(),
             string str => str,
             IFormattable formattable => formattable.ToString(null, culture),
-            _ => Value.ToString()
+            _ => value.ToString()
         };
     }
 
@@ -261,17 +320,38 @@ public class Cell
 
     internal void OnChanged()
     {
-        Changed?.Invoke(this);
+        extras?.Changed?.Invoke(this);
     }
 
-    internal event Action<Cell>? Changed;
+    internal event Action<Cell>? Changed
+    {
+        add => Rare.Changed += value;
+        remove
+        {
+            if (extras is not null)
+            {
+                extras.Changed -= value;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets the type of value contained in the cell.
     /// </summary>
-    public CellDataType ValueType => Data.Type;
+    public CellDataType ValueType => type;
 
-    internal FormulaSyntaxTree? FormulaSyntaxTree { get; private set; }
+    internal FormulaSyntaxTree? FormulaSyntaxTree
+    {
+        get => extras?.FormulaSyntaxTree;
+        private set
+        {
+            if (value is null && extras is null)
+            {
+                return;
+            }
+            Rare.FormulaSyntaxTree = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether the cell value was entered with
@@ -280,7 +360,18 @@ public class Cell
     /// </summary>
     public bool QuotePrefix { get; set; }
 
-    private string? formula;
+    private string? formula
+    {
+        get => extras?.Formula;
+        set
+        {
+            if (value is null && extras is null)
+            {
+                return;
+            }
+            Rare.Formula = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the formula of the cell.
@@ -307,7 +398,8 @@ public class Cell
     /// <summary>
     /// Gets a value indicating whether this cell has no meaningful content (no value, formula, format, or hyperlink).
     /// </summary>
-    public bool IsEmpty => Value is null && Formula is null && format is null && Hyperlink is null && !QuotePrefix;
+    public bool IsEmpty => value is null && extras?.Formula is null && extras?.Format is null &&
+        extras?.Hyperlink is null && !QuotePrefix;
 
     /// <summary>
     /// Gets the address of the cell.
@@ -331,11 +423,25 @@ public class Cell
     /// <summary>
     /// Gets the validation errors for the cell.
     /// </summary>
-    public IReadOnlyList<string> ValidationErrors { get; private set; } = [];
+    public IReadOnlyList<string> ValidationErrors
+    {
+        get => extras?.ValidationErrors ?? [];
+        private set
+        {
+            if (value.Count == 0 && extras is null)
+            {
+                return;
+            }
+            Rare.ValidationErrors = value;
+        }
+    }
 
     internal void ClearValidationErrors()
     {
-        ValidationErrors = [];
+        if (extras is not null)
+        {
+            extras.ValidationErrors = null;
+        }
     }
 
     internal Cell(Worksheet sheet, CellRef address)
@@ -343,4 +449,17 @@ public class Cell
         Address = address;
         Worksheet = sheet;
     }
+
+    internal Cell(Worksheet sheet, CellRef address, object? value, CellDataType type, bool quotePrefix)
+    {
+        Address = address;
+        Worksheet = sheet;
+        this.value = value;
+        this.type = type;
+        QuotePrefix = quotePrefix;
+    }
+
+    internal object? StoredValue => value;
+
+    internal CellDataType StoredType => type;
 }

--- a/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
@@ -87,7 +87,7 @@ static class TypeExtensions
 /// Represents a value of a spreadsheet cell along with its type.
 /// </summary>
 [SuppressMessage("Design", "CA1036:Override methods on comparable types", Justification = "Comparison operators are intentionally omitted; use explicit comparison helpers.")]
-public class CellData : IComparable, IComparable<CellData>
+public class CellData : IComparable, IComparable<CellData>, IEquatable<CellData>
 {
     /// <summary>
     /// Returns the data contained in the cell.
@@ -119,10 +119,18 @@ public class CellData : IComparable, IComparable<CellData>
 
     internal CellData(object? data, CultureInfo culture)
     {
+        Infer(data, culture, out var inferred, out var inferredType);
+
+        Value = inferred;
+        Type = inferredType;
+    }
+
+    internal static void Infer(object? data, CultureInfo culture, out object? value, out CellDataType type)
+    {
         if (data is null)
         {
-            Value = null;
-            Type = CellDataType.Empty;
+            value = null;
+            type = CellDataType.Empty;
             return;
         }
 
@@ -135,19 +143,21 @@ public class CellData : IComparable, IComparable<CellData>
             var converted = TryConvertFromString(data.ToString(), culture, out var convertedData, out var valueType);
             if (converted)
             {
-                Value = convertedData;
-                Type = valueType!.Value;
+                value = convertedData;
+                type = valueType!.Value;
             }
             else
             {
-                Value = data;
-                Type = CellDataType.String;
+                value = data;
+                type = CellDataType.String;
             }
         }
         else
         {
-            Type = GetValueType(data, valType, isNullable, nullableType);
-            Value = (Type == CellDataType.Number) ? Convert.ToDouble(data, CultureInfo.InvariantCulture) : data;
+            type = GetValueType(data, valType, isNullable, nullableType);
+            value = (type == CellDataType.Number && data is not double)
+                ? Convert.ToDouble(data, CultureInfo.InvariantCulture)
+                : data;
         }
     }
 
@@ -492,7 +502,6 @@ public class CellData : IComparable, IComparable<CellData>
     /// <inheritdoc />
     public int CompareTo(object? obj) => obj is CellData value ? CompareTo(value) : -1;
 
-
     /// <summary>
     /// Returns true if the cell is empty (null or empty string).
     /// </summary>
@@ -584,6 +593,18 @@ public class CellData : IComparable, IComparable<CellData>
         var compareResult = CompareValues(Value, other.Value);
         return compareResult >= 0;
     }
+
+    /// <summary>
+    /// Determines whether this instance holds the same value and type as another.
+    /// </summary>
+    /// <remarks>
+    /// A cell builds its <see cref="Cell.Data"/> when asked rather than holding one, so two reads of
+    /// an unchanged cell are two instances. They compare equal, and hash alike.
+    /// </remarks>
+    public bool Equals(CellData? other) => other is not null && Type == other.Type && Equals(Value, other.Value);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => Equals(obj as CellData);
 
     /// <inheritdoc />
     public override int GetHashCode()

--- a/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace Radzen.Documents.Spreadsheet;
 
@@ -16,10 +17,21 @@ public class CellStore(Worksheet sheet)
     /// </summary>
     public Worksheet Worksheet { get; } = sheet;
 
-    /// <summary>
-    /// Stores the cells in a dictionary, where the key is a tuple of (row, column).
-    /// </summary>
-    protected readonly Dictionary<(int row, int column), Cell> data = [];
+    private readonly Dictionary<(int row, int column), object?> data = [];
+
+    internal static CellDataType TypeOf(object? value) => value switch
+    {
+        null => CellDataType.Empty,
+        string => CellDataType.String,
+        double => CellDataType.Number,
+        bool => CellDataType.Boolean,
+        DateTime => CellDataType.Date,
+        CellError => CellDataType.Error,
+        _ => CellDataType.String,
+    };
+
+    private static Cell Materialise(Worksheet sheet, int row, int column, object? content) =>
+        new(sheet, new CellRef(row, column), content, TypeOf(content), quotePrefix: false);
 
     /// <summary>
     /// Gets a cell at the specified row and column.
@@ -103,7 +115,31 @@ public class CellStore(Worksheet sheet)
         return cell is not null;
     }
 
-    internal IEnumerable<Cell> GetPopulatedCells() => data.Values;
+    internal IEnumerable<CellView> GetPopulatedViews()
+    {
+        foreach (var entry in data)
+        {
+            var address = new CellRef(entry.Key.row, entry.Key.column);
+
+            yield return entry.Value is Cell cell
+                ? new CellView(cell)
+                : new CellView(address, entry.Value, TypeOf(entry.Value), quotePrefix: false);
+        }
+    }
+
+    internal bool IsWrittenAt(int row, int column) =>
+        data.TryGetValue((row, column), out var content) &&
+        (content is Cell cell ? cell.Value is not null || cell.Formula is not null : content is not null);
+
+    internal IEnumerable<Cell> GetPopulatedCells()
+    {
+        foreach (var key in keysBuffer())
+        {
+            yield return Adopt(key.row, key.column);
+        }
+
+        List<(int row, int column)> keysBuffer() => [.. data.Keys];
+    }
 
     internal int Compact()
     {
@@ -111,7 +147,7 @@ public class CellStore(Worksheet sheet)
 
         foreach (var kvp in data)
         {
-            if (kvp.Value.IsEmpty)
+            if (kvp.Value is Cell cell ? cell.IsEmpty : kvp.Value is null)
             {
                 keysToRemove.Add(kvp.Key);
             }
@@ -127,39 +163,39 @@ public class CellStore(Worksheet sheet)
 
     internal int PopulatedCount => data.Count;
 
-    internal bool HasCell(int row, int column) => Find(row, column) is not null;
+    internal bool HasCell(int row, int column) => data.ContainsKey((row, column));
 
-    internal Cell? Find(int row, int column) => data.TryGetValue((row, column), out var cell) ? cell : null;
+    internal Cell? Find(int row, int column) => data.ContainsKey((row, column)) ? Adopt(row, column) : null;
 
-    private static void UpdateCellAddress((int row, int column) oldKey, (int row, int column) newKey, Cell cell)
+    private static void UpdateCellAddress((int row, int column) oldKey, (int row, int column) newKey, object? content)
     {
-        if (oldKey != newKey)
+        if (oldKey != newKey && content is Cell cell)
         {
             cell.Address = new CellRef(newKey.row, newKey.column);
         }
     }
 
     internal void ShiftRowsUp(int deletedRow) =>
-        DictionaryShift.Remap<(int row, int column), Cell>(data, k =>
+        DictionaryShift.Remap<(int row, int column), object?>(data, k =>
             k.row < deletedRow ? k :
             k.row == deletedRow ? null :
             (k.row - 1, k.column),
             UpdateCellAddress);
 
     internal void ShiftRowsDown(int fromRow, int count) =>
-        DictionaryShift.Remap<(int row, int column), Cell>(data, k =>
+        DictionaryShift.Remap<(int row, int column), object?>(data, k =>
             k.row < fromRow ? k : (k.row + count, k.column),
             UpdateCellAddress);
 
     internal void ShiftColumnsLeft(int deletedColumn) =>
-        DictionaryShift.Remap<(int row, int column), Cell>(data, k =>
+        DictionaryShift.Remap<(int row, int column), object?>(data, k =>
             k.column < deletedColumn ? k :
             k.column == deletedColumn ? null :
             (k.row, k.column - 1),
             UpdateCellAddress);
 
     internal void ShiftColumnsRight(int fromColumn, int count) =>
-        DictionaryShift.Remap<(int row, int column), Cell>(data, k =>
+        DictionaryShift.Remap<(int row, int column), object?>(data, k =>
             k.column < fromColumn ? k : (k.row, k.column + count),
             UpdateCellAddress);
 
@@ -271,6 +307,8 @@ public class CellStore(Worksheet sheet)
 
         data.EnsureCapacity(data.Count + total);
 
+        var derived = GetType() != typeof(CellStore);
+
         for (var r = 0; r < values.Count; r++)
         {
             if (values[r] is not { } line)
@@ -280,20 +318,57 @@ public class CellStore(Worksheet sheet)
 
             for (var c = 0; c < line.Count; c++)
             {
-                var cell = GetOrAdd(row + r, column + c);
+                if (derived)
+                {
+                    var dispatched = GetOrAdd(row + r, column + c);
 
-                cell.Formula = null;
-                cell.Value = line[c];
+                    dispatched.Formula = null;
+                    dispatched.Value = line[c];
+                    continue;
+                }
+
+                ref var content = ref CollectionsMarshal.GetValueRefOrAddDefault(data, (row + r, column + c), out _);
+
+                if (content is Cell cell)
+                {
+                    cell.Formula = null;
+                    cell.Value = line[c];
+                    continue;
+                }
+
+                CellData.Infer(line[c], Worksheet.Culture, out content, out _);
             }
         }
     }
 
     private Cell GetOrAdd(int row, int column)
     {
-        if (!data.TryGetValue((row, column), out var cell))
+        data.TryGetValue((row, column), out var content);
+
+        if (content is Cell existing)
         {
-            this[row, column] = cell = new Cell(Worksheet, new CellRef(row, column));
+            return existing;
         }
+
+        var cell = Materialise(Worksheet, row, column, content);
+
+        this[row, column] = cell;
+
+        return cell;
+    }
+
+    private Cell Adopt(int row, int column)
+    {
+        ref var content = ref CollectionsMarshal.GetValueRefOrAddDefault(data, (row, column), out _);
+
+        if (content is Cell existing)
+        {
+            return existing;
+        }
+
+        var cell = Materialise(Worksheet, row, column, content);
+
+        content = cell;
 
         return cell;
     }

--- a/Radzen.Blazor/Documents/Spreadsheet/CellView.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellView.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+
+namespace Radzen.Documents.Spreadsheet;
+
+#nullable enable
+
+internal readonly struct CellView
+{
+    private readonly Cell? cell;
+    private readonly object? value;
+    private readonly CellDataType type;
+    private readonly bool quotePrefix;
+
+    public readonly CellRef Address;
+
+    public CellView(Cell cell)
+    {
+        this.cell = cell;
+        Address = cell.Address;
+        value = null;
+        type = CellDataType.Empty;
+        quotePrefix = false;
+    }
+
+    public CellView(CellRef address, object? value, CellDataType type, bool quotePrefix)
+    {
+        cell = null;
+        Address = address;
+        this.value = value;
+        this.type = type;
+        this.quotePrefix = quotePrefix;
+    }
+
+    public object? Value => cell is not null ? cell.Value : value;
+
+    public CellDataType ValueType => cell is not null ? cell.ValueType : type;
+
+    public bool QuotePrefix => cell is not null ? cell.QuotePrefix : quotePrefix;
+
+    public string? Formula => cell?.Formula;
+
+    public Format? FormatOrNull => cell?.FormatOrNull;
+
+    public Hyperlink? Hyperlink => cell?.Hyperlink;
+
+    public string? FormatDisplayText(CultureInfo culture) => cell is not null
+        ? cell.FormatDisplayText(culture)
+        : NumberFormat.Apply(null, value, type, culture) ?? Cell.FormatValue(value, culture);
+}

--- a/Radzen.Blazor/Documents/Spreadsheet/CsvWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CsvWriter.cs
@@ -31,10 +31,10 @@ class CsvWriter(Worksheet sheet, CsvExportOptions options)
 
     private string BuildContent()
     {
-        var cells = new Dictionary<(int Row, int Column), Cell>();
+        var cells = new Dictionary<(int Row, int Column), CellView>();
         var maxRow = -1;
         var maxCol = -1;
-        foreach (var cell in sheet.Cells.GetPopulatedCells())
+        foreach (var cell in sheet.Cells.GetPopulatedViews())
         {
             if (cell.Value is null && string.IsNullOrEmpty(cell.Formula))
             {
@@ -78,7 +78,7 @@ class CsvWriter(Worksheet sheet, CsvExportOptions options)
         return StringBuilderCache.GetStringAndRelease(sb);
     }
 
-    private static string FormatCell(Cell cell)
+    private static string FormatCell(in CellView cell)
     {
         // Formula cells emit the cached evaluated value, never the formula text.
         // The XLSX writer applies the same rule.

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1012,7 +1012,7 @@ class XlsxWriter(Workbook sourceWorkbook)
 
         XElement? hyperlinksElement = null;
 
-        foreach (var cell in sheet.Cells.GetPopulatedCells())
+        foreach (var cell in sheet.Cells.GetPopulatedViews())
         {
             if (cell.Hyperlink is not null)
             {
@@ -1184,20 +1184,32 @@ class XlsxWriter(Workbook sourceWorkbook)
     {
         var widths = new Dictionary<int, double>();
 
-        foreach (var cell in sheet.Cells.GetPopulatedCells().ToList())
+        if (!sheet.Columns.HasAutoFit)
         {
-            var col = cell.Address.Column;
+            return widths;
+        }
 
-            if (!sheet.Columns.IsAutoFit(col) || sheet.MergedCells.Contains(cell.Address))
+        var measured = new List<CellRef>();
+
+        foreach (var view in sheet.Cells.GetPopulatedViews())
+        {
+            if (sheet.Columns.IsAutoFit(view.Address.Column) && !sheet.MergedCells.Contains(view.Address))
             {
-                continue;
+                measured.Add(view.Address);
             }
+        }
+
+        foreach (var address in measured)
+        {
+            var col = address.Column;
 
             string? text;
             Format? format;
 
             try
             {
+                var cell = sheet.Cells[address];
+
                 // Autofit widths must be culture-independent so saved <col> XML is deterministic.
                 text = cell.FormatDisplayText(CultureInfo.InvariantCulture);
                 format = cell.GetEffectiveFormat();
@@ -1231,7 +1243,7 @@ class XlsxWriter(Workbook sourceWorkbook)
     {
         var formulas = new Dictionary<CellRef, string>();
 
-        foreach (var cell in sheet.Cells.GetPopulatedCells())
+        foreach (var cell in sheet.Cells.GetPopulatedViews())
         {
             if (!string.IsNullOrEmpty(cell.Formula))
             {
@@ -1341,7 +1353,7 @@ class XlsxWriter(Workbook sourceWorkbook)
     {
         var sharedFormulas = BuildSharedFormulaGroups(sheet);
 
-        var cells = ArrayPool<Cell>.Shared.Rent(sheet.Cells.PopulatedCount);
+        var cells = ArrayPool<CellView>.Shared.Rent(sheet.Cells.PopulatedCount);
 
         try
         {
@@ -1349,15 +1361,15 @@ class XlsxWriter(Workbook sourceWorkbook)
         }
         finally
         {
-            ArrayPool<Cell>.Shared.Return(cells, clearArray: true);
+            ArrayPool<CellView>.Shared.Return(cells, clearArray: true);
         }
     }
 
-    private void WriteRows(XmlWriter writer, Worksheet sheet, Cell[] cells, StyleTracker styleTracker, SharedStringTable sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    private void WriteRows(XmlWriter writer, Worksheet sheet, CellView[] cells, StyleTracker styleTracker, SharedStringTable sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var count = 0;
 
-        foreach (var cell in sheet.Cells.GetPopulatedCells())
+        foreach (var cell in sheet.Cells.GetPopulatedViews())
         {
             if (IsWritten(cell))
             {
@@ -1536,7 +1548,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteEndElement();
     }
 
-    private void WriteCell(XmlWriter writer, Cell cell, StyleTracker styleTracker, SharedStringTable sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    private void WriteCell(XmlWriter writer, in CellView cell, StyleTracker styleTracker, SharedStringTable sharedStrings, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var isFormula = !string.IsNullOrEmpty(cell.Formula);
 
@@ -1572,7 +1584,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteEndElement();
     }
 
-    private static string? CellTypeAttribute(Cell cell, bool isFormula) => cell.ValueType switch
+    private static string? CellTypeAttribute(in CellView cell, bool isFormula) => cell.ValueType switch
     {
         CellDataType.String => isFormula ? "str" : "s",
         CellDataType.Boolean => "b",
@@ -1580,7 +1592,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         _ => null,
     };
 
-    private void WriteFormula(XmlWriter writer, Cell cell, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
+    private void WriteFormula(XmlWriter writer, in CellView cell, Dictionary<CellRef, (int Si, string? Ref)> sharedFormulas)
     {
         var formula = cell.Formula!.StartsWith('=') ? cell.Formula![1..] : cell.Formula!;
 
@@ -1609,7 +1621,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteFullEndElement();
     }
 
-    private void WriteTypedValue(XmlWriter writer, Cell cell)
+    private void WriteTypedValue(XmlWriter writer, in CellView cell)
     {
         switch (cell.ValueType)
         {
@@ -1673,7 +1685,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         foreach (var range in sheet.MergedCells.Ranges)
         {
             var anchor = sheet.Cells.Find(range.Start.Row, range.Start.Column);
-            var style = anchor is not null && HasCellFormatting(anchor) ? new MergeAnchor(anchor) : null;
+            var style = anchor is not null && HasCellFormatting(new CellView(anchor)) ? new MergeAnchor(anchor) : null;
 
             for (var r = range.Start.Row; r <= range.End.Row; r++)
             {
@@ -1684,9 +1696,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                         continue;
                     }
 
-                    var cell = sheet.Cells.Find(r, c);
-
-                    if (cell is not null && IsWritten(cell))
+                    if (sheet.Cells.IsWrittenAt(r, c))
                     {
                         continue;
                     }
@@ -1708,7 +1718,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             return null;
         }
 
-        return anchor.StyleId ??= GetOrCreateCellStyle(anchor.Cell, styleTracker);
+        return anchor.StyleId ??= GetOrCreateCellStyle(new CellView(anchor.Cell), styleTracker);
     }
 
     private sealed class MergeAnchor(Cell cell)
@@ -1735,19 +1745,19 @@ class XlsxWriter(Workbook sourceWorkbook)
         }
     }
 
-    private sealed class CellOrder : IComparer<Cell>
+    private sealed class CellOrder : IComparer<CellView>
     {
         public static readonly CellOrder Instance = new();
 
-        public int Compare(Cell? left, Cell? right)
+        public int Compare(CellView left, CellView right)
         {
-            var byRow = left!.Address.Row.CompareTo(right!.Address.Row);
+            var byRow = left.Address.Row.CompareTo(right.Address.Row);
 
             return byRow != 0 ? byRow : left.Address.Column.CompareTo(right.Address.Column);
         }
     }
 
-    private static bool IsWritten(Cell cell) => cell.Value is not null || cell.Formula is not null;
+    private static bool IsWritten(in CellView cell) => cell.Value is not null || cell.Formula is not null;
 
     private static List<int> CollectStyledRowIndices(Worksheet sheet)
     {
@@ -1768,14 +1778,14 @@ class XlsxWriter(Workbook sourceWorkbook)
         return rows;
     }
 
-    private static bool HasCellFormatting(Cell cell)
+    private static bool HasCellFormatting(in CellView cell)
     {
         return cell.FormatOrNull?.IsDefault == false || cell.ValueType == CellDataType.Date || cell.QuotePrefix;
     }
 
     private static readonly Format DefaultFormat = new();
 
-    private int GetOrCreateCellStyle(Cell cell, StyleTracker styleTracker)
+    private int GetOrCreateCellStyle(in CellView cell, StyleTracker styleTracker)
     {
         var format = cell.FormatOrNull ?? DefaultFormat;
 
@@ -1888,7 +1898,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         borderElement.Add(sideElement);
     }
 
-    private static int GetOrCreateNumberFormat(Cell cell, Format format, StyleTracker styleTracker)
+    private static int GetOrCreateNumberFormat(in CellView cell, Format format, StyleTracker styleTracker)
     {
         var formatCode = format.NumberFormat;
 
@@ -1987,7 +1997,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         styleTracker.FillsElement.Attribute("count")!.Value = (styleTracker.FillStyles.Count + 2).ToString(CultureInfo.InvariantCulture);
     }
 
-    private void CreateCellStyleElement(Cell cell, Format format, int fontId, int fillId, int borderId, int numFmtId, StyleTracker styleTracker)
+    private void CreateCellStyleElement(in CellView cell, Format format, int fontId, int fillId, int borderId, int numFmtId, StyleTracker styleTracker)
     {
         var xfElement = new XElement(XName.Get("xf", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
             new XAttribute("numFmtId", numFmtId.ToString(CultureInfo.InvariantCulture)),


### PR DESCRIPTION
Follows #2708. The written Xlsx is unchanged; allocations reduced.

A `Cell` carried ten fields, six of which most cells never use. It now holds its value and type inline and the rest behind one reference, allocated only when a cell needs one.

The store keeps a value per address rather than a cell. A bulk fill writes values and builds nothing; the first caller to ask for a cell at an address gets one and it is kept, so `Cells[r, c]` still returns the same instance every time.

`CellView` lets the writer read a cell it does not have to build.

## Measurement

550,000 cells, eleven columns of mixed strings, numbers, dates and booleans, values built outside the measured region.

| | allocated | B / cell | Gen0 | Gen1 | Gen2 |
| --- | --- | --- | --- | --- | --- |
| `SetValues` | 94.0 → **18.4 MB** | 179 → 35 | 10 → **0** | 5 → **0** | 1 → **0** |
| a cell at a time | 113.7 → **75.9 MB** | 217 → 145 | 10 → 6 | 5 → 3 | 1 → 1 |
| fill and save, into `Stream.Null` | 103.6 → **23.9 MB** | 198 → 46 | 10 → **0** | 5 → **0** | 1 → **0** |

**A bulk fill and the save it feeds cause no garbage collection of any generation.** An address costs what it did before when a cell is built for it, and a third of that when none is. The same sheet filled one row in ten over 500,000 rows reports the same figures, so a sparse sheet is not paying for a dense one.

Times are not quoted: allocation repeated to a tenth of a megabyte across every run and time did not.

## Behavior

`Cell.Data` is built when asked rather than held, so two reads of an unchanged cell are two instances. `CellData` compares by type and value, matching the hash it already had, and four tests cover it. `IsEqualTo` is untouched and remains the lenient comparison a sheet uses, where an empty string equals a blank.

`HyperlinkCommand_UndoRestoresExactCellData` asserted the identity of `Cell.Data`. It now asserts the value and the type it was written to protect, and still fails if undo rebuilds the value from its text.

A cell the indexer builds is assigned through the indexer, so a derived store overriding the setter still observes it, and a derived store takes a per-cell path through that setter for a bulk fill as well. `CellStore.data` is private rather than protected, and nothing in the library derives from `CellStore`.

## Tests

`CellDataTests`, `CellStoreRegressionTests`, `AutoFitExportTests` and additions to `SpreadsheetCultureTests` cover the value-versus-cell storage, the derived-store dispatch, the type and quote-prefix inference, and auto-fit over a shrunk row count. The full suite passes: 5,206 tests.

