### PR TITLE
RangeNavigator: opt-in hover tooltip

### DIFF
--- a/Radzen.Blazor.Tests/RangeNavigatorTests.cs
+++ b/Radzen.Blazor.Tests/RangeNavigatorTests.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
 using Bunit;
+using Microsoft.AspNetCore.Components;
+using Radzen.Blazor.Rendering;
 using Xunit;
 using static Radzen.Blazor.Tests.ChartTestHelper;
 
@@ -184,15 +189,218 @@ namespace Radzen.Blazor.Tests
             Assert.DoesNotContain("NaN", component.Markup);
         }
 
-        private static IRenderedComponent<RadzenRangeNavigator> RenderNavigatorWithLineSeries(TestContext ctx)
+        [Fact]
+        public void RangeNavigator_TooltipPoints_OnePerItem_Ordered()
         {
-            return ctx.RenderComponent<RadzenRangeNavigator>(parameters =>
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx, parameters =>
+                parameters.Add(p => p.TooltipFormatString, "{0:N1}"));
+
+            var points = component.Instance.GetTooltipPoints();
+
+            Assert.Equal(new[] { "A: 10.0", "B: 20.0", "C: 15.0" }, points.Select(Describe));
+            Assert.True(points[0].X < points[1].X && points[1].X < points[2].X);
+            Assert.All(points, p => Assert.InRange(p.X, 0, 1));
+        }
+
+        [Fact]
+        public void RangeNavigator_TooltipPoints_PlacedOnTheLine()
+        {
+            using var ctx = CreateChartContext();
+
+            var points = RenderNavigatorWithLineSeries(ctx).Instance.GetTooltipPoints();
+
+            Assert.All(points, p => Assert.InRange(p.Y, 0, 1));
+            Assert.True(points[1].Y < points[2].Y && points[2].Y < points[0].Y);
+        }
+
+        [Fact]
+        public void RangeNavigator_TooltipPoints_TakeTheSeriesColor()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = ctx.RenderComponent<RadzenRangeNavigator>(parameters =>
                 parameters.AddChildContent<RadzenRangeNavigatorLineSeries<DataItem>>(series =>
                 {
                     series.Add(p => p.Data, SampleData);
                     series.Add(p => p.CategoryProperty, nameof(DataItem.Category));
                     series.Add(p => p.ValueProperty, nameof(DataItem.Value));
+                    series.Add(p => p.Stroke, "#1E88E5");
                 }));
