### PR TITLE
Fix: RangeNavigator keeps stale scales when its series data changes

### DIFF
--- a/Radzen.Blazor.Tests/RangeNavigatorTests.cs
+++ b/Radzen.Blazor.Tests/RangeNavigatorTests.cs
@@ -184,6 +184,36 @@ namespace Radzen.Blazor.Tests
             Assert.DoesNotContain("NaN", component.Markup);
         }
 
+        [Fact]
+        public void RangeNavigator_WithLineSeries_UpdatesScales_WhenSeriesDataChanges()
+        {
+            // The scales used to keep the domain of the data first seen until a resize (#2713).
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx);
+
+            Assert.Equal(10, component.Instance.ValueScale.Input.Start);
+            Assert.Equal(20, component.Instance.ValueScale.Input.End);
+
+            component.SetParametersAndRender(parameters =>
+                parameters.AddChildContent<RadzenRangeNavigatorLineSeries<DataItem>>(series =>
+                {
+                    series.Add(p => p.Data, WiderData);
+                    series.Add(p => p.CategoryProperty, nameof(DataItem.Category));
+                    series.Add(p => p.ValueProperty, nameof(DataItem.Value));
+                }));
+
+            Assert.Equal(100, component.Instance.ValueScale.Input.Start);
+            Assert.Equal(300, component.Instance.ValueScale.Input.End);
+        }
+
+        private static DataItem[] WiderData => new[]
+        {
+            new DataItem { Category = "A", Value = 100 },
+            new DataItem { Category = "B", Value = 300 },
+            new DataItem { Category = "C", Value = 200 },
+        };
+
         private static IRenderedComponent<RadzenRangeNavigator> RenderNavigatorWithLineSeries(TestContext ctx)
         {
             return ctx.RenderComponent<RadzenRangeNavigator>(parameters =>

--- a/Radzen.Blazor.Tests/RangeNavigatorTests.cs
+++ b/Radzen.Blazor.Tests/RangeNavigatorTests.cs
@@ -207,6 +207,46 @@ namespace Radzen.Blazor.Tests
             Assert.Equal(300, component.Instance.ValueScale.Input.End);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RangeNavigator_Rerenders_WhenDataChangesWithinTheSameDomain(bool renameCategories)
+        {
+            using var ctx = CreateChartContext();
+            var component = RenderNavigatorWithLineSeries(ctx);
+            component.SetParametersAndRender(p => p.Add(x => x.ShowAxis, true));
+            var data = new[]
+            {
+                new DataItem { Category = renameCategories ? "X" : "A", Value = 10 },
+                new DataItem { Category = renameCategories ? "Y" : "B", Value = 20 },
+                new DataItem { Category = renameCategories ? "Z" : "C", Value = renameCategories ? 15 : 12 },
+            };
+
+            component.SetParametersAndRender(parameters =>
+                parameters.AddChildContent<RadzenRangeNavigatorLineSeries<DataItem>>(series =>
+                {
+                    series.Add(p => p.Data, data);
+                    series.Add(p => p.CategoryProperty, nameof(DataItem.Category));
+                    series.Add(p => p.ValueProperty, nameof(DataItem.Value));
+                }));
+
+            Assert.Equal(10, component.Instance.ValueScale.Input.Start);
+            Assert.Equal(20, component.Instance.ValueScale.Input.End);
+            if (renameCategories)
+            {
+                Assert.DoesNotContain(">A<", component.Markup);
+                Assert.Contains(">X<", component.Markup);
+            }
+            else
+            {
+                Assert.Contains("166.66666666666669 160 ", component.Markup);
+                Assert.DoesNotContain("166.66666666666669 100 ", component.Markup);
+            }
+            var renders = component.RenderCount;
+            component.SetParametersAndRender(p => p.Add(x => x.Start, 0.2));
+            Assert.Equal(renders + 1, component.RenderCount);
+        }
+
         private static DataItem[] WiderData => new[]
         {
             new DataItem { Category = "A", Value = 100 },

--- a/Radzen.Blazor/RadzenRangeNavigator.razor.cs
+++ b/Radzen.Blazor/RadzenRangeNavigator.razor.cs
@@ -130,12 +130,15 @@ namespace Radzen.Blazor
             NavigatorSeries.Remove(series);
         }
 
-        internal void UpdateScales()
+        internal bool UpdateScales()
         {
             if (Width <= 0)
             {
-                return;
+                return false;
             }
+
+            var previousCategoryScale = CategoryScale;
+            var previousValueScale = ValueScale;
 
             CategoryScale = new LinearScale();
             ValueScale = new LinearScale();
@@ -163,7 +166,15 @@ namespace Radzen.Blazor
             ValueScale.Fit(10);
 
             UpdateJSLabelConfig();
+
+            return !SameDomain(previousCategoryScale, CategoryScale)
+                || !SameDomain(previousValueScale, ValueScale);
         }
+
+        private static bool SameDomain(ScaleBase left, ScaleBase right) =>
+            left.GetType() == right.GetType()
+            && left.Input.Start.Equals(right.Input.Start)
+            && left.Input.End.Equals(right.Input.End);
 
         internal IList<AxisTick> GetAxisTicks()
         {
@@ -370,6 +381,10 @@ namespace Radzen.Blazor
                         StateHasChanged();
                     }
                 }
+            }
+            else if (UpdateScales())
+            {
+                StateHasChanged();
             }
         }
 

