### PR TITLE
Spreadsheet: keep the format of a cell that has no value

### DIFF
--- a/Radzen.Blazor.Tests/Spreadsheet/FormattedEmptyCellRoundTripTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/FormattedEmptyCellRoundTripTests.cs
@@ -1,0 +1,147 @@
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using Radzen.Documents.Spreadsheet;
+using Xunit;
+
+namespace Radzen.Blazor.Spreadsheet.Tests;
+
+#nullable enable
+
+public class FormattedEmptyCellRoundTripTests
+{
+    private static readonly XNamespace Main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private static MemoryStream Save(Workbook workbook)
+    {
+        var stream = new MemoryStream();
+
+        workbook.SaveToStream(stream);
+        stream.Position = 0;
+
+        return stream;
+    }
+
+    private static XElement[] Cells(MemoryStream stream)
+    {
+        stream.Position = 0;
+
+        using var zip = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+        using var content = zip.GetEntry("xl/worksheets/sheet1.xml")!.Open();
+
+        return XDocument.Load(content).Descendants(Main + "c").ToArray();
+    }
+
+    private static Worksheet Load(MemoryStream stream)
+    {
+        stream.Position = 0;
+
+        return Workbook.LoadFromStream(stream).Sheets[0];
+    }
+
+    [Fact]
+    public void AnEmptyCellKeepsItsFormat()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 3);
+
+        sheet.Cells[0, 0].SetValue("Name");
+        sheet.Cells[1, 1].Format.BackgroundColor = "#EEEEEE";
+        sheet.Cells[1, 1].Format.BorderBottom = new BorderStyle { LineStyle = BorderLineStyle.Thin, Color = "#000000" };
+
+        var loaded = Load(Save(workbook));
+
+        Assert.Null(loaded.Cells[1, 1].Value);
+        Assert.Equal("#EEEEEE", loaded.Cells[1, 1].Format.BackgroundColor);
+        Assert.Equal(BorderLineStyle.Thin, loaded.Cells[1, 1].Format.BorderBottom?.LineStyle);
+    }
+
+    [Fact]
+    public void AnEmptyCellKeepsItsQuotePrefix()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 2);
+
+        sheet.Cells[0, 0].SetValue("Name");
+        sheet.Cells[1, 1].QuotePrefix = true;
+
+        var loaded = Load(Save(Load(Save(workbook)).Workbook));
+
+        Assert.Null(loaded.Cells[1, 1].Value);
+        Assert.True(loaded.Cells[1, 1].QuotePrefix);
+    }
+
+    [Fact]
+    public void ACoveredCellOfAMergeKeepsItsOwnFormat()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 3);
+
+        sheet.Cells[0, 0].SetValue("Title");
+        sheet.Cells[0, 0].Format.Bold = true;
+        sheet.Cells[0, 2].Format.BorderRight = new BorderStyle { LineStyle = BorderLineStyle.Thin, Color = "#000000" };
+        sheet.MergedCells.Add(new RangeRef(new CellRef(0, 0), new CellRef(0, 2)));
+
+        var styles = Cells(Save(workbook)).ToDictionary(c => (string)c.Attribute("r")!, c => (string?)c.Attribute("s"));
+
+        Assert.Equal(styles["A1"], styles["B1"]);
+        Assert.NotEqual(styles["A1"], styles["C1"]);
+        Assert.NotNull(styles["C1"]);
+    }
+
+    [Fact]
+    public void AnEmptyCellWithADefaultFormatIsNotWritten()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 3);
+
+        sheet.Cells[0, 0].SetValue("Name");
+        Assert.True(sheet.Cells[1, 1].Format.IsDefault);
+        sheet.Cells[1, 2].Format.Bold = true;
+
+        var cells = Cells(Save(workbook));
+
+        Assert.Equal(new[] { "A1", "C2" }, cells.Select(c => (string?)c.Attribute("r")));
+        Assert.Empty(cells[1].Nodes());
+        Assert.NotNull(cells[1].Attribute("s"));
+    }
+
+    [Fact]
+    public void AnEmptyCellAnotherWriterWroteKeepsItsFormat()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet("Sheet1", 2, 2);
+
+        sheet.Cells[0, 0].SetValue("Name");
+        sheet.Cells[0, 0].Format.Bold = true;
+
+        var stream = Save(workbook);
+        var style = (string)Cells(stream).Single().Attribute("s")!;
+
+        using (var zip = new ZipArchive(stream, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = zip.GetEntry("xl/worksheets/sheet1.xml")!;
+            XDocument document;
+
+            using (var content = entry.Open())
+            {
+                document = XDocument.Load(content);
+            }
+
+            document.Descendants(Main + "sheetData").Single().ReplaceNodes(
+                new XElement(Main + "row", new XAttribute("r", "2"),
+                    new XElement(Main + "c", new XAttribute("r", "B2"), new XAttribute("s", style))));
+
+            entry.Delete();
+
+            using var output = zip.CreateEntry("xl/worksheets/sheet1.xml").Open();
+            document.Save(output);
+        }
+
+        var loaded = Load(stream);
+
+        Assert.Null(loaded.Cells[1, 1].Value);
+        Assert.True(loaded.Cells[1, 1].Format.Bold);
+    }
+}