+
+            Assert.All(component.Instance.GetTooltipPoints(), p => Assert.Equal("#1E88E5", p.Color));
+        }
+
+        [Fact]
+        public void RangeNavigator_TooltipPoints_DateCategory_UsesHandleLabelFormat()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithDateSeries(ctx, parameters =>
+                parameters.Add(p => p.HandleLabelFormatString, "{0:yyyy-MM-dd}"));
+
+            var points = component.Instance.GetTooltipPoints();
+
+            Assert.Equal(new[] { "2024-01-01: 3", "2024-01-02: 5" }, points.Select(Describe));
+        }
+
+        [Fact]
+        public void RangeNavigator_TooltipPoints_EmptyForCustomSeriesWithoutGetDataPoints()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = ctx.RenderComponent<RadzenRangeNavigator>();
+            component.Instance.AddSeries(new CustomSeries());
+
+            Assert.Empty(component.Instance.GetTooltipPoints());
+        }
+
+        [Fact]
+        public void RangeNavigator_ShowTooltip_SendsPoints()
+        {
+            using var ctx = CreateChartContext();
+
+            RenderNavigatorWithLineSeries(ctx, parameters => parameters.Add(p => p.ShowTooltip, true));
+
+            Assert.Single(ctx.JSInterop.Invocations, i => i.Identifier == "Radzen.updateRangeNavigatorTooltip");
+            Assert.Equal(new[] { "A: 10", "B: 20", "C: 15" }, LastSentTexts(ctx));
+        }
+
+        [Fact]
+        public void RangeNavigator_ShowTooltip_EnabledLater_SendsPoints()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx);
+            component.SetParametersAndRender(parameters => parameters.Add(p => p.ShowTooltip, true));
+
+            Assert.Contains(ctx.JSInterop.Invocations, i => i.Identifier == "Radzen.updateRangeNavigatorTooltip");
+        }
+
+        [Fact]
+        public void RangeNavigator_TooltipPoints_SkipsPointsWithoutAPosition()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx);
+            component.Instance.AddSeries(new CustomSeriesWithPoints(new Point { X = double.NaN, Y = 1 }));
+
+            Assert.Equal(3, component.Instance.GetTooltipPoints().Count);
+        }
+
+        [Fact]
+        public void RangeNavigator_TooltipValue_UsesCulture()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx, parameters =>
+            {
+                parameters.Add(p => p.Culture, CultureInfo.GetCultureInfo("de-DE"));
+                parameters.Add(p => p.TooltipFormatString, "{0:N1}");
+            });
+
+            Assert.Equal("A: 10,0", Describe(component.Instance.GetTooltipPoints()[0]));
+        }
+
+        [Fact]
+        public async Task RangeNavigator_ChartWrapper_ForwardsTooltipParameters()
+        {
+            using var ctx = CreateChartContext();
+
+            var chart = ctx.RenderComponent<RadzenChart>(p => p
+                .AddChildContent<RadzenChartRangeNavigator>(n => n
+                    .Add(x => x.ShowTooltip, true)
+                    .Add(x => x.TooltipFormatString, "{0:N1}")));
+            await chart.InvokeAsync(() => chart.Instance.Resize(400, 300));
+
+            var navigator = chart.FindComponent<RadzenRangeNavigator>().Instance;
+            Assert.True(navigator.ShowTooltip);
+            Assert.Equal("{0:N1}", navigator.TooltipFormatString);
+        }
+
+        [Fact]
+        public void RangeNavigator_ShowTooltip_RendersTooltipElement()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx, parameters => parameters.Add(p => p.ShowTooltip, true));
+
+            Assert.Single(component.FindAll(".rz-range-nav-tooltip .rz-chart-tooltip.rz-top-chart-tooltip .rz-chart-tooltip-title"));
+            Assert.Single(component.FindAll(".rz-range-nav-tooltip .rz-chart-tooltip-item-value"));
+            Assert.Single(component.FindAll(".rz-range-nav-tooltip .rz-active-point .rz-active-point-dot"));
+        }
+
+        [Fact]
+        public void RangeNavigator_ShowTooltip_DefaultFalse()
+        {
+            using var ctx = CreateChartContext();
+
+            var component = RenderNavigatorWithLineSeries(ctx);
+
+            Assert.False(component.Instance.ShowTooltip);
+            Assert.DoesNotContain(ctx.JSInterop.Invocations, i => i.Identifier == "Radzen.updateRangeNavigatorTooltip");
+        }
+
+        private static IRenderedComponent<RadzenRangeNavigator> RenderNavigatorWithLineSeries(TestContext ctx,
+            Action<ComponentParameterCollectionBuilder<RadzenRangeNavigator>> configure = null)
+        {
+            return RenderNavigator(ctx, SampleData, nameof(DataItem.Category), nameof(DataItem.Value), configure);
+        }
+
+        private static IRenderedComponent<RadzenRangeNavigator> RenderNavigatorWithDateSeries(TestContext ctx,
+            Action<ComponentParameterCollectionBuilder<RadzenRangeNavigator>> configure = null)
+        {
+            var data = new[]
+            {
+                new DateItem { Date = new DateTime(2024, 1, 1), Value = 3 },
+                new DateItem { Date = new DateTime(2024, 1, 2), Value = 5 },
+            };
+
+            return RenderNavigator(ctx, data, nameof(DateItem.Date), nameof(DateItem.Value), configure);
+        }
+
+        private static IRenderedComponent<RadzenRangeNavigator> RenderNavigator<TItem>(TestContext ctx, IEnumerable<TItem> data,
+            string categoryProperty, string valueProperty, Action<ComponentParameterCollectionBuilder<RadzenRangeNavigator>> configure)
+        {
+            return ctx.RenderComponent<RadzenRangeNavigator>(parameters =>
+            {
+                configure?.Invoke(parameters);
+                parameters.AddChildContent<RadzenRangeNavigatorLineSeries<TItem>>(series =>
+                {
+                    series.Add(p => p.Data, data);
+                    series.Add(p => p.CategoryProperty, categoryProperty);
+                    series.Add(p => p.ValueProperty, valueProperty);
+                });
+            });
+        }
+
+        private static string Describe(RadzenRangeNavigator.TooltipPoint point) => $"{point.Category}: {point.Value}";
+
+        private static string[] LastSentTexts(TestContext ctx)
+        {
+            var last = ctx.JSInterop.Invocations.Last(i => i.Identifier == "Radzen.updateRangeNavigatorTooltip");
+            return Assert.IsAssignableFrom<IEnumerable<RadzenRangeNavigator.TooltipPoint>>(last.Arguments[1]).Select(Describe).ToArray();
+        }
+
+        private class DateItem
+        {
+            public DateTime Date { get; set; }
+            public double Value { get; set; }
+        }
+
+        private class CustomSeriesWithPoints(params Point[] points) : CustomSeries, IRangeNavigatorSeries
+        {
+            public IEnumerable<Point> GetDataPoints(ScaleBase categoryScale) => points;
+        }
+
+        private class CustomSeries : IRangeNavigatorSeries
+        {
+            public ScaleBase TransformCategoryScale(ScaleBase scale) => scale;
+
+            public ScaleBase TransformValueScale(ScaleBase scale) => scale;
+
+            public RenderFragment Render(ScaleBase categoryScale, ScaleBase valueScale) => _ => { };
         }
     }
 }

