### PR TITLE
Spreadsheet: Stream to a sheet from a row source

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/AutoFitXlsxRoundTripTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/AutoFitXlsxRoundTripTests.cs
@@ -138,6 +138,51 @@ public class AutoFitXlsxRoundTripTests
         Assert.Equal(78, sheet.Columns[0]);
     }
 
+    // A Top 10 rule reads every address in its range through the indexer, which adds the cells it does
+    // not find and throws past the sheet's bounds. Measuring an auto fitted column asks that rule for a
+    // format, so the width pass has to survive both.
+    [Fact]
+    public void Write_AutoFitColumn_SurvivesATop10RuleOverUnpopulatedCells()
+    {
+        var wb = Build();
+        var sheet = wb.Sheets[0];
+
+        for (var row = 0; row < 4; row++)
+        {
+            sheet.Cells[row, 0].Value = row * 1.5;
+        }
+
+        sheet.Columns.SetAutoFit(0);
+        sheet.ConditionalFormats.Add(
+            new RangeRef(new CellRef(0, 0), new CellRef(9, 0)),
+            new Top10Rule { Count = 2, Format = new Format { Bold = true } });
+
+        using var ms = Save(wb);
+
+        Assert.Single(ReadSheetXml(ms).Descendants(Ns + "col"));
+    }
+
+    [Fact]
+    public void Write_AutoFitColumn_SurvivesATop10RulePastTheSheetBounds()
+    {
+        var wb = Build();
+        var sheet = wb.Sheets[0];
+
+        for (var row = 0; row < 4; row++)
+        {
+            sheet.Cells[row, 0].Value = row * 1.5;
+        }
+
+        sheet.Columns.SetAutoFit(0);
+        sheet.ConditionalFormats.Add(
+            new RangeRef(new CellRef(0, 0), new CellRef(40, 0)),
+            new Top10Rule { Count = 2, Format = new Format { Bold = true } });
+
+        using var ms = Save(wb);
+
+        Assert.Single(ReadSheetXml(ms).Descendants(Ns + "col"));
+    }
+
     [Fact]
     public void Write_AutoFitColumn_KeepsWiderModelWidth()
     {

--- a/Radzen.Blazor.Tests/Spreadsheet/StreamedSheetPipelineTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/StreamedSheetPipelineTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+/// <summary>
+/// §66: that the rows are pulled one at a time and written as they arrive, rather than drained first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every allocation figure this feature quotes rests on the source and the writer alternating: a path
+/// that read the rows into anything before writing them would report the same bytes per row on a small
+/// sheet and fall over on a large one. Allocation cannot see the difference - a list that is filled and
+/// dropped inside one measured region looks like garbage either way - so this asserts the ordering
+/// itself, by watching what the source has yielded at the moment bytes reach the destination.
+/// </para>
+/// <para>
+/// It is not a claim that nothing anywhere buffers. The zip's deflate stream holds tens of kilobytes
+/// before it passes any on, which is why the bound below is generous rather than one row; a real
+/// provider's reader holds a packet of rows for the same kind of reason. What is asserted is that
+/// <em>this</em> code holds nothing: writing begins while the source is near its start, and the source
+/// is still being read when the last of the file is written.
+/// </para>
+/// </remarks>
+public class StreamedSheetPipelineTests
+{
+    private const int Rows = 20_000;
+
+    private sealed class Source
+    {
+        public int Yielded;
+
+        public async IAsyncEnumerable<int> Read()
+        {
+            for (var i = 0; i < Rows; i++)
+            {
+                Yielded++;
+
+                yield return i;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+
+    private sealed class Watcher(Source source) : Stream
+    {
+        public int FirstWriteAtRow = -1;
+        public int LastWriteAtRow = -1;
+        public long Length_;
+
+        public override void Write(byte[] buffer, int offset, int count) => Note(count);
+
+        public override void Write(ReadOnlySpan<byte> buffer) => Note(buffer.Length);
+
+        private void Note(int count)
+        {
+            if (FirstWriteAtRow < 0)
+            {
+                FirstWriteAtRow = source.Yielded;
+            }
+
+            LastWriteAtRow = source.Yielded;
+            Length_ += count;
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => Length_;
+        public override long Position { get => Length_; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+    private static StreamedSheet<int> Sheet(Source source, ColumnWidthMode mode) => new()
+    {
+        Rows = source.Read(),
+        WidthMode = mode,
+        Columns =
+        {
+            new StreamedColumn<int> { Title = "Index", Value = i => i },
+            new StreamedColumn<int> { Title = "Name", Value = i => "row " + (i % 100) },
+        },
+    };
+
+    /// <summary>
+    /// Bytes reach the destination while the source is near its beginning, and the source is still
+    /// being read when the last of them do.
+    /// </summary>
+    [Fact]
+    public async Task TheRowsAreWrittenAsTheyArrive()
+    {
+        var source = new Source();
+        var watcher = new Watcher(source);
+
+        await Workbook.SaveToStreamAsync(watcher, Sheet(source, ColumnWidthMode.Declared));
+
+        Assert.Equal(Rows, source.Yielded);
+
+        Assert.InRange(watcher.FirstWriteAtRow, 0, Rows / 4);
+
+        Assert.Equal(Rows, watcher.LastWriteAtRow);
+    }
+
+    /// <summary>
+    /// The sample is the one thing that reads ahead, and it reads exactly as far as it was told to.
+    /// </summary>
+    [Fact]
+    public async Task TheSampleReadsAheadAndNothingElseDoes()
+    {
+        var source = new Source();
+        var watcher = new Watcher(source);
+
+        await Workbook.SaveToStreamAsync(watcher, Sheet(source, ColumnWidthMode.Sampled(200)));
+
+        Assert.InRange(watcher.FirstWriteAtRow, 200, Rows / 4);
+        Assert.Equal(Rows, watcher.LastWriteAtRow);
+    }
+
+    /// <summary>
+    /// A source that stops early stops the write with it - nothing was read past the row that threw.
+    /// </summary>
+    [Fact]
+    public async Task AFaultingSourceIsNotReadPast()
+    {
+        var source = new Source();
+
+        async IAsyncEnumerable<int> Faulting()
+        {
+            await foreach (var row in source.Read())
+            {
+                if (row == 500)
+                {
+                    throw new InvalidOperationException("the source gave up");
+                }
+
+                yield return row;
+            }
+        }
+
+        var sheet = Sheet(source, ColumnWidthMode.Declared);
+        sheet.Rows = Faulting();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Workbook.SaveToStreamAsync(new Watcher(source), sheet));
+
+        Assert.Equal(501, source.Yielded);
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/StreamedSheetTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/StreamedSheetTests.cs
@@ -1,0 +1,670 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class StreamedSheetTests
+{
+    private sealed record Person(string Name, int Age, DateTime Joined, bool Active);
+
+    private static readonly DateTime Seed = new(2020, 1, 1);
+
+    private static Person[] People(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new Person($"Person {i}", 20 + (i % 50), Seed.AddDays(i % 900), i % 2 == 0))
+            .ToArray();
+
+    private static async IAsyncEnumerable<T> Async<T>(IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            await Task.Yield();
+
+            yield return item;
+        }
+    }
+
+    private static StreamedSheet<Person> Sheet(IEnumerable<Person> rows) => new()
+    {
+        Name = "People",
+        Rows = Async(rows),
+        Columns =
+        {
+            new StreamedColumn<Person> { Title = "Name", Value = p => p.Name },
+            new StreamedColumn<Person> { Title = "Age", Value = p => p.Age },
+            new StreamedColumn<Person> { Title = "Joined", Value = p => p.Joined },
+            new StreamedColumn<Person> { Title = "Active", Value = p => p.Active },
+        },
+    };
+
+    private static Workbook Built(IReadOnlyList<Person> rows, bool header = true)
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("People", rows.Count + (header ? 1 : 0), 4);
+
+        var offset = 0;
+
+        if (header)
+        {
+            var titles = new[] { "Name", "Age", "Joined", "Active" };
+
+            for (var column = 0; column < titles.Length; column++)
+            {
+                var cell = sheet.Cells[0, column];
+                cell.Value = titles[column];
+                cell.Format.Bold = true;
+            }
+
+            offset = 1;
+        }
+
+        for (var row = 0; row < rows.Count; row++)
+        {
+            sheet.Cells.SetValues(row + offset, 0,
+            [
+                [rows[row].Name, (double)rows[row].Age, rows[row].Joined, rows[row].Active],
+            ]);
+        }
+
+        return workbook;
+    }
+
+    private static async Task<MemoryStream> Stream(StreamedSheet sheet, CancellationToken cancellationToken = default)
+    {
+        var stream = new MemoryStream();
+
+        await Workbook.SaveToStreamAsync(stream, sheet, cancellationToken);
+
+        stream.Position = 0;
+
+        return stream;
+    }
+
+    private static MemoryStream Save(Workbook workbook)
+    {
+        var stream = new MemoryStream();
+
+        workbook.SaveToStream(stream);
+        stream.Position = 0;
+
+        return stream;
+    }
+
+    private static Worksheet Read(MemoryStream stream)
+    {
+        stream.Position = 0;
+
+        var sheet = Workbook.LoadFromStream(stream).Sheets[0];
+
+        stream.Position = 0;
+
+        return sheet;
+    }
+
+    private static XDocument SheetXml(MemoryStream stream)
+    {
+        stream.Position = 0;
+
+        using var zip = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+        using var entry = zip.GetEntry("xl/worksheets/sheet1.xml")!.Open();
+
+        var doc = XDocument.Load(entry);
+
+        stream.Position = 0;
+
+        return doc;
+    }
+
+    private static void AssertCellsEqual(Worksheet expected, Worksheet actual, int rows, int columns)
+    {
+        for (var row = 0; row < rows; row++)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                var left = expected.Cells[row, column];
+                var right = actual.Cells[row, column];
+
+                Assert.Equal(left.Value, right.Value);
+                Assert.Equal(left.ValueType, right.ValueType);
+                Assert.Equal(left.GetEffectiveFormat()?.Bold, right.GetEffectiveFormat()?.Bold);
+                Assert.Equal(left.GetEffectiveFormat()?.NumberFormat, right.GetEffectiveFormat()?.NumberFormat);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Writes_the_header_and_every_row()
+    {
+        var people = People(5);
+
+        var sheet = Read(await Stream(Sheet(people)));
+
+        Assert.Equal("People", sheet.Name);
+        Assert.Equal("Name", sheet.Cells[0, 0].Value);
+        Assert.True(sheet.Cells[0, 0].GetEffectiveFormat()?.Bold);
+
+        for (var row = 0; row < people.Length; row++)
+        {
+            Assert.Equal(people[row].Name, sheet.Cells[row + 1, 0].Value);
+            Assert.Equal((double)people[row].Age, sheet.Cells[row + 1, 1].Value);
+            Assert.Equal(people[row].Joined.ToNumber(), sheet.Cells[row + 1, 2].Value);
+            Assert.Equal("mm/dd/yyyy", sheet.Cells[row + 1, 2].GetEffectiveFormat()?.NumberFormat);
+            Assert.Equal(people[row].Active, sheet.Cells[row + 1, 3].Value);
+        }
+    }
+
+    [Fact]
+    public async Task Types_a_cell_as_the_builder_does()
+    {
+        var people = People(5);
+
+        var streamed = Read(await Stream(Sheet(people)));
+        var built = Read(Save(Built(people)));
+
+        AssertCellsEqual(built, streamed, people.Length + 1, 4);
+    }
+
+    [Fact]
+    public async Task Defaults_reproduce_the_built_file()
+    {
+        var people = People(120);
+
+        var streamed = Read(await Stream(Sheet(people)));
+        var built = Read(Save(Built(people)));
+
+        Assert.Equal(built.RowCount, streamed.RowCount);
+        Assert.Equal(built.ColumnCount, streamed.ColumnCount);
+
+        AssertCellsEqual(built, streamed, built.RowCount, built.ColumnCount);
+    }
+
+    [Fact]
+    public async Task Writes_no_rows_for_an_empty_source_but_still_writes_the_header()
+    {
+        var stream = await Stream(Sheet([]));
+        var sheet = Read(stream);
+
+        Assert.Equal("Name", sheet.Cells[0, 0].Value);
+        Assert.Equal(1, sheet.RowCount);
+    }
+
+    [Fact]
+    public async Task Omits_the_header_when_asked()
+    {
+        var people = People(3);
+        var spec = Sheet(people);
+        spec.IncludeHeader = false;
+
+        var sheet = Read(await Stream(spec));
+
+        Assert.Equal(people[0].Name, sheet.Cells[0, 0].Value);
+    }
+
+    [Fact]
+    public async Task Freezes_the_rows_and_columns_it_was_given()
+    {
+        var spec = Sheet(People(3));
+        spec.FrozenRows = 1;
+        spec.FrozenColumns = 2;
+
+        var sheet = Read(await Stream(spec));
+
+        Assert.Equal(1, sheet.Rows.Frozen);
+        Assert.Equal(2, sheet.Columns.Frozen);
+    }
+
+    [Fact]
+    public async Task Writes_a_declared_width_without_reading_a_row()
+    {
+        var spec = Sheet(People(50));
+        spec.WidthMode = ColumnWidthMode.Declared;
+        spec.Columns[0].Width = 240;
+
+        var sheet = Read(await Stream(spec));
+
+        Assert.Equal(240, sheet.Columns[0], 0);
+    }
+
+    [Fact]
+    public async Task Measures_an_auto_fit_column_over_the_sample()
+    {
+        var people = People(10).Append(new Person(new string('x', 60), 1, Seed, true)).ToArray();
+
+        var spec = Sheet(people);
+        spec.WidthMode = ColumnWidthMode.Sampled(200);
+        spec.Columns[0].AutoFit = true;
+
+        var sheet = Read(await Stream(spec));
+
+        Assert.True(sheet.Columns[0] > sheet.Columns[1]);
+        Assert.True(sheet.Columns.IsAutoFit(0));
+    }
+
+    [Fact]
+    public async Task Measures_past_a_value_its_own_format_cannot_render()
+    {
+        var spec = new StreamedSheet<double>
+        {
+            Name = "Sheet1",
+            WidthMode = ColumnWidthMode.Sampled(200),
+            Rows = Async(new[] { 1e10, 1d }),
+            Columns =
+            {
+                new StreamedColumn<double>
+                {
+                    Title = "when",
+                    Value = d => d,
+                    AutoFit = true,
+                    Format = new Format { NumberFormat = "yyyy-mm-dd" },
+                },
+            },
+        };
+
+        var stream = new MemoryStream();
+        await Workbook.SaveToStreamAsync(stream, spec);
+
+        Assert.True(stream.Length > 0);
+        Assert.True(Read(stream).Columns.IsAutoFit(0));
+    }
+
+    [Fact]
+    public async Task A_table_is_not_written_for_a_source_that_had_only_a_header()
+    {
+        var spec = Sheet([]);
+        spec.TableName = "People";
+
+        var stream = await Stream(spec);
+
+        Assert.Empty(Read(stream).Tables);
+
+        stream.Position = 0;
+
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+
+        Assert.Null(archive.GetEntry("xl/tables/table1.xml"));
+        Assert.Null(archive.GetEntry("xl/worksheets/_rels/sheet1.xml.rels"));
+
+        using var entry = archive.GetEntry("xl/worksheets/sheet1.xml")!.Open();
+        using var reader = new StreamReader(entry);
+
+        Assert.DoesNotContain("tablePart", reader.ReadToEnd(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_recovery_that_cannot_run_does_not_replace_the_failure()
+    {
+        var spec = Sheet(People(3));
+        spec.Rows = Faulting();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Workbook.SaveToStreamAsync(new FixedLength(), spec));
+
+        static async IAsyncEnumerable<Person> Faulting()
+        {
+            await Task.Yield();
+
+            yield return new Person("Ada", 1, Seed, true);
+
+            throw new InvalidOperationException("the source failed");
+        }
+    }
+
+    private sealed class FixedLength : MemoryStream
+    {
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task Types_a_value_through_the_culture_it_was_given()
+    {
+        var german = CultureInfo.GetCultureInfo("de-DE");
+
+        var spec = new StreamedSheet<string>
+        {
+            Name = "Sheet1",
+            Culture = german,
+            Rows = Async(new[] { "17.08.2024" }),
+            Columns = { new StreamedColumn<string> { Title = "when", Value = v => v } },
+        };
+
+        var german_ = Read(await Stream(spec)).Cells[1, 0];
+
+        var invariant = new StreamedSheet<string>
+        {
+            Name = "Sheet1",
+            Culture = CultureInfo.InvariantCulture,
+            Rows = Async(new[] { "17.08.2024" }),
+            Columns = { new StreamedColumn<string> { Title = "when", Value = v => v } },
+        };
+
+        var invariant_ = Read(await Stream(invariant)).Cells[1, 0];
+
+        Assert.Equal(CellDataType.Number, german_.ValueType);
+        Assert.Equal(CellDataType.String, invariant_.ValueType);
+        Assert.Equal(new DateTime(2024, 8, 17), Assert.IsType<double>(german_.Value).ToDate());
+    }
+
+    [Fact]
+    public async Task A_sheet_wider_than_the_format_is_refused_before_a_row_is_read()
+    {
+        var read = false;
+
+        var spec = new StreamedSheet<int> { Name = "Sheet1", Rows = Counted() };
+
+        for (var c = 0; c <= 16_384; c++)
+        {
+            spec.Columns.Add(new StreamedColumn<int> { Title = "c" + c, Value = v => v });
+        }
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            Workbook.SaveToStreamAsync(new MemoryStream(), spec));
+
+        Assert.False(read);
+
+        async IAsyncEnumerable<int> Counted()
+        {
+            read = true;
+
+            await Task.Yield();
+
+            yield return 1;
+        }
+    }
+
+    [Fact]
+    public async Task A_source_longer_than_the_format_can_hold_is_refused()
+    {
+        var spec = new StreamedSheet<int>
+        {
+            Name = "Sheet1",
+            IncludeHeader = false,
+            WidthMode = ColumnWidthMode.Declared,
+            Rows = Endless(),
+            Columns = { new StreamedColumn<int> { Title = "n", Value = v => v } },
+        };
+
+        var stream = new MemoryStream();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Workbook.SaveToStreamAsync(stream, spec));
+
+        Assert.Equal(0, stream.Length);
+
+        static async IAsyncEnumerable<int> Endless()
+        {
+            for (var i = 0; i <= 1_048_576; i++)
+            {
+                yield return i;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task A_row_count_the_source_does_not_keep_is_refused()
+    {
+        var spec = Sheet(People(3));
+        spec.RowCount = 5;
+        spec.WidthMode = ColumnWidthMode.Declared;
+
+        var stream = new MemoryStream();
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Workbook.SaveToStreamAsync(stream, spec));
+
+        Assert.Contains("RowCount", error.Message, StringComparison.Ordinal);
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
+    public async Task Does_not_measure_past_the_sample()
+    {
+        var people = People(10).Append(new Person(new string('x', 200), 1, Seed, true)).ToArray();
+
+        var spec = Sheet(people);
+        spec.WidthMode = ColumnWidthMode.Sampled(4);
+        spec.Columns[0].AutoFit = true;
+
+        var narrow = Read(await Stream(spec));
+
+        var wide = Sheet(people);
+        wide.WidthMode = ColumnWidthMode.Sampled(200);
+        wide.Columns[0].AutoFit = true;
+
+        Assert.True(Read(await Stream(wide)).Columns[0] > narrow.Columns[0]);
+    }
+
+    [Fact]
+    public async Task Writes_the_dimension_when_the_sample_held_the_source()
+    {
+        var stream = await Stream(Sheet(People(5)));
+
+        var dimension = SheetXml(stream).Root!
+            .Elements()
+            .FirstOrDefault(e => e.Name.LocalName == "dimension")?
+            .Attribute("ref")?.Value;
+
+        Assert.Equal("A1:D6", dimension);
+    }
+
+    [Fact]
+    public async Task Omits_the_dimension_when_the_count_is_unknown()
+    {
+        var spec = Sheet(People(20));
+        spec.WidthMode = ColumnWidthMode.Sampled(4);
+
+        var stream = await Stream(spec);
+
+        Assert.DoesNotContain(SheetXml(stream).Root!.Elements(), e => e.Name.LocalName == "dimension");
+    }
+
+    [Fact]
+    public async Task Writes_the_dimension_the_caller_declared()
+    {
+        var spec = Sheet(People(20));
+        spec.WidthMode = ColumnWidthMode.Sampled(4);
+        spec.RowCount = 20;
+
+        var stream = await Stream(spec);
+
+        var dimension = SheetXml(stream).Root!
+            .Elements()
+            .First(e => e.Name.LocalName == "dimension")
+            .Attribute("ref")!.Value;
+
+        Assert.Equal("A1:D21", dimension);
+    }
+
+    [Fact]
+    public async Task Interns_strings_by_default_and_inlines_them_when_asked()
+    {
+        var people = People(6);
+
+        var shared = await Stream(Sheet(people));
+
+        using (var zip = new ZipArchive(shared, ZipArchiveMode.Read, leaveOpen: true))
+        {
+            Assert.NotNull(zip.GetEntry("xl/sharedStrings.xml"));
+        }
+
+        var spec = Sheet(people);
+        spec.InlineStrings = true;
+
+        var inline = await Stream(spec);
+
+        using (var zip = new ZipArchive(inline, ZipArchiveMode.Read, leaveOpen: true))
+        {
+            Assert.Null(zip.GetEntry("xl/sharedStrings.xml"));
+        }
+
+        Assert.Equal(people[0].Name, Read(inline).Cells[1, 0].Value);
+    }
+
+    [Fact]
+    public async Task Sizes_the_table_to_the_rows_it_wrote()
+    {
+        var spec = Sheet(People(7));
+        spec.TableName = "People";
+
+        var stream = await Stream(spec);
+        var sheet = Read(stream);
+
+        var table = Assert.Single(sheet.Tables);
+
+        Assert.Equal("A1:D8", $"{table.Range.Start}:{table.Range.End}");
+        Assert.Equal("Name", table.Columns[0].Name);
+    }
+
+    [Fact]
+    public async Task Applies_a_column_format_to_every_cell_of_it()
+    {
+        var spec = Sheet(People(4));
+        spec.Columns[1].Format = new Format { NumberFormat = "0.00" };
+
+        var sheet = Read(await Stream(spec));
+
+        Assert.Equal("0.00", sheet.Cells[1, 1].GetEffectiveFormat()?.NumberFormat);
+        Assert.Equal("0.00", sheet.Cells[4, 1].GetEffectiveFormat()?.NumberFormat);
+    }
+
+    [Fact]
+    public async Task A_faulting_source_leaves_nothing_that_opens()
+    {
+        static async IAsyncEnumerable<Person> Faulting()
+        {
+            await Task.Yield();
+
+            yield return new Person("first", 1, Seed, true);
+
+            throw new InvalidOperationException("the source gave up");
+        }
+
+        var stream = new MemoryStream();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Workbook.SaveToStreamAsync(stream, new StreamedSheet<Person>
+            {
+                Rows = Faulting(),
+                Columns = { new StreamedColumn<Person> { Title = "Name", Value = p => p.Name } },
+            }));
+
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
+    public async Task A_source_that_cancels_as_it_ends_leaves_nothing_that_opens()
+    {
+        using var cancellation = new CancellationTokenSource();
+
+        async IAsyncEnumerable<Person> CancelsLast()
+        {
+            await Task.Yield();
+
+            yield return new Person("first", 1, Seed, true);
+
+            cancellation.Cancel();
+        }
+
+        var stream = new MemoryStream();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            Workbook.SaveToStreamAsync(stream, new StreamedSheet<Person>
+            {
+                Rows = CancelsLast(),
+                Columns = { new StreamedColumn<Person> { Title = "Name", Value = p => p.Name } },
+            }, cancellation.Token));
+
+        Assert.Equal(0, stream.Length);
+    }
+
+    // The source above fits the sample, so the buffering loop's check is what catches it. A source
+    // longer than the sample gets past that loop and is read by the streaming one, whose own end is the
+    // second place a token cancelled after the last row can slip through.
+    [Fact]
+    public async Task A_source_longer_than_the_sample_that_cancels_as_it_ends_leaves_nothing_that_opens()
+    {
+        using var cancellation = new CancellationTokenSource();
+
+        async IAsyncEnumerable<Person> CancelsLast()
+        {
+            foreach (var person in People(6))
+            {
+                await Task.Yield();
+
+                yield return person;
+            }
+
+            cancellation.Cancel();
+        }
+
+        var stream = new MemoryStream();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            Workbook.SaveToStreamAsync(stream, new StreamedSheet<Person>
+            {
+                WidthMode = ColumnWidthMode.Sampled(2),
+                Rows = CancelsLast(),
+                Columns = { new StreamedColumn<Person> { Title = "Name", Value = p => p.Name } },
+            }, cancellation.Token));
+
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
+    public async Task A_table_column_keeps_a_heading_that_reads_as_a_number()
+    {
+        var spec = Sheet(People(3));
+        spec.TableName = "People";
+        spec.Columns[0].Title = "2026";
+
+        var stream = await Stream(spec);
+
+        var header = SheetXml(stream).Root!
+            .Elements().First(e => e.Name.LocalName == "sheetData")
+            .Elements().First()
+            .Elements().First();
+
+        Assert.Equal("s", header.Attribute("t")?.Value);
+        Assert.Equal("2026", Assert.Single(Read(stream).Tables).Columns[0].Name);
+    }
+
+    [Fact]
+    public async Task A_cancelled_write_leaves_nothing_that_opens()
+    {
+        using var cancellation = new CancellationTokenSource();
+
+        async IAsyncEnumerable<Person> Cancelling()
+        {
+            await Task.Yield();
+
+            yield return new Person("first", 1, Seed, true);
+
+            cancellation.Cancel();
+
+            yield return new Person("second", 2, Seed, true);
+        }
+
+        var stream = new MemoryStream();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            Workbook.SaveToStreamAsync(stream, new StreamedSheet<Person>
+            {
+                Rows = Cancelling(),
+                Columns = { new StreamedColumn<Person> { Title = "Name", Value = p => p.Name } },
+            }, cancellation.Token));
+
+        Assert.Equal(0, stream.Length);
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/StreamedSheetTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/StreamedSheetTests.cs
@@ -413,6 +413,63 @@ public class StreamedSheetTests
     }
 
     [Fact]
+    public async Task A_cell_longer_than_the_format_can_hold_is_refused()
+    {
+        var spec = Text(new string('x', 32_768));
+
+        var stream = new MemoryStream();
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Workbook.SaveToStreamAsync(stream, spec));
+
+        Assert.Contains("32767", error.Message, StringComparison.Ordinal);
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
+    public async Task A_cell_of_exactly_the_longest_the_format_holds_is_written()
+    {
+        var spec = Text(new string('x', 32_767));
+
+        var stream = new MemoryStream();
+
+        await Workbook.SaveToStreamAsync(stream, spec);
+
+        Assert.Equal(32_767, Read(stream).Cells[0, 0].Value as string is { } text ? text.Length : 0);
+    }
+
+    [Fact]
+    public async Task A_title_longer_than_the_format_can_hold_is_refused()
+    {
+        var spec = Text("short");
+        spec.IncludeHeader = true;
+        spec.Columns[0].Title = new string('t', 32_768);
+
+        var stream = new MemoryStream();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Workbook.SaveToStreamAsync(stream, spec));
+
+        Assert.Equal(0, stream.Length);
+    }
+
+    private static StreamedSheet<string> Text(string value) => new()
+    {
+        Name = "Sheet1",
+        IncludeHeader = false,
+        WidthMode = ColumnWidthMode.Declared,
+        Rows = One(value),
+        Columns = { new StreamedColumn<string> { Title = "t", Value = v => v } },
+    };
+
+    private static async IAsyncEnumerable<string> One(string value)
+    {
+        await Task.CompletedTask;
+
+        yield return value;
+    }
+
+    [Fact]
     public async Task A_row_count_the_source_does_not_keep_is_refused()
     {
         var spec = Sheet(People(3));

--- a/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Cell.cs
@@ -224,15 +224,17 @@ public class Cell
     /// </summary>
     public string? GetValueAsString() => FormatValue(Culture);
 
-    private string? FormatValue(CultureInfo culture)
+    private string? FormatValue(CultureInfo culture) => FormatValue(Value, culture);
+
+    internal static string? FormatValue(object? value, CultureInfo culture)
     {
-        return Value switch
+        return value switch
         {
             null => null,
             CellError error => error.ToString(),
             string str => str,
             IFormattable formattable => formattable.ToString(null, culture),
-            _ => Value.ToString()
+            _ => value.ToString()
         };
     }
 

--- a/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
@@ -119,10 +119,18 @@ public class CellData : IComparable, IComparable<CellData>
 
     internal CellData(object? data, CultureInfo culture)
     {
+        Infer(data, culture, out var inferred, out var inferredType);
+
+        Value = inferred;
+        Type = inferredType;
+    }
+
+    internal static void Infer(object? data, CultureInfo culture, out object? value, out CellDataType type)
+    {
         if (data is null)
         {
-            Value = null;
-            Type = CellDataType.Empty;
+            value = null;
+            type = CellDataType.Empty;
             return;
         }
 
@@ -135,19 +143,19 @@ public class CellData : IComparable, IComparable<CellData>
             var converted = TryConvertFromString(data.ToString(), culture, out var convertedData, out var valueType);
             if (converted)
             {
-                Value = convertedData;
-                Type = valueType!.Value;
+                value = convertedData;
+                type = valueType!.Value;
             }
             else
             {
-                Value = data;
-                Type = CellDataType.String;
+                value = data;
+                type = CellDataType.String;
             }
         }
         else
         {
-            Type = GetValueType(data, valType, isNullable, nullableType);
-            Value = (Type == CellDataType.Number) ? Convert.ToDouble(data, CultureInfo.InvariantCulture) : data;
+            type = GetValueType(data, valType, isNullable, nullableType);
+            value = (type == CellDataType.Number) ? Convert.ToDouble(data, CultureInfo.InvariantCulture) : data;
         }
     }
 

--- a/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/CellData.cs
@@ -155,7 +155,9 @@ public class CellData : IComparable, IComparable<CellData>
         else
         {
             type = GetValueType(data, valType, isNullable, nullableType);
-            value = (type == CellDataType.Number) ? Convert.ToDouble(data, CultureInfo.InvariantCulture) : data;
+            value = type == CellDataType.Number && data is not double
+                ? Convert.ToDouble(data, CultureInfo.InvariantCulture)
+                : data;
         }
     }
 

--- a/Radzen.Blazor/Documents/Spreadsheet/StreamedSheet.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/StreamedSheet.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Radzen.Documents.Spreadsheet;
+
+#nullable enable
+
+/// <summary>
+/// How a streamed sheet decides the column widths it has to write before it has seen the rows.
+/// </summary>
+/// <remarks>
+/// The <c>cols</c> element precedes <c>sheetData</c> in the same part, so a width is chosen before a
+/// single row has been read. <see cref="Declared"/> takes the widths it was given and reads nothing;
+/// <see cref="Sampled"/> buffers a bounded prefix of the rows, measures those, and replays the buffer.
+/// Both are streaming: neither holds a number of rows that grows with the source.
+/// </remarks>
+public readonly struct ColumnWidthMode : IEquatable<ColumnWidthMode>
+{
+    private readonly int rows;
+
+    private ColumnWidthMode(int rows) => this.rows = rows;
+
+    /// <summary>
+    /// Writes the width each column declares and measures nothing.
+    /// </summary>
+    public static ColumnWidthMode Declared => new(0);
+
+    /// <summary>
+    /// Buffers the first <paramref name="rows"/> rows, measures the auto-fit columns over them, then
+    /// replays the buffer and streams the rest.
+    /// </summary>
+    /// <param name="rows">How many rows to buffer. Must be greater than zero.</param>
+    public static ColumnWidthMode Sampled(int rows = 200)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(rows, 1);
+
+        return new(rows);
+    }
+
+    /// <summary>
+    /// Whether this mode measures nothing.
+    /// </summary>
+    public bool IsDeclared => rows == 0;
+
+    internal int SampleRows => rows;
+
+    /// <inheritdoc />
+    public bool Equals(ColumnWidthMode other) => rows == other.rows;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ColumnWidthMode other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => rows;
+
+    /// <summary>Compares two modes.</summary>
+    public static bool operator ==(ColumnWidthMode left, ColumnWidthMode right) => left.Equals(right);
+
+    /// <summary>Compares two modes.</summary>
+    public static bool operator !=(ColumnWidthMode left, ColumnWidthMode right) => !left.Equals(right);
+}
+
+/// <summary>
+/// One column of a <see cref="StreamedSheet{T}"/>: its heading, the value it reads from a row, and the
+/// format both are written with.
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+public sealed class StreamedColumn<T>
+{
+    /// <summary>
+    /// The heading written in the header row.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Reads the cell value from a row. The value is typed exactly as it would be if it were assigned
+    /// to a <see cref="Cell.Value"/>, so a streamed column and a built one produce the same cell.
+    /// </summary>
+    public Func<T, object?> Value { get; set; } = static _ => null;
+
+    /// <summary>
+    /// The format applied to every data cell of the column. Null leaves them unformatted.
+    /// </summary>
+    public Format? Format { get; set; }
+
+    /// <summary>
+    /// The column width in pixels. Null takes the sheet's default width.
+    /// </summary>
+    public double? Width { get; set; }
+
+    /// <summary>
+    /// Whether the column is measured from its content under <see cref="ColumnWidthMode.Sampled"/>,
+    /// and persisted as <c>bestFit</c>. Ignored under <see cref="ColumnWidthMode.Declared"/>.
+    /// </summary>
+    public bool AutoFit { get; set; }
+}
+
+/// <summary>
+/// A sheet written from a row source rather than built. The rows are read once, in order, and never
+/// retained, so what is written costs the same in memory whether the source has a hundred rows or a
+/// million.
+/// </summary>
+/// <remarks>
+/// Passed to <see cref="Workbook.SaveToStreamAsync(System.IO.Stream, StreamedSheet, CancellationToken)"/>.
+/// Construct <see cref="StreamedSheet{T}"/>; this base is what the writer is handed.
+/// </remarks>
+public abstract class StreamedSheet
+{
+    private protected StreamedSheet()
+    {
+    }
+
+    /// <summary>
+    /// The sheet name.
+    /// </summary>
+    public string Name { get; set; } = "Sheet1";
+
+    /// <summary>
+    /// The culture the column values are typed through, matching <see cref="Workbook.Culture"/> on the
+    /// built path. If not set, falls back to <see cref="CultureInfo.CurrentCulture"/>, so a sheet whose
+    /// columns yield strings that parse as numbers or dates should set it rather than inherit whatever
+    /// the machine writing the file happens to use. File storage is invariant regardless.
+    /// </summary>
+    public CultureInfo? Culture { get; set; }
+
+    /// <summary>
+    /// How the column widths are decided. Defaults to <see cref="ColumnWidthMode.Sampled"/> over 200
+    /// rows, which is what a built sheet's auto-fit measures over all of them.
+    /// </summary>
+    public ColumnWidthMode WidthMode { get; set; } = ColumnWidthMode.Sampled();
+
+    /// <summary>
+    /// Writes each string into the cell that holds it instead of interning it in the shared string
+    /// table. The table's memory is <c>O(distinct strings)</c> and usually small; turning this on makes
+    /// the whole write <c>O(1)</c> in rows at the cost of a larger file.
+    /// </summary>
+    public bool InlineStrings { get; set; }
+
+    /// <summary>
+    /// Whether the column titles are written as the first row, and counted in the table range when it
+    /// is written. Freezing it is <see cref="FrozenRows"/>, which counts the header.
+    /// </summary>
+    public bool IncludeHeader { get; set; } = true;
+
+    /// <summary>
+    /// The format of the header row. Defaults to bold.
+    /// </summary>
+    public Format? HeaderFormat { get; set; } = new Format { Bold = true };
+
+    /// <summary>
+    /// The number of rows frozen at the top of the sheet, header included.
+    /// </summary>
+    public int FrozenRows { get; set; }
+
+    /// <summary>
+    /// The number of columns frozen at the left of the sheet.
+    /// </summary>
+    public int FrozenColumns { get; set; }
+
+    /// <summary>
+    /// The name of a table over the written range, or null for no table. The range is closed after the
+    /// last row, so the table part costs nothing to size. A table needs a row of its own: a source that
+    /// yields none leaves the sheet without one, header or no header.
+    /// </summary>
+    public string? TableName { get; set; }
+
+    /// <summary>
+    /// How many rows the source will yield, when that is known without asking for them.
+    /// </summary>
+    /// <remarks>
+    /// Only the <c>dimension</c> element needs it, and only because it precedes the rows. Left null the
+    /// element is omitted, which readers are required to tolerate, and a reader then sizes the sheet
+    /// from the rows it finds. A sampled write whose source ends inside the sample knows the count
+    /// without being told and writes the element anyway; a source that exactly fills the sample does
+    /// not, because nothing has asked it for another row.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown by the write when the source yields a different number of rows. The element goes in
+    /// before the rows do, so a count that turns out wrong cannot be corrected, and a sheet whose
+    /// dimension disagrees with its own rows is worse than one that omits it.
+    /// </exception>
+    public int? RowCount { get; set; }
+
+    internal abstract int ColumnCount { get; }
+
+    internal abstract string TitleAt(int column);
+
+    internal abstract Format? FormatAt(int column);
+
+    internal abstract double? WidthAt(int column);
+
+    internal abstract bool AutoFitAt(int column);
+
+    internal abstract IAsyncEnumerable<object?[]> Read(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// A <see cref="StreamedSheet"/> over a typed asynchronous row source.
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+public sealed class StreamedSheet<T> : StreamedSheet
+{
+    /// <summary>
+    /// The rows, read once and in the order they arrive. Nothing is filtered, sorted or counted on the
+    /// way through.
+    /// </summary>
+    public IAsyncEnumerable<T> Rows { get; set; } = EmptyRows();
+
+    /// <summary>
+    /// The columns, in the order they are written.
+    /// </summary>
+    public IList<StreamedColumn<T>> Columns { get; } = [];
+
+    private static async IAsyncEnumerable<T> EmptyRows()
+    {
+        await Task.CompletedTask;
+
+        yield break;
+    }
+
+    internal override int ColumnCount => Columns.Count;
+
+    internal override string TitleAt(int column) => Columns[column].Title ?? string.Empty;
+
+    internal override Format? FormatAt(int column) => Columns[column].Format;
+
+    internal override double? WidthAt(int column) => Columns[column].Width;
+
+    internal override bool AutoFitAt(int column) => Columns[column].AutoFit;
+
+    internal override async IAsyncEnumerable<object?[]> Read(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var count = Columns.Count;
+        var readers = new Func<T, object?>[count];
+
+        for (var i = 0; i < count; i++)
+        {
+            readers[i] = Columns[i].Value ?? (static _ => null);
+        }
+
+        var line = new object?[count];
+
+        await foreach (var row in Rows.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            for (var i = 0; i < count; i++)
+            {
+                line[i] = readers[i](row);
+            }
+
+            yield return line;
+        }
+    }
+}

--- a/Radzen.Blazor/Documents/Spreadsheet/Workbook.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/Workbook.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Radzen.Documents.Spreadsheet;
 
@@ -140,6 +142,42 @@ public class Workbook
     public void SaveToStream(Stream stream)
     {
         new XlsxWriter(this).Write(stream);
+    }
+
+    /// <summary>
+    /// Writes a single sheet to the specified stream in the Open XML Spreadsheet format (XLSX),
+    /// reading its rows once and retaining none of them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Static because there is no workbook: what a streamed sheet needs is its columns and a row
+    /// source, and building the cells to hold the rows is the cost this exists to avoid. The rows are
+    /// written in the order they arrive, through the columns given, and nothing is filtered, sorted or
+    /// counted on the way through.
+    /// </para>
+    /// <para>
+    /// The XML is written synchronously into the archive; what is awaited is the row source. A source
+    /// that faults or is cancelled leaves nothing that opens: the archive's central directory is never
+    /// written, so whatever reached the destination is not a readable package. A seekable destination
+    /// is truncated back to where it started; one that cannot seek keeps the bytes already written,
+    /// so a caller streaming to a response body should treat a fault as a failed download.
+    /// </para>
+    /// </remarks>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="sheet">The sheet to write.</param>
+    /// <param name="cancellationToken">Cancels the write between rows.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The sheet declares more than 16,384 columns.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The source yields more than the 1,048,576 rows a worksheet holds, or a number that disagrees
+    /// with <see cref="StreamedSheet.RowCount"/>. Both are caught as they happen, so the destination is
+    /// left with nothing that opens rather than with a file no reader will accept.
+    /// </exception>
+    public static Task SaveToStreamAsync(Stream stream, StreamedSheet sheet, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(sheet);
+
+        return XlsxWriter.WriteStreamedAsync(stream, sheet, cancellationToken);
     }
 
     /// <summary>

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.Streaming.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.Streaming.cs
@@ -87,6 +87,8 @@ partial class XlsxWriter
 
     private const int MaxColumns = 16_384;
 
+    private const int MaxCellCharacters = 32_767;
+
     private static int HeaderRows(StreamedSheet spec) => spec.IncludeHeader ? 1 : 0;
 
     private static bool HasTable(StreamedSheet spec, int written) =>
@@ -469,6 +471,12 @@ partial class XlsxWriter
         if (type == CellDataType.String)
         {
             var text = content as string ?? string.Empty;
+
+            if (text.Length > MaxCellCharacters)
+            {
+                throw new InvalidOperationException(
+                    $"A cell holds at most {MaxCellCharacters} characters, and {address} was given {text.Length}.");
+            }
 
             if (inlineStrings)
             {

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.Streaming.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.Streaming.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Radzen.Documents.Spreadsheet;
+
+#nullable enable
+
+partial class XlsxWriter
+{
+    internal static async Task WriteStreamedAsync(Stream destination, StreamedSheet spec, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        ArgumentNullException.ThrowIfNull(spec);
+
+        if (spec.ColumnCount > MaxColumns)
+        {
+            throw new ArgumentOutOfRangeException(nameof(spec), spec.ColumnCount,
+                $"A worksheet holds at most {MaxColumns} columns.");
+        }
+
+        var scaffold = new Workbook();
+
+        if (spec.Culture is not null)
+        {
+            scaffold.Culture = spec.Culture;
+        }
+
+        var sheet = scaffold.AddSheet(spec.Name, rows: 1, columns: Math.Max(spec.ColumnCount, 1));
+
+        sheet.Rows.Frozen = spec.FrozenRows;
+        sheet.Columns.Frozen = spec.FrozenColumns;
+
+        await new XlsxWriter(scaffold).WriteStreamedAsync(destination, spec, sheet, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WriteStreamedAsync(Stream destination, StreamedSheet spec, Worksheet sheet, CancellationToken cancellationToken)
+    {
+        var start = destination.CanSeek ? destination.Position : -1L;
+
+        var archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true);
+
+        try
+        {
+            var styleTracker = CreateStylesDocument();
+            using var sharedStrings = new SharedStringTable();
+
+            var table = await SaveStreamedSheetAsync(archive, spec, sheet, styleTracker, sharedStrings, cancellationToken)
+                .ConfigureAwait(false);
+
+            SaveStreamedWorkbookRelationships(archive, sharedStrings.Count > 0);
+            SaveStyles(archive, styleTracker);
+            SaveSharedStrings(archive, sharedStrings);
+            SaveWorkbook(archive);
+            SaveTheme(archive);
+            SaveDocPropsCore(archive);
+            SaveDocPropsApp(archive);
+            SaveContentTypes(archive, includeSharedStrings: sharedStrings.Count > 0, tableCount: table ? 1 : 0);
+            SaveRelationships(archive);
+        }
+        catch
+        {
+            Discard(destination, start);
+
+            throw;
+        }
+
+        try
+        {
+            archive.Dispose();
+        }
+        catch
+        {
+            Discard(destination, start);
+
+            throw;
+        }
+    }
+
+    private const int MaxRows = 1_048_576;
+
+    private const int MaxColumns = 16_384;
+
+    private static int HeaderRows(StreamedSheet spec) => spec.IncludeHeader ? 1 : 0;
+
+    private static bool HasTable(StreamedSheet spec, int written) =>
+        spec.TableName is not null && written > HeaderRows(spec);
+
+    private static void Discard(Stream destination, long start)
+    {
+        if (start < 0)
+        {
+            return;
+        }
+
+        try
+        {
+            destination.SetLength(start);
+            destination.Position = start;
+        }
+        catch
+        {
+        }
+    }
+
+    private async Task<bool> SaveStreamedSheetAsync(
+        ZipArchive archive,
+        StreamedSheet spec,
+        Worksheet sheet,
+        StyleTracker styleTracker,
+        SharedStringTable sharedStrings,
+        CancellationToken cancellationToken)
+    {
+        var columns = spec.ColumnCount;
+
+        await using var rows = spec.Read(cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+        List<object?[]>? buffered = null;
+        var complete = false;
+
+        if (!spec.WidthMode.IsDeclared)
+        {
+            buffered = [];
+
+            var limit = spec.WidthMode.SampleRows;
+
+            while (buffered.Count < limit)
+            {
+                if (!await rows.MoveNextAsync().ConfigureAwait(false))
+                {
+                    complete = true;
+                    break;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                buffered.Add((object?[])rows.Current.Clone());
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        var headerRows = HeaderRows(spec);
+
+        int? declaredRows = complete ? buffered!.Count : spec.RowCount;
+
+        ApplyStreamedWidths(spec, sheet, buffered);
+
+        if (declaredRows is { } total)
+        {
+            sheet.Rows.Count = Math.Max(total + headerRows, 1);
+        }
+
+        var written = 0;
+
+        using (var entry = archive.CreateEntry("xl/worksheets/sheet1.xml").Open())
+        {
+            written = await WriteStreamedSheetXmlAsync(entry, spec, sheet, styleTracker, sharedStrings, buffered, rows, declaredRows is not null, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (declaredRows is { } promised && written - headerRows != promised)
+        {
+            throw new InvalidOperationException(
+                $"RowCount said {promised} rows and the source yielded {written - headerRows}, so the "
+                + "dimension written before them does not describe the sheet.");
+        }
+
+        if (spec.TableName is not { } tableName || written <= headerRows)
+        {
+            return false;
+        }
+
+        sheet.Rows.Count = Math.Max(written, 1);
+
+        if (spec.IncludeHeader)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                sheet.Cells[0, column].SetText(spec.TitleAt(column));
+            }
+        }
+
+        var range = new RangeRef(new CellRef(0, 0), new CellRef(written - 1, Math.Max(columns - 1, 0)));
+
+        SaveTable(archive, sheet.AddTable(tableName, range, hasHeaders: spec.IncludeHeader), tableId: 1);
+
+        SaveSheetRelationships(archive, "sheet1.xml",
+        [
+            ("rId1", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table", "../tables/table1.xml", false),
+        ]);
+
+        return true;
+    }
+
+    private void SaveStreamedWorkbookRelationships(ZipArchive archive, bool includeSharedStrings)
+    {
+        var pkgNs = "http://schemas.openxmlformats.org/package/2006/relationships";
+        var rels = CreateWorkbookRelationships();
+
+        rels.Root!.Add(new XElement(XName.Get("Relationship", pkgNs),
+            new XAttribute("Id", "rId2"),
+            new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"),
+            new XAttribute("Target", "styles.xml")));
+
+        rels.Root!.Add(new XElement(XName.Get("Relationship", pkgNs),
+            new XAttribute("Id", "rId3"),
+            new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"),
+            new XAttribute("Target", "worksheets/sheet1.xml")));
+
+        rels.Root!.Add(new XElement(XName.Get("Relationship", pkgNs),
+            new XAttribute("Id", "rId4"),
+            new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"),
+            new XAttribute("Target", "theme/theme1.xml")));
+
+        if (includeSharedStrings)
+        {
+            rels.Root!.Add(new XElement(XName.Get("Relationship", pkgNs),
+                new XAttribute("Id", "rId1"),
+                new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"),
+                new XAttribute("Target", "sharedStrings.xml")));
+        }
+
+        using var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels").Open();
+        rels.Save(entry);
+    }
+
+    private async Task<int> WriteStreamedSheetXmlAsync(
+        Stream stream,
+        StreamedSheet spec,
+        Worksheet sheet,
+        StyleTracker styleTracker,
+        SharedStringTable sharedStrings,
+        List<object?[]>? buffered,
+        IAsyncEnumerator<object?[]> rows,
+        bool hasDimension,
+        CancellationToken cancellationToken)
+    {
+        var sheetDoc = CreateSheetDocument(sheet, sheetId: 1, relId: "rId3");
+
+        if (!hasDimension)
+        {
+            sheetDoc.Root!.Element(XName.Get("dimension", Main))?.Remove();
+        }
+
+        var root = sheetDoc.Root!;
+        var written = 0;
+
+        using var writer = XmlWriter.Create(stream, PartXmlSettings);
+
+        writer.WriteStartDocument();
+        writer.WriteStartElement(root.Name.LocalName, root.Name.NamespaceName);
+
+        foreach (var attribute in root.Attributes())
+        {
+            writer.WriteAttributeString(attribute.Name.LocalName, attribute.Name.NamespaceName, attribute.Value);
+        }
+
+        foreach (var element in root.Elements())
+        {
+            if (element.Name == SheetDataElement)
+            {
+                writer.WriteStartElement(SheetDataElement.LocalName, Main);
+
+                written = await WriteStreamedRowsAsync(writer, spec, sheet, styleTracker, sharedStrings, buffered, rows, cancellationToken)
+                    .ConfigureAwait(false);
+
+                writer.WriteEndElement();
+            }
+            else
+            {
+                element.WriteTo(writer);
+            }
+        }
+
+        CreatePageMargins().WriteTo(writer);
+
+        if (HasTable(spec, written))
+        {
+            XNamespace rNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+            new XElement(XName.Get("tableParts", Main),
+                new XAttribute("count", "1"),
+                new XElement(XName.Get("tablePart", Main), new XAttribute(rNs + "id", "rId1")))
+                .WriteTo(writer);
+        }
+
+        writer.WriteEndElement();
+        writer.WriteEndDocument();
+
+        return written;
+    }
+
+    private async Task<int> WriteStreamedRowsAsync(
+        XmlWriter writer,
+        StreamedSheet spec,
+        Worksheet sheet,
+        StyleTracker styleTracker,
+        SharedStringTable sharedStrings,
+        List<object?[]>? buffered,
+        IAsyncEnumerator<object?[]> rows,
+        CancellationToken cancellationToken)
+    {
+        var columns = spec.ColumnCount;
+        var styles = new Dictionary<(int Column, CellDataType Type), int?>();
+        var row = 0;
+
+        if (spec.IncludeHeader)
+        {
+            WriteStreamedHeader(writer, spec, sheet, styleTracker, sharedStrings, columns);
+            row++;
+        }
+
+        if (buffered is not null)
+        {
+            foreach (var line in buffered)
+            {
+                WriteStreamedRow(writer, spec, sheet, styleTracker, sharedStrings, styles, line, row++, columns);
+            }
+        }
+
+        while (await rows.MoveNextAsync().ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (row == MaxRows)
+            {
+                throw new InvalidOperationException(
+                    $"The row source yielded more than the {MaxRows} rows a worksheet can hold.");
+            }
+
+            WriteStreamedRow(writer, spec, sheet, styleTracker, sharedStrings, styles, rows.Current, row++, columns);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return row;
+    }
+
+    private void WriteStreamedHeader(
+        XmlWriter writer,
+        StreamedSheet spec,
+        Worksheet sheet,
+        StyleTracker styleTracker,
+        SharedStringTable sharedStrings,
+        int columns)
+    {
+        var format = spec.HeaderFormat;
+        var style = format?.IsDefault == false
+            ? GetOrCreateCellStyle(format ?? DefaultFormat, CellDataType.String, quotePrefix: false, styleTracker)
+            : (int?)null;
+
+        var first = -1;
+        var last = -1;
+
+        for (var column = 0; column < columns; column++)
+        {
+            if (!string.IsNullOrEmpty(spec.TitleAt(column)))
+            {
+                if (first < 0)
+                {
+                    first = column;
+                }
+
+                last = column;
+            }
+        }
+
+        WriteRowStart(writer, sheet, row: 0, first, last);
+
+        for (var column = 0; column < columns; column++)
+        {
+            var title = spec.TitleAt(column);
+
+            if (!string.IsNullOrEmpty(title))
+            {
+                WriteStreamedCell(writer, new CellRef(0, column), title, CellDataType.String, style, sharedStrings, spec.InlineStrings);
+            }
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private void WriteStreamedRow(
+        XmlWriter writer,
+        StreamedSheet spec,
+        Worksheet sheet,
+        StyleTracker styleTracker,
+        SharedStringTable sharedStrings,
+        Dictionary<(int Column, CellDataType Type), int?> styles,
+        object?[] line,
+        int row,
+        int columns)
+    {
+        var first = -1;
+        var last = -1;
+
+        for (var column = 0; column < columns; column++)
+        {
+            if (line[column] is not null)
+            {
+                if (first < 0)
+                {
+                    first = column;
+                }
+
+                last = column;
+            }
+        }
+
+        WriteRowStart(writer, sheet, row, first, last);
+
+        for (var column = 0; column < columns; column++)
+        {
+            if (line[column] is null)
+            {
+                continue;
+            }
+
+            CellData.Infer(line[column], sheet.Workbook!.Culture, out var content, out var type);
+
+            if (content is null)
+            {
+                continue;
+            }
+
+            var key = (column, type);
+
+            if (!styles.TryGetValue(key, out var style))
+            {
+                var format = spec.FormatAt(column);
+
+                style = format?.IsDefault == false || type == CellDataType.Date
+                    ? GetOrCreateCellStyle(format ?? DefaultFormat, type, quotePrefix: false, styleTracker)
+                    : null;
+
+                styles[key] = style;
+            }
+
+            WriteStreamedCell(writer, new CellRef(row, column), content, type, style, sharedStrings, spec.InlineStrings);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private void WriteStreamedCell(
+        XmlWriter writer,
+        CellRef address,
+        object? content,
+        CellDataType type,
+        int? styleId,
+        SharedStringTable sharedStrings,
+        bool inlineStrings)
+    {
+        writer.WriteStartElement("c", Main);
+        WriteReferenceAttribute(writer, address);
+
+        if (styleId is not null)
+        {
+            WriteNumberAttribute(writer, "s", styleId.Value);
+        }
+
+        if (type == CellDataType.String)
+        {
+            var text = content as string ?? string.Empty;
+
+            if (inlineStrings)
+            {
+                writer.WriteAttributeString("t", "inlineStr");
+                writer.WriteStartElement("is", Main);
+                writer.WriteStartElement("t", Main);
+                writer.WriteString(text);
+                writer.WriteFullEndElement();
+                writer.WriteFullEndElement();
+            }
+            else
+            {
+                writer.WriteAttributeString("t", "s");
+
+                WriteNumberValue(writer, sharedStrings.GetOrAdd(text));
+            }
+        }
+        else
+        {
+            var type_ = CellTypeAttribute(type, isFormula: false);
+
+            if (type_ is not null)
+            {
+                writer.WriteAttributeString("t", type_);
+            }
+
+            WriteTypedValue(writer, content, type);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static void ApplyStreamedWidths(StreamedSheet spec, Worksheet sheet, List<object?[]>? buffered)
+    {
+        var columns = spec.ColumnCount;
+
+        for (var column = 0; column < columns; column++)
+        {
+            if (spec.WidthAt(column) is { } width)
+            {
+                sheet.Columns[column] = width;
+            }
+        }
+
+        if (buffered is null)
+        {
+            return;
+        }
+
+        for (var column = 0; column < columns; column++)
+        {
+            if (!spec.AutoFitAt(column))
+            {
+                continue;
+            }
+
+            var format = spec.FormatAt(column);
+            var widest = sheet.Columns[column];
+
+            if (spec.IncludeHeader)
+            {
+                widest = Math.Max(widest, MeasureStreamed(spec.TitleAt(column), spec.HeaderFormat));
+            }
+
+            foreach (var line in buffered)
+            {
+                var value = line[column];
+
+                if (value is null)
+                {
+                    continue;
+                }
+
+                string? text;
+
+                try
+                {
+                    CellData.Infer(value, sheet.Workbook!.Culture, out var content, out var type);
+
+                    text = NumberFormat.Apply(format?.NumberFormat, content, type, CultureInfo.InvariantCulture)
+                        ?? Cell.FormatValue(content, CultureInfo.InvariantCulture);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    continue;
+                }
+
+                widest = Math.Max(widest, MeasureStreamed(text, format));
+            }
+
+            sheet.Columns[column] = Math.Min(widest, ColumnWidthConversion.MaxWidthInPixels);
+            sheet.Columns.SetAutoFit(column);
+        }
+    }
+
+    private static double MeasureStreamed(string? text, Format? format)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        return ExcelTextMetrics.EstimateWidth(
+            ExcelTextMetrics.DisplayLine(text, format?.WrapText == true),
+            format?.Bold == true,
+            format?.FontSize) + 5;
+    }
+}

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -11,7 +11,7 @@ namespace Radzen.Documents.Spreadsheet;
 
 #nullable enable
 
-class XlsxWriter(Workbook sourceWorkbook)
+partial class XlsxWriter(Workbook sourceWorkbook)
 {
     private const double EmuPerPixel = 9525.0;
 
@@ -1548,7 +1548,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             WriteNumberAttribute(writer, "s", GetOrCreateCellStyle(cell, styleTracker));
         }
 
-        var type = CellTypeAttribute(cell, isFormula);
+        var type = CellTypeAttribute(cell.ValueType, isFormula);
 
         if (type is not null)
         {
@@ -1558,7 +1558,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         if (isFormula)
         {
             WriteFormula(writer, cell, sharedFormulas);
-            WriteTypedValue(writer, cell);
+            WriteTypedValue(writer, cell.Value, cell.ValueType);
         }
         else if (cell.ValueType == CellDataType.String)
         {
@@ -1566,13 +1566,13 @@ class XlsxWriter(Workbook sourceWorkbook)
         }
         else
         {
-            WriteTypedValue(writer, cell);
+            WriteTypedValue(writer, cell.Value, cell.ValueType);
         }
 
         writer.WriteEndElement();
     }
 
-    private static string? CellTypeAttribute(Cell cell, bool isFormula) => cell.ValueType switch
+    private static string? CellTypeAttribute(CellDataType valueType, bool isFormula) => valueType switch
     {
         CellDataType.String => isFormula ? "str" : "s",
         CellDataType.Boolean => "b",
@@ -1609,28 +1609,28 @@ class XlsxWriter(Workbook sourceWorkbook)
         writer.WriteFullEndElement();
     }
 
-    private void WriteTypedValue(XmlWriter writer, Cell cell)
+    private void WriteTypedValue(XmlWriter writer, object? value, CellDataType valueType)
     {
-        switch (cell.ValueType)
+        switch (valueType)
         {
             case CellDataType.Number:
             case CellDataType.String:
-                if (TryFormatNumber(cell.Value, out var length))
+                if (TryFormatNumber(value, out var length))
                 {
                     WriteRawValue(writer, length);
                 }
                 else
                 {
-                    WriteValue(writer, FormatValueInvariant(cell.Value));
+                    WriteValue(writer, FormatValueInvariant(value));
                 }
                 break;
 
             case CellDataType.Boolean:
-                WriteValue(writer, cell.Value is true ? "1" : "0");
+                WriteValue(writer, value is true ? "1" : "0");
                 break;
 
             case CellDataType.Date:
-                if (cell.Value is DateTime dateValue)
+                if (value is DateTime dateValue)
                 {
                     dateValue.ToNumber().TryFormat(scratch, out var digits, provider: CultureInfo.InvariantCulture);
 
@@ -1639,7 +1639,7 @@ class XlsxWriter(Workbook sourceWorkbook)
                 break;
 
             case CellDataType.Error:
-                WriteValue(writer, cell.Value is CellError error ? CellErrorToString(error) : "#NAME?");
+                WriteValue(writer, value is CellError error ? CellErrorToString(error) : "#NAME?");
                 break;
 
             case CellDataType.Empty:
@@ -1775,22 +1775,23 @@ class XlsxWriter(Workbook sourceWorkbook)
 
     private static readonly Format DefaultFormat = new();
 
-    private int GetOrCreateCellStyle(Cell cell, StyleTracker styleTracker)
-    {
-        var format = cell.FormatOrNull ?? DefaultFormat;
+    private int GetOrCreateCellStyle(Cell cell, StyleTracker styleTracker) =>
+        GetOrCreateCellStyle(cell.FormatOrNull ?? DefaultFormat, cell.ValueType, cell.QuotePrefix, styleTracker);
 
+    private int GetOrCreateCellStyle(Format format, CellDataType valueType, bool quotePrefix, StyleTracker styleTracker)
+    {
         var fontId = GetOrCreateFontStyle(format, styleTracker);
         var fillId = GetOrCreateFillStyle(format, styleTracker);
-        var numFmtId = GetOrCreateNumberFormat(cell, format, styleTracker);
+        var numFmtId = GetOrCreateNumberFormat(valueType, format, styleTracker);
         var borderId = GetOrCreateBorderStyle(format, styleTracker);
 
-        var styleKey = new CellStyleKey(fontId, fillId, borderId, format.TextAlign, format.VerticalAlign, format.WrapText, numFmtId, format.Locked, format.FormulaHidden, cell.QuotePrefix);
+        var styleKey = new CellStyleKey(fontId, fillId, borderId, format.TextAlign, format.VerticalAlign, format.WrapText, numFmtId, format.Locked, format.FormulaHidden, quotePrefix);
 
         if (!styleTracker.CellStyles.TryGetValue(styleKey, out int styleId))
         {
             styleId = styleTracker.CellStyles.Count + 1;
             styleTracker.CellStyles[styleKey] = styleId;
-            CreateCellStyleElement(cell, format, fontId, fillId, borderId, numFmtId, styleTracker);
+            CreateCellStyleElement(format, fontId, fillId, borderId, numFmtId, quotePrefix, styleTracker);
         }
 
         return styleId;
@@ -1888,12 +1889,12 @@ class XlsxWriter(Workbook sourceWorkbook)
         borderElement.Add(sideElement);
     }
 
-    private static int GetOrCreateNumberFormat(Cell cell, Format format, StyleTracker styleTracker)
+    private static int GetOrCreateNumberFormat(CellDataType valueType, Format format, StyleTracker styleTracker)
     {
         var formatCode = format.NumberFormat;
 
         // Auto-apply default date format for date values without explicit format
-        if (string.IsNullOrEmpty(formatCode) && cell.ValueType == CellDataType.Date)
+        if (string.IsNullOrEmpty(formatCode) && valueType == CellDataType.Date)
         {
             return 14; // mm/dd/yyyy
         }
@@ -1987,7 +1988,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         styleTracker.FillsElement.Attribute("count")!.Value = (styleTracker.FillStyles.Count + 2).ToString(CultureInfo.InvariantCulture);
     }
 
-    private void CreateCellStyleElement(Cell cell, Format format, int fontId, int fillId, int borderId, int numFmtId, StyleTracker styleTracker)
+    private void CreateCellStyleElement(Format format, int fontId, int fillId, int borderId, int numFmtId, bool quotePrefix, StyleTracker styleTracker)
     {
         var xfElement = new XElement(XName.Get("xf", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
             new XAttribute("numFmtId", numFmtId.ToString(CultureInfo.InvariantCulture)),
@@ -2022,7 +2023,7 @@ class XlsxWriter(Workbook sourceWorkbook)
             xfElement.Add(new XAttribute("applyProtection", "1"));
         }
 
-        if (cell.QuotePrefix)
+        if (quotePrefix)
         {
             xfElement.Add(new XAttribute("quotePrefix", "1"));
             xfElement.Add(new XAttribute("applyQuotePrefix", "1"));

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1184,14 +1184,19 @@ partial class XlsxWriter(Workbook sourceWorkbook)
     {
         var widths = new Dictionary<int, double>();
 
-        foreach (var cell in sheet.Cells.GetPopulatedCells().ToList())
+        var measured = new List<Cell>();
+
+        foreach (var cell in sheet.Cells.GetPopulatedCells())
+        {
+            if (sheet.Columns.IsAutoFit(cell.Address.Column) && !sheet.MergedCells.Contains(cell.Address))
+            {
+                measured.Add(cell);
+            }
+        }
+
+        foreach (var cell in measured)
         {
             var col = cell.Address.Column;
-
-            if (!sheet.Columns.IsAutoFit(col) || sheet.MergedCells.Contains(cell.Address))
-            {
-                continue;
-            }
 
             string? text;
             Format? format;

--- a/RadzenBlazorDemos/Pages/SpreadsheetStreamedExport.razor
+++ b/RadzenBlazorDemos/Pages/SpreadsheetStreamedExport.razor
@@ -1,0 +1,135 @@
+@using RadzenBlazorDemos.Data
+@using RadzenBlazorDemos.Models.Northwind
+@using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
+@using System.IO
+@using Radzen.Documents.Spreadsheet
+
+@inherits DbContextPage
+@inject IJSRuntime JSRuntime
+
+<RadzenStack Gap="1rem">
+    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="1rem">
+        <RadzenButton Icon="download" Text="Download XLSX" ButtonStyle="ButtonStyle.Primary"
+                      IsBusy=@busy BusyText="Writing..." Click=@Download />
+        <RadzenText TextStyle="TextStyle.Body2">
+            @rowCount.ToString("N0") order lines, @ColumnCount columns -
+            @((rowCount * ColumnCount).ToString("N0")) cells the streamed write never builds.
+        </RadzenText>
+    </RadzenStack>
+
+    <RadzenDataGrid Data="@preview" TItem="OrderLine" AllowPaging="true" PageSize="10">
+        <Columns>
+            <RadzenDataGridColumn TItem="OrderLine" Property="OrderId" Title="Order" Width="90px" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="OrderDate" Title="Date" FormatString="{0:d}" Width="110px" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="Customer" Title="Customer" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="Country" Title="Country" Width="120px" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="Employee" Title="Employee" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="Category" Title="Category" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="Product" Title="Product" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="Quantity" Title="Qty" Width="80px" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="UnitPrice" Title="Unit price" FormatString="{0:C}" Width="120px" />
+            <RadzenDataGridColumn TItem="OrderLine" Property="LineTotal" Title="Line total" FormatString="{0:C}" Width="120px" />
+        </Columns>
+    </RadzenDataGrid>
+</RadzenStack>
+
+@code {
+    const int ColumnCount = 10;
+
+    public record OrderLine(
+        int OrderId,
+        DateTime? OrderDate,
+        string Customer,
+        string Country,
+        string Employee,
+        string Category,
+        string Product,
+        short Quantity,
+        decimal UnitPrice,
+        decimal LineTotal);
+
+    bool busy;
+    int rowCount;
+    IEnumerable<OrderLine> preview = Array.Empty<OrderLine>();
+
+    IQueryable<OrderLine> Query() =>
+        dbContext.OrderDetails
+            .Include(detail => detail.Order).ThenInclude(order => order.Customer)
+            .Include(detail => detail.Order).ThenInclude(order => order.Employee)
+            .Include(detail => detail.Product).ThenInclude(product => product.Category)
+            .Where(detail => detail.Order.OrderDate != null
+                && detail.Quantity != null
+                && detail.UnitPrice != null
+                && detail.Discount != null)
+            .OrderBy(detail => detail.Order.OrderDate)
+            .ThenBy(detail => detail.OrderID)
+            .Select(detail => new OrderLine(
+                detail.OrderID,
+                detail.Order.OrderDate,
+                detail.Order.Customer == null ? "" : detail.Order.Customer.CompanyName,
+                detail.Order.ShipCountry,
+                detail.Order.Employee == null
+                    ? ""
+                    : detail.Order.Employee.FirstName + " " + detail.Order.Employee.LastName,
+                detail.Product.Category == null ? "" : detail.Product.Category.CategoryName,
+                detail.Product.ProductName,
+                detail.Quantity.Value,
+                (decimal)detail.UnitPrice.Value,
+                (decimal)(detail.UnitPrice.Value * detail.Quantity.Value * (1 - detail.Discount.Value))));
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        rowCount = await Query().CountAsync();
+        preview = await Query().Take(50).ToListAsync();
+    }
+
+    StreamedSheet<OrderLine> Sheet() => new()
+    {
+        Name = "Order lines",
+        Rows = Query().AsAsyncEnumerable(),
+        RowCount = rowCount,
+        TableName = "OrderLines",
+        FrozenRows = 1,
+        Columns =
+        {
+            new StreamedColumn<OrderLine> { Title = "Order", Value = line => line.OrderId, AutoFit = true },
+            new StreamedColumn<OrderLine> { Title = "Date", Value = line => line.OrderDate, AutoFit = true,
+                Format = new Format { NumberFormat = "yyyy-mm-dd" } },
+            new StreamedColumn<OrderLine> { Title = "Customer", Value = line => line.Customer, AutoFit = true },
+            new StreamedColumn<OrderLine> { Title = "Country", Value = line => line.Country, AutoFit = true },
+            new StreamedColumn<OrderLine> { Title = "Employee", Value = line => line.Employee, AutoFit = true },
+            new StreamedColumn<OrderLine> { Title = "Category", Value = line => line.Category, AutoFit = true },
+            new StreamedColumn<OrderLine> { Title = "Product", Value = line => line.Product, AutoFit = true },
+            new StreamedColumn<OrderLine> { Title = "Qty", Value = line => line.Quantity, AutoFit = true },
+            new StreamedColumn<OrderLine> { Title = "Unit price", Value = line => line.UnitPrice, AutoFit = true,
+                Format = new Format { NumberFormat = "#,##0.00" } },
+            new StreamedColumn<OrderLine> { Title = "Line total", Value = line => line.LineTotal, AutoFit = true,
+                Format = new Format { NumberFormat = "#,##0.00" } },
+        },
+    };
+
+    async Task Download()
+    {
+        busy = true;
+
+        try
+        {
+            using var stream = new MemoryStream();
+
+            await Workbook.SaveToStreamAsync(stream, Sheet());
+
+            stream.Position = 0;
+
+            using var streamRef = new DotNetStreamReference(stream);
+
+            await JSRuntime.InvokeVoidAsync("Radzen.downloadFile", "order-lines.xlsx", streamRef);
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+}

--- a/RadzenBlazorDemos/Pages/SpreadsheetStreamedExportPage.razor
+++ b/RadzenBlazorDemos/Pages/SpreadsheetStreamedExportPage.razor
@@ -1,0 +1,13 @@
+@page "/spreadsheet-streamed-export"
+
+<RadzenText TextStyle="TextStyle.H2" TagName="TagName.H1" class="rz-pt-8">
+    Streamed Export
+</RadzenText>
+<RadzenText TextStyle="TextStyle.Subtitle1" TagName="TagName.P" class="rz-pb-4">
+    Write an XLSX file straight from an Entity Framework query. The rows are read once, in order, and
+    never held, so the memory the write needs does not grow with the number of rows.
+</RadzenText>
+
+<RadzenExample ComponentName="Spreadsheet" Example="SpreadsheetStreamedExport">
+    <SpreadsheetStreamedExport />
+</RadzenExample>

--- a/RadzenBlazorDemos/Services/ExampleService.cs
+++ b/RadzenBlazorDemos/Services/ExampleService.cs
@@ -3213,6 +3213,15 @@ namespace RadzenBlazorDemos
                 },
                 new Example
                 {
+                    Name = "Streamed Export",
+                    Path = "spreadsheet-streamed-export",
+                    Title = "Stream an Entity Framework Query to Excel in Blazor | Radzen",
+                    Description = "Write an XLSX file directly from an Entity Framework query. Rows are read once and never held, so memory does not grow with the row count.",
+                    Tags = new [] { "document", "processing", "export", "xlsx", "excel", "stream", "streaming", "async", "entity", "framework", "queryable", "large", "memory" },
+                    Related = new [] { "document-processing-import-export", "document-processing-spreadsheet" }
+                },
+                new Example
+                {
                     Name = "Localization",
                     Path = "document-processing-localization",
                     Title = "Culture-Aware Excel Processing in Blazor and C# | Radzen",


### PR DESCRIPTION
This introduces a path for performant streaming to a sheet, for bulk export scenarios.  (i.e. large grids or tables)

`Workbook.SaveToStreamAsync` takes a `StreamedSheet` instead of a workbook: a sheet name, a column list, and an `IAsyncEnumerable<T>` of rows. The rows are read once, in order, and never retained, so what the write holds does not grow with them.

The XML goes into the archive synchronously and only the row source is awaited, so the streamed path calls the same `WriteCell`, `WriteTypedValue` and `WriteRowStart` per usual, and types values through the same `CellData` inference. A streamed file and a built one agree cell for cell, which is what the equivalence test asserts.

The shared string table and the table part are written after the sheet, so the table range gets the final row count for free. `cols` and `dimension` precede the rows and cannot:

- `ColumnWidthMode.Declared` writes what each column declares and reads nothing. `Sampled(n)` buffers the first n rows (200 by default), measures the auto-fit columns over them, replays the buffer and streams the rest — bounded by n, not by the data.
- `InlineStrings` writes each string into the cell that holds it, trading the shared string table for a larger file.
- `dimension` is exact when `RowCount` is set, and exact without being told when the sample held the whole source; otherwise it is omitted, which the schema allows.

## Scope

Additive and opt-in. `SaveToStream(workbook)` is untouched, and the existing path stays the one for formatted reports.

A streamed sheet writes column widths (declared or sampled auto-fit), frozen panes, one table, per-column and header formats, and shared or inline strings. At this time it does not do merged cells, conditional formatting, data validation, protection, hyperlinks, images, autofilter, formulas, per-cell formats, multiple sheets or row heights.

Most of those sit after `sheetData` in `CT_Worksheet`, where this already emits `tableParts`, so they are additions a caller could declare up front rather than things streaming rules out. None is needed for what this serves: a flat extract too large for the built path to hold.

## Limits

The XLSX format limits are enforced as they are reached, rather than left for whatever opens the file: at most 16,384 columns (refused before a row is read), 1,048,576 rows, and 32,767 characters in a cell. `RowCount` is a promise, and a source that yields a different number faults the write.

## Measurement

Tested w 11 columns written to `Stream.Null`.

| rows | streamed, string columns | streamed, mixed types | built, then saved |
| --- | ---: | ---: | ---: |
| 10,000 | 173 KB | 2.7 MB | 26.8 MB |
| 50,000 | 186 KB | 12.8 MB | 131.0 MB |
| 200,000 | 173 KB | 50.5 MB | 533.8 MB |

**Read the two streamed arms as different questions.** The string-column arm is the writer alone, and it is flat: 171–173 KB whatever the row count, causing no collection of any generation. The mixed-type arm is what a caller with `int`, `DateTime` and `bool` columns pays.  A column is a `Func<T, object?>`, so every non-string cell boxes. Those boxes die in gen0 unwritten, though at 200,000 rows they are the whole of the 50.5 MB.

Against the built path the streamed one is **10.6x** cheaper on mixed types and **3,000x** on strings. The built arm is the control: if a sweep does not move it, the instrument is not resolving anything.

As a note: the ordinary save is a bit cheaper: 550.6 MB → 533.8 MB over 200,000 rows by eleven columns, and a save with no auto-fit column now copies no cells at all.

## Demo

`spreadsheet-streamed-export` writes an XLSX straight from an EF query of Northwind order lines joined across five tables, handed to the writer through `AsAsyncEnumerable`.

**Drop that commit if you would rather this PR stayed on the writer.** It is the last one and touches only `RadzenBlazorDemos`.