--- a/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
+++ b/Radzen.Blazor.Tests/Spreadsheet/XlsxWriterSheetOrderTests.cs
@@ -155,7 +155,7 @@ public class XlsxWriterSheetOrderTests
     }
 
     [Fact]
-    public void Save_NumbersAMergeAnchorsStyleWhereItsFirstPlaceholderIsWritten()
+    public void Save_WritesAFormattedEmptyMergeAnchorInTheStyleItsPlaceholdersShare()
     {
         var workbook = new Workbook();
         var sheet = workbook.AddSheet("Sheet1", 4, 4);
@@ -169,8 +169,8 @@ public class XlsxWriterSheetOrderTests
         var cells = Part(workbook, "xl/worksheets/sheet1.xml").Descendants(Main + "c")
             .ToDictionary(c => (string)c.Attribute("r")!, c => int.Parse((string)c.Attribute("s")!, CultureInfo.InvariantCulture));
 
-        Assert.False(cells.ContainsKey("A3"));
-        Assert.True(cells["A1"] < cells["B3"]);
+        Assert.True(cells["A1"] < cells["A3"]);
+        Assert.Equal(cells["A3"], cells["B3"]);
         Assert.Equal(cells["B3"], cells["C3"]);
     }
 

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxReader.cs
@@ -727,8 +727,12 @@ static class XlsxReader
         var formulaElem = cellElem.Element(sNs + "f");
         var inlineElem = cellElem.Element(sNs + "is");
 
+        var style = ResolveStyle(cellElem, styleInfo);
+
         if (valueElem is null && formulaElem is null && inlineElem is null)
         {
+            ApplyCellStyle(sheet, address, styleInfo, style);
+
             return;
         }
 
@@ -740,8 +744,6 @@ static class XlsxReader
 
             cellType = "inlineStr";
         }
-
-        var style = ResolveStyle(cellElem, styleInfo);
 
         var formulaValue = formulaElem?.Value;
 

--- a/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
+++ b/Radzen.Blazor/Documents/Spreadsheet/XlsxWriter.cs
@@ -1747,7 +1747,7 @@ class XlsxWriter(Workbook sourceWorkbook)
         }
     }
 
-    private static bool IsWritten(Cell cell) => cell.Value is not null || cell.Formula is not null;
+    private static bool IsWritten(Cell cell) => cell.Value is not null || cell.Formula is not null || HasCellFormatting(cell);
 
     private static List<int> CollectStyledRowIndices(Worksheet sheet)
     {


### PR DESCRIPTION
A cell with a format but no value was lost on save, because the writer wrote only cells with a value or a formula, and on load, because the reader returned before styling a `<c>` with neither. Both now keep it: a shaded, bordered or quote-prefixed empty cell round-trips, and a cell whose format is default is still not written.

A covered cell of a merge now keeps its own format rather than the anchor's placeholder, as Excel writes it. A workbook with no formatted empty cells saves the same bytes as before.