--- a/Radzen.Blazor.Tests/RangeNavigatorTests.cs
+++ b/Radzen.Blazor.Tests/RangeNavigatorTests.cs
@@ -238,11 +238,14 @@ namespace Radzen.Blazor.Tests
             using var ctx = CreateChartContext();
 
             var component = RenderNavigatorWithDateSeries(ctx, parameters =>
-                parameters.Add(p => p.HandleLabelFormatString, "{0:yyyy-MM-dd}"));
+            {
+                parameters.Add(p => p.HandleLabelFormatString, "{0:yyyy-MM-dd}");
+                parameters.Add(p => p.Culture, CultureInfo.InvariantCulture);
+            });
 
             var points = component.Instance.GetTooltipPoints();
 
-            Assert.Equal(new[] { "2024-01-01: 3", "2024-01-02: 5" }, points.Select(Describe));
+            Assert.Equal(new[] { "2024-01-01: 3.00", "2024-01-02: 5.00" }, points.Select(Describe));
         }
 
         [Fact]
@@ -261,10 +264,14 @@ namespace Radzen.Blazor.Tests
         {
             using var ctx = CreateChartContext();
 
-            RenderNavigatorWithLineSeries(ctx, parameters => parameters.Add(p => p.ShowTooltip, true));
+            RenderNavigatorWithLineSeries(ctx, parameters =>
+            {
+                parameters.Add(p => p.ShowTooltip, true);
+                parameters.Add(p => p.Culture, CultureInfo.InvariantCulture);
+            });
 
             Assert.Single(ctx.JSInterop.Invocations, i => i.Identifier == "Radzen.updateRangeNavigatorTooltip");
-            Assert.Equal(new[] { "A: 10", "B: 20", "C: 15" }, LastSentTexts(ctx));
+            Assert.Equal(new[] { "A: 10.00", "B: 20.00", "C: 15.00" }, LastSentTexts(ctx));
         }
 
         [Fact]
@@ -340,6 +347,29 @@ namespace Radzen.Blazor.Tests
 
             Assert.False(component.Instance.ShowTooltip);
             Assert.DoesNotContain(ctx.JSInterop.Invocations, i => i.Identifier == "Radzen.updateRangeNavigatorTooltip");
+        }
+
+        [Fact]
+        public void RangeNavigator_Tooltip_RefreshesFormattingAndClearsDisabledPoints()
+        {
+            using var ctx = CreateChartContext();
+            var component = RenderNavigatorWithLineSeries(ctx, p =>
+            {
+                p.Add(x => x.ShowTooltip, true);
+                p.Add(x => x.Culture, CultureInfo.InvariantCulture);
+            });
+            Assert.Equal("A: 10.00", LastSentTexts(ctx)[0]);
+
+            component.SetParametersAndRender(p => p.Add(x => x.TooltipFormatString, "{0:N1}"));
+            Assert.Equal("A: 10.0", LastSentTexts(ctx)[0]);
+
+            component.SetParametersAndRender(p => p.Add(x => x.Culture, CultureInfo.GetCultureInfo("de-DE")));
+            Assert.Equal("A: 10,0", LastSentTexts(ctx)[0]);
+
+            component.SetParametersAndRender(p => p.Add(x => x.ShowTooltip, false));
+            Assert.Empty(LastSentTexts(ctx));
+            component.SetParametersAndRender(p => p.Add(x => x.ShowTooltip, true));
+            Assert.Equal("A: 10,0", LastSentTexts(ctx)[0]);
         }
 
         private static IRenderedComponent<RadzenRangeNavigator> RenderNavigatorWithLineSeries(TestContext ctx,

--- a/Radzen.Blazor/IRangeNavigatorSeries.cs
+++ b/Radzen.Blazor/IRangeNavigatorSeries.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Components;
+using Radzen.Blazor.Rendering;
 
 namespace Radzen.Blazor
 {
@@ -21,5 +24,17 @@ namespace Radzen.Blazor
         /// Renders the series using the specified scales.
         /// </summary>
         RenderFragment Render(ScaleBase categoryScale, ScaleBase valueScale);
+
+        /// <summary>
+        /// Gets the series data for the navigator tooltip: each point's X is its category in the input units
+        /// of <paramref name="categoryScale" /> and its Y is its value. A series that returns no points shows no tooltip.
+        /// </summary>
+        IEnumerable<Point> GetDataPoints(ScaleBase categoryScale) => Enumerable.Empty<Point>();
+
+        /// <summary>
+        /// Gets the color of the tooltip's marker and border for this series' points.
+        /// When <c>null</c>, the navigator's text color is used.
+        /// </summary>
+        string? Color => null;
     }
 }