--- a/Radzen.Blazor/RadzenRangeNavigator.razor.cs
+++ b/Radzen.Blazor/RadzenRangeNavigator.razor.cs
@@ -130,15 +130,18 @@ namespace Radzen.Blazor
             NavigatorSeries.Remove(series);
         }
 
-        internal bool UpdateScales()
+        internal void Refresh()
+        {
+            UpdateScales();
+            StateHasChanged();
+        }
+
+        internal void UpdateScales()
         {
             if (Width <= 0)
             {
-                return false;
+                return;
             }
-
-            var previousCategoryScale = CategoryScale;
-            var previousValueScale = ValueScale;
 
             CategoryScale = new LinearScale();
             ValueScale = new LinearScale();
@@ -166,15 +169,7 @@ namespace Radzen.Blazor
             ValueScale.Fit(10);
 
             UpdateJSLabelConfig();
-
-            return !SameDomain(previousCategoryScale, CategoryScale)
-                || !SameDomain(previousValueScale, ValueScale);
         }
-
-        private static bool SameDomain(ScaleBase left, ScaleBase right) =>
-            left.GetType() == right.GetType()
-            && left.Input.Start.Equals(right.Input.Start)
-            && left.Input.End.Equals(right.Input.End);
 
         internal IList<AxisTick> GetAxisTicks()
         {
@@ -381,10 +376,6 @@ namespace Radzen.Blazor
                         StateHasChanged();
                     }
                 }
-            }
-            else if (UpdateScales())
-            {
-                StateHasChanged();
             }
         }
 

--- a/Radzen.Blazor/RadzenRangeNavigatorLineSeries.razor.cs
+++ b/Radzen.Blazor/RadzenRangeNavigatorLineSeries.razor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Radzen.Blazor.Rendering;
 
@@ -81,13 +82,22 @@ namespace Radzen.Blazor
         private IList<TItem> Items { get; set; } = new List<TItem>();
 
         /// <inheritdoc />
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            var dataChanged = parameters.DidParameterChange(nameof(Data), Data);
+
+            await base.SetParametersAsync(parameters);
+
+            if (dataChanged)
+            {
+                Navigator?.Refresh();
+            }
+        }
+
+        /// <inheritdoc />
         protected override void OnParametersSet()
         {
-            if (Data != null)
-            {
-                Items = Data.ToList();
-            }
-
+            Items = Data?.ToList() ?? new List<TItem>();
             Navigator?.AddSeries(this);
         }
 


### PR DESCRIPTION
Fixes #2713.

Changing a RangeNavigator series' data leaves its axis, handle labels, and SVG path stale until resize. This also affects changes that preserve the scale domain: renaming A/B/C to X/Y/Z or changing values from 10/20/15 to 10/20/12.

The line series now detects a changed Data reference in SetParametersAsync and asks the navigator to refresh after its items have been updated. Refresh recomputes the scales and renders the navigator, which owns the series SVG. Repassing the same Data reference does not request another refresh. This replaces the post-render domain comparison and removes the duplicate SameDomain helper.

Validation: all 16 RangeNavigator tests pass, including changed bounds, renamed categories, changed values within the same bounds, and a same-reference render check.