--- a/Radzen.Blazor/RadzenChart.razor
+++ b/Radzen.Blazor/RadzenChart.razor
@@ -81,6 +81,9 @@
         ShowHandleLabels="@RangeNavigator.ShowHandleLabels"
         HandleLabelFormatString="@RangeNavigator.HandleLabelFormatString"
         HandleLabelFormatter="@RangeNavigator.HandleLabelFormatter"
+        ShowTooltip="@RangeNavigator.ShowTooltip"
+        TooltipFormatString="@RangeNavigator.TooltipFormatString"
+        Culture="@Culture"
         Style="@($"height: {RangeNavigator.Height.ToInvariantString()}px; margin-top: 0.5rem; margin-inline-start: {MarginLeft.ToInvariantString()}px; margin-inline-end: {MarginRight.ToInvariantString()}px;")">
         @RangeNavigator.ChildContent
     </RadzenRangeNavigator>

--- a/Radzen.Blazor/RadzenChartRangeNavigator.cs
+++ b/Radzen.Blazor/RadzenChartRangeNavigator.cs
@@ -58,6 +58,20 @@ namespace Radzen.Blazor
         public Func<object, string>? HandleLabelFormatter { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether hovering the navigator shows the nearest point's category and value.
+        /// </summary>
+        /// <value><c>true</c> to show the tooltip; otherwise, <c>false</c>. Default is <c>false</c>.</value>
+        [Parameter]
+        public bool ShowTooltip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format string used to format the value shown in the tooltip.
+        /// </summary>
+        /// <value>The tooltip value format string.</value>
+        [Parameter]
+        public string? TooltipFormatString { get; set; }
+
+        /// <summary>
         /// Gets or sets the child content. Used to declare <see cref="RadzenRangeNavigatorLineSeries{TItem}" /> preview series.
         /// </summary>
         /// <value>The child content.</value>
@@ -79,7 +93,9 @@ namespace Radzen.Blazor
             return parameters.DidParameterChange(nameof(Visible), Visible)
                 || parameters.DidParameterChange(nameof(Height), Height)
                 || parameters.DidParameterChange(nameof(ShowHandleLabels), ShowHandleLabels)
-                || parameters.DidParameterChange(nameof(HandleLabelFormatString), HandleLabelFormatString);
+                || parameters.DidParameterChange(nameof(HandleLabelFormatString), HandleLabelFormatString)
+                || parameters.DidParameterChange(nameof(ShowTooltip), ShowTooltip)
+                || parameters.DidParameterChange(nameof(TooltipFormatString), TooltipFormatString);
         }
     }
 }

--- a/Radzen.Blazor/RadzenRangeNavigator.razor
+++ b/Radzen.Blazor/RadzenRangeNavigator.razor
@@ -32,6 +32,23 @@
         </div>
     </div>
     <div class="rz-range-nav-shade rz-range-nav-shade-end" style="width: @(((1 - End) * 100).ToInvariantString())%"></div>
+    @if (ShowTooltip && Width > 0)
+    {
+        <div class="rz-range-nav-tooltip" style="position: absolute; inset-block-start: 0; width: 0; height: 0; pointer-events: none; z-index: 4; display: none">
+            <svg style="position: absolute; left: -12px; top: -12px; width: 24px; height: 24px; overflow: visible">
+                <g class="rz-active-point">
+                    <circle class="rz-active-point-halo" cx="12" cy="12" r="12"></circle>
+                    <circle class="rz-active-point-dot" cx="12" cy="12" r="5"></circle>
+                </g>
+            </svg>
+            <div class="rz-chart-tooltip rz-top-chart-tooltip">
+                <div class="rz-chart-tooltip-content">
+                    <div class="rz-chart-tooltip-title"></div>
+                    <div><span class="rz-chart-tooltip-item-value"></span></div>
+                </div>
+            </div>
+        </div>
+    }
     @if (ShowAxis && Width > 0)
     {
         <div class="rz-range-nav-axis">

--- a/Radzen.Blazor/RadzenRangeNavigator.razor.cs
+++ b/Radzen.Blazor/RadzenRangeNavigator.razor.cs
@@ -3,6 +3,7 @@ using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Radzen.Blazor
@@ -63,6 +64,19 @@ namespace Radzen.Blazor
         public Func<object, string>? HandleLabelFormatter { get; set; }
 
         /// <summary>
+        /// Gets or sets whether hovering the navigator shows the nearest point's category and value.
+        /// Date and numeric categories are formatted the same way as the handle labels.
+        /// </summary>
+        [Parameter]
+        public bool ShowTooltip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format string for the value shown in the tooltip, e.g. <c>"{0:N0}"</c>.
+        /// </summary>
+        [Parameter]
+        public string? TooltipFormatString { get; set; }
+
+        /// <summary>
         /// Gets or sets whether an axis with tick labels is displayed below the navigator.
         /// </summary>
         [Parameter]
@@ -105,6 +119,15 @@ namespace Radzen.Blazor
 
         private bool firstRender = true;
         private bool isDragging;
+        private bool tooltipChanged;
+
+        /// <inheritdoc />
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            tooltipChanged |= parameters.DidParameterChange(nameof(ShowTooltip), ShowTooltip);
+
+            await base.SetParametersAsync(parameters);
+        }
 
         /// <inheritdoc />
         protected override bool ShouldRender()
@@ -163,6 +186,7 @@ namespace Radzen.Blazor
             ValueScale.Fit(10);
 
             UpdateJSLabelConfig();
+            UpdateJSTooltipConfig();
         }
 
         internal IList<AxisTick> GetAxisTicks()
@@ -290,6 +314,66 @@ namespace Radzen.Blazor
             }
         }
 
+        private void UpdateJSTooltipConfig()
+        {
+            tooltipChanged = false;
+
+            if (!ShowTooltip || JSRuntime == null || firstRender)
+            {
+                return;
+            }
+
+            try
+            {
+                JSRuntime.InvokeVoidAsync("Radzen.updateRangeNavigatorTooltip", Element, GetTooltipPoints());
+            }
+            catch
+            {
+                // Ignore errors
+            }
+        }
+
+        internal IList<TooltipPoint> GetTooltipPoints()
+        {
+            var points = new List<TooltipPoint>();
+
+            if (Width <= 0 || Height <= 0)
+            {
+                return points;
+            }
+
+            foreach (var series in NavigatorSeries)
+            {
+                foreach (var point in series.GetDataPoints(CategoryScale))
+                {
+                    var x = CategoryScale.Scale(point.X) / Width;
+                    var y = ValueScale.Scale(point.Y) / Height;
+
+                    if (double.IsNaN(x) || double.IsNaN(y))
+                    {
+                        continue;
+                    }
+
+                    points.Add(new TooltipPoint(Math.Clamp(x, 0, 1), Math.Clamp(y, 0, 1), series.Color,
+                        GetTooltipCategory(point.X), string.Format(Culture, TooltipFormatString ?? "{0}", point.Y)));
+                }
+            }
+
+            return points.OrderBy(point => point.X).ToList();
+        }
+
+        private string GetTooltipCategory(double value)
+        {
+            if (CategoryScale is OrdinalScale)
+            {
+                return CategoryScale.Value(value)?.ToString() ?? "";
+            }
+
+            return FormatCategory(value);
+        }
+
+        internal sealed record TooltipPoint(double X, double Y, string? Color, string Category, string Value);
+
         internal string GetHandleLabel(double fraction)
         {
             if (CategoryScale?.Input == null)
@@ -305,8 +389,11 @@ namespace Radzen.Blazor
                 return "";
             }
 
-            var value = inputStart + fraction * (inputEnd - inputStart);
+            return FormatCategory(inputStart + fraction * (inputEnd - inputStart));
+        }
 
+        private string FormatCategory(double value)
+        {
             if (CategoryScale is DateScale)
             {
                 var date = new DateTime((long)value);
@@ -353,6 +440,11 @@ namespace Radzen.Blazor
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
+
+            if (!firstRender && tooltipChanged)
+            {
+                UpdateJSTooltipConfig();
+            }
 
             if (firstRender)
             {

--- a/Radzen.Blazor/RadzenRangeNavigator.razor.cs
+++ b/Radzen.Blazor/RadzenRangeNavigator.razor.cs
@@ -71,7 +71,7 @@ namespace Radzen.Blazor
         public bool ShowTooltip { get; set; }
 
         /// <summary>
-        /// Gets or sets the format string for the value shown in the tooltip, e.g. <c>"{0:N0}"</c>.
+        /// Gets or sets the format string for the value shown in the tooltip, e.g. <c>"{0:N0}"</c>. Defaults to <c>"{0:N}"</c> when not set.
         /// </summary>
         [Parameter]
         public string? TooltipFormatString { get; set; }
@@ -124,7 +124,9 @@ namespace Radzen.Blazor
         /// <inheritdoc />
         public override async Task SetParametersAsync(ParameterView parameters)
         {
-            tooltipChanged |= parameters.DidParameterChange(nameof(ShowTooltip), ShowTooltip);
+            tooltipChanged |= parameters.DidParameterChange(nameof(ShowTooltip), ShowTooltip)
+                || parameters.DidParameterChange(nameof(TooltipFormatString), TooltipFormatString)
+                || parameters.DidParameterChange(nameof(Culture), Culture);
 
             await base.SetParametersAsync(parameters);
         }
@@ -316,16 +318,21 @@ namespace Radzen.Blazor
 
         private void UpdateJSTooltipConfig()
         {
+            if (!ShowTooltip && !tooltipChanged)
+            {
+                return;
+            }
+
             tooltipChanged = false;
 
-            if (!ShowTooltip || JSRuntime == null || firstRender)
+            if (JSRuntime == null || firstRender)
             {
                 return;
             }
 
             try
             {
-                JSRuntime.InvokeVoidAsync("Radzen.updateRangeNavigatorTooltip", Element, GetTooltipPoints());
+                JSRuntime.InvokeVoidAsync("Radzen.updateRangeNavigatorTooltip", Element, ShowTooltip ? GetTooltipPoints() : new List<TooltipPoint>());
             }
             catch
             {
@@ -355,7 +362,7 @@ namespace Radzen.Blazor
                     }
 
                     points.Add(new TooltipPoint(Math.Clamp(x, 0, 1), Math.Clamp(y, 0, 1), series.Color,
-                        GetTooltipCategory(point.X), string.Format(Culture, TooltipFormatString ?? "{0}", point.Y)));
+                        GetTooltipCategory(point.X), string.Format(Culture, TooltipFormatString ?? "{0:N}", point.Y)));
                 }
             }
 

--- a/Radzen.Blazor/RadzenRangeNavigatorLineSeries.razor.cs
+++ b/Radzen.Blazor/RadzenRangeNavigatorLineSeries.razor.cs
@@ -244,6 +244,22 @@ namespace Radzen.Blazor
             };
         }
 
+        string? IRangeNavigatorSeries.Color => Stroke;
+
+        /// <inheritdoc />
+        public IEnumerable<Point> GetDataPoints(ScaleBase categoryScale)
+        {
+            if (Items == null || !Items.Any())
+            {
+                return Enumerable.Empty<Point>();
+            }
+
+            var category = Category(categoryScale);
+            var value = Value;
+
+            return Items.Select(item => new Point { X = category(item), Y = value(item) }).ToList();
+        }
+
         private Func<TItem, double> Category(ScaleBase scale)
         {
             if (IsNumeric(CategoryProperty))

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -3489,6 +3489,106 @@ window.Radzen = {
       updateLabels(start, end);
     }
 
+    ref.navTooltipPoints = [];
+
+    ref.navHideTooltip = function () {
+      var tooltip = ref.querySelector('.rz-range-nav-tooltip');
+      if (tooltip) tooltip.style.display = 'none';
+    };
+
+    function nearestPoint(pos) {
+      var points = ref.navTooltipPoints;
+      var lo = 0, hi = points.length - 1;
+      while (lo < hi) {
+        var mid = (lo + hi) >> 1;
+        if (points[mid].x < pos) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+      if (lo > 0 && pos - points[lo - 1].x < points[lo].x - pos) lo--;
+      return points[lo];
+    }
+
+    function isOverTrack(e) {
+      var rect = ref.getBoundingClientRect();
+      return e.clientY <= rect.bottom - (parseFloat(getComputedStyle(ref).paddingBottom) || 0);
+    }
+
+    function clipBounds() {
+      var bounds = { top: 0, left: 0, right: document.documentElement.clientWidth };
+      for (var el = ref.parentElement; el && el !== document.body; el = el.parentElement) {
+        var style = getComputedStyle(el);
+        var rect = el.getBoundingClientRect();
+        if (style.overflowY !== 'visible') {
+          bounds.top = Math.max(bounds.top, rect.top);
+        }
+        if (style.overflowX !== 'visible') {
+          bounds.left = Math.max(bounds.left, rect.left);
+          bounds.right = Math.min(bounds.right, rect.right);
+        }
+        if (style.position === 'fixed') {
+          break;
+        }
+      }
+      return bounds;
+    }
+
+    function positionTooltip(tooltip, point) {
+      var track = ref.querySelector('svg');
+      tooltip.style.insetInlineStart = (point.x * 100) + '%';
+      tooltip.style.insetBlockStart = (point.y * (track ? track.clientHeight : 0)) + 'px';
+
+      var content = tooltip.querySelector('.rz-chart-tooltip-content');
+      var popup = content.parentElement;
+      var bounds = clipBounds();
+      popup.style.left = '';
+      popup.classList.remove('rz-bottom-chart-tooltip');
+      popup.classList.add('rz-top-chart-tooltip');
+      if (content.getBoundingClientRect().top < bounds.top) {
+        popup.classList.remove('rz-top-chart-tooltip');
+        popup.classList.add('rz-bottom-chart-tooltip');
+      }
+
+      var rect = popup.getBoundingClientRect();
+      if (rect.left < bounds.left) {
+        popup.style.left = (bounds.left - rect.left) + 'px';
+      } else if (rect.right > bounds.right) {
+        popup.style.left = (bounds.right - rect.right) + 'px';
+      }
+    }
+
+    var tooltipPoint = null;
+
+    ref.navHover = function (e) {
+      var tooltip = ref.querySelector('.rz-range-nav-tooltip');
+      if (!tooltip || dragging || !ref.navTooltipPoints.length || !isOverTrack(e)) {
+        ref.navHideTooltip();
+        return;
+      }
+      var point = nearestPoint(getPositionFromEvent(e));
+      var wasHidden = tooltip.style.display === 'none';
+      var content = tooltip.querySelector('.rz-chart-tooltip-content');
+
+      if (point !== tooltipPoint || wasHidden) {
+        tooltipPoint = point;
+        tooltip.querySelector('.rz-chart-tooltip-title').textContent = point.category;
+        tooltip.querySelector('.rz-chart-tooltip-item-value').textContent = point.value;
+        tooltip.style.setProperty('--rz-series-color', point.color || 'currentColor');
+        content.style.border = '1px solid ' + getComputedStyle(tooltip.querySelector('.rz-active-point-dot')).fill;
+      }
+
+      tooltip.style.display = '';
+      positionTooltip(tooltip, point);
+
+      if (wasHidden) {
+        content.classList.remove('rz-chart-tooltip-enter');
+        void content.offsetWidth;
+        content.classList.add('rz-chart-tooltip-enter');
+      }
+    };
+
     function notifyBlazor(start, end) {
       instance.invokeMethodAsync('OnNavigatorDrag', snap(start), snap(end)).catch(function (ex) {
         console.error('RangeNav invoke error:', ex);
@@ -3498,6 +3598,7 @@ window.Radzen = {
     readPositionFromDOM();
 
     ref.navMouseDown = function (e) {
+      ref.navHideTooltip();
       // Always read fresh position from DOM on mousedown
       readPositionFromDOM();
 
@@ -3573,6 +3674,8 @@ window.Radzen = {
 
     ref.addEventListener('mousedown', ref.navMouseDown);
     ref.addEventListener('touchstart', ref.navMouseDown, { passive: false });
+    ref.addEventListener('mousemove', ref.navHover);
+    ref.addEventListener('mouseleave', ref.navHideTooltip);
     document.addEventListener('mousemove', ref.navMouseMove);
     document.addEventListener('touchmove', ref.navMouseMove, { passive: false });
     document.addEventListener('mouseup', ref.navMouseUp);
@@ -3594,6 +3697,12 @@ window.Radzen = {
         ref.removeEventListener('mousedown', ref.navMouseDown);
         ref.removeEventListener('touchstart', ref.navMouseDown);
         delete ref.navMouseDown;
+      }
+      if (ref.navHover) {
+        ref.removeEventListener('mousemove', ref.navHover);
+        ref.removeEventListener('mouseleave', ref.navHideTooltip);
+        delete ref.navHover;
+        delete ref.navHideTooltip;
       }
       if (ref.navMouseMove) {
         document.removeEventListener('mousemove', ref.navMouseMove);
@@ -3619,6 +3728,12 @@ window.Radzen = {
         ref.navLabelInputStart = inputStart;
         ref.navLabelInputEnd = inputEnd;
         ref.handleLabelFormatString = handleLabelFormatString;
+    },
+
+    updateRangeNavigatorTooltip: function (ref, points) {
+        if (!ref) return;
+        ref.navTooltipPoints = points || [];
+        if (!ref.navTooltipPoints.length && ref.navHideTooltip) ref.navHideTooltip();
     },
 
   destroyGauge: function (ref) {

--- a/Radzen.Blazor/wwwroot/Radzen.Blazor.js
+++ b/Radzen.Blazor/wwwroot/Radzen.Blazor.js
@@ -3562,8 +3562,10 @@ window.Radzen = {
     var tooltipPoint = null;
 
     ref.navHover = function (e) {
+      if (!ref.navTooltipPoints.length) return;
+
       var tooltip = ref.querySelector('.rz-range-nav-tooltip');
-      if (!tooltip || dragging || !ref.navTooltipPoints.length || !isOverTrack(e)) {
+      if (!tooltip || dragging || !isOverTrack(e)) {
         ref.navHideTooltip();
         return;
       }

--- a/RadzenBlazorDemos/Pages/RangeNavigatorConfig.razor
+++ b/RadzenBlazorDemos/Pages/RangeNavigatorConfig.razor
@@ -23,7 +23,8 @@
             <RadzenAxisTitle Text="Price (USD)" />
         </RadzenValueAxis>
         <RadzenLegend Position="LegendPosition.Bottom" />
-        <RadzenChartRangeNavigator Height="80" ShowHandleLabels="true" HandleLabelFormatter="@FormatHandleLabel">
+        <RadzenChartRangeNavigator Height="80" ShowHandleLabels="true" HandleLabelFormatter="@FormatHandleLabel"
+                                   ShowTooltip="true" TooltipFormatString="${0:N2}">
             <RadzenRangeNavigatorLineSeries FillMode="FillMode.Gradient" Data="@stockData" CategoryProperty="Date" ValueProperty="Close" Stroke="#1E88E5" />
         </RadzenChartRangeNavigator>
     </RadzenChart>

--- a/RadzenBlazorDemos/Pages/RangeNavigatorPage.razor
+++ b/RadzenBlazorDemos/Pages/RangeNavigatorPage.razor
@@ -13,6 +13,7 @@
 <RadzenText TextStyle="TextStyle.Body1" class="rz-mb-8">
     Use <code>RadzenRangeNavigatorLineSeries</code> as child content to display a mini-chart preview of the full data range inside the navigator.
     Set <code>ShowHandleLabels</code> to display the current range values next to the drag handles - format them with <code>HandleLabelFormatString</code> or provide a <code>HandleLabelFormatter</code> function for full control (e.g. custom calendars or culture-specific output).
+    Set <code>ShowTooltip</code> to show the nearest point's category and value while hovering the navigator, and format the value with <code>TooltipFormatString</code>.
 </RadzenText>
 <RadzenExample ComponentName="RangeNavigator" Example="RangeNavigatorConfig">
     <RangeNavigatorConfig />


### PR DESCRIPTION
Fixes #2717.

Adds an opt-in hover tooltip to `RadzenRangeNavigator`. Hovering the track highlights the nearest point on the line and shows its category and value, the way chart series do. That makes it possible to read a peak or gap without dragging a handle onto it, which would move the selection being inspected.

- `ShowTooltip` turns it on and `TooltipFormatString` formats the value, defaulting to `{0:N}`. Changes to the format or culture refresh the tooltip at runtime.
- Disabling the tooltip clears its points so hover events skip DOM lookup.
- It works on the chart-attached `RadzenChartRangeNavigator` too, and the range navigator demo now shows it.
- It reuses the chart's tooltip and active-point styles, so themes need no changes.
- Custom `IRangeNavigatorSeries` implementations keep compiling; they show no tooltip until they implement `GetDataPoints`.

With several series, the tooltip shows only the single nearest point and doesn't name its series.

Validation: all 26 RangeNavigator tests pass, including runtime format/culture changes and disabling/re-enabling tooltips. JavaScript syntax and the disabled-hover early exit were also checked.
